### PR TITLE
chore: make workflow stateless

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
@@ -145,19 +145,6 @@ public abstract class Workflow<S> {
     this.currentState = Optional.ofNullable(state);
   }
 
-  /**
-   * INTERNAL API
-   *
-   * @hidden
-   */
-  @InternalApi
-  public void _internalClear() {
-    this.stateHasBeenSet = false;
-    this.currentState = Optional.empty();
-    this.commandContext = Optional.empty();
-    this.timerScheduler = Optional.empty();
-  }
-
 
   /**
    * @return A workflow definition in a form of steps and transitions between them.

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/WorkflowImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/WorkflowImpl.scala
@@ -68,10 +68,11 @@ class WorkflowImpl[S, W <: Workflow[S]](
   private val context = new WorkflowContextImpl(workflowId)
 
   private val router =
-    new ReflectiveWorkflowRouter[S, W](instanceFactory(context), componentDescriptor.commandHandlers, serializer)
+    new ReflectiveWorkflowRouter[S, W](context, instanceFactory, componentDescriptor.commandHandlers, serializer)
 
   override def configuration: SpiWorkflow.WorkflowConfig = {
-    val definition = router.workflow.definition()
+    val workflow = instanceFactory(context)
+    val definition = workflow.definition()
 
     def toRecovery(sdkRecoverStrategy: SdkRecoverStrategy[_]): SpiWorkflow.RecoverStrategy = {
 

--- a/samples/transfer-workflow-compensation/src/main/java/com/example/transfer/application/TransferWorkflow.java
+++ b/samples/transfer-workflow-compensation/src/main/java/com/example/transfer/application/TransferWorkflow.java
@@ -47,12 +47,9 @@ public class TransferWorkflow extends Workflow<TransferState> {
         .asyncCall(Withdraw.class, cmd -> {
           logger.info("Running withdraw: {}", cmd);
 
-          // saving the wallet id in var because it's being used in thenCompose
-          var fromWalletId = currentState().transfer().from();
-
           // cancelling the timer in case it was scheduled
           return timers().cancel("acceptationTimout-" + currentState().transferId()).thenCompose(__ ->
-            componentClient.forEventSourcedEntity(fromWalletId)
+            componentClient.forEventSourcedEntity(currentState().transfer().from())
               .method(WalletEntity::withdraw)
               .invokeAsync(cmd));
         })


### PR DESCRIPTION
Create a new instance of workflow on each iteration: handle command, execute step and transition. 

This make it safe to capture the workflow state in flatMaps. 
Also, since we serialize/deserialize the state each time, the state on which a user can operate is always a unique and fresh object. 