### PR TITLE
chore: Re-introduce trace spans for timed actions and consumers

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -494,6 +494,7 @@ private final class Sdk(
         val timedActionClass = clz.asInstanceOf[Class[TimedAction]]
         val timedActionSpi =
           new TimedActionImpl[TimedAction](
+            componentId,
             () => wiredInstance(timedActionClass)(sideEffectingComponentInjects(None)),
             timedActionClass,
             system.classicSystem,
@@ -510,6 +511,7 @@ private final class Sdk(
         val consumerClass = clz.asInstanceOf[Class[Consumer]]
         val timedActionSpi =
           new ConsumerImpl[Consumer](
+            componentId,
             () => wiredInstance(consumerClass)(sideEffectingComponentInjects(None)),
             consumerClass,
             system.classicSystem,

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/eventsourcedentity/EventSourcedEntityImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/eventsourcedentity/EventSourcedEntityImpl.scala
@@ -109,7 +109,7 @@ private[impl] final class EventSourcedEntityImpl[S, E, ES <: EventSourcedEntity[
       command: SpiEntity.Command): Future[SpiEventSourcedEntity.Effect] = {
 
     val span: Option[Span] =
-      traceInstrumentation.buildSpan(ComponentType.EventSourcedEntity, componentId, entityId, command)
+      traceInstrumentation.buildEntityCommandSpan(ComponentType.EventSourcedEntity, componentId, entityId, command)
     span.foreach(s => MDC.put(Telemetry.TRACE_ID, s.getSpanContext.getTraceId))
     // smuggling 0 arity method called from component client through here
     val cmdPayload = command.payload.getOrElse(BytesPayload.empty)

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/keyvalueentity/KeyValueEntityImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/keyvalueentity/KeyValueEntityImpl.scala
@@ -103,7 +103,7 @@ private[impl] final class KeyValueEntityImpl[S, KV <: KeyValueEntity[S]](
       command: SpiEntity.Command): Future[SpiEventSourcedEntity.Effect] = {
 
     val span: Option[Span] =
-      traceInstrumentation.buildSpan(ComponentType.KeyValueEntity, componentId, entityId, command)
+      traceInstrumentation.buildEntityCommandSpan(ComponentType.KeyValueEntity, componentId, entityId, command)
     span.foreach(s => MDC.put(Telemetry.TRACE_ID, s.getSpanContext.getTraceId))
     // smuggling 0 arity method called from component client through here
     val cmdPayload = command.payload.getOrElse(BytesPayload.empty)

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewDescriptorFactory.scala
@@ -387,7 +387,6 @@ private[impl] object ViewDescriptorFactory {
     }
 
     override def handle(input: SpiTableUpdateEnvelope): Future[SpiTableUpdateEffect] = Future {
-      // FIXME tracing span?
       val existingState: Option[AnyRef] = input.existingTableRow.map(serializer.fromBytes)
       val metadata = MetadataImpl.of(input.metadata)
       val addedToMDC = metadata.traceId match {

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/timedaction/TimedActionImplSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/timedaction/TimedActionImplSpec.scala
@@ -54,6 +54,7 @@ class TimedActionImplSpec
 
   def create(componentDescriptor: ComponentDescriptor): TimedActionImpl[TestTimedAction] = {
     new TimedActionImpl(
+      "dummy-id",
       () => new TestTimedAction,
       classOf[TestTimedAction],
       classicSystem,


### PR DESCRIPTION
Refs https://github.com/lightbend/kalix-runtime/issues/3274

Jaeger screenshots:

Consumer (event-sourced-customer-registry sample)
<img width="2389" alt="Screenshot 2024-12-19 at 14 44 08" src="https://github.com/user-attachments/assets/5a84869f-7615-454e-80a9-1166a8cfb79f" />

Reliable timers cancelling pizza order after timeout
<img width="2389" alt="Screenshot 2024-12-19 at 14 45 15" src="https://github.com/user-attachments/assets/b54319b7-1e51-4b46-9079-fe58b9a7aebd" />
