### PR TITLE
docs: A working CLI CORS-enable snippet

### DIFF
--- a/docs/src/modules/operations/pages/services/invoke-service.adoc
+++ b/docs/src/modules/operations/pages/services/invoke-service.adoc
@@ -183,7 +183,7 @@ CORS can be enabled by configuring at least one allowed origin, for example:
 
 [source,bash]
 ----
-akka route update acme-ecommerce --cors-origin https://www.acme.org
+akka route update acme-ecommerce --cors-origin https://www.acme.org --cors-method GET --cors-method POST
 ----
 
 ==== Securing routes


### PR DESCRIPTION
Noticed while working on verifying gRPC-web, the snippet with only CORS origin does not give you working CORS, it requires allowed methods as well, so include those in the snippet for easy copy pasta and understanding how it works.