### PR TITLE
fix: reference to field in GoogleCloud spec

### DIFF
--- a/docs/src/modules/operations/pages/observability-and-monitoring/observability-exports.adoc
+++ b/docs/src/modules/operations/pages/observability-and-monitoring/observability-exports.adoc
@@ -207,7 +207,7 @@ In addition, the Splunk HEC exporter supports <<TLS configuration>>. A full refe
 [#_google_cloud]
 === Google Cloud
 
-Google Cloud is supported for exporting logs, metrics, and traces. The primary piece of configuration it needs is a service account JSON key. The service account that the key is for must have the following IAM roles:
+Google Cloud is supported for exporting logs, metrics, and traces. The primary piece of configuration it needs is a service account JSON key. The service account associated with the key must have the following IAM roles:
 
 * If exporting metrics to Google Cloud, it must have the `roles/monitoring.metricWriter` role.
 * If exporting logs to Google Cloud, it must have the `roles/logging.logWriter` role.
@@ -255,7 +255,7 @@ Descriptor::
 ----
 default:
   googleCloud:
-    serviceAccountSecret:
+    serviceAccountKeySecret:
       name: gcp-credentials
 ----
 CLI::

--- a/docs/src/modules/reference/pages/descriptors/observability-descriptor.adoc
+++ b/docs/src/modules/reference/pages/descriptors/observability-descriptor.adoc
@@ -124,7 +124,7 @@ Configuration for a Google Cloud exporter.
 |===
 |Field                  |Type                          |Description
 
-|*serviceAccountSecret* |<<ObjectRef>> _required_ |A secret containing a Google service account JSON key, in a property called `key.json`.
+|*serviceAccountKeySecret* |<<ObjectRef>> _required_ |A secret containing a Google service account JSON key, in a property called `key.json`.
 
 The service account used must have the `roles/logging.logWriter` role if exporting logs. The `roles/monitoring.metricWriter` role if exporting metrics. The `roles/cloudtrace.agent` role if exporting traces.
 |===


### PR DESCRIPTION
See https://github.com/lightbend/kalix/blob/3acc461ecfd9c2ffc3fdeb333316652d449c609a/operators/deployment/apis/kalix/v1alpha1/kalixobservability_types.go#L208