### PR TITLE
chore: Populate ComponentDescriptor once, in SdkRunner

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -372,8 +372,8 @@ private final class Sdk(
     logger.debug(s"Registering Workflow [${clz.getName}]")
     new WorkflowImpl[S, W](
       factoryContext.workflowId,
-      clz,
       serializer,
+      ComponentDescriptor.descriptorFor(clz, serializer),
       timerClient = runtimeComponentClients.timerClient,
       sdkExecutionContext,
       sdkTracerFactory,
@@ -435,9 +435,9 @@ private final class Sdk(
             sdkSettings,
             sdkTracerFactory,
             componentId,
-            clz,
             factoryContext.entityId,
             serializer,
+            ComponentDescriptor.descriptorFor(clz, serializer),
             context =>
               wiredInstance(clz.asInstanceOf[Class[EventSourcedEntity[AnyRef, AnyRef]]]) {
                 // remember to update component type API doc and docs if changing the set of injectables
@@ -457,9 +457,9 @@ private final class Sdk(
             sdkSettings,
             sdkTracerFactory,
             componentId,
-            clz,
             factoryContext.entityId,
             serializer,
+            ComponentDescriptor.descriptorFor(clz, serializer),
             context =>
               wiredInstance(clz.asInstanceOf[Class[KeyValueEntity[AnyRef]]]) {
                 // remember to update component type API doc and docs if changing the set of injectables

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/eventsourcedentity/EventSourcedEntityImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/eventsourcedentity/EventSourcedEntityImpl.scala
@@ -83,17 +83,15 @@ private[impl] final class EventSourcedEntityImpl[S, E, ES <: EventSourcedEntity[
     configuration: Settings,
     tracerFactory: () => Tracer,
     componentId: String,
-    componentClass: Class[_],
     entityId: String,
     serializer: JsonSerializer,
+    componentDescriptor: ComponentDescriptor,
     factory: EventSourcedEntityContext => ES)
     extends SpiEventSourcedEntity {
   import EventSourcedEntityImpl._
 
   // FIXME
 //  private val traceInstrumentation = new TraceInstrumentation(componentId, EventSourcedEntityCategory, tracerFactory)
-
-  private val componentDescriptor = ComponentDescriptor.descriptorFor(componentClass, serializer)
 
   private val router: ReflectiveEventSourcedEntityRouter[AnyRef, AnyRef, EventSourcedEntity[AnyRef, AnyRef]] = {
     val context = new EventSourcedEntityContextImpl(entityId)

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/keyvalueentity/KeyValueEntityImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/keyvalueentity/KeyValueEntityImpl.scala
@@ -76,9 +76,9 @@ private[impl] final class KeyValueEntityImpl[S, KV <: KeyValueEntity[S]](
     configuration: Settings,
     tracerFactory: () => Tracer,
     componentId: String,
-    componentClass: Class[_],
     entityId: String,
     serializer: JsonSerializer,
+    componentDescriptor: ComponentDescriptor,
     factory: KeyValueEntityContext => KV)
     extends SpiEventSourcedEntity {
   import KeyValueEntityEffectImpl._
@@ -86,8 +86,6 @@ private[impl] final class KeyValueEntityImpl[S, KV <: KeyValueEntity[S]](
 
   // FIXME
 //  private val traceInstrumentation = new TraceInstrumentation(componentId, EventSourcedEntityCategory, tracerFactory)
-
-  private val componentDescriptor = ComponentDescriptor.descriptorFor(componentClass, serializer)
 
   private val router: ReflectiveKeyValueEntityRouter[AnyRef, KeyValueEntity[AnyRef]] = {
     val context = new KeyValueEntityContextImpl(entityId)

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/WorkflowImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/WorkflowImpl.scala
@@ -57,15 +57,14 @@ import kalix.protocol.workflow_entity.WorkflowEntities
 @InternalApi
 class WorkflowImpl[S, W <: Workflow[S]](
     workflowId: String,
-    componentClass: Class[_],
     serializer: JsonSerializer,
+    componentDescriptor: ComponentDescriptor,
     timerClient: TimerClient,
     sdkExecutionContext: ExecutionContext,
     tracerFactory: () => Tracer,
     instanceFactory: Function[WorkflowContext, W])
     extends SpiWorkflow {
 
-  private val componentDescriptor = ComponentDescriptor.descriptorFor(componentClass, serializer)
   private val context = new WorkflowContextImpl(workflowId)
 
   private val router =


### PR DESCRIPTION
* once per class instead of for each entity instance
* used for the command handler lookup
