### PR TITLE
docs: Add a sample snippet to the view stream updates docs

### DIFF
--- a/docs/src/modules/java/pages/http-endpoints.adoc
+++ b/docs/src/modules/java/pages/http-endpoints.adoc
@@ -312,8 +312,8 @@ include::example$doc-snippets/src/main/java/com/example/api/ExampleEndpoint.java
 <2> Every time a tick is seen, we turn it into a system clock timestamp
 <3> Passing the `Source` to `serverSentEvents` returns a `HttpResponse` for the endpoint method.
 
-A more realistic use case would be to stream the changes from a view, using the `streamUpdates` view
-feature.
+A more realistic use case would be to stream the changes from a view, using the xref:views.adoc#_streaming_view_updates[stream view updates view
+feature].
 
 [source,java]
 .{sample-base-url}/key-value-customer-registry/src/main/java/customer/api/CustomerEndpoint.java[CustomerEndpoint.java]

--- a/docs/src/modules/java/pages/views.adoc
+++ b/docs/src/modules/java/pages/views.adoc
@@ -231,6 +231,13 @@ include::example$key-value-customer-registry/src/main/java/customer/application/
 Instead of collecting the query result in memory as a collection before returning it, the entries can be streamed.
 To return the result as a stream, modify the returned type to be `QueryStreamEffect` and use `queryStreamResult()` to return the stream.
 
+[source,java]
+.{sample-base-url}/key-value-customer-registry/src/main/java/customer/application/CustomersByCity.java[CustomersByCity.java]
+----
+include::example$key-value-customer-registry/src/main/java/customer/application/CustomersByCity.java[tag=stream]
+----
+
+[#_streaming_view_updates]
 ==== Streaming view updates
 
 A query can provide a near real-time stream of results for the query, emitting new entries matching the query as they are added or updated in
@@ -239,16 +246,17 @@ the view.
 This will first list the complete result for the query and then keep the response stream open, emitting new or updated
 entries matching the query as they are added to the view. The stream does not complete until the client closes it.
 
-To use streaming, the returned type must be `QueryStreamEffect`, add `streamUpdates = true` to the `Query` annotation.
+To use streaming updates add `streamUpdates = true` to the `Query` annotation, the returned type of the
+query method must be `QueryStreamEffect`.
 
 [source,java]
-.{sample-base-url}/event-sourced-customer-registry/src/main/java/customer/application/CustomerByEmailView.java[CustomerList.java]
+.{sample-base-url}/key-value-customer-registry/src/main/java/customer/application/CustomersByCity.java[CustomersByCity.java]
 ----
-include::example$event-sourced-customer-registry/src/main/java/customer/application/CustomerByEmailView.java[tag=stream-updates]
+include::example$key-value-customer-registry/src/main/java/customer/application/CustomersByCity.java[tag=continuous-stream]
 ----
 
-This example would return the customers using the same email, and then emit every time a new `CustomerRow`
-with the queried email address is added to the view, or one of the existing rows changes.
+This example would return the customers living in the same city, and then emit every time a customer
+already in the city is changed, or when a new customer is added to the view with the given city.
 
 Streaming updates can be streamed all the way to a gRPC or HTTP client via a xref:grpc-endpoints.adoc[gRPC Endpoint] or an xref:http-endpoints.adoc#sse[HTTP
 endpoint using SSE].

--- a/docs/src/modules/java/pages/views.adoc
+++ b/docs/src/modules/java/pages/views.adoc
@@ -239,7 +239,19 @@ the view.
 This will first list the complete result for the query and then keep the response stream open, emitting new or updated
 entries matching the query as they are added to the view. The stream does not complete until the client closes it.
 
-To use streaming, modify the returned type to be `QueryStreamEffect` instead and use `queryStreamResult()` to return the stream, then add `streamUpdates = true` to the `Query` annotation.
+To use streaming, the returned type must be `QueryStreamEffect`, add `streamUpdates = true` to the `Query` annotation.
+
+[source,java]
+.{sample-base-url}/event-sourced-customer-registry/src/main/java/customer/application/CustomerByEmailView.java[CustomerList.java]
+----
+include::example$event-sourced-customer-registry/src/main/java/customer/application/CustomerByEmailView.java[tag=stream-updates]
+----
+
+This example would return the customers using the same email, and then emit every time a new `CustomerRow`
+with the queried email address is added to the view, or one of the existing rows changes.
+
+Streaming updates can be streamed all the way to a gRPC or HTTP client via a xref:grpc-endpoints.adoc[gRPC Endpoint] or an xref:http-endpoints.adoc#sse[HTTP
+endpoint using SSE].
 
 NOTE: This is not intended as transport for xref:consuming-producing.adoc#s2s-eventing[service to service] propagation of updates, and it does not guarantee delivery. For such use cases you
 should instead publish events to a topic, see xref:consuming-producing.adoc[]

--- a/docs/src/modules/java/pages/views.adoc
+++ b/docs/src/modules/java/pages/views.adoc
@@ -246,7 +246,7 @@ the view.
 This will first list the complete result for the query and then keep the response stream open, emitting new or updated
 entries matching the query as they are added to the view. The stream does not complete until the client closes it.
 
-To use streaming updates add `streamUpdates = true` to the `Query` annotation, the returned type of the
+To use streaming updates, add `streamUpdates = true` to the `Query` annotation. The returned type of the
 query method must be `QueryStreamEffect`.
 
 [source,java]

--- a/samples/event-sourced-customer-registry/src/main/java/customer/application/CustomerByEmailView.java
+++ b/samples/event-sourced-customer-registry/src/main/java/customer/application/CustomerByEmailView.java
@@ -17,12 +17,10 @@ public class CustomerByEmailView extends View {
     return queryResult();
   }
 
-  // tag::stream-updates[]
   @Query(value = "SELECT * FROM customers_by_email WHERE email = :email", streamUpdates = true)
   public QueryStreamEffect<CustomerRow> getCustomersStream(String email) {
     return queryStreamResult();
   }
-  // end::stream-updates[]
 
   @Consume.FromEventSourcedEntity(CustomerEntity.class)
   public static class CustomersByEmail extends TableUpdater<CustomerRow> {

--- a/samples/event-sourced-customer-registry/src/main/java/customer/application/CustomerByEmailView.java
+++ b/samples/event-sourced-customer-registry/src/main/java/customer/application/CustomerByEmailView.java
@@ -17,10 +17,12 @@ public class CustomerByEmailView extends View {
     return queryResult();
   }
 
+  // tag::stream-updates[]
   @Query(value = "SELECT * FROM customers_by_email WHERE email = :email", streamUpdates = true)
   public QueryStreamEffect<CustomerRow> getCustomersStream(String email) {
     return queryStreamResult();
   }
+  // end::stream-updates[]
 
   @Consume.FromEventSourcedEntity(CustomerEntity.class)
   public static class CustomersByEmail extends TableUpdater<CustomerRow> {

--- a/samples/key-value-customer-registry/README.md
+++ b/samples/key-value-customer-registry/README.md
@@ -156,7 +156,7 @@ curl localhost:9000/customer/stream-customer-changes/001
 ```
 
 Start with either streaming request in one terminal window while triggering updates in another terminal window, for example
-changing the address to and from "City Test" or adding more customers with different ids in the same name city, to see the
+changing the address to and from "City Test" or adding more customers with different ids in the same city, to see the
 updates appear.
 
 ## Deploying

--- a/samples/key-value-customer-registry/README.md
+++ b/samples/key-value-customer-registry/README.md
@@ -146,7 +146,7 @@ curl localhost:9000/customer/001
   stay running, continuously stream updates to a view matching the query:
 
 ```shell
-curl localhost:9000/customer/by-name-sse/Jan%20Janssen 
+curl localhost:9000/customer/by-city-sse/City%20Test
 ```
 
 * And one that emits changes to a specific customer:
@@ -156,7 +156,7 @@ curl localhost:9000/customer/stream-customer-changes/001
 ```
 
 Start with either streaming request in one terminal window while triggering updates in another terminal window, for example
-changing the name to and from "Jan Janssen" or adding more customers with different ids and the same name, to see the
+changing the address to and from "City Test" or adding more customers with different ids in the same name city, to see the
 updates appear.
 
 ## Deploying

--- a/samples/key-value-customer-registry/src/main/java/customer/api/CustomerEndpoint.java
+++ b/samples/key-value-customer-registry/src/main/java/customer/api/CustomerEndpoint.java
@@ -109,12 +109,12 @@ public class CustomerEndpoint {
   }
 
   // tag::sse-view-updates[]
-  @Get("/by-name-sse/{name}")
-  public HttpResponse continousByNameServerSentEvents(String name) {
+  @Get("/by-city-sse/{cityName}")
+  public HttpResponse continousByCityNameServerSentEvents(String cityName) {
     // view will keep stream going, toggled with streamUpdates = true on the query
-    Source<CustomersByName.CustomerSummary, NotUsed> customerSummarySource = componentClient.forView() // <1>
-        .stream(CustomersByName::continuousGetCustomerSummaryStream)
-        .source(name);
+    Source<Customer, NotUsed> customerSummarySource = componentClient.forView() // <1>
+        .stream(CustomersByCity::continuousCustomersInCity)
+        .source(cityName);
 
     return HttpResponses.serverSentEvents(customerSummarySource); // <2>
   }

--- a/samples/key-value-customer-registry/src/main/java/customer/application/CustomersByCity.java
+++ b/samples/key-value-customer-registry/src/main/java/customer/application/CustomersByCity.java
@@ -24,5 +24,21 @@ public class CustomersByCity extends View {
   public QueryEffect<CustomerList> getCustomers(List<String> cities) {
     return queryResult();
   }
+
+  // tag::stream[]
+  @Query(value = "SELECT * FROM customers_by_city WHERE address.city = :city")
+  public QueryStreamEffect<Customer> streamCustomersInCity(String city) {
+    return queryStreamResult();
+  }
+  // end::stream[]
+
+  // tag::continuous-stream[]
+  @Query(value = "SELECT * FROM customers_by_city WHERE address.city = :city", streamUpdates = true)
+  public QueryStreamEffect<Customer> continuousCustomersInCity(String city) {
+    return queryStreamResult();
+  }
+  // end::continuous-stream[]
+
+
 }
 // end::view-test[]

--- a/samples/key-value-customer-registry/src/main/java/customer/application/CustomersByName.java
+++ b/samples/key-value-customer-registry/src/main/java/customer/application/CustomersByName.java
@@ -46,12 +46,6 @@ public class CustomersByName extends View {
   }
   // end::stream[]
 
-  // tag::continuous-stream[]
-  @Query(value = "SELECT * FROM customers_by_name WHERE name = :name", streamUpdates = true)
-  public QueryStreamEffect<CustomerSummary> continuousGetCustomerSummaryStream(String name) {
-    return queryStreamResult();
-  }
-  // end::continuous-stream[]
 // tag::class[]
 }
 // end::class[]


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/lightbend/kalix-runtime/issues/3077

Adds snippets for both regular stream result and for stream updates with a somewhat realistic query on customer city.
