### PR TITLE
chore: tests for ACL support in gRPC endpoints

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/GrpcEndpointTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/GrpcEndpointTest.java
@@ -5,27 +5,30 @@
 package akkajavasdk;
 
 import akka.grpc.GrpcClientSettings;
+import akka.grpc.GrpcServiceException;
 import akka.javasdk.testkit.TestKitSupport;
 import akkajavasdk.protocol.TestGrpcServiceClient;
+import akkajavasdk.protocol.TestGrpcServiceClientPowerApi;
 import akkajavasdk.protocol.TestGrpcServiceOuterClass;
-import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.concurrent.TimeUnit;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 @ExtendWith(Junit5LogCapturing.class)
 public class GrpcEndpointTest extends TestKitSupport {
 
-  @Test
-  public void shouldProvideBasicGrpcEndpoint() {
-    var testClient = TestGrpcServiceClient.create(
+  private TestGrpcServiceClient createGrpcClient() {
+    return TestGrpcServiceClient.create(
         GrpcClientSettings.connectToServiceAt("localhost", testKit.getPort(),testKit.getActorSystem())
             .withTls(false),
         testKit.getActorSystem());
+  }
+
+  @Test
+  public void shouldProvideBasicGrpcEndpoint() {
+    var testClient = createGrpcClient();
 
     try {
       var request = TestGrpcServiceOuterClass.In.newBuilder().setData("Hello world").build();
@@ -39,10 +42,7 @@ public class GrpcEndpointTest extends TestKitSupport {
 
   @Test
   public void shouldAllowExternalGrpcCall() {
-    var testClient = TestGrpcServiceClient.create(
-        GrpcClientSettings.connectToServiceAt("localhost", testKit.getPort(),testKit.getActorSystem())
-            .withTls(false),
-        testKit.getActorSystem());
+    var testClient = createGrpcClient();
     try {
 
       var request = TestGrpcServiceOuterClass.In.newBuilder().setData("Hello world").build();
@@ -56,10 +56,7 @@ public class GrpcEndpointTest extends TestKitSupport {
 
   @Test
   public void shouldAllowCrossServiceGrpcCall() {
-    var testClient = TestGrpcServiceClient.create(
-        GrpcClientSettings.connectToServiceAt("localhost", testKit.getPort(),testKit.getActorSystem())
-            .withTls(false),
-        testKit.getActorSystem());
+    var testClient = createGrpcClient();
     try {
 
       var request = TestGrpcServiceOuterClass.In.newBuilder().setData("Hello world").build();
@@ -71,6 +68,53 @@ public class GrpcEndpointTest extends TestKitSupport {
     }
   }
 
+  @Test
+  public void shouldAllowGrpcCallFromInternet() {
+    var testClient = createGrpcClient();
+    try {
 
+      var request = TestGrpcServiceOuterClass.In.newBuilder().setData("Hello world").build();
+      var response = await(testClient.aclPublicMethod(request));
+
+      assertThat(response.getData()).isEqualTo(request.getData());
+    } finally {
+      testClient.close();
+    }
+  }
+
+  @Test
+  public void shouldDenyGrpcCallFromInternetWithCustomCode() {
+    var testClient = createGrpcClient();
+    try {
+      var request = TestGrpcServiceOuterClass.In.newBuilder().setData("Hello world").build();
+      await(testClient.aclPrivateMethod(request));
+      fail("Expected exception");
+    } catch(GrpcServiceException e) {
+      assertThat(e.getMessage()).contains("UNAVAILABLE");
+    } finally {
+      testClient.close();
+    }
+  }
+
+  @Test
+  public void shouldAllowGrpcCallFromOtherService() {
+    // FIXME update to avoid casting when we give better access to send headers
+    var testClient = (TestGrpcServiceClientPowerApi) createGrpcClient();
+
+    var request = TestGrpcServiceOuterClass.In.newBuilder().setData("Hello world").build();
+    var response = await(testClient.aclServiceMethod()
+        .addHeader("impersonate-service", "other-service")
+        .invoke(request));
+    assertThat(response.getData()).isEqualTo(request.getData());
+
+    // should still fail when called from internet since it should override component level ACL
+    try {
+      await(testClient.aclServiceMethod()
+          .invoke(request));
+      fail("Expected exception");
+    } catch(GrpcServiceException e) {
+      assertThat(e.getMessage()).contains("PERMISSION_DENIED");
+    }
+  }
 
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/grpc/TestGrpcServiceImpl.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/grpc/TestGrpcServiceImpl.java
@@ -44,4 +44,23 @@ public class TestGrpcServiceImpl implements TestGrpcService {
     return grpcServiceClient.simple(in);
   }
 
+  @Override
+  public CompletionStage<TestGrpcServiceOuterClass.Out> aclPublicMethod(TestGrpcServiceOuterClass.In in) {
+    return simple(in);
+  }
+
+  @Acl(deny = @Acl.Matcher(principal = Acl.Principal.ALL), denyCode = Acl.DenyStatusCode.SERVICE_UNAVAILABLE)
+  @Override
+  public CompletionStage<TestGrpcServiceOuterClass.Out> aclPrivateMethod(TestGrpcServiceOuterClass.In in) {
+    return simple(in);
+  }
+
+  @Acl(
+      allow = @Acl.Matcher(service = "other-service"),
+      deny = @Acl.Matcher(principal = Acl.Principal.INTERNET))
+  @Override
+  public CompletionStage<TestGrpcServiceOuterClass.Out> aclServiceMethod(TestGrpcServiceOuterClass.In in) {
+    return simple(in);
+  }
+
 }

--- a/akka-javasdk-tests/src/test/protobuf/akkajavasdk/test_grpc_service.proto
+++ b/akka-javasdk-tests/src/test/protobuf/akkajavasdk/test_grpc_service.proto
@@ -20,4 +20,7 @@ service TestGrpcService {
   rpc Simple(In) returns (Out) {};
   rpc DelegateToAkkaService(In) returns (Out) {};
   rpc DelegateToExternal(In) returns (Out) {};
+  rpc AclPublicMethod(In) returns (Out) {};
+  rpc AclPrivateMethod(In) returns (Out) {};
+  rpc AclServiceMethod(In) returns (Out) {};
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/AclDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/AclDescriptorFactory.scala
@@ -11,6 +11,7 @@ import akka.runtime.sdk.spi.All
 import akka.runtime.sdk.spi.Internet
 import akka.runtime.sdk.spi.PrincipalMatcher
 import akka.runtime.sdk.spi.ServiceNamePattern
+import com.google.rpc.Code
 
 /**
  * INTERNAL API
@@ -37,8 +38,8 @@ private[impl] object AclDescriptorFactory {
       new ACL(
         allow = Option(ann.allow).map(toPrincipalMatcher).getOrElse(Nil),
         deny = Option(ann.deny).map(toPrincipalMatcher).getOrElse(Nil),
-        denyHttpCode = None // FIXME we can probably use http codes instead of grpc ones
-      )
+        denyHttpCode = None, // FIXME we can probably use http codes instead of grpc ones
+        denyGrpcCode = Option(Code.forNumber(ann.denyCode().value)))
     }
 
   private def toPrincipalMatcher(matchers: Array[Acl.Matcher]): List[PrincipalMatcher] =


### PR DESCRIPTION
Refs https://github.com/lightbend/kalix-runtime/issues/3348

Just some basic tests for ACLs on the sdk side. The more extensive coverage is done on the runtime.
Also, sets the grpc deny code from annotation. (We have some work to do around the deny codes I think but that is for another issue)

I wont disclose how much time I spent debugging a test failing because I was calling the wrong grpc method. 🤕 