### PR TITLE
docs: adding sync status

### DIFF
--- a/docs/src/modules/reference/pages/cli/akka-cli/akka_services_list.adoc
+++ b/docs/src/modules/reference/pages/cli/akka-cli/akka_services_list.adoc
@@ -16,8 +16,8 @@ akka services list [flags]
 ----
 
 > akka services list
-NAME               AGE    INSTANCES   STATUS   IMAGE TAG
-shopping-cart      4h20m  3           Ready    0.0.2
+NAME               AGE    INSTANCES   STATUS   IMAGE TAG    SYNC STATUS
+shopping-cart      4h20m  3           Ready    0.0.2        Synced
 ----
 
 == Options


### PR DESCRIPTION
Now that we are here we could add the three different `sync status` we have and maybe the `status` as well. Although I'm afraid to open a can of worms. For two reasons. One, doing something equivalent for each command would be some work and two, because all those changes would be more prone to get out of sync with the code base. 
