### PR TITLE
fix(docs): developer service deletion permissions

### DIFF
--- a/docs/src/modules/operations/pages/projects/manage-project-access.adoc
+++ b/docs/src/modules/operations/pages/projects/manage-project-access.adoc
@@ -12,7 +12,7 @@ Access to projects is controlled by assigning specific roles to users. The avail
 |View services                     |✅     |✅        |✅     |❌
 |Deploy services                   |✅     |✅        |❌     |❌
 |Update services                   |✅     |✅        |❌     |❌
-|Delete services                   |✅     |❌        |❌     |❌
+|Delete services                   |✅     |✅        |❌     |❌
 |View routes                       |✅     |✅        |✅     |❌
 |Manage routes                     |✅     |✅        |❌     |❌
 |View secrets                      |✅     |✅        |✅     |❌


### PR DESCRIPTION
Update permissions table to reflect that users that have Developer role assigned to them can delete services.

Closes: lightbend/kalix#12442