### PR TITLE
chore: wrong callout number

### DIFF
--- a/docs/src/modules/java/pages/workflows.adoc
+++ b/docs/src/modules/java/pages/workflows.adoc
@@ -114,7 +114,7 @@ include::example$transfer-workflow/src/main/java/com/example/transfer/applicatio
 <3> We instruct Akka to run a given asynchronous call to withdraw funds from a wallet.
 <4> After successful withdrawal we return an `Effect` that will update the workflow state and move to the next step called "deposit." An input parameter for this step is a `Deposit` record.
 <5> Another workflow step action to deposit funds to a given wallet.
-<6> This time we return an effect that will stop workflow processing, by using special `end` method.
+<6> This time we return an effect that will stop workflow processing, by using the special `end` method.
 <7> We collect all steps to form a workflow definition.
 
 IMPORTANT: In the following example all `WalletEntity` interactions are not idempotent. It means that if the workflow step retries, it will make the deposit or withdraw again. In a real-world scenario, you should consider making all interactions idempotent with a proper deduplication mechanism. A very basic example of handling retries for workflows can be found in https://github.com/akka/akka-sdk/blob/main/samples/transfer-workflow-compensation/src/main/java/com/example/wallet/domain/Wallet.java[this] sample.

--- a/samples/transfer-workflow/src/main/java/com/example/transfer/application/TransferWorkflow.java
+++ b/samples/transfer-workflow/src/main/java/com/example/transfer/application/TransferWorkflow.java
@@ -50,11 +50,11 @@ public class TransferWorkflow extends Workflow<TransferState> { // <2>
         });
 
     Step deposit =
-      step("deposit") // <1>
+      step("deposit") // <5>
         .asyncCall(Deposit.class, cmd ->
           componentClient.forEventSourcedEntity(cmd.to)
             .method(WalletEntity::deposit)
-            .invokeAsync(cmd.amount)) // <5>
+            .invokeAsync(cmd.amount))
         .andThen(Done.class, __ -> {
           return effects()
             .updateState(currentState().withStatus(COMPLETED))


### PR DESCRIPTION
See https://doc.akka.io/java/workflows.html#_workflow_definition 
the callout 1 being duplicated in combination with 5 don't quite make sense. 


Now: 


<img width="762" alt="Screenshot 2025-03-31 at 15 22 40" src="https://github.com/user-attachments/assets/a1faac36-fa82-4c89-9242-6e7c64315cad" />

```
<1> Each step should have a unique name.
<2> Using the xref:component-and-service-calls.adoc#_component_client[ComponentClient], which is injected in the constructor.
<3> We instruct Akka to run a given asynchronous call to withdraw funds from a wallet.
<4> After successful withdrawal we return an `Effect` that will update the workflow state and move to the next step called "deposit." An input parameter for this step is a `Deposit` record.
<5> Another workflow step action to deposit funds to a given wallet.
<6> This time we return an effect that will stop workflow processing, by using the special `end` method.
<7> We collect all steps to form a workflow definition.
```

