### PR TITLE
chore: Drop some more protobuf refs

### DIFF
--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -160,8 +160,6 @@
                                                         <exclude>com.typesafe.akka:akka-stream_2.13</exclude>
                                                         <exclude>com.hierynomus:asn-one</exclude>
                                                         <exclude>org.reactivestreams:reactive-streams</exclude>
-                                                        <!-- Runtime -->
-                                                        <exclude>io.kalix:kalix-proxy-protocol</exclude>
                                                         <!-- Scala stdlib -->
                                                         <exclude>org.scala-lang.modules:scala-collection-compat_2.13</exclude>
                                                         <exclude>org.scala-lang:scala-library</exclude>

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/AnySupportSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/AnySupportSpec.scala
@@ -4,8 +4,6 @@
 
 package akka.javasdk.impl
 
-import kalix.protocol.discovery.{ DiscoveryProto, UserFunctionError }
-import kalix.protocol.event_sourced_entity.EventSourcedEntityProto
 import com.google.protobuf.any.{ Any => ScalaPbAny }
 import com.google.protobuf.{ Any => JavaPbAny }
 import com.google.protobuf.ByteString
@@ -15,28 +13,12 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class AnySupportSpec extends AnyWordSpec with Matchers with OptionValues {
 
-  private val anySupport = new AnySupport(
-    Array(EventSourcedEntityProto.javaDescriptor, DiscoveryProto.javaDescriptor),
-    getClass.getClassLoader,
-    "com.example")
+  private val anySupport = new AnySupport(Array.empty, getClass.getClassLoader, "com.example")
 
-  private val anySupportScala = new AnySupport(
-    Array(EventSourcedEntityProto.javaDescriptor, DiscoveryProto.javaDescriptor),
-    getClass.getClassLoader,
-    "com.example",
-    AnySupport.PREFER_SCALA)
+  private val anySupportScala =
+    new AnySupport(Array.empty, getClass.getClassLoader, "com.example", AnySupport.PREFER_SCALA)
 
   "Any support for Java" should {
-
-    "support se/deserializing scala protobufs" in {
-      val error = UserFunctionError("error")
-      val any = anySupport.encodeScala(UserFunctionError("error"))
-      any.typeUrl should ===("com.example/kalix.protocol.UserFunctionError")
-
-      val decoded = anySupport.decodePossiblyPrimitive(any)
-      decoded.getClass should ===(error.getClass)
-      decoded should ===(error)
-    }
 
     def testPrimitive[T](name: String, value: T, defaultValue: T) = {
       val any = anySupport.encodeScala(value)

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,9 @@ lazy val akkaJavaSdkTestKit =
         "runtimeImage" -> Kalix.RuntimeImage,
         "runtimeVersion" -> Kalix.RuntimeVersion,
         "scalaVersion" -> scalaVersion.value),
-      buildInfoPackage := "akka.javasdk.testkit")
+      buildInfoPackage := "akka.javasdk.testkit",
+      // eventing testkit client
+      akkaGrpcGeneratedSources := Seq(AkkaGrpc.Client))
     .settings(DocSettings.forModule("Akka SDK Testkit"))
     .settings(Dependencies.javaSdkTestKit)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,9 +35,6 @@ object Dependencies {
   val CommonsIoVersion = "2.11.0"
   val MunitVersion = "0.7.29"
 
-  val kalixProxyProtocol = "io.kalix" % "kalix-proxy-protocol" % Kalix.RuntimeVersion
-  val kalixSdkProtocol = "io.kalix" % "kalix-sdk-protocol" % Kalix.RuntimeVersion
-  val kalixTckProtocol = "io.kalix" % "kalix-tck-protocol" % Kalix.RuntimeVersion
   val kalixTestkitProtocol = "io.kalix" % "kalix-testkit-protocol" % Kalix.RuntimeVersion
   val kalixSdkSpi = "io.akka" %% "akka-sdk-spi" % Kalix.RuntimeVersion
 


### PR DESCRIPTION
One test case breaking from runtime protobuf cleanup, then some unused protobuf module references.