### PR TITLE
feat: uniform deny codes for HTTP and gRPC endpoints

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/grpc/TestGrpcServiceImpl.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/grpc/TestGrpcServiceImpl.java
@@ -49,7 +49,7 @@ public class TestGrpcServiceImpl implements TestGrpcService {
     return simple(in);
   }
 
-  @Acl(deny = @Acl.Matcher(principal = Acl.Principal.ALL), denyCode = Acl.DenyStatusCode.SERVICE_UNAVAILABLE)
+  @Acl(deny = @Acl.Matcher(principal = Acl.Principal.ALL), denyCode = 14)
   @Override
   public CompletionStage<TestGrpcServiceOuterClass.Out> aclOverrideDenyCodeMethod(TestGrpcServiceOuterClass.In in) {
     return simple(in);

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/grpc/TestGrpcServiceImpl.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/grpc/TestGrpcServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 
-@Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET), denyCode = Acl.DenyStatusCode.NOT_FOUND)
+@Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET), denyCode = 5)
 @GrpcEndpoint
 public class TestGrpcServiceImpl implements TestGrpcService {
 

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/Acl.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/Acl.java
@@ -37,27 +37,7 @@ public @interface Acl {
    * annotated with their own @Acl definition.
    *
    */
-  DenyStatusCode denyCode() default DenyStatusCode.FORBIDDEN;
-
-  enum DenyStatusCode {
-    BAD_REQUEST(3),
-    FORBIDDEN(7),
-    NOT_FOUND(5),
-    AUTHENTICATION_REQUIRED(16),
-    CONFLICT(6),
-    INTERNAL_SERVER_ERROR(13),
-    SERVICE_UNAVAILABLE(14),
-    GATEWAY_TIMEOUT(4);
-
-
-
-    public final int value;
-    DenyStatusCode(int value) {
-      this.value = value;
-    }
-
-  }
-
+  int denyCode() default -1;
 
   /**
    * A principal matcher that can be used in an ACL.

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/Acl.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/Acl.java
@@ -32,9 +32,14 @@ public @interface Acl {
   /**
    * The status code to respond with when access is denied.
    * <p>
-   * By default, this will be 'Forbidden', but alternatives might include 'Authentication required' or 'Not
-   * Found'. If set at class-level, it will automatically be inherited by all methods in the class that are not
+   * By default, this will be '403 Forbidden' for HTTP endpoints and 'PERMISSION DENIED (7)' for gRPC endpoints.
+   * If set at class-level, it will automatically be inherited by all methods in the class that are not
    * annotated with their own @Acl definition.
+   *
+   * For HTTP, common used values are between 400 and 599,
+   * see exhaustive list at https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes
+   *
+   * For gRPC, the status codes values can be consulted at https://grpc.github.io/grpc/core/md_doc_statuscodes.html
    *
    */
   int denyCode() default -1;

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/AclDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/AclDescriptorFactory.scala
@@ -5,6 +5,8 @@
 package akka.javasdk.impl
 
 import akka.annotation.InternalApi
+import akka.http.scaladsl.model.StatusCode
+import akka.http.scaladsl.model.StatusCodes.Forbidden
 import akka.javasdk.annotations.Acl
 import akka.runtime.sdk.spi.ACL
 import akka.runtime.sdk.spi.All
@@ -30,7 +32,7 @@ private[impl] object AclDescriptorFactory {
 
   // receives the method, checks if it is annotated with @Acl and if so,
   // converts that into ACL spi object
-  def deriveAclOptions(aclAnnotation: Option[Acl]): Option[ACL] =
+  def deriveAclOptions(aclAnnotation: Option[Acl], isGrpc: Boolean = false): Option[ACL] =
     aclAnnotation.map { ann =>
       ann.allow().foreach(matcher => validateMatcher(matcher))
       ann.deny().foreach(matcher => validateMatcher(matcher))
@@ -38,8 +40,8 @@ private[impl] object AclDescriptorFactory {
       new ACL(
         allow = Option(ann.allow).map(toPrincipalMatcher).getOrElse(Nil),
         deny = Option(ann.deny).map(toPrincipalMatcher).getOrElse(Nil),
-        denyHttpCode = None, // FIXME we can probably use http codes instead of grpc ones
-        denyGrpcCode = Option(Code.forNumber(ann.denyCode().value)))
+        denyHttpCode = if (isGrpc) None else deriveHttpCode(ann.denyCode()),
+        denyGrpcCode = if (isGrpc) deriveGrpcCode(ann.denyCode()) else None)
     }
 
   private def toPrincipalMatcher(matchers: Array[Acl.Matcher]): List[PrincipalMatcher] =
@@ -51,4 +53,22 @@ private[impl] object AclDescriptorFactory {
       }
     }.toList
 
+  private val denyCodeUndefined = -1
+  private def deriveHttpCode(code: Integer): Some[StatusCode] = try {
+    if (code == denyCodeUndefined) Some(Forbidden)
+    else Some(StatusCode.int2StatusCode(code))
+  } catch {
+    case _: RuntimeException => throw new IllegalArgumentException(s"Invalid HTTP status code: $code")
+  }
+
+  private def deriveGrpcCode(code: Integer): Option[Code] = {
+    val parsedCode =
+      if (code == denyCodeUndefined) Some(Code.PERMISSION_DENIED)
+      else Option(Code.forNumber(code))
+
+    if (parsedCode.isEmpty)
+      throw new IllegalArgumentException(s"Invalid gRPC status code: $code")
+    else
+      parsedCode
+  }
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/GrpcEndpointDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/GrpcEndpointDescriptorFactory.scala
@@ -63,14 +63,14 @@ object GrpcEndpointDescriptorFactory {
     }
 
     val componentOptions =
-      new ComponentOptions(deriveAclOptions(Option(grpcEndpointClass.getAnnotation(classOf[Acl]))), None)
+      new ComponentOptions(deriveAclOptions(Option(grpcEndpointClass.getAnnotation(classOf[Acl])), isGrpc = true), None)
 
     val methodOptions: Map[String, MethodOptions] = grpcEndpointClass.getMethods
       .filter(m => hasAcl(m))
       .map { m =>
         // FIXME just do to lower case and change runtime to handle it
         capitalizeFirstLetter(m.getName) -> new MethodOptions(
-          deriveAclOptions(Option(m.getAnnotation(classOf[Acl]))),
+          deriveAclOptions(Option(m.getAnnotation(classOf[Acl])), isGrpc = true),
           None)
       }
       .toMap

--- a/akka-javasdk/src/test/java/akka/javasdk/impl/http/TestEndpoints.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/impl/http/TestEndpoints.java
@@ -59,7 +59,7 @@ public class TestEndpoints {
         }
     }
 
-    @Acl(deny = @Acl.Matcher(principal = Acl.Principal.ALL))
+    @Acl(deny = @Acl.Matcher(principal = Acl.Principal.ALL), denyCode = 404)
     @HttpEndpoint("acls")
     public static class TestEndpointAcls {
 
@@ -71,7 +71,8 @@ public class TestEndpoints {
         @Get("/secret")
         @Acl(
             allow = @Acl.Matcher(service = "backoffice-service"),
-            deny = @Acl.Matcher(principal = Acl.Principal.INTERNET))
+            deny = @Acl.Matcher(principal = Acl.Principal.INTERNET),
+            denyCode = 401)
         public String secret() {
             return "the greatest secret";
         }
@@ -91,7 +92,15 @@ public class TestEndpoints {
         public String invalid() {
             return "invalid matcher";
         }
+    }
 
+    @HttpEndpoint("invalid-acl-denycode")
+    public static class TestEndpointInvalidAclDenyCode {
+        @Get("/invalid")
+        @Acl(allow = @Acl.Matcher(service = "*"), denyCode = 123123)
+        public String invalid() {
+            return "invalid matcher";
+        }
     }
 
     @HttpEndpoint("my-endpoint")

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/AclTestModels.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/AclTestModels.java
@@ -5,7 +5,6 @@
 package akka.javasdk.testmodels;
 
 import akka.javasdk.annotations.Acl;
-import akka.javasdk.annotations.Acl.DenyStatusCode;
 import akka.javasdk.annotations.Acl.Matcher;
 import akka.javasdk.annotations.Acl.Principal;
 
@@ -43,6 +42,6 @@ public class AclTestModels {
   @Acl(allow = @Matcher(principal = Principal.ALL, service = "*"))
   public static class MainWithInvalidDenyAnnotation {}
 
-  @Acl(denyCode = DenyStatusCode.CONFLICT)
+  @Acl(denyCode = 409)
   public static class MainDenyWithCode {}
 }

--- a/samples/doc-snippets/src/main/java/com/example/acl/UserEndpoint.java
+++ b/samples/doc-snippets/src/main/java/com/example/acl/UserEndpoint.java
@@ -15,7 +15,7 @@ import akka.javasdk.http.AbstractHttpEndpoint;
 /*
 // tag::deny-class-level[]
 @Acl(allow = @Acl.Matcher(service = "service-a"),
-     denyCode = Acl.DenyStatusCode.NOT_FOUND)
+     denyCode = 404)
 // end::deny-class-level[]
  */
 // tag::endpoint-class[]


### PR DESCRIPTION
Close https://github.com/lightbend/kalix-runtime/issues/3407

I tinkered a bit with having 2 different methods on the annotation `httpDenyCode` and `grpcDenyCode` but then ended up with only `denyCode`. Let me know your thoughts.

Note that the `denyCode` was actually not being applied for HTTP endpoints (although we have it documented already). Thus, although this change might required source code changes for anyone using `denyCode` already (unlikely), it should not really impact anything.