### PR TITLE
docs: missing patch version redirect for insights docs

### DIFF
--- a/docs/src-static/.htaccess
+++ b/docs/src-static/.htaccess
@@ -416,3 +416,7 @@ RedirectMatch 301 ^/docs/([^/]+)/(.*)$       https://doc.akka.io/libraries/$1/$2
 
 # TODO remove once the real docs are published
 RedirectMatch 301 ^/akka-cli(/?|/.*)$      https://doc.akka.io/snapshots/akka-documentation/akka-cli$1
+
+# Fix links from https://doc.akka.io/libraries/akka-dependencies/current/#akka-insights
+# e.g. From https://doc.akka.io/libraries/akka-insights/2.20/home.html to https://doc.akka.io/libraries/akka-insights/2.20.x/home.html
+RedirectMatch 301 ^/libraries/akka-insights/(\d+\.\d+)?(/?|/.*)$ https://doc.akka.io/libraries/akka-insights/$1.x$2


### PR DESCRIPTION
Fix urls without the patch version (`.x`) in the url. E.g. from

- https://doc.akka.io/libraries/akka-insights/2.20/home.html

to

- https://doc.akka.io/libraries/akka-insights/2.20.x/home.html

