### PR TITLE
fix: deserialize table updater row state

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewDescriptorFactory.scala
@@ -65,16 +65,7 @@ private[impl] object ViewDescriptorFactory {
       tableUpdaters
         .map { tableUpdaterClass =>
           // View class type parameter declares table type
-          val tableRowClass: Class[_] =
-            tableUpdaterClass.getGenericSuperclass
-              .asInstanceOf[ParameterizedType]
-              .getActualTypeArguments
-              .head match {
-              case clazz: Class[_] => clazz
-              case other =>
-                throw new IllegalArgumentException(
-                  s"Expected [$tableUpdaterClass] to extends TableUpdater[] for a concrete table row type but cannot figure out type parameter because type argument is unexpected [$other] ")
-            }
+          val tableRowClass: Class[_] = Reflect.tableUpdaterRowType(tableUpdaterClass)
 
           val tableName: String = {
             if (tableUpdaters.size > 1) {


### PR DESCRIPTION
after restarting the app with persistence enabled, I noticed:
```
Caused by: java.lang.IllegalStateException: Cannot decode [json.akka.io/customer.domain.CustomerRow] message type. Class mapping not found.
	at akka.javasdk.impl.serialization.JsonSerializer.fromBytes(JsonSerializer.scala:97)
	at akka.javasdk.impl.view.ViewDescriptorFactory$UpdateHandlerImpl.$anonfun$handle$2(ViewDescriptorFactory.scala:394)
	at scala.Option.map(Option.scala:242)
	at akka.javasdk.impl.view.ViewDescriptorFactory$UpdateHandlerImpl.$anonfun$handle$1(ViewDescriptorFactory.scala:394)
	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:687)
	at scala.concurrent.impl.Promise$Transformation.run$$$capture(Promise.scala:467)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at scala.concurrent.impl.Promise$Transformation.<init>(Promise.scala:416)
	at scala.concurrent.impl.Promise$Transformation.<init>(Promise.scala:418)
```

the possible solution for that was to register that type with `serializer.registerTypeHints`, but then any class name change would require a migration, that's why the more flexible solution would be just to try to deserialize with a given type.