### PR TITLE
Revert "bump: Confluent Kafka/Zookeeper 7.9.0 in Docker compose"

### DIFF
--- a/.github/kafka.yml
+++ b/.github/kafka.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   kafka:
-    image: confluentinc/cp-kafka:7.9.0
+    image: confluentinc/cp-kafka:7.2.6
     depends_on:
       - zookeeper
     ports:
@@ -26,6 +26,6 @@ services:
       retries: 10
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.9.0
+    image: zookeeper:3.9
     ports:
       - "2181:2181"

--- a/samples/event-sourced-counter-brokers/docker-compose.yml
+++ b/samples/event-sourced-counter-brokers/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kafka:
-    image: confluentinc/cp-kafka:7.9.0
+    image: confluentinc/cp-kafka:7.2.6
     depends_on:
       - zookeeper
     ports:
@@ -25,7 +25,7 @@ services:
       retries: 10
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.9.0
+    image: zookeeper:3.9
     ports:
       - "2181:2181"
 


### PR DESCRIPTION
Reverts akka/akka-sdk#353

References: https://github.com/lightbend/kalix-runtime/issues/3728

Sample test fails consistently in main with this, needs more investigation before we can bump.