### PR TITLE
fix: propagate custom gRPC status to client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Restore Coursier cache
         # https://github.com/actions/cache/releases
-        # v4.0.2
+        # v4.2.0
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: |
@@ -100,7 +100,7 @@ jobs:
 
       - name: Cache Coursier cache
         # https://github.com/actions/cache/releases
-        # v4.0.2
+        # v4.2.0
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: |
@@ -122,7 +122,7 @@ jobs:
 
       - name: Cache Maven repository
         # https://github.com/actions/cache/releases
-        # v4.0.2
+        # v4.2.0
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: ~/.m2/repository
@@ -181,7 +181,7 @@ jobs:
 
       - name: Restore Coursier cache
         # https://github.com/actions/cache/releases
-        # v4.0.2
+        # v4.2.0
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: |
@@ -236,7 +236,7 @@ jobs:
 
       - name: Restore Coursier cache
         # https://github.com/actions/cache/releases
-        # v4.0.2
+        # v4.2.0
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: |
@@ -298,7 +298,7 @@ jobs:
 
       - name: Cache Maven repository
         # https://github.com/actions/cache/releases
-        # v4.0.2
+        # v4.2.0
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: ~/.m2/repository
@@ -396,7 +396,7 @@ jobs:
 
       - name: Cache Maven repository
         # https://github.com/actions/cache/releases
-        # v4.0.2
+        # v4.2.0
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: ~/.m2/repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Restore Coursier cache
         # https://github.com/actions/cache/releases
         # v4.0.2
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: |
             ~/.cache/coursier
@@ -101,7 +101,7 @@ jobs:
       - name: Cache Coursier cache
         # https://github.com/actions/cache/releases
         # v4.0.2
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: |
             ~/.cache/coursier
@@ -123,7 +123,7 @@ jobs:
       - name: Cache Maven repository
         # https://github.com/actions/cache/releases
         # v4.0.2
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('akka-javasdk-maven/pom.xml') }}
@@ -182,7 +182,7 @@ jobs:
       - name: Restore Coursier cache
         # https://github.com/actions/cache/releases
         # v4.0.2
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: |
             ~/.cache/coursier
@@ -237,7 +237,7 @@ jobs:
       - name: Restore Coursier cache
         # https://github.com/actions/cache/releases
         # v4.0.2
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: |
             ~/.cache/coursier
@@ -299,7 +299,7 @@ jobs:
       - name: Cache Maven repository
         # https://github.com/actions/cache/releases
         # v4.0.2
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('akka-javasdk-maven/pom.xml') }}
@@ -397,7 +397,7 @@ jobs:
       - name: Cache Maven repository
         # https://github.com/actions/cache/releases
         # v4.0.2
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('akka-javasdk-maven/pom.xml') }}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/GrpcEndpointTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/GrpcEndpointTest.java
@@ -50,6 +50,18 @@ public class GrpcEndpointTest extends TestKitSupport {
   }
 
   @Test
+  public void shouldPropagateCustomStatusToClient() {
+    var testClient = getGrpcEndpointClient(TestGrpcServiceClient.class);
+    var request = TestGrpcServiceOuterClass.In.newBuilder().setData("error").build();
+    try {
+      await(testClient.customStatus(request));
+      fail("Expected exception");
+    } catch (GrpcServiceException e) {
+      assertThat(e.getMessage()).contains("INVALID_ARGUMENT");
+    }
+  }
+
+  @Test
   public void shouldAllowGrpcCallFromInternet() {
     var testClient = getGrpcEndpointClient(TestGrpcServiceClient.class);
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/grpc/TestGrpcServiceImpl.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/grpc/TestGrpcServiceImpl.java
@@ -9,6 +9,7 @@ import akka.javasdk.annotations.GrpcEndpoint;
 import akka.javasdk.annotations.JWT;
 import akka.javasdk.grpc.GrpcClientProvider;
 import akkajavasdk.protocol.*;
+import io.grpc.Status;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -43,6 +44,15 @@ public class TestGrpcServiceImpl implements TestGrpcService {
     // alias for external defined in application.conf
     var grpcServiceClient = grpcClientProvider.grpcClientFor(TestGrpcServiceClient.class, "some.example.com");
     return grpcServiceClient.simple(in);
+  }
+
+  @Override
+  public CompletionStage<TestGrpcServiceOuterClass.Out> customStatus(TestGrpcServiceOuterClass.In in) {
+    if (in.getData().equals("error")) {
+      throw Status.INVALID_ARGUMENT.augmentDescription("Invalid data").asRuntimeException();
+    }
+
+    return simple(in);
   }
 
   @Override

--- a/akka-javasdk-tests/src/test/protobuf/akkajavasdk/test_grpc_service.proto
+++ b/akka-javasdk-tests/src/test/protobuf/akkajavasdk/test_grpc_service.proto
@@ -20,6 +20,7 @@ service TestGrpcService {
   rpc Simple(In) returns (Out) {};
   rpc DelegateToAkkaService(In) returns (Out) {};
   rpc DelegateToExternal(In) returns (Out) {};
+  rpc CustomStatus(In) returns (Out) {};
   rpc AclPublic(In) returns (Out) {};
   rpc AclService(In) returns (Out) {};
   rpc AclInheritedDenyCode(In) returns (Out) {};

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/GrpcEndpointDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/GrpcEndpointDescriptorFactory.scala
@@ -4,8 +4,10 @@
 
 package akka.javasdk.impl
 
+import akka.actor.{ ActorSystem => ClassicActorSystem }
 import akka.actor.typed.ActorSystem
 import akka.grpc.ServiceDescription
+import akka.grpc.Trailers
 import akka.grpc.scaladsl.GrpcExceptionHandler
 import akka.grpc.scaladsl.InstancePerRequestFactory
 import akka.http.scaladsl.model.HttpRequest
@@ -20,13 +22,21 @@ import akka.runtime.sdk.spi.ComponentOptions
 import akka.runtime.sdk.spi.GrpcEndpointDescriptor
 import akka.runtime.sdk.spi.GrpcEndpointRequestConstructionContext
 import akka.runtime.sdk.spi.MethodOptions
+import io.grpc.Status
 import io.opentelemetry.api.trace.Span
 
+import java.util.concurrent.CompletionException
 import scala.concurrent.Future
 
 object GrpcEndpointDescriptorFactory {
 
   val logger: org.slf4j.Logger = org.slf4j.LoggerFactory.getLogger(GrpcEndpointDescriptorFactory.getClass)
+
+  private def failedCompletionMapper(system: ClassicActorSystem): PartialFunction[Throwable, Trailers] = {
+    case e: CompletionException =>
+      if (e.getCause == null) Trailers(Status.INTERNAL)
+      else GrpcExceptionHandler.defaultMapper(system.classicSystem)(e.getCause)
+  }
 
   def apply[T](grpcEndpointClass: Class[T], factory: Option[Span] => T)(implicit
       system: ActorSystem[_]): GrpcEndpointDescriptor[T] = {
@@ -62,7 +72,7 @@ object GrpcEndpointDescriptorFactory {
         serviceFactory,
         description.name,
         // FIXME would be better if this was up to the runtime
-        GrpcExceptionHandler.defaultMapper(system.classicSystem),
+        failedCompletionMapper(system.classicSystem).orElse(GrpcExceptionHandler.defaultMapper(system.classicSystem)),
         system)
     }
 


### PR DESCRIPTION
Noticed when writing docs for error responses. When throwing from user function with a GrpcStatusException or StatusRuntimeException, it would end up as Internal anyway on the client side without the message. This is because we are using the GrpcExceptionHandler from scaladsl (and not javadsl) and that one does not unwrap `CompletionException` exceptions as the one from java [does](https://github.com/akka/akka-grpc/blob/e51e4c685595bf13d91907d127e77c3710961cc8/runtime/src/main/scala/akka/grpc/javadsl/GrpcExceptionHandler.scala#L45).

I guess modifying the scala one to add that case does not make much sense, so composing the partial fucntion locally seemed OK.
