### PR TITLE
chore: allow running service and integration tests

### DIFF
--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -461,7 +461,7 @@ public class TestKit {
               proxyPort,
               settings.aclEnabled,
               false,
-              settings.serviceName,
+              settings.serviceName + "-IT-" + System.currentTimeMillis(),
               eventingSettings,
               mockedEventingSettings,
               true);

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -149,7 +149,8 @@ class SdkRunner private (dependencyProvider: Option[DependencyProvider]) extends
         startContext.remoteIdentification,
         startContext.tracerFactory,
         dependencyProvider,
-        startedPromise)
+        startedPromise,
+        getSettings.devMode.map(_.serviceName))
       Future.successful(app.spiEndpoints)
     } catch {
       case NonFatal(ex) =>
@@ -261,7 +262,8 @@ private final class Sdk(
     remoteIdentification: Option[RemoteIdentification],
     tracerFactory: String => Tracer,
     dependencyProviderOverride: Option[DependencyProvider],
-    startedPromise: Promise[StartupContext]) {
+    startedPromise: Promise[StartupContext],
+    serviceNameOverride: Option[String]) {
   private val logger = LoggerFactory.getLogger(getClass)
   private val messageCodec = new JsonMessageCodec
   private val ComponentLocator.LocatedClasses(componentClasses, maybeServiceClass) =
@@ -442,7 +444,7 @@ private final class Sdk(
       case _ => None
     }
 
-    val devModeServiceName = sdkSettings.devModeSettings.map(_.serviceName)
+    val devModeServiceName = serviceNameOverride.orElse(sdkSettings.devModeSettings.map(_.serviceName))
     val discoveryEndpoint =
       new DiscoveryImpl(
         classicSystem,


### PR DESCRIPTION
This PR overrides the service name used when running integration tests. The service name is used for local registration, throwing an error when the same service is registered for 2 different ports. In this case, the tests will be considered a different service.