### PR TITLE
bug: Update curl to match code change

### DIFF
--- a/docs/src/modules/java/pages/author-your-first-service.adoc
+++ b/docs/src/modules/java/pages/author-your-first-service.adoc
@@ -190,7 +190,7 @@ Restart the service and curl this command:
 
 [source, command line]
 ----
-curl localhost:9000/hello/hello/Bob/30
+curl localhost:9000/hello/hello-response/Bob/30
 ----
 
 == Explore the local console


### PR DESCRIPTION
The updated response code change alters the endpoint to be hello-response - that is because the example code comes from the same code file that also has the hello endpoint unaltered. If we do not want to change the curl then we can update the code so it is separate files.