### PR TITLE
docs: Executor injection

### DIFF
--- a/docs/src/modules/java/pages/setup-and-dependency-injection.adoc
+++ b/docs/src/modules/java/pages/setup-and-dependency-injection.adoc
@@ -64,6 +64,8 @@ The following types can be injected in Service Setup, HTTP Endpoints, gRPC Endpo
 | Access the user defined configuration picked up from `application.conf`
 | `akka.javasdk.Retries`
 | Utility for retrying calls
+| `java.util.concurrent.Executor`
+| An executor which runs each task in a virtual thread, and is safe to use for blocking async work, for example with `CompletableFuture.supplyAsync(() -> blocking, executor)`
 |===
 
 Furthermore, the following component specific types can also be injected:


### PR DESCRIPTION
It was added in wrong place in https://github.com/akka/akka-sdk/pull/366
flatdocs is for that ask-akka sample

cc @johanandren 

Leaving it in the flatdoc. We should anyway regenerate that since it's very outdated.