### PR TITLE
docs: understanding gRPC vs HTTP endpoints

### DIFF
--- a/docs/src/modules/concepts/nav.adoc
+++ b/docs/src/modules/concepts/nav.adoc
@@ -7,3 +7,4 @@
 *** xref:concepts:state-model.adoc[]
 *** xref:concepts:multi-region.adoc[]
 *** xref:concepts:saga-patterns.adoc[]
+*** xref:concepts:grpc-vs-http-endpoints.adoc[]

--- a/docs/src/modules/concepts/pages/development-process.adoc
+++ b/docs/src/modules/concepts/pages/development-process.adoc
@@ -73,7 +73,7 @@ For more details and examples take a look at the following topics:
 
 [#_endpoints]
 == Exposing components through Endpoints and Consumers
-Endpoints are the primary means of exposing your service to external clients. You can use HTTP Endpoints or gRPC Endpoints to handle incoming requests and return responses to users or other services. Endpoints are stateless.
+Endpoints are the primary means of exposing your service to external clients. You can use HTTP or gRPC Endpoints to handle incoming requests and return responses to users or other services. Endpoints are stateless.
 
 To handle event-driven communication, Akka uses Consumers. Consumers listen for and process events or messages from various sources, such as Event Sourced Entities, Key Value Entities, or external messaging systems. They play a key role in enabling asynchronous, event-driven architectures by subscribing to event streams and reacting to changes in state or incoming data.
 

--- a/docs/src/modules/concepts/pages/grpc-vs-http-endpoints.adoc
+++ b/docs/src/modules/concepts/pages/grpc-vs-http-endpoints.adoc
@@ -51,3 +51,8 @@ For more information on designing and implementing HTTP and gRPC Endpoints in Ak
 
 - xref:java:http-endpoints.adoc[]
 - xref:java:grpc-endpoints.adoc[]
+
+Additionally, note that both endpoint types can be secured using ACLs and JWTs, see:
+
+- xref:java:access-control.adoc[]
+- xref:java:auth-with-jwts.adoc[]

--- a/docs/src/modules/concepts/pages/grpc-vs-http-endpoints.adoc
+++ b/docs/src/modules/concepts/pages/grpc-vs-http-endpoints.adoc
@@ -1,0 +1,53 @@
+= Endpoints
+
+Endpoints components are how you expose your services to the outside world, be it another Akka service, external dependencies or client-facing applications. Two different types of endpoints are available: HTTP and gRPC Endpoints.
+
+When designing APIs, choosing between HTTP and gRPC endpoints depends on the use case. This document outlines the key differences, strengths, and recommended usage for each approach.
+
+== Key Differences
+
+HTTP endpoints follow the traditional request-response model and are widely used for exposing APIs to external consumers. They use standard HTTP methods (GET, POST, PUT, DELETE, etc.) and typically exchange data in JSON format. This makes them accessible to web and mobile clients and easy to debug using common tools like browsers and API clients.
+
+gRPC endpoints use the HTTP/2 protocol and Protobuf for data serialization, providing efficient and structured communication between services. They support various types of RPC calls, including unary and streaming, and are designed for high-performance, low-latency interactions. gRPC is commonly used for internal service-to-service communication due to its strong typing and schema evolution capabilities.
+
+[cols="2,2,2"]
+|===
+| Aspect | HTTP Endpoints | gRPC Endpoints
+
+| Protocol | HTTP/1.1 or HTTP/2 | HTTP/2
+| Serialization | JSON (text-based) | Protobuf (binary, compact)
+| Performance | Higher latency due to JSON parsing | Lower latency with efficient binary serialization
+| Streaming | Streaming from server (SSE) | Native bidirectional streaming
+| Tooling & Debugging | Easy to inspect and test with browser and other tools | Requires specialized tools due to binary format
+| Browser Support | Works natively in browsers | Requires gRPC-Web for use in browser
+| Backward Compatibility | Requires versioned endpoints or careful contract management | Supports schema evolution with Protobuf
+|===
+
+== When to use HTTP Endpoints
+
+HTTP endpoints are recommended for client-facing APIs, including web and mobile apps. They offer broad compatibility, easy debugging, and integration with frontend frameworks.
+
+Use HTTP endpoints when:
+
+- The API is consumed directly by web browsers.
+- Human readability and easy debugging are important.
+- RESTful semantics, including standard HTTP methods and query parameters, are required.
+- Familiarity among frontend developers is beneficial.
+
+== When to use gRPC Endpoints
+
+gRPC endpoints are recommended for service-to-service communication due to their efficiency and strong contract enforcement.
+
+Use gRPC endpoints when:
+
+- Services need to communicate with low latency and high throughput.
+- Streaming (unary, client-streaming, server-streaming, bidirectional) is required.
+- Backward and forward compatibility is essential for evolving services.
+- Strongly typed service contracts are beneficial.
+
+== Next Steps
+
+For more information on designing and implementing HTTP and gRPC Endpoints in Akka, refer to the following guides:
+
+- xref:java:http-endpoints.adoc[]
+- xref:java:grpc-endpoints.adoc[]

--- a/docs/src/modules/java/pages/component-and-service-calls.adoc
+++ b/docs/src/modules/java/pages/component-and-service-calls.adoc
@@ -54,7 +54,7 @@ include::java:example$doc-snippets/src/main/java/com/example/callanotherservice/
 <4> Invoking the call will return a `CompletionStage<StrictResponse<T>>` with details about the result as well as the deserialized response body.
 <5> Handle the response, which may be successful, or an error
 
-NOTE: The HTTP client provider is only available for injection in the following types of components: HTTP Endpoints, gRPC endpoints, Workflows, Consumers and Timed Actions.
+NOTE: The HTTP client provider is only available for injection in the following types of components: HTTP Endpoints, gRPC Endpoints, Workflows, Consumers and Timed Actions.
 
 === External HTTP services
 

--- a/docs/src/modules/java/pages/grpc-endpoints.adoc
+++ b/docs/src/modules/java/pages/grpc-endpoints.adoc
@@ -2,16 +2,14 @@
 
 include::ROOT:partial$include.adoc[]
 
-An Endpoint is a component that creates an externally accessible API. Endpoints are how you expose your services to the outside world. Two different types of endpoints are available: HTTP endpoints and gRPC endpoints. In this page, we will focus on gRPC endpoints.
+An Endpoint is a component that creates an externally accessible API. Endpoints are how you expose your services to the outside world. Two different types of endpoints are available: HTTP and gRPC endpoints. In this page, we will focus on gRPC endpoints.
 
 gRPC was designed to support service evolution and decoupling by enforcing a protocol-first design through `.proto` files. This ensures that service contracts are explicitly defined, providing a clear structure for communication. Protobuf, the underlying serialization format, supports backward and forward compatibility, avoiding tight coupling by making it easier to evolve services without breaking existing clients. Additionally, gRPC's efficient binary serialization and support for both unary and streaming calls make it a good choice for high-performance, scalable service-to-service communication. For more information on gRPC and Protobuf, see https://grpc.io and link:https://protobuf.dev/programming-guides/proto3/[the Protobuf 3 guide].
 
 gRPC Endpoint components make it possible to conveniently define APIs accepting and responding in protobuf --
 the binary, typed protocol used by gRPC which is designed to handle evolution of a service over time.
 
-TIP: Our recommendation is to use gRPC Endpoints for cross-service calls (be it with another Akka service or other backend services) and HTTP Endpoints for APIs consumed directly by client-facing / frontend applications -- for which the use of gRPC comes at a greater cost.
-
-ifdef::todo[For a deeper dive into the differences between gRPC and HTTP Endpoints, see xref:concepts:grpc-vs-http-endpoints.adoc[]]
+TIP: Our recommendation is to use gRPC Endpoints for cross-service calls (be it with another Akka service or other backend services) and HTTP Endpoints for APIs consumed directly by client-facing / frontend applications -- for which the use of gRPC comes at a greater cost. For a deeper dive into the differences between gRPC and HTTP Endpoints, see xref:concepts:grpc-vs-http-endpoints.adoc[].
 
 
 == Basics ==


### PR DESCRIPTION
Addressing Brent's [suggestion](https://github.com/lightbend/kalix-runtime/issues/3353#issuecomment-2660213149):

> I actually think doing the opposite of that would be best. I suggest a detailed doc page on where it's best to use HTTP vs gRPC Endpoints. This would be a great fit for the [Understanding section](https://doc.akka.io/concepts/index.html).