### PR TITLE
chore: Mark Akka gRPC generated sources dir for IntelliJ autodetect

### DIFF
--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -228,11 +228,11 @@
                 </plugin>
 
                 <plugin>
-                    <!-- configure src/it/java and src/it/resources -->
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${build-helper-maven-plugin.version}</version>
                     <executions>
+                        <!-- configure src/it/java and src/it/resources legacy paths for integration tests -->
                         <execution>
                             <id>add-integration-test-source</id>
                             <phase>generate-test-sources</phase>
@@ -257,6 +257,19 @@
                                         <directory>${basedir}/src/it/resources</directory>
                                     </resource>
                                 </resources>
+                            </configuration>
+                        </execution>
+                        <!-- add generated protobuf and gRPC sources so that IntelliJ finds them automatically -->
+                        <execution>
+                            <id>add-java-source</id>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>add-source</goal>
+                            </goals>
+                            <configuration>
+                                <sources>
+                                    <source>${project.build.directory}/generated-sources/akka-grpc-java</source>
+                                </sources>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/lightbend/kalix-runtime/issues/3570

Rather feels like this is something missing upstream, in the akka-grpc maven plugin. Leaving this as draft and investigating that.