### PR TITLE
fix: Shutdown immediately if runtime fails

### DIFF
--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -313,6 +313,7 @@
                     <version>3.4.1</version>
                     <configuration>
                         <mainClass>kalix.runtime.AkkaRuntimeMain</mainClass>
+                        <cleanupDaemonThreads>false</cleanupDaemonThreads>
                         <systemProperties>
                             <systemProperty>
                                 <key>akka.javasdk.dev-mode.enabled</key>


### PR DESCRIPTION
* if there are validations in the runtime that fails and terminates the ActorSystem, the jvm was not shutdown immediately
* cleanupDaemonThreads is by default true and that means that exec plugin will attempt to interrupt or join any daemon threads before shutting down
* setting this to false will simply shut down the VM when non-daemon thread execution completes
* see https://www.mojohaus.org/exec-maven-plugin/java-mojo.html#cleanupDaemonThreads
