### PR TITLE
feat: Customizable object mapper for endpoints

### DIFF
--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -40,7 +40,7 @@
 
         <!-- These are dependent on runtime environment and cannot be customized by users -->
         <maven.compiler.release>21</maven.compiler.release>
-        <kalix-runtime.version>1.4.2-21-726c2742-SNAPSHOT</kalix-runtime.version>
+        <kalix-runtime.version>1.4.3</kalix-runtime.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skip.docker>false</skip.docker>

--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -40,7 +40,7 @@
 
         <!-- These are dependent on runtime environment and cannot be customized by users -->
         <maven.compiler.release>21</maven.compiler.release>
-        <kalix-runtime.version>1.4.2</kalix-runtime.version>
+        <kalix-runtime.version>1.4.2-21-726c2742-SNAPSHOT</kalix-runtime.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skip.docker>false</skip.docker>

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/SerializationTestkit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/SerializationTestkit.java
@@ -26,7 +26,7 @@ public final class SerializationTestkit {
     BytesPayload bytesPayload = jsonSerializer.toBytes(value);
     SerializedPayload serializedPayload = new SerializedPayload(bytesPayload.contentType(), bytesPayload.bytes().toArray());
     try {
-      return jsonSerializer.getInternalObjectMapper().writeValueAsBytes(serializedPayload);
+      return jsonSerializer.objectMapper().writeValueAsBytes(serializedPayload);
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Unexpected serialization error", e);
     }
@@ -34,7 +34,7 @@ public final class SerializationTestkit {
 
   public static <T> T deserialize(Class<T> valueClass, byte[] bytes) {
     try {
-      SerializedPayload serializedPayload = jsonSerializer.getInternalObjectMapper().readValue(bytes, SerializedPayload.class);
+      SerializedPayload serializedPayload = jsonSerializer.objectMapper().readValue(bytes, SerializedPayload.class);
       return jsonSerializer.fromBytes(valueClass, new BytesPayload(ByteString.fromArray(serializedPayload.bytes), serializedPayload.contentType));
     } catch (IOException e) {
       throw new RuntimeException("Unexpected deserialization error", e);

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/SerializationTestkit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/SerializationTestkit.java
@@ -4,7 +4,6 @@
 
 package akka.javasdk.testkit;
 
-import akka.javasdk.JsonSupport;
 import akka.javasdk.impl.serialization.JsonSerializer;
 import akka.runtime.sdk.spi.BytesPayload;
 import akka.util.ByteString;
@@ -21,13 +20,13 @@ public final class SerializationTestkit {
   private record SerializedPayload(String contentType, byte[] bytes) {
   }
 
-  private static JsonSerializer jsonSerializer = new JsonSerializer();
+  private static final JsonSerializer jsonSerializer = new JsonSerializer();
 
   public static <T> byte[] serialize(T value) {
     BytesPayload bytesPayload = jsonSerializer.toBytes(value);
     SerializedPayload serializedPayload = new SerializedPayload(bytesPayload.contentType(), bytesPayload.bytes().toArray());
     try {
-      return JsonSupport.getObjectMapper().writeValueAsBytes(serializedPayload);
+      return jsonSerializer.getInternalObjectMapper().writeValueAsBytes(serializedPayload);
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Unexpected serialization error", e);
     }
@@ -35,7 +34,7 @@ public final class SerializationTestkit {
 
   public static <T> T deserialize(Class<T> valueClass, byte[] bytes) {
     try {
-      SerializedPayload serializedPayload = JsonSupport.getObjectMapper().readValue(bytes, SerializedPayload.class);
+      SerializedPayload serializedPayload = jsonSerializer.getInternalObjectMapper().readValue(bytes, SerializedPayload.class);
       return jsonSerializer.fromBytes(valueClass, new BytesPayload(ByteString.fromArray(serializedPayload.bytes), serializedPayload.contentType));
     } catch (IOException e) {
       throw new RuntimeException("Unexpected deserialization error", e);

--- a/akka-javasdk/src/main/java/akka/javasdk/JsonSupport.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/JsonSupport.java
@@ -42,9 +42,7 @@ import java.util.Optional;
 public final class JsonSupport {
 
   // object mapper for HTTP endpoints and explicit serialization/deserialization
-  // of objects in user code, customizable for by users
-  // FIXME should this also be used for consumers when events come from the outside
-  //       or are published to the outside?
+  // of objects in user code, customizable for by users, not used for "internal" serialization in component client, views etc.
   private static final ObjectMapper objectMapper = akka.javasdk.impl.serialization.JsonSerializer.newObjectMapperWithDefaults();
 
   /**
@@ -58,9 +56,8 @@ public final class JsonSupport {
     return objectMapper;
   }
 
-  // FIXME should this really be in here at all?
-  // internal serialization object
-  private static akka.javasdk.impl.serialization.JsonSerializer jsonSerializer = new akka.javasdk.impl.serialization.JsonSerializer();
+  // internal serialization object, but using the public/configurable mapper
+  private static akka.javasdk.impl.serialization.JsonSerializer jsonSerializer = new akka.javasdk.impl.serialization.JsonSerializer(objectMapper);
 
   private JsonSupport() {
   }

--- a/akka-javasdk/src/main/java/akka/javasdk/JsonSupport.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/JsonSupport.java
@@ -352,6 +352,10 @@ public final class JsonSupport {
 
 }
 
+/**
+ * @deprecated Not indented for public use and no longer used internally
+ */
+@Deprecated
 class DoneSerializer extends JsonSerializer<Done> {
 
   @Override
@@ -370,6 +374,10 @@ class DoneSerializer extends JsonSerializer<Done> {
   }
 }
 
+/**
+ * @deprecated Not indented for public use and no longer used internally
+ */
+@Deprecated
 class DoneDeserializer extends JsonDeserializer<Done> {
 
   @Override

--- a/akka-javasdk/src/main/java/akka/javasdk/JsonSupport.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/JsonSupport.java
@@ -41,47 +41,25 @@ import java.util.Optional;
 
 public final class JsonSupport {
 
-  // FIXME maybe move things to JsonSerializer, and delegate to it from here. Only handle the
-  // PbAny <-> BytesPayload here. However, public api with PbAny makes no sense now.
-  private static final ObjectMapper objectMapper = new ObjectMapper();
-
-  static {
-    // Date/time in ISO-8601 (rfc3339) yyyy-MM-dd'T'HH:mm:ss.SSSZ format
-    // as defined by com.fasterxml.jackson.databind.util.StdDateFormat
-    // For interoperability it's better to use the ISO format, i.e. WRITE_DATES_AS_TIMESTAMPS=off,
-    // but WRITE_DATES_AS_TIMESTAMPS=on has better performance.
-    objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-    objectMapper.configure(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false);
-
-    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
-    objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-
-    // ParameterNamesModule needs the parameter to ensure that single-parameter
-    // constructors are handled the same way as constructors with multiple parameters.
-    // See https://github.com/FasterXML/jackson-module-parameter-names#delegating-creator
-    objectMapper.registerModule(
-        new com.fasterxml.jackson.module.paramnames.ParameterNamesModule(
-            JsonCreator.Mode.PROPERTIES));
-    objectMapper.registerModule(new com.fasterxml.jackson.datatype.jdk8.Jdk8Module());
-    objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
-
-    SimpleModule module = new SimpleModule();
-    module.addSerializer(Done.class, new DoneSerializer());
-    module.addDeserializer(Done.class, new DoneDeserializer());
-
-    objectMapper.registerModule(module);
-  }
+  // object mapper for HTTP endpoints and explicit serialization/deserialization
+  // of objects in user code, customizable for by users
+  // FIXME should this also be used for consumers when events come from the outside
+  //       or are published to the outside?
+  private static final ObjectMapper objectMapper = akka.javasdk.impl.serialization.JsonSerializer.newObjectMapperWithDefaults();
 
   /**
-   * The Jackson ObjectMapper that is used for encoding and decoding JSON. You may adjust it's
-   * configuration, but that must only be performed before starting the service,
+   * The Jackson ObjectMapper that is used for encoding and decoding JSON for HTTP endpoints
+   * and HTTP requests.
+   *
+   * You may adjust its configuration, but that must only be performed before starting the service,
    * from {@link akka.javasdk.ServiceSetup#onStartup}.
    */
   public static ObjectMapper getObjectMapper() {
     return objectMapper;
   }
 
+  // FIXME should this really be in here at all?
+  // internal serialization object
   private static akka.javasdk.impl.serialization.JsonSerializer jsonSerializer = new akka.javasdk.impl.serialization.JsonSerializer();
 
   private JsonSupport() {
@@ -340,10 +318,18 @@ public final class JsonSupport {
     }
   }
 
+  /**
+   * @deprecated was only intended for internal use
+   */
+  @Deprecated
   public static <T, C extends Collection<T>> C decodeJsonCollection(Class<T> valueClass, Class<C> collectionType, akka.util.ByteString bytes) {
     return jsonSerializer.fromBytes(valueClass, collectionType, new BytesPayload(bytes, jsonSerializer.contentTypeFor(valueClass)));
   }
 
+  /**
+   * @deprecated was only intended for internal use
+   */
+  @Deprecated
   public static <T, C extends Collection<T>> C decodeJsonCollection(Class<T> valueClass, Class<C> collectionType, byte[] bytes) {
     return decodeJsonCollection(valueClass, collectionType, akka.util.ByteString.fromArrayUnsafe(bytes));
   }

--- a/akka-javasdk/src/main/resources/reference.conf
+++ b/akka-javasdk/src/main/resources/reference.conf
@@ -58,14 +58,10 @@ akka.javasdk {
     # the default will anyway not trigger any snapshots)
     snapshot-every = 100
 
-    # When EventSourcedEntity is deleted the existence of the entity is completely cleaned up after this duration..
+    # When a EventSourcedEntity or KeyValueEntity is deleted the existence of the entity is completely cleaned up after
+    # this duration.
     # The events and snapshots will be deleted later to give downstream consumers time to process all prior events,
     # including final deleted event.
-    cleanup-deleted-after = 7 days
-  }
-
-  key-value-entity {
-    # When KeyValueEntity is deleted the existence of the entity is completely cleaned up after this duration.
     cleanup-deleted-after = 7 days
   }
 

--- a/akka-javasdk/src/main/resources/reference.conf
+++ b/akka-javasdk/src/main/resources/reference.conf
@@ -52,16 +52,20 @@ akka.javasdk {
     http-port = 39390
   }
 
+  entity {
+    # When a EventSourcedEntity or KeyValueEntity is deleted the existence of the entity is completely cleaned up after
+    # this duration. The events and snapshots will be deleted later to give downstream consumers time to process all
+    # prior events, including final deleted event. Default is 7 days.
+    cleanup-deleted-after =  ${akka.javasdk.event-sourced-entity.cleanup-deleted-after}
+  }
+
   event-sourced-entity {
     # It is strongly recommended to not disable snapshotting unless it is known that
     # event sourced entities will never have more than 100 events (in which case
     # the default will anyway not trigger any snapshots)
     snapshot-every = 100
 
-    # When a EventSourcedEntity or KeyValueEntity is deleted the existence of the entity is completely cleaned up after
-    # this duration.
-    # The events and snapshots will be deleted later to give downstream consumers time to process all prior events,
-    # including final deleted event.
+    # Deprecated, use akka.javasdk.entity.cleanup-deleted-after
     cleanup-deleted-after = 7 days
   }
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/HttpEndpointDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/HttpEndpointDescriptorFactory.scala
@@ -8,6 +8,7 @@ import akka.http.scaladsl.model.HttpMethods
 import akka.javasdk.impl.reflection.Reflect
 import akka.annotation.InternalApi
 import akka.http.scaladsl.model.Uri.Path
+import akka.javasdk.JsonSupport
 import akka.javasdk.annotations.Acl
 import akka.javasdk.annotations.http.Delete
 import akka.javasdk.annotations.http.Get
@@ -139,7 +140,9 @@ private[javasdk] object HttpEndpointDescriptorFactory {
         methods = methods.toVector,
         componentOptions = new ComponentOptions(
           deriveAclOptions(Option(endpointClass.getAnnotation(classOf[Acl]))),
-          deriveJWTOptions(Option(endpointClass.getAnnotation(classOf[JWT])), endpointClass.getCanonicalName)))
+          deriveJWTOptions(Option(endpointClass.getAnnotation(classOf[JWT])), endpointClass.getCanonicalName)),
+        implementationClassName = endpointClass.getName,
+        objectMapper = Some(JsonSupport.getObjectMapper))
     }
   }
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -139,7 +139,7 @@ class SdkRunner private (dependencyProvider: Option[DependencyProvider], disable
 
     val eventSourcedEntitySnapshotEvery = applicationConfig.getInt("akka.javasdk.event-sourced-entity.snapshot-every")
     val cleanupDeletedEntityAfter =
-      applicationConf.getDuration("akka.javasdk.event-sourced-entity.cleanup-deleted-after")
+      applicationConf.getDuration("akka.javasdk.entity.cleanup-deleted-after")
 
     val devModeSettings =
       if (applicationConf.getBoolean("akka.javasdk.dev-mode.enabled"))

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -580,11 +580,13 @@ private final class Sdk(
         val componentId = clz.getAnnotation(classOf[ComponentId]).value
         val consumerClass = clz.asInstanceOf[Class[Consumer]]
         val consumerDest = consumerDestination(consumerClass)
+        val consumerSrc = consumerSource(consumerClass)
         val consumerSpi =
           new ConsumerImpl[Consumer](
             componentId,
             () => wiredInstance(consumerClass)(sideEffectingComponentInjects(None)),
             consumerClass,
+            consumerSrc,
             consumerDest,
             system.classicSystem,
             runtimeComponentClients.timerClient,
@@ -595,12 +597,7 @@ private final class Sdk(
             ComponentDescriptor.descriptorFor(consumerClass, serializer),
             regionInfo)
         consumerDescriptors :+=
-          new ConsumerDescriptor(
-            componentId,
-            clz.getName,
-            consumerSource(consumerClass),
-            consumerDestination(consumerClass),
-            consumerSpi)
+          new ConsumerDescriptor(componentId, clz.getName, consumerSrc, consumerDestination(consumerClass), consumerSpi)
 
       case clz if classOf[View].isAssignableFrom(clz) =>
         viewDescriptors :+= ViewDescriptorFactory(clz, serializer, regionInfo, sdkExecutionContext)

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -10,7 +10,6 @@ import java.lang.reflect.Method
 import java.util
 import java.util.Optional
 import java.util.concurrent.CompletionStage
-import scala.annotation.nowarn
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
@@ -135,11 +134,12 @@ class SdkRunner private (dependencyProvider: Option[DependencyProvider], disable
   def applicationConfig: Config =
     ApplicationConfig.loadApplicationConf
 
-  @nowarn("msg=deprecated") //TODO remove deprecation once we remove the old constructor
   override def getSettings: SpiSettings = {
     val applicationConf = applicationConfig
 
     val eventSourcedEntitySnapshotEvery = applicationConfig.getInt("akka.javasdk.event-sourced-entity.snapshot-every")
+    val cleanupDeletedEntityAfter =
+      applicationConf.getDuration("akka.javasdk.event-sourced-entity.cleanup-deleted-after")
 
     val devModeSettings =
       if (applicationConf.getBoolean("akka.javasdk.dev-mode.enabled"))
@@ -155,7 +155,7 @@ class SdkRunner private (dependencyProvider: Option[DependencyProvider], disable
       else
         None
 
-    new SpiSettings(eventSourcedEntitySnapshotEvery, devModeSettings)
+    new SpiSettings(eventSourcedEntitySnapshotEvery, cleanupDeletedEntityAfter, devModeSettings)
   }
 
   private def extractBrokerConfig(eventingConf: Config): SpiEventingSupportSettings = {
@@ -481,7 +481,6 @@ private final class Sdk(
 
         val instanceFactory: SpiEventSourcedEntity.FactoryContext => SpiEventSourcedEntity = { factoryContext =>
           new EventSourcedEntityImpl[AnyRef, AnyRef, EventSourcedEntity[AnyRef, AnyRef]](
-            sdkSettings,
             sdkTracerFactory,
             componentId,
             factoryContext.entityId,

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/Settings.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/Settings.scala
@@ -4,8 +4,6 @@
 
 package akka.javasdk.impl
 
-import java.time.Duration
-
 import akka.annotation.InternalApi
 import Settings.DevModeSettings
 import com.typesafe.config.Config
@@ -17,13 +15,10 @@ import com.typesafe.config.Config
 private[impl] object Settings {
 
   def apply(sdkConfig: Config): Settings = {
-    Settings(
-      cleanupDeletedEventSourcedEntityAfter = sdkConfig.getDuration("event-sourced-entity.cleanup-deleted-after"),
-      cleanupDeletedKeyValueEntityAfter = sdkConfig.getDuration("key-value-entity.cleanup-deleted-after"),
-      devModeSettings = Option.when(sdkConfig.getBoolean("dev-mode.enabled"))(
-        DevModeSettings(
-          serviceName = sdkConfig.getString("dev-mode.service-name"),
-          httpPort = sdkConfig.getInt("dev-mode.http-port"))))
+    Settings(devModeSettings = Option.when(sdkConfig.getBoolean("dev-mode.enabled"))(
+      DevModeSettings(
+        serviceName = sdkConfig.getString("dev-mode.service-name"),
+        httpPort = sdkConfig.getInt("dev-mode.http-port"))))
   }
 
   final case class DevModeSettings(serviceName: String, httpPort: Int)
@@ -33,7 +28,4 @@ private[impl] object Settings {
  * INTERNAL API
  */
 @InternalApi
-private[impl] final case class Settings(
-    cleanupDeletedEventSourcedEntityAfter: Duration,
-    cleanupDeletedKeyValueEntityAfter: Duration,
-    devModeSettings: Option[DevModeSettings])
+private[impl] final case class Settings(devModeSettings: Option[DevModeSettings])

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/eventsourcedentity/EventSourcedEntityImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/eventsourcedentity/EventSourcedEntityImpl.scala
@@ -23,7 +23,6 @@ import akka.javasdk.impl.ComponentType
 import akka.javasdk.impl.EntityExceptions.EntityException
 import akka.javasdk.impl.ErrorHandling.BadRequestException
 import akka.javasdk.impl.MetadataImpl
-import akka.javasdk.impl.Settings
 import akka.javasdk.impl.effect.ErrorReplyImpl
 import akka.javasdk.impl.effect.MessageReplyImpl
 import akka.javasdk.impl.effect.NoSecondaryEffectImpl
@@ -84,7 +83,6 @@ private[impl] object EventSourcedEntityImpl {
  */
 @InternalApi
 private[impl] final class EventSourcedEntityImpl[S, E, ES <: EventSourcedEntity[S, E]](
-    configuration: Settings,
     tracerFactory: () => Tracer,
     componentId: String,
     entityId: String,

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/eventsourcedentity/EventSourcedEntityImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/eventsourcedentity/EventSourcedEntityImpl.scala
@@ -167,10 +167,6 @@ private[impl] final class EventSourcedEntityImpl[S, E, ES <: EventSourcedEntity[
             case Left(err) =>
               Future.successful(new SpiEventSourcedEntity.ErrorEffect(err))
             case Right((reply, metadata)) =>
-              val delete =
-                if (deleteEntity) Some(configuration.cleanupDeletedEventSourcedEntityAfter)
-                else None
-
               val serializedEvents = events.map(event => serializer.toBytes(event)).toVector
 
               Future.successful(
@@ -179,7 +175,7 @@ private[impl] final class EventSourcedEntityImpl[S, E, ES <: EventSourcedEntity[
                   updatedState,
                   reply,
                   metadata,
-                  delete))
+                  deleteEntity))
           }
 
         case NoPrimaryEffect =>

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/http/JwtClaimsImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/http/JwtClaimsImpl.scala
@@ -230,6 +230,7 @@ class JwtClaimsImpl(jwtClaims: RuntimeJwtClaims) extends JwtClaims {
    *   The object claim, if present. Returns empty if the claim is not an object or can't be parsed as an object.
    */
   def getObject(name: String): Optional[JsonNode] = getString(name).flatMap((value: String) => {
+    // FIXME should this be the internal JsonSerialization rather?
     try Optional.of(JsonSupport.getObjectMapper.readTree(value))
     catch {
       case e: JsonProcessingException =>

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/keyvalueentity/KeyValueEntityImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/keyvalueentity/KeyValueEntityImpl.scala
@@ -146,7 +146,7 @@ private[impl] final class KeyValueEntityImpl[S, KV <: KeyValueEntity[S]](
                   updatedState,
                   reply,
                   metadata,
-                  delete = None))
+                  deleteEntity = false))
           }
 
         case DeleteEntity =>
@@ -154,9 +154,13 @@ private[impl] final class KeyValueEntityImpl[S, KV <: KeyValueEntity[S]](
             case Left(err) =>
               Future.successful(new SpiEventSourcedEntity.ErrorEffect(err))
             case Right((reply, metadata)) =>
-              val delete = Some(configuration.cleanupDeletedEventSourcedEntityAfter)
               Future.successful(
-                new SpiEventSourcedEntity.PersistEffect(events = Vector.empty, null, reply, metadata, delete))
+                new SpiEventSourcedEntity.PersistEffect(
+                  events = Vector.empty,
+                  null,
+                  reply,
+                  metadata,
+                  deleteEntity = true))
           }
 
         case NoPrimaryEffect =>

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/serialization/JsonSerializer.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/serialization/JsonSerializer.scala
@@ -125,17 +125,21 @@ object JsonSerializer {
  * INTERNAL API
  */
 @InternalApi
-final class JsonSerializer {
+final class JsonSerializer(val objectMapper: ObjectMapper) {
   import JsonSerializer._
+
+  def this() = this(JsonSerializer.internalObjectMapper)
+
+  /* Mostly used for internal serialization (events, snapshots, messages sent through component client)
+   * but in some places (consumers) it is created using the user configured object mapper if interacting
+   * with the outside world (message broker consume or publish) so that users can configure for surprising
+   * external formats.
+   */
 
   private val typeHints: ConcurrentMap[Class[_], TypeHint] = new ConcurrentHashMap()
   val reversedTypeHints: ConcurrentMap[String, Class[_]] = new ConcurrentHashMap()
 
   override def toString: String = s"JsonSerializer: ${typeHints.keySet().size()} registered types"
-
-  private val objectMapper = JsonSerializer.internalObjectMapper
-
-  def getInternalObjectMapper: ObjectMapper = objectMapper
 
   def toBytes(value: Any): BytesPayload = {
     if (value == null) throw NullSerializationException

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/serialization/JsonSerializer.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/serialization/JsonSerializer.scala
@@ -4,33 +4,128 @@
 
 package akka.javasdk.impl.serialization
 
+import akka.Done
+import akka.annotation.InternalApi
+
 import java.io.IOException
 import java.lang
 import java.lang.reflect.InvocationTargetException
 import java.util
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
-
 import akka.javasdk.JsonMigration
-import akka.javasdk.JsonSupport
 import akka.javasdk.annotations.Migration
 import akka.javasdk.annotations.TypeName
 import akka.javasdk.impl.AnySupport.BytesPrimitive
 import akka.javasdk.impl.NullSerializationException
 import akka.runtime.sdk.spi.BytesPayload
 import akka.util.ByteString
+import com.fasterxml.jackson.annotation.JsonAutoDetect
+import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.PropertyAccessor
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer
+import com.fasterxml.jackson.databind.module.SimpleModule
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 object JsonSerializer {
   val JsonContentTypePrefix: String = "json.akka.io/"
   private val KalixJsonContentTypePrefix: String = "json.kalix.io/"
 
   final case class TypeHint(currenTypeHintWithVersion: String, allTypeHints: List[String])
 
+  def newObjectMapperWithDefaults(): ObjectMapper = {
+    val mapper = new ObjectMapper
+
+    // Date/time in ISO-8601 (rfc3339) yyyy-MM-dd'T'HH:mm:ss.SSSZ format
+    // as defined by com.fasterxml.jackson.databind.util.StdDateFormat
+    // For interoperability it's better to use the ISO format, i.e. WRITE_DATES_AS_TIMESTAMPS=off,
+    // but WRITE_DATES_AS_TIMESTAMPS=on has better performance.
+    mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+    mapper.configure(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false)
+
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+    mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+
+    // ParameterNamesModule needs the parameter to ensure that single-parameter
+    // constructors are handled the same way as constructors with multiple parameters.
+    // See https://github.com/FasterXML/jackson-module-parameter-names#delegating-creator
+    mapper.registerModule(new com.fasterxml.jackson.module.paramnames.ParameterNamesModule(JsonCreator.Mode.PROPERTIES))
+    mapper.registerModule(new com.fasterxml.jackson.datatype.jdk8.Jdk8Module())
+    mapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
+
+    val module = new SimpleModule()
+    module.addSerializer(classOf[Done], DoneSerializer)
+    module.addDeserializer(classOf[Done], DoneDeserializer)
+    mapper.registerModule(module)
+
+    mapper
+  }
+
+  // internal mapper used for serialization when passing objects to the runtime
+  val internalObjectMapper: ObjectMapper = newObjectMapperWithDefaults()
+
+  object DoneSerializer extends com.fasterxml.jackson.databind.JsonSerializer[Done] {
+
+    override def serialize(value: Done, gen: JsonGenerator, serializers: SerializerProvider): Unit = {
+      gen.writeStartObject()
+      gen.writeEndObject()
+    }
+
+    override def serializeWithType(
+        value: Done,
+        gen: JsonGenerator,
+        serializers: SerializerProvider,
+        typeSer: TypeSerializer): Unit = {
+      val typeId = typeSer.typeId(value, JsonToken.START_OBJECT)
+      typeSer.writeTypePrefix(gen, typeId)
+      gen.writeFieldName("value")
+      gen.writeStartObject()
+      gen.writeEndObject()
+      typeSer.writeTypeSuffix(gen, typeId)
+    }
+
+  }
+
+  object DoneDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer[Done] {
+
+    override def deserialize(p: JsonParser, ctxt: DeserializationContext): Done = {
+      if (p.currentToken() == JsonToken.START_OBJECT && p.nextToken() == JsonToken.END_OBJECT) {
+        Done
+      } else {
+        throw JsonMappingException.from(ctxt, "Cannot deserialize Done class, expecting empty object '{}'")
+      }
+    }
+
+    override def deserializeWithType(
+        p: JsonParser,
+        ctxt: DeserializationContext,
+        typeDeserializer: TypeDeserializer): AnyRef =
+      typeDeserializer.deserializeTypedFromObject(p, ctxt)
+
+  }
 }
 
-class JsonSerializer {
+/**
+ * INTERNAL API
+ */
+@InternalApi
+final class JsonSerializer {
   import JsonSerializer._
 
   private val typeHints: ConcurrentMap[Class[_], TypeHint] = new ConcurrentHashMap()
@@ -38,7 +133,9 @@ class JsonSerializer {
 
   override def toString: String = s"JsonSerializer: ${typeHints.keySet().size()} registered types"
 
-  private val objectMapper = JsonSupport.getObjectMapper
+  private val objectMapper = JsonSerializer.internalObjectMapper
+
+  def getInternalObjectMapper: ObjectMapper = objectMapper
 
   def toBytes(value: Any): BytesPayload = {
     if (value == null) throw NullSerializationException

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/serialization/JsonSerializationSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/serialization/JsonSerializationSpec.scala
@@ -6,9 +6,7 @@ package akka.javasdk.impl.serialization
 
 import java.util
 import java.util.Optional
-
 import scala.beans.BeanProperty
-
 import akka.Done
 import akka.javasdk.DummyClass
 import akka.javasdk.DummyClass2
@@ -24,6 +22,7 @@ import akka.javasdk.impl.serialization.JsonSerializationSpec.SimpleClassUpdated
 import akka.runtime.sdk.spi.BytesPayload
 import akka.util.ByteString
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.IntNode
 import com.fasterxml.jackson.databind.node.ObjectNode
@@ -89,6 +88,8 @@ object JsonSerializationSpec {
     @TypeName(" ")
     final case class Elephant(name: String, age: Int) extends Animal
   }
+
+  final case class SomeTypeWithOptional(optional: Optional[String])
 
 }
 class JsonSerializationSpec extends AnyWordSpec with Matchers {
@@ -418,6 +419,14 @@ class JsonSerializationSpec extends AnyWordSpec with Matchers {
 
       val payloadBigOne = serializer.encodeDynamicToAkkaByteString("value", java.math.BigDecimal.valueOf(10d))
       payloadBigOne.utf8String shouldBe """{"value":10.0}"""
+    }
+
+    "use the provided object mapper" in {
+      val customMapper = JsonSerializer.newObjectMapperWithDefaults()
+      customMapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
+      val customSerializer = new JsonSerializer(customMapper)
+      val bytesPayload = customSerializer.toBytes(JsonSerializationSpec.SomeTypeWithOptional(Optional.empty()))
+      bytesPayload.bytes.utf8String shouldBe "{}"
     }
 
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val ProtocolVersionMinor = 1
     val RuntimeImage = "gcr.io/kalix-public/kalix-runtime"
     // Remember to bump kalix-runtime.version in akka-javasdk-maven/akka-javasdk-parent if bumping this
-    val RuntimeVersion = sys.props.getOrElse("kalix-runtime.version", "1.4.2-21-726c2742-SNAPSHOT")
+    val RuntimeVersion = sys.props.getOrElse("kalix-runtime.version", "1.4.3")
   }
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val ProtocolVersionMinor = 1
     val RuntimeImage = "gcr.io/kalix-public/kalix-runtime"
     // Remember to bump kalix-runtime.version in akka-javasdk-maven/akka-javasdk-parent if bumping this
-    val RuntimeVersion = sys.props.getOrElse("kalix-runtime.version", "1.4.2")
+    val RuntimeVersion = sys.props.getOrElse("kalix-runtime.version", "1.4.2-21-726c2742-SNAPSHOT")
   }
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/lightbend/kalix-runtime/issues/3423

The object mapper available for customization through JsonSupport is now used, and only used, for HTTP endpoint and consumers when consuming from topics or producing to topics.

For internal JSON; stored in journal, used for component client, and in views, a separate, predictable/non-configurable object mapper is used.

Includes bump to runtime 1.4.3


