### PR TITLE
linking shopping cart sample to github repo

### DIFF
--- a/docs/src/modules/java/pages/event-sourced-entities.adoc
+++ b/docs/src/modules/java/pages/event-sourced-entities.adoc
@@ -30,7 +30,7 @@ The steps necessary to implement an Event Sourced Entity include:
 . Model the entity's state and its domain events.
 . Implementing behavior in command and event handlers.
 
-The following sections walk through these steps using a shopping cart service as an example (working sample can be downloaded as a link:../java/_attachments/shopping-cart-quickstart.zip[zip file]).
+The following sections walk through these steps using a shopping cart service as an example (working sample can be downloaded from link:https://github.com/akka-samples/shopping-cart-quickstart[Github]).
 
 == Modeling the Entity
 

--- a/docs/src/modules/java/pages/samples.adoc
+++ b/docs/src/modules/java/pages/samples.adoc
@@ -8,7 +8,7 @@ include::ROOT:partial$include.adoc[]
 xref:java:author-your-first-service.adoc[] to get a minimal "Hello World!" Akka service and run it locally.
 ====
 
-Samples are available that demonstrate important patterns and abstractions. These can be downloaded as zip files. Please refer to the `README` file in each zip for setup and usage instructions.
+Samples are available that demonstrate important patterns and abstractions. These can be cloned from their respective repositories. Please refer to the `README` file in each repository for setup and usage instructions.
 
 [options="header", cols="3,2,1"]
 |=======================

--- a/docs/src/modules/java/pages/samples.adoc
+++ b/docs/src/modules/java/pages/samples.adoc
@@ -13,7 +13,7 @@ Samples are available that demonstrate important patterns and abstractions. Thes
 [options="header", cols="3,2,1"]
 |=======================
 | Description | Source download | Level
-| xref:shopping-cart-quickstart.adoc[Build a shopping cart] | link:../java/_attachments/shopping-cart-quickstart.zip[shopping-cart-quickstart.zip] |Beginner
+| xref:shopping-cart-quickstart.adoc[Build a shopping cart] | link:https://github.com/akka-samples/shopping-cart-quickstart[Github Repository] |Beginner
 | A customer registry with query capabilities | link:../java/_attachments/customer-registry-quickstart.zip[customer-registry-quickstart.zip] |Intermediate
 | A funds transfer workflow between two wallets | link:../java/_attachments/workflow-quickstart.zip[workflow-quickstart.zip] |Intermediate
 | A user registration service implemented as a Choreography Saga | link:../java/_attachments/choreography-saga-quickstart.zip[choreography-saga-quickstart.zip] |Advanced

--- a/docs/src/modules/java/pages/shopping-cart-quickstart.adoc
+++ b/docs/src/modules/java/pages/shopping-cart-quickstart.adoc
@@ -10,7 +10,7 @@ The shopping cart service implements a cart that allows users to add and remove 
 
 In this guide you will:
 
-* Download a completed shopping cart service to examine and run it locally.
+* Clone a completed shopping cart service repository to examine and run it locally.
 * Be introduced to key Akka concepts including xref:java:event-sourced-entities.adoc[Event Sourced Entities].
 * See how the Akka xref:concepts:architecture-model.adoc[] provides a clear separation of concerns in your microservices.
 * Run the service locally and explore it with the local Akka console.
@@ -20,9 +20,9 @@ In this guide you will:
 
 include::ROOT:partial$cloud-dev-prerequisites.adoc[]
 
-== Download the sample
+== Clone the sample
 
-. Download the full source code of the Shopping Cart sample from link:https://github.com/akka-samples/shopping-cart-quickstart[Github], or use the Akka CLI command below to download and unzip this quickstart project.
+. Clone the full source code of the Shopping Cart sample from link:https://github.com/akka-samples/shopping-cart-quickstart[Github], or use the Akka CLI command below to download and unzip this quickstart project.
 +
 [source,bash]
 ----

--- a/docs/src/modules/java/pages/shopping-cart-quickstart.adoc
+++ b/docs/src/modules/java/pages/shopping-cart-quickstart.adoc
@@ -22,7 +22,7 @@ include::ROOT:partial$cloud-dev-prerequisites.adoc[]
 
 == Download the sample
 
-. Download the full source code of the Shopping Cart sample as a link:_attachments/shopping-cart-quickstart.zip[zip file], or use the Akka CLI command below to download and unzip this quickstart project.
+. Download the full source code of the Shopping Cart sample from link:https://github.com/akka-samples/shopping-cart-quickstart[Github], or use the Akka CLI command below to download and unzip this quickstart project.
 +
 [source,bash]
 ----


### PR DESCRIPTION
Changes the default location to obtain the shopping cart sample from the ZIP file to the Github repository.
