### PR TITLE
feat: create and delete methods for TimerScheduler

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/SdkIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/SdkIntegrationTest.java
@@ -104,7 +104,7 @@ public class SdkIntegrationTest extends TestKitSupport {
   @Test
   public void verifyEchoActionWiring() {
 
-    timerScheduler.startSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
+    timerScheduler.createSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
       .method(EchoAction::stringMessage)
       .deferred("hello"));
 
@@ -119,7 +119,7 @@ public class SdkIntegrationTest extends TestKitSupport {
   @Test
   public void verifyHierarchyTimedActionWiring() {
 
-    timerScheduler.startSingleTimer("wired", ofMillis(0), componentClient.forTimedAction()
+    timerScheduler.createSingleTimer("wired", ofMillis(0), componentClient.forTimedAction()
       .method(HierarchyTimed::stringMessage)
       .deferred("hello"));
 
@@ -134,7 +134,7 @@ public class SdkIntegrationTest extends TestKitSupport {
   @Test
   public void verifyTimedActionListCommand() {
 
-    timerScheduler.startSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
+    timerScheduler.createSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
       .method(EchoAction::stringMessages)
       .deferred(List.of("hello", "mr")));
 
@@ -145,7 +145,7 @@ public class SdkIntegrationTest extends TestKitSupport {
         assertThat(value).isEqualTo("hello mr");
       });
 
-    timerScheduler.startSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
+    timerScheduler.createSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
       .method(EchoAction::commandMessages)
       .deferred(List.of(new EchoAction.SomeCommand("tambourine"), new EchoAction.SomeCommand("man"))));
 
@@ -159,7 +159,7 @@ public class SdkIntegrationTest extends TestKitSupport {
 
   @Test
   public void verifyTimedActionEmpty() {
-    timerScheduler.startSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
+    timerScheduler.createSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
       .method(EchoAction::emptyMessage)
       .deferred());
 
@@ -173,7 +173,7 @@ public class SdkIntegrationTest extends TestKitSupport {
 
   @Test
   public void verifyTimedActionRunsOnVirtualThread() {
-    timerScheduler.startSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
+    timerScheduler.createSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
         .method(EchoAction::stringMessage)
         .deferred("check-if-virtual-thread"));
 
@@ -302,7 +302,7 @@ public class SdkIntegrationTest extends TestKitSupport {
     String veHeaderValue = "ve-value";
     String esHeaderValue = "es-value";
 
-    timerScheduler.startSingleTimer("metadata", ofMillis(0), componentClient.forTimedAction()
+    timerScheduler.createSingleTimer("metadata", ofMillis(0), componentClient.forTimedAction()
       .method(ActionWithMetadata::processWithMeta)
       .withMetadata(Metadata.EMPTY.add(ActionWithMetadata.SOME_HEADER, metadataValue))
       .deferred());

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithTimer.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithTimer.java
@@ -38,7 +38,7 @@ public class WorkflowWithTimer extends Workflow<FailingCounterState> {
               .method(WorkflowWithTimer::pingWorkflow)
               .deferred(new CounterScheduledValue(12));
 
-          timers().startSingleTimer("ping", Duration.ofSeconds(2), pingWorkflow);
+          timers().createSingleTimer("ping", Duration.ofSeconds(2), pingWorkflow);
 
           return CompletableFuture.completedFuture(Done.done()); // FIXME remove once we have sync/blocking workflow calls
         })

--- a/akka-javasdk/src/main/java/akka/javasdk/timer/TimerScheduler.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/timer/TimerScheduler.java
@@ -30,7 +30,7 @@ public interface TimerScheduler {
    * @param delay delay, starting from now, in which the timer should be triggered
    * @param deferredCall a call to component that will be executed when the timer is triggered
    */
-  <I, O> void startSingleTimer(String name, Duration delay, DeferredCall<I, O> deferredCall);
+  <I, O> void createSingleTimer(String name, Duration delay, DeferredCall<I, O> deferredCall);
 
   /**
    * Schedule a single timer. Timers allow for scheduling calls in the future. For example, to
@@ -51,14 +51,15 @@ public interface TimerScheduler {
    * @param maxRetries Retry up to this many times before giving up
    * @param deferredCall a call to component that will be executed when the timer is triggered
    */
-  <I, O> void startSingleTimer(
+  <I, O> void createSingleTimer(
       String name, Duration delay, int maxRetries, DeferredCall<I, O> deferredCall);
 
   /**
-   * Cancel an existing timer. This completes successfully if not timer is registered for the passed
+   * Delete an existing timer. This completes successfully if no timer is registered for the passed
    * name.
    */
-  void cancel(String name);
+  void delete(String name);
+
 
   /**
    * Schedule a single timer. Timers allow for scheduling calls in the future. For example, to
@@ -80,7 +81,7 @@ public interface TimerScheduler {
    * @return A completion stage that is completed successfully or failed, once the timer has been
    *     scheduled
    */
-  <I, O> CompletionStage<Done> startSingleTimerAsync(
+  <I, O> CompletionStage<Done> createSingleTimerAsync(
       String name, Duration delay, DeferredCall<I, O> deferredCall);
 
   /**
@@ -104,12 +105,35 @@ public interface TimerScheduler {
    * @return A completion stage that is completed successfully or failed, once the timer has been
    *     scheduled
    */
-  <I, O> CompletionStage<Done> startSingleTimerAsync(
+  <I, O> CompletionStage<Done> createSingleTimerAsync(
       String name, Duration delay, int maxRetries, DeferredCall<I, O> deferredCall);
 
+
   /**
-   * Cancel an existing timer. This completes successfully if not timer is registered for the passed
+   * Delete an existing timer. This completes successfully if no timer is registered for the passed
    * name.
    */
-  CompletionStage<Done> cancelAsync(String name);
+  CompletionStage<Done> deleteAsync(String name);
+
+
+  /**
+   * @deprecated Use {@link TimerScheduler#createSingleTimerAsync(String, Duration, DeferredCall)} instead.
+   */
+  @Deprecated(since = "3.3.0", forRemoval = true)
+  <I, O> CompletionStage<Done> startSingleTimer(
+    String name, Duration delay, DeferredCall<I, O> deferredCall);
+
+
+  /**
+   * @deprecated Use {@link TimerScheduler#createSingleTimerAsync(String, Duration, int, DeferredCall)} instead.
+   */
+  @Deprecated(since = "3.3.0", forRemoval = true)
+  <I, O> CompletionStage<Done> startSingleTimer(
+    String name, Duration delay, int maxRetries, DeferredCall<I, O> deferredCall);
+
+  /**
+   * @deprecated User {@link TimerScheduler#deleteAsync(String)} instead.
+   */
+  @Deprecated(since = "3.3.0", forRemoval = true)
+  CompletionStage<Done> cancel(String name);
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/timer/TimerScheduler.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/timer/TimerScheduler.java
@@ -60,7 +60,6 @@ public interface TimerScheduler {
    */
   void delete(String name);
 
-
   /**
    * Schedule a single timer. Timers allow for scheduling calls in the future. For example, to
    * verify that some process have been completed or not.
@@ -108,32 +107,29 @@ public interface TimerScheduler {
   <I, O> CompletionStage<Done> createSingleTimerAsync(
       String name, Duration delay, int maxRetries, DeferredCall<I, O> deferredCall);
 
-
   /**
    * Delete an existing timer. This completes successfully if no timer is registered for the passed
    * name.
    */
   CompletionStage<Done> deleteAsync(String name);
 
-
   /**
-   * @deprecated Use {@link TimerScheduler#createSingleTimerAsync(String, Duration, DeferredCall)} instead.
+   * @deprecated Use {@link TimerScheduler#createSingleTimerAsync(String, Duration, DeferredCall)}
+   *     instead.
    */
   @Deprecated(since = "3.3.0", forRemoval = true)
   <I, O> CompletionStage<Done> startSingleTimer(
-    String name, Duration delay, DeferredCall<I, O> deferredCall);
-
+      String name, Duration delay, DeferredCall<I, O> deferredCall);
 
   /**
-   * @deprecated Use {@link TimerScheduler#createSingleTimerAsync(String, Duration, int, DeferredCall)} instead.
+   * @deprecated Use {@link TimerScheduler#createSingleTimerAsync(String, Duration, int,
+   *     DeferredCall)} instead.
    */
   @Deprecated(since = "3.3.0", forRemoval = true)
   <I, O> CompletionStage<Done> startSingleTimer(
-    String name, Duration delay, int maxRetries, DeferredCall<I, O> deferredCall);
+      String name, Duration delay, int maxRetries, DeferredCall<I, O> deferredCall);
 
-  /**
-   * @deprecated User {@link TimerScheduler#deleteAsync(String)} instead.
-   */
+  /** @deprecated User {@link TimerScheduler#deleteAsync(String)} instead. */
   @Deprecated(since = "3.3.0", forRemoval = true)
   CompletionStage<Done> cancel(String name);
 }

--- a/docs/src/modules/reference/pages/migration-guide.adoc
+++ b/docs/src/modules/reference/pages/migration-guide.adoc
@@ -10,11 +10,19 @@ You no longer need to use `CompletionStage` or `CompletableFuture` composition w
 
 === Breaking Changes
 
-To simplify usage and improve developer experience, this release includes several breaking changes. If your service relies on any of the following features, you will need to update your implementation:
+To simplify usage and improve developer experience, this release includes a few breaking changes. If your service
+relies on any of the following features, you will need to update your implementation:
 
-* Timer scheduling and cancellation via `TimerScheduler.startSingleTimer(...)` and `TimerScheduler.cancel()` are now blocking operations that return `void`. If you still prefer non-blocking operations, new asynchronous alternatives have been introduced: `startSingleTimerAsync()` and `cancelAsync()`.
 * gRPC endpoints for unary and client streaming methods now return the response message directly, instead of wrapping it in a `CompletionStage`.
 * gRPC clients now return the response value directly for unary and client streaming calls. For asynchronous behavior, the request builder APIs (`grpcClient.someMethod().invokeAsync(parameter)`) are still available.
+
+=== Deprecations
+
+Timer scheduling and cancellation via `TimerScheduler.startSingleTimer(...)` and `TimerScheduler.cancel()` are now
+deprecated. Instead, use `TimerScheduler.createSingleTimer(...)` and `TimerScheduler.delete()`. Note that this two
+new methods are blocking operations that return `void`.
+
+If you still prefer non-blocking operations, new asynchronous alternatives have been introduced: `createSingleTimerAsync()` and `deleteAsync()`.
 
 === Blocking and Parallelism
 

--- a/docs/src/modules/reference/pages/migration-guide.adoc
+++ b/docs/src/modules/reference/pages/migration-guide.adoc
@@ -19,7 +19,7 @@ relies on any of the following features, you will need to update your implementa
 === Deprecations
 
 Timer scheduling and cancellation via `TimerScheduler.startSingleTimer(...)` and `TimerScheduler.cancel()` are now
-deprecated. Instead, use `TimerScheduler.createSingleTimer(...)` and `TimerScheduler.delete()`. Note that this two
+deprecated. Instead, use `TimerScheduler.createSingleTimer(...)` and `TimerScheduler.delete()`. Note that these two
 new methods are blocking operations that return `void`.
 
 If you still prefer non-blocking operations, new asynchronous alternatives have been introduced: `createSingleTimerAsync()` and `deleteAsync()`.

--- a/samples/choreography-saga-quickstart/src/main/java/user/registry/application/UniqueEmailConsumer.java
+++ b/samples/choreography-saga-quickstart/src/main/java/user/registry/application/UniqueEmailConsumer.java
@@ -57,7 +57,7 @@ public class UniqueEmailConsumer extends Consumer {
           .forKeyValueEntity(email.address())
           .method(UniqueEmailEntity::cancelReservation).deferred();
 
-      timers().startSingleTimer(
+      timers().createSingleTimer(
         timerId,
         delay,
         callToUnReserve);

--- a/samples/reliable-timers/src/main/java/com/example/api/OrderEndpoint.java
+++ b/samples/reliable-timers/src/main/java/com/example/api/OrderEndpoint.java
@@ -44,7 +44,7 @@ public class OrderEndpoint {
 
     var orderId = UUID.randomUUID().toString(); // <2>
 
-    timerScheduler.startSingleTimer( // <3>
+    timerScheduler.createSingleTimer( // <3>
       timerName(orderId), // <4>
       Duration.ofSeconds(10), // <5>
       componentClient.forTimedAction()

--- a/samples/tracing/src/main/java/com/example/tracing/api/TracingEndpoint.java
+++ b/samples/tracing/src/main/java/com/example/tracing/api/TracingEndpoint.java
@@ -39,7 +39,7 @@ public class TracingEndpoint {
 
     @Post("/")
     public void postDelayed(PostId id) {
-        timerScheduler.startSingleTimer(
+        timerScheduler.createSingleTimer(
             UUID.randomUUID().toString(), //not planning to cancel the timer
             Duration.ofSeconds(1L),
             componentClient.forTimedAction().method(TracingAction::callAnotherService).deferred(id.id));

--- a/samples/transfer-workflow-compensation/src/main/java/com/example/transfer/application/TransferWorkflow.java
+++ b/samples/transfer-workflow-compensation/src/main/java/com/example/transfer/application/TransferWorkflow.java
@@ -148,7 +148,7 @@ public class TransferWorkflow extends Workflow<TransferState> {
       step("wait-for-acceptation")
         .call(() -> {
           String transferId = currentState().transferId();
-          timers().startSingleTimer(
+          timers().createSingleTimer(
             "acceptationTimeout-" + transferId,
             ofHours(8),
             componentClient.forWorkflow(transferId)


### PR DESCRIPTION
@johanandren, here is the follow-up as discussed in #373

I have to introduce a `delete` method to pair with `create`. Also because the `cancel` is back to what it was and is now deprecated as well. 

I don't have strong opinions about it either. We can also close this PR if we believe it's not worth to introduce a deprecation cycle.