### PR TITLE
bump: Antora 3.1.10 (was 3.1.9) with ARM images

### DIFF
--- a/docs/antora-docker/Dockerfile
+++ b/docs/antora-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM antora/antora:3.1.9
+FROM antora/antora:3.1.10
 
 # "Alpine Linux v3.11"
 RUN npm install -g @antora/lunr-extension


### PR DESCRIPTION
The main focus of this release is to publish a variant of the Antora Docker image compiled for linux/arm64.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References
- https://docs.antora.org/antora/latest/whats-new/#antora-3-1-10
