### PR TITLE
chore: fail build on verify

### DIFF
--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -284,6 +284,7 @@
                         <execution>
                             <goals>
                                 <goal>integration-test</goal>
+                                <goal>verify</goal>
                             </goals>
                             <configuration>
                                 <includes>


### PR DESCRIPTION
Without this change, the build will pass even when integration tests are failed:
```
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   CartIntegrationTest>TestKitSupport.beforeAll:56 » Runtime Error while starting testkit
[INFO] 
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.092 s
[INFO] Finished at: 2025-02-21T12:13:12+01:00
[INFO] ------------------------------------------------------------------------
```