### PR TITLE
chore: fail build on verify

### DIFF
--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -284,6 +284,7 @@
                         <execution>
                             <goals>
                                 <goal>integration-test</goal>
+                                <goal>verify</goal>
                             </goals>
                             <configuration>
                                 <includes>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned
   // for prod code, they are marked as Provided, but testkit still requires the alignment
-  val AkkaVersion = "2.10.1"
+  val AkkaVersion = "2.10.2"
   val AkkaHttpVersion = "10.7.0" // Note: should at least the Akka HTTP version required by Akka gRPC
 
   // Note: the Scala version must be aligned with the runtime


### PR DESCRIPTION
Without this change, the build will pass even when integration tests are failed:
```
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   CartIntegrationTest>TestKitSupport.beforeAll:56 » Runtime Error while starting testkit
[INFO] 
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.092 s
[INFO] Finished at: 2025-02-21T12:13:12+01:00
[INFO] ------------------------------------------------------------------------
```