### PR TITLE
fix: access updateContext from inside emptyRow

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewDescriptorFactory.scala
@@ -430,8 +430,8 @@ private[impl] object ViewDescriptorFactory {
               val tableUpdaterInstance = tableUpdater()
               try {
 
-                tableUpdaterInstance._internalSetViewState(existingState.getOrElse(tableUpdaterInstance.emptyRow()))
                 tableUpdaterInstance._internalSetUpdateContext(Optional.of(updateContext))
+                tableUpdaterInstance._internalSetViewState(existingState.getOrElse(tableUpdaterInstance.emptyRow()))
 
                 val result =
                   if (deleteHandler) method.invoke(tableUpdaterInstance)


### PR DESCRIPTION
We should be able to access `updateContext` from inside `emptyRow` for example, when we want to use the subject id as part of the view initial state.