### PR TITLE
docs: Use mvn verify instead of mvn integration-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,7 +440,7 @@ jobs:
           fi
           if [ true == '${{matrix.it}}' ]; then
             ${PRE_CMD}
-            KALIX_TESTKIT_DEBUG=true mvn integration-test --no-transfer-progress
+            KALIX_TESTKIT_DEBUG=true mvn verify --no-transfer-progress
           fi
 
       - name: ${{ matrix.sample }} rm & test-compile

--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -389,7 +389,7 @@
                                 </goals>
                                 <configuration>
                                     <source>
-                                        log.warn('The 'it' profile is deprecated. It will be removed in future versions. Integration tests only need `mvn integration-test` to run.')
+                                        log.warn('The 'it' profile is deprecated. It will be removed in future versions. Integration tests only need `mvn verify` to run.')
                                     </source>
                                 </configuration>
                             </execution>

--- a/docs/src/modules/java/pages/event-sourced-entities.adoc
+++ b/docs/src/modules/java/pages/event-sourced-entities.adoc
@@ -240,4 +240,4 @@ include::example$shopping-cart-quickstart/src/test/java/shoppingcart/ShoppingCar
 <5> Request to retrieve current status of the shopping cart.
 <6> Assert there should only be one item.
 
-NOTE: The integration tests in samples can be run using `mvn integration-test`.
+NOTE: The integration tests in samples can be run using `mvn verify`.

--- a/docs/src/modules/java/pages/key-value-entities.adoc
+++ b/docs/src/modules/java/pages/key-value-entities.adoc
@@ -160,4 +160,4 @@ include::example$key-value-counter/src/test/java/com/example/CounterIntegrationT
 <4> Request to increase the value of counter `bar`. Response should have value `1`.
 <5> Explicitly request current value of `bar`. It should be `1`.
 
-NOTE: The integration tests in samples can be run using `mvn integration-test`.
+NOTE: The integration tests in samples can be run using `mvn verify`.

--- a/docs/src/modules/reference/pages/release-notes.adoc
+++ b/docs/src/modules/reference/pages/release-notes.adoc
@@ -26,7 +26,7 @@ Current versions
     - Updates to configure SSO integrations
 
 * https://github.com/akka/akka-sdk/releases/tag/v3.0.2[Akka SDK 3.0.2]
-    - Integration Tests are now bound to `mvn integration-test` and not a specific profile
+    - Integration Tests are now bound to `mvn verify` and not a specific profile
 
 * Platform update 2024-12-10
     - New internal structure to capture usage data

--- a/samples/event-sourced-counter-brokers/README.md
+++ b/samples/event-sourced-counter-brokers/README.md
@@ -102,5 +102,5 @@ docker compose up
 
 Then run:
 ```shell
-mvn integration-test
+mvn verify
 ```

--- a/samples/transfer-workflow-compensation/README.md
+++ b/samples/transfer-workflow-compensation/README.md
@@ -104,7 +104,7 @@ curl http://localhost:9000/transfer/1
 To run the integration tests located in `src/test/java`:
 
 ```shell
-mvn integration-test
+mvn verify
 ```
 
 ## Troubleshooting

--- a/samples/transfer-workflow/README.md
+++ b/samples/transfer-workflow/README.md
@@ -106,7 +106,7 @@ curl http://localhost:9000/transfer/1
 To run the integration tests located in `src/test/java`:
 
 ```shell
-mvn integration-test
+mvn verify
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
It seems `mvn integration-test` does not fail the build on test failure in all circumstances and `verify` is anyway the recommended way to run surefire integration tests according to their docs.