### PR TITLE
docs: restore missing snippet and remove all warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ antora-local:
 		-v ${ROOT_DIR}:/antora \
 		--rm \
 		-t ${antora_docker_image}:${antora_docker_image_tag} \
-		--cache-dir=.cache/antora --stacktrace --log-failure-level=error \
+		--cache-dir=.cache/antora --stacktrace --log-failure-level=warn \
 		docs/antora-playbook-local.yml
 
 antora-prod:
@@ -96,7 +96,7 @@ antora-prod:
 		-v ${ROOT_DIR}:/antora \
 		--rm \
 		-t ${antora_docker_image}:${antora_docker_image_tag} \
-		--cache-dir=.cache/antora --stacktrace --log-level error --log-failure-level=fatal \
+		--cache-dir=.cache/antora --stacktrace --log-level error --log-failure-level=warn \
 		docs/antora-playbook-prod.yml
 
 validate-links:

--- a/docs/antora-playbook-local.yml
+++ b/docs/antora-playbook-local.yml
@@ -1,7 +1,6 @@
 site:
   title: "Akka Documentation"
   url: https://doc.akka.io
-  start_page: ROOT::index.adoc
   robots: disallow
   keys:
     cookie_consent: '28b912e7-09e9-43d5-91e4-3d1897044004-test'

--- a/docs/antora-playbook-prod.yml
+++ b/docs/antora-playbook-prod.yml
@@ -1,7 +1,6 @@
 site:
   title: "Akka Documentation"
   url: https://doc.akka.io
-  start_page: ROOT::index.adoc
   keys:
     cookie_consent: '28b912e7-09e9-43d5-91e4-3d1897044004'
 

--- a/docs/src/modules/operations/pages/observability-and-monitoring/view-logs.adoc
+++ b/docs/src/modules/operations/pages/observability-and-monitoring/view-logs.adoc
@@ -32,7 +32,7 @@ Logs can be exported for searching, reporting, alerting and long term storage by
 
 == Correlating logs
 
-You can correlate your log statements, those that you write in your application, by adding the MDC pattern `%mdc{trace_id}` to your log file when tracing is xref:operations:observability-and-monitoring/observability-exports.adoc#activating_tracing[enabled]. Like the following:
+You can correlate your log statements, those that you write in your application, by adding the MDC pattern `%mdc\{trace_id}` to your log file when tracing is xref:operations:observability-and-monitoring/observability-exports.adoc#activating_tracing[enabled]. Like the following:
 
 [source,xml]
 .logback.xml

--- a/samples/shopping-cart-quickstart/src/main/java/shoppingcart/api/ShoppingCartEndpoint.java
+++ b/samples/shopping-cart-quickstart/src/main/java/shoppingcart/api/ShoppingCartEndpoint.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletionStage;
 
 // Opened up for access from the public internet to make the sample service easy to try out.
 // For actual services meant for production this must be carefully considered, and often set more limited
+// tag::endpoint-component-interaction[]
 @Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET))
 @HttpEndpoint("/carts") // <1>
 public class ShoppingCartEndpoint {
@@ -59,6 +60,7 @@ public class ShoppingCartEndpoint {
       .invokeAsync(item)
       .thenApply(__ -> HttpResponses.ok()); // <7>
   }
+  // end::endpoint-component-interaction[]
 
   // end::addItem[]
 


### PR DESCRIPTION
This PR:
- restores snippet inadvertedly remove [here](https://github.com/akka/akka-sdk/pull/245)
- fixes 2 warns so that we can turn build failure on warn
  - (this is arguable maybe... we can turn on and then see? if it turns out too annoying we can turn off again)