### PR TITLE
fix: view query table name extractor

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewDescriptorFactory.scala
@@ -53,7 +53,7 @@ import org.slf4j.MDC
 @InternalApi
 private[impl] object ViewDescriptorFactory {
 
-  val TableNamePattern: Regex = """FROM\s+`?([A-Za-z][A-Za-z0-9_]*)""".r
+  val TableNamePattern: Regex = """(?i)FROM(?-i)\s+(?:`([^`]+)`|([A-Za-z][A-Za-z0-9_]*))""".r
 
   def apply(
       viewClass: Class[_],
@@ -85,7 +85,7 @@ private[impl] object ViewDescriptorFactory {
                   s"View [$componentId] does not have any queries defined, must have at least one query"))
               TableNamePattern
                 .findFirstMatchIn(query)
-                .map(_.group(1))
+                .map(m => Option(m.group(1)).getOrElse(m.group(2))) // optionally quoted in first group
                 .getOrElse(throw new RuntimeException(s"Could not extract table name from query [${query}]"))
             }
           }

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/view/ViewTestModels.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/view/ViewTestModels.java
@@ -123,6 +123,30 @@ public class ViewTestModels {
   }
 
   @ComponentId("users_view")
+  public static class ViewWithLowerCaseQuery extends View {
+
+    @Consume.FromKeyValueEntity(UserEntity.class)
+    public static class UserUpdater extends TableUpdater<User> {}
+
+    @Query("select * from users where email = :email")
+    public QueryEffect<User> getUser(String email) {
+      return queryResult();
+    }
+  }
+
+  @ComponentId("users_view")
+  public static class ViewWithQuotedTableName extends View {
+
+    @Consume.FromKeyValueEntity(UserEntity.class)
+    public static class UserUpdater extends TableUpdater<User> {}
+
+    @Query("SELECT * FROM `üsérs tåble` WHERE email = :email")
+    public QueryEffect<User> getUser(String email) {
+      return queryResult();
+    }
+  }
+
+  @ComponentId("users_view")
   public static class ViewWithNoTableUpdater extends View {
 
     @Query("SELECT * FROM users WHERE email = :email")
@@ -130,7 +154,6 @@ public class ViewTestModels {
       return queryResult();
     }
   }
-
 
   @ComponentId("users_view")
   @Table("users")


### PR DESCRIPTION
Refs https://github.com/lightbend/kalix-runtime/issues/3593

Update table name regex to be case insensitive when matching the FROM keyword.

Also align with view query parsing in the runtime, where quoted table names can contain any characters.