### PR TITLE
chore: improve propagation / conversion of exceptions

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/grpc/TestGrpcServiceImpl.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/grpc/TestGrpcServiceImpl.java
@@ -62,6 +62,10 @@ public class TestGrpcServiceImpl implements TestGrpcService {
   public CompletionStage<TestGrpcServiceOuterClass.Out> customStatus(TestGrpcServiceOuterClass.In in) {
     if (in.getData().equals("error")) {
       throw Status.INVALID_ARGUMENT.augmentDescription("Invalid data").asRuntimeException();
+    } else if (in.getData().equals("illegal")) {
+      throw new IllegalArgumentException("Invalid data");
+    } else if (in.getData().equals("error-dev-details")) {
+      throw new RuntimeException("All the details in dev mode");
     }
 
     return simple(in);

--- a/docs/src/modules/java/pages/grpc-endpoints.adoc
+++ b/docs/src/modules/java/pages/grpc-endpoints.adoc
@@ -53,7 +53,13 @@ To signal an error in the response, throw a `GrpcServiceException` as shown in t
 include::example$event-sourced-customer-registry/src/main/java/customer/api/CustomerGrpcEndpointImpl.java[tag=exception]
 ----
 
-ifdef::todo[TODO: add more details on exception handling after fix for bubble up and details in dev mode]
+In addition to the special `GrpcServiceException` and `StatusRuntimeException`, exceptions are handled like this:
+
+* `IllegalArgumentException` is turned into a `INVALID_ARGUMENT`
+* Any other exception is turned into a `INTERNAL` error.
+** In production the error is logged together with a correlation
+id and the response message only includes the correlation id to not leak service internals to an untrusted client.
+** In local development and integration tests the full exception is returned as response body.
 
 == Interacting with other components ==
 


### PR DESCRIPTION
Previous PR https://github.com/akka/akka-sdk/pull/205 fixed propagation of Grpc status exception but we still didn't log any details of the exception in dev mode neither did we provide a correlation id for the response.

With this PR, we let the exception bubble up to runtime to be taken care of there, where we put a correlation id and log all the details (if in dev mode).

... or should we duplicate the logic to handle different exceptions and log correlation id in the sdk side?