### PR TITLE
chore: Otel trace propagation through gRPC clients

### DIFF
--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -40,7 +40,7 @@
 
         <!-- These are dependent on runtime environment and cannot be customized by users -->
         <maven.compiler.release>21</maven.compiler.release>
-        <kalix-runtime.version>1.3.2-3-dd5a0598-dev-SNAPSHOT</kalix-runtime.version>
+        <kalix-runtime.version>1.3.2-240d8b7</kalix-runtime.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skip.docker>false</skip.docker>

--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -36,7 +36,7 @@
 
         <akka-javasdk.version>3.0.2</akka-javasdk.version>
         <!-- must be carefully kept in sync with sdk and runtime version -->
-        <akka.grpc.version>2.5.1-5-988292fa-SNAPSHOT</akka.grpc.version>
+        <akka.grpc.version>2.5.2</akka.grpc.version>
 
         <!-- These are dependent on runtime environment and cannot be customized by users -->
         <maven.compiler.release>21</maven.compiler.release>

--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -36,11 +36,11 @@
 
         <akka-javasdk.version>3.0.2</akka-javasdk.version>
         <!-- must be carefully kept in sync with sdk and runtime version -->
-        <akka.grpc.version>2.5.1</akka.grpc.version>
+        <akka.grpc.version>2.5.1-5-988292fa-SNAPSHOT</akka.grpc.version>
 
         <!-- These are dependent on runtime environment and cannot be customized by users -->
         <maven.compiler.release>21</maven.compiler.release>
-        <kalix-runtime.version>1.3.1</kalix-runtime.version>
+        <kalix-runtime.version>1.3.2-3-dd5a0598-dev-SNAPSHOT</kalix-runtime.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skip.docker>false</skip.docker>

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/GrpcEndpointDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/GrpcEndpointDescriptorFactory.scala
@@ -16,6 +16,7 @@ import akka.runtime.sdk.spi.ComponentOptions
 import akka.runtime.sdk.spi.GrpcEndpointDescriptor
 import akka.runtime.sdk.spi.GrpcEndpointRequestConstructionContext
 import akka.runtime.sdk.spi.MethodOptions
+import io.opentelemetry.api.trace.Span
 
 import scala.concurrent.Future
 
@@ -23,7 +24,7 @@ object GrpcEndpointDescriptorFactory {
 
   val logger: org.slf4j.Logger = org.slf4j.LoggerFactory.getLogger(GrpcEndpointDescriptorFactory.getClass)
 
-  def apply[T](grpcEndpointClass: Class[T], factory: () => T)(implicit
+  def apply[T](grpcEndpointClass: Class[T], factory: Option[Span] => T)(implicit
       system: ActorSystem[_]): GrpcEndpointDescriptor[T] = {
     // FIXME now way right now to know that it is a gRPC service interface
     val serviceDefinitionClass: Class[_] = {
@@ -36,8 +37,8 @@ object GrpcEndpointDescriptorFactory {
     }
 
     // FIXME a derivative should be injectable into user code as well
-    val instanceFactory = { (_: GrpcEndpointRequestConstructionContext) =>
-      factory()
+    val instanceFactory = { (ctx: GrpcEndpointRequestConstructionContext) =>
+      factory(ctx.openTelemetrySpan)
     }
 
     val handlerFactory =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val ProtocolVersionMinor = 1
     val RuntimeImage = "gcr.io/kalix-public/kalix-runtime"
     // Remember to bump kalix-runtime.version in akka-javasdk-maven/akka-javasdk-parent if bumping this
-    val RuntimeVersion = sys.props.getOrElse("kalix-runtime.version", "1.3.1")
+    val RuntimeVersion = sys.props.getOrElse("kalix-runtime.version", "1.3.2-3-dd5a0598-dev-SNAPSHOT")
   }
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned
   // for prod code, they are marked as Provided, but testkit still requires the alignment
-  val AkkaVersion = "2.10.0"
+  val AkkaVersion = "2.10.1"
   val AkkaHttpVersion = "10.7.0" // Note: should at least the Akka HTTP version required by Akka gRPC
 
   // Note: the Scala version must be aligned with the runtime

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val ProtocolVersionMinor = 1
     val RuntimeImage = "gcr.io/kalix-public/kalix-runtime"
     // Remember to bump kalix-runtime.version in akka-javasdk-maven/akka-javasdk-parent if bumping this
-    val RuntimeVersion = sys.props.getOrElse("kalix-runtime.version", "1.3.2-3-dd5a0598-dev-SNAPSHOT")
+    val RuntimeVersion = sys.props.getOrElse("kalix-runtime.version", "1.3.2-240d8b7")
   }
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += "Akka repository".at("https://repo.akka.io/maven")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 // Note: akka-grpc must be carefully kept in sync with the version used in the runtime.
 //       Whenever this is bumped, akka-javasdk-maven/akka-javasdk-parent/pom.xml must be bumped to the same version
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.5.1-5-988292fa-SNAPSHOT")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.5.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += "Akka repository".at("https://repo.akka.io/maven")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 // Note: akka-grpc must be carefully kept in sync with the version used in the runtime.
 //       Whenever this is bumped, akka-javasdk-maven/akka-javasdk-parent/pom.xml must be bumped to the same version
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.5.1")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.5.1-5-988292fa-SNAPSHOT")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")


### PR DESCRIPTION
Depends on an Akka gRPC release and upstream bump in runtime before ready, but tested to work locally with Jaeger:


<img width="1198" alt="Screenshot 2025-01-29 at 16 38 56" src="https://github.com/user-attachments/assets/341b5b75-2abb-4ff9-84cd-a8bd0daecafe" />
