### PR TITLE
docs: cross references

### DIFF
--- a/docs/src/modules/java/pages/access-control.adoc
+++ b/docs/src/modules/java/pages/access-control.adoc
@@ -7,6 +7,8 @@ specify lists of what can access your services, at multiple granularity. For exa
 initiates a payment on a payment service to only accept requests from the shopping cart service. You can also control
 whether services or methods can be invoked from the Internet.
 
+For a conceptual introduction, see xref:security:acls.adoc[] in the **Security** section.
+
 ==  Principals
 
 A principal in Akka is an abstract concept that represents anything that can make or be the source of a request.

--- a/docs/src/modules/java/pages/event-sourced-entities.adoc
+++ b/docs/src/modules/java/pages/event-sourced-entities.adoc
@@ -271,3 +271,7 @@ curl localhost:9000/akka/v1.0/entity/carts/12345/addItem \
   -XPOST \
   --data '{"productId":"akka-tshirt","name":"Akka Tshirt","quantity":10}'
 ----
+
+== See also
+
+- xref:java:key-value-entities.adoc[]

--- a/docs/src/modules/java/pages/http-endpoints.adoc
+++ b/docs/src/modules/java/pages/http-endpoints.adoc
@@ -244,3 +244,8 @@ include::example$doc-snippets/src/main/java/com/example/api/ExampleEndpoint.java
 <1> Accept the materializer and keep it in a field
 <2> Make sure to discard the request body when failing
 <3> Or collect the bytes into memory
+
+== See also
+
+- xref:java:access-control.adoc[]
+- xref:security:tls-certificates.adoc[]

--- a/docs/src/modules/security/pages/acls.adoc
+++ b/docs/src/modules/security/pages/acls.adoc
@@ -1,4 +1,4 @@
-= Access Control Lists (ACLs)
+= Access Control List concepts
 
 include::ROOT:partial$include.adoc[]
 


### PR DESCRIPTION
- improve discoverability of ACLs from endpoint docs
- avoid two pages with the exact same title (ACLs)