### PR TITLE
feat: support Runnable in Workflow calls

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/WorkflowTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/WorkflowTest.java
@@ -86,6 +86,18 @@ public class WorkflowTest extends TestKitSupport {
         assertThat(balance1).isEqualTo(90);
         assertThat(balance2).isEqualTo(110);
       });
+
+
+    Awaitility.await()
+      .ignoreExceptions()
+      .atMost(20, TimeUnit.of(SECONDS))
+      .untilAsserted(() -> {
+        // this is mostly to verify that the last step (Runnable + Supplier) worked as expect
+        String lastStep =
+          componentClient.forWorkflow(transferId)
+            .method(TransferWorkflow::getLastStep).invoke().text();
+        assertThat(lastStep).isEqualTo("logAndStop");
+      });
   }
 
   @Test

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/WorkflowTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/WorkflowTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -231,10 +230,10 @@ public class WorkflowTest extends TestKitSupport {
       .atMost(20, TimeUnit.of(SECONDS))
       .untilAsserted(() -> {
 
-        var transferState = await(
+        var transferState =
           componentClient.forWorkflow(transferId)
             .method(TransferWorkflowWithFraudDetection::getTransferState)
-            .invokeAsync());
+            .invoke();
 
         assertThat(transferState.finished()).isFalse();
         assertThat(transferState.accepted()).isFalse();
@@ -295,10 +294,10 @@ public class WorkflowTest extends TestKitSupport {
         assertThat(balance1).isEqualTo(100);
         assertThat(balance2).isEqualTo(100);
 
-        var transferState = await(
+        var transferState =
           componentClient.forWorkflow(transferId)
             .method(TransferWorkflowWithFraudDetection::getTransferState)
-            .invokeAsync());
+            .invoke();
 
         assertThat(transferState.finished()).isTrue();
         assertThat(transferState.accepted()).isFalse();
@@ -349,10 +348,10 @@ public class WorkflowTest extends TestKitSupport {
     var workflowId = randomId();
 
     //when
-    Message response = await(
+    Message response =
       componentClient.forWorkflow(workflowId)
         .method(WorkflowWithRecoverStrategy::startFailingCounter)
-        .invokeAsync(counterId));
+        .invoke(counterId);
 
     assertThat(response.text()).isEqualTo("workflow started");
 
@@ -369,10 +368,10 @@ public class WorkflowTest extends TestKitSupport {
       .ignoreExceptions()
       .atMost(20, TimeUnit.of(SECONDS))
       .untilAsserted(() -> {
-        var state = await(
+        var state =
           componentClient.forWorkflow(workflowId)
             .method(WorkflowWithRecoverStrategy::get)
-            .invokeAsync());
+            .invoke();
 
         assertThat(state.finished()).isTrue();
       });
@@ -385,10 +384,10 @@ public class WorkflowTest extends TestKitSupport {
     var workflowId = randomId();
 
     //when
-    Message response = await(
+    Message response =
       componentClient.forWorkflow(workflowId)
         .method(WorkflowWithRecoverStrategyAndAsyncCall::startFailingCounter)
-        .invokeAsync(counterId));
+        .invoke(counterId);
 
     assertThat(response.text()).isEqualTo("workflow started");
 
@@ -420,10 +419,10 @@ public class WorkflowTest extends TestKitSupport {
     var workflowId = randomId();
 
     //when
-    Message response = await(
+    Message response =
       componentClient.forWorkflow(workflowId)
         .method(WorkflowWithTimeout::startFailingCounter)
-        .invokeAsync(counterId));
+        .invoke(counterId);
 
     assertThat(response.text()).isEqualTo("workflow started");
 
@@ -440,10 +439,10 @@ public class WorkflowTest extends TestKitSupport {
       .ignoreExceptions()
       .atMost(20, TimeUnit.of(SECONDS))
       .untilAsserted(() -> {
-        var state = await(
+        var state =
           componentClient.forWorkflow(workflowId)
             .method(WorkflowWithTimeout::get)
-            .invokeAsync());
+            .invoke();
         assertThat(state.finished()).isTrue();
       });
   }
@@ -455,10 +454,10 @@ public class WorkflowTest extends TestKitSupport {
     var workflowId = randomId();
 
     //when
-    Message response = await(
+    Message response =
       componentClient.forWorkflow(workflowId)
         .method(WorkflowWithStepTimeout::startFailingCounter)
-        .invokeAsync(counterId));
+        .invoke(counterId);
 
     assertThat(response.text()).isEqualTo("workflow started");
 
@@ -467,10 +466,10 @@ public class WorkflowTest extends TestKitSupport {
       .ignoreExceptions()
       .atMost(20, TimeUnit.of(SECONDS))
       .untilAsserted(() -> {
-        var state = await(
+        var state =
           componentClient.forWorkflow(workflowId)
             .method(WorkflowWithStepTimeout::get)
-            .invokeAsync());
+            .invoke();
 
         assertThat(state.value()).isEqualTo(2);
         assertThat(state.finished()).isTrue();
@@ -484,10 +483,10 @@ public class WorkflowTest extends TestKitSupport {
     var workflowId = randomId();
 
     //when
-    Message response = await(
+    Message response =
       componentClient.forWorkflow(workflowId)
         .method(WorkflowWithTimer::startFailingCounter)
-        .invokeAsync(counterId));
+        .invoke(counterId);
 
     assertThat(response.text()).isEqualTo("workflow started");
 
@@ -496,10 +495,10 @@ public class WorkflowTest extends TestKitSupport {
       .ignoreExceptions()
       .atMost(20, TimeUnit.of(SECONDS))
       .untilAsserted(() -> {
-        var state = await(
+        var state =
           componentClient.forWorkflow(workflowId)
             .method(WorkflowWithTimer::get)
-            .invokeAsync());
+            .invoke();
 
         assertThat(state.finished()).isTrue();
         assertThat(state.value()).isEqualTo(12);
@@ -511,28 +510,28 @@ public class WorkflowTest extends TestKitSupport {
   public void shouldNotUpdateWorkflowStateAfterEndTransition() {
     //given
     var workflowId = randomId();
-    await(
       componentClient.forWorkflow(workflowId)
         .method(DummyWorkflow::startAndFinish)
-        .invokeAsync()
-    );
-    assertThat(await(
+        .invoke();
+
+    assertThat(
       componentClient.forWorkflow(workflowId)
-        .method(DummyWorkflow::get).invokeAsync())).isEqualTo(10);
+        .method(DummyWorkflow::get)
+        .invoke()).isEqualTo(10);
 
     //when
     try {
-      await(
+
         componentClient.forWorkflow(workflowId)
-          .method(DummyWorkflow::update).invokeAsync());
+          .method(DummyWorkflow::update).invoke();
     } catch (RuntimeException exception) {
       // ignore "500 Internal Server Error" exception from the proxy
     }
 
     //then
-    assertThat(await(
+    assertThat(
       componentClient.forWorkflow(workflowId)
-        .method(DummyWorkflow::get).invokeAsync())).isEqualTo(10);
+        .method(DummyWorkflow::get).invoke()).isEqualTo(10);
   }
 
   @Test
@@ -541,8 +540,8 @@ public class WorkflowTest extends TestKitSupport {
     var workflowId = randomId();
 
     //when
-    String response = await(componentClient.forWorkflow(workflowId)
-      .method(WorkflowWithoutInitialState::start).invokeAsync());
+    String response = componentClient.forWorkflow(workflowId)
+      .method(WorkflowWithoutInitialState::start).invoke();
 
     assertThat(response).contains("ok");
 
@@ -559,12 +558,12 @@ public class WorkflowTest extends TestKitSupport {
   @Test
   public void shouldAllowHierarchyWorkflow() {
     var workflowId = randomId();
-    await(componentClient.forWorkflow(workflowId)
-      .method(TextWorkflow::setText).invokeAsync("some text"));
+    componentClient.forWorkflow(workflowId)
+      .method(TextWorkflow::setText).invoke("some text");
 
 
-    var result = await(componentClient.forWorkflow(workflowId)
-      .method(TextWorkflow::getText).invokeAsync());
+    var result = componentClient.forWorkflow(workflowId)
+      .method(TextWorkflow::getText).invoke();
 
     assertThat(result).isEqualTo(Optional.of("some text"));
   }
@@ -572,15 +571,15 @@ public class WorkflowTest extends TestKitSupport {
   @Test
   public void shouldBeCallableWithGenericParameter() {
     var workflowId = randomId();
-    String response1 = await(componentClient.forWorkflow(workflowId)
+    String response1 = componentClient.forWorkflow(workflowId)
       .method(TransferWorkflow::genericStringsCall)
-      .invokeAsync(List.of("somestring"))).text();
+      .invoke(List.of("somestring")).text();
 
     assertThat(response1).isEqualTo("genericCall ok");
 
-    String response2 = await(componentClient.forWorkflow(workflowId)
+    String response2 = componentClient.forWorkflow(workflowId)
       .method(TransferWorkflow::genericCall)
-      .invokeAsync(List.of(new TransferWorkflow.SomeClass("somestring")))).text();
+      .invoke(List.of(new TransferWorkflow.SomeClass("somestring"))).text();
 
     assertThat(response2).isEqualTo("genericCall ok");
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferState.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferState.java
@@ -11,7 +11,7 @@ public record TransferState(Transfer transfer, String lastStep, boolean finished
   }
 
   public TransferState withLastStep(String lastStep) {
-    return new TransferState(transfer, lastStep);
+    return new TransferState(transfer, lastStep, finished, accepted);
   }
 
   public TransferState asAccepted() {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflow.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflow.java
@@ -4,10 +4,10 @@
 
 package akkajavasdk.components.workflowentities;
 
-import akkajavasdk.components.actions.echo.Message;
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
+import akkajavasdk.components.actions.echo.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,8 +32,8 @@ public class TransferWorkflow extends Workflow<TransferState> {
   public WorkflowDef<TransferState> definition() {
     var withdraw =
         step(withdrawStepName)
-            .call(Withdraw.class, cmd -> componentClient.forKeyValueEntity(cmd.from).method(WalletEntity::withdraw).invoke(cmd.amount))
-            .andThen(String.class, __ -> {
+          .call(Withdraw.class, cmd -> componentClient.forKeyValueEntity(cmd.from).method(WalletEntity::withdraw).invoke(cmd.amount))
+          .andThen(() -> {
               var state = currentState().withLastStep("withdrawn").asAccepted();
 
               var depositInput = new Deposit(currentState().transfer().to(), currentState().transfer().amount());
@@ -45,8 +45,8 @@ public class TransferWorkflow extends Workflow<TransferState> {
 
     var deposit =
         step(depositStepName)
-            .call(Deposit.class, cmd -> componentClient.forKeyValueEntity(cmd.to).method(WalletEntity::deposit).invoke(cmd.amount)
-            ).andThen(String.class, __ -> {
+          .call(Deposit.class, cmd -> componentClient.forKeyValueEntity(cmd.to).method(WalletEntity::deposit).invoke(cmd.amount))
+          .andThen(() -> {
               var state = currentState().withLastStep("deposited").asFinished();
               return effects().updateState(state).end();
             });

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflow.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflow.java
@@ -94,9 +94,6 @@ public class TransferWorkflow extends Workflow<TransferState> {
     return effects().reply(new Message("genericCall ok"));
   }
 
-  public Effect<Boolean> isFinished() {
-    return effects().reply(currentState().finished());
-  }
 
   public Effect<Message> getLastStep() {
     return effects().reply(new Message(currentState().lastStep()));

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflowWithoutInputs.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflowWithoutInputs.java
@@ -31,7 +31,7 @@ public class TransferWorkflowWithoutInputs extends Workflow<TransferState> {
           var transfer = currentState().transfer();
           return componentClient.forKeyValueEntity(transfer.from()).method(WalletEntity::withdraw).invoke(transfer.amount());
         })
-        .andThen(String.class, response -> {
+        .andThen(() -> {
           var state = currentState().withLastStep("withdrawn").asAccepted();
           return effects()
             .updateState(state)
@@ -44,7 +44,7 @@ public class TransferWorkflowWithoutInputs extends Workflow<TransferState> {
           var transfer = currentState().transfer();
           return componentClient.forKeyValueEntity(transfer.from()).method(WalletEntity::withdraw).invokeAsync(transfer.amount());
         })
-        .andThen(String.class, response -> {
+        .andThen(() -> {
           var state = currentState().withLastStep("withdrawn").asAccepted();
           return effects()
             .updateState(state)
@@ -58,7 +58,7 @@ public class TransferWorkflowWithoutInputs extends Workflow<TransferState> {
           var transfer = currentState().transfer();
           return componentClient.forKeyValueEntity(transfer.to()).method(WalletEntity::deposit).invoke(transfer.amount());
         })
-        .andThen(String.class, __ -> {
+        .andThen(() -> {
           var state = currentState().withLastStep("deposited").asFinished();
           return effects().updateState(state).end();
         });
@@ -69,7 +69,7 @@ public class TransferWorkflowWithoutInputs extends Workflow<TransferState> {
           var transfer = currentState().transfer();
           return componentClient.forKeyValueEntity(transfer.to()).method(WalletEntity::deposit).invokeAsync(transfer.amount());
         })
-        .andThen(String.class, __ -> {
+        .andThen(() -> {
           var state = currentState().withLastStep("deposited").asFinished();
           return effects().updateState(state).end();
         });

--- a/akka-javasdk/src/main/java/akka/javasdk/workflow/StepBuilder.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/workflow/StepBuilder.java
@@ -138,6 +138,10 @@ public class StepBuilder {
     public Workflow.CallStep<CallInput, CallOutput, ?> andThen(Class<CallOutput> transitionInputClass, Function<CallOutput, Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
       return new Workflow.CallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
     }
+
+    public Workflow.CallStep<CallInput, CallOutput, ?> andThen(Supplier<Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
+      return new Workflow.CallStep<>(name, callInputClass, callFunc, null, __ -> transitionFunc.get());
+    }
   }
 
   public static class RunnableStepBuilder {
@@ -168,7 +172,6 @@ public class StepBuilder {
       return new Workflow.RunnableStep(name, runnable, transitionFunc);
     }
   }
-
 
   public static class AsyncCallStepBuilder<CallInput, CallOutput> {
 
@@ -203,6 +206,11 @@ public class StepBuilder {
      */
     public Workflow.AsyncCallStep<CallInput, CallOutput, ?> andThen(Class<CallOutput> transitionInputClass, Function<CallOutput, Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
       return new Workflow.AsyncCallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
+    }
+
+    public Workflow.AsyncCallStep<CallInput, CallOutput, ?> andThen(Supplier<
+      Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
+      return new Workflow.AsyncCallStep<>(name, callInputClass, callFunc, null, __ -> transitionFunc.get());
     }
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/workflow/StepBuilder.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/workflow/StepBuilder.java
@@ -82,8 +82,8 @@ public class StepBuilder {
    *
    * @param callInputClass Input class for call factory.
    * @param callFactory    Factory method for creating async call.
-   * @param <Input>        Input for async call factory, provided by transition method.
-   * @param <Output>       Output of async call.
+   * @param <Input>        Input for the async call factory, provided by transition method.
+   * @param <Output>       Output of the async call.
    * @return Step builder.
    */
   public <Input, Output> AsyncCallStepBuilder<Input, Output> asyncCall(Class<Input> callInputClass, Function<Input, CompletionStage<Output>> callFactory) {
@@ -101,7 +101,7 @@ public class StepBuilder {
    * On failure, the step will be retried according to the default retry strategy or the one defined in the step configuration.
    *
    * @param callSupplier Factory method for creating async call.
-   * @param <Output>     Output of async call.
+   * @param <Output>     Output of the async call.
    * @return Step builder.
    */
   public <Output> AsyncCallStepBuilder<Void, Output> asyncCall(Supplier<CompletionStage<Output>> callSupplier) {
@@ -133,12 +133,26 @@ public class StepBuilder {
      *
      * @param transitionInputClass Input class for transition.
      * @param transitionFunc       Function that transform the action result to a {@link Workflow.Effect.TransitionalEffect}
-     * @return AsyncCallStep
+     * @return CallStep
      */
     public Workflow.CallStep<CallInput, CallOutput, ?> andThen(Class<CallOutput> transitionInputClass, Function<CallOutput, Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
       return new Workflow.CallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
     }
 
+    /**
+     * Transition to the next step after the step call completes.
+     * <p>
+     * The {@link Supplier} passed to this method should return an {@link Workflow.Effect.TransitionalEffect}
+     * describing the next step to transition to. Note that the output of the call is not passed to this function.
+     * <p>
+     * When defining the Effect, you can update the workflow state and indicate the next step to transition to.
+     * This can be another step, or a pause or end of the workflow.
+     * <p>
+     * When transition to another step, you can also pass an input parameter to the next step.
+     *
+     * @param transitionFunc       Supplier of {@link Workflow.Effect.TransitionalEffect}
+     * @return CallStep
+     */
     public Workflow.CallStep<CallInput, CallOutput, ?> andThen(Supplier<Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
       return new Workflow.CallStep<>(name, callInputClass, callFunc, null, __ -> transitionFunc.get());
     }
@@ -165,8 +179,8 @@ public class StepBuilder {
      * <p>
      * When transition to another step, you can also pass an input parameter to the next step.
      *
-     * @param transitionFunc       Supplier of{@link Workflow.Effect.TransitionalEffect}
-     * @return AsyncCallStep
+     * @param transitionFunc       Supplier of {@link Workflow.Effect.TransitionalEffect}
+     * @return RunnableStep
      */
     public Workflow.RunnableStep andThen(Supplier<Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
       return new Workflow.RunnableStep(name, runnable, transitionFunc);
@@ -208,8 +222,21 @@ public class StepBuilder {
       return new Workflow.AsyncCallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
     }
 
-    public Workflow.AsyncCallStep<CallInput, CallOutput, ?> andThen(Supplier<
-      Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
+    /**
+     * Transition to the next step after the step call completes.
+     * <p>
+     * The {@link Supplier} passed to this method should return an {@link Workflow.Effect.TransitionalEffect}
+     * describing the next step to transition to. Note that the output of the call is not passed to this function.
+     * <p>
+     * When defining the Effect, you can update the workflow state and indicate the next step to transition to.
+     * This can be another step, or a pause or end of the workflow.
+     * <p>
+     * When transition to another step, you can also pass an input parameter to the next step.
+     *
+     * @param transitionFunc       Supplier of {@link Workflow.Effect.TransitionalEffect}
+     * @return AsyncCallStep
+     */
+    public Workflow.AsyncCallStep<CallInput, CallOutput, ?> andThen(Supplier<Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
       return new Workflow.AsyncCallStep<>(name, callInputClass, callFunc, null, __ -> transitionFunc.get());
     }
   }

--- a/akka-javasdk/src/main/java/akka/javasdk/workflow/StepBuilder.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/workflow/StepBuilder.java
@@ -26,16 +26,15 @@ public class StepBuilder {
   /**
    * Build a step action with a  call.
    * <p>
-   * The {@link Function} passed to this method should return a {@link CompletionStage}.
-   * On successful completion, its result is made available to this workflow via the {@code andThen} method.
+   * The value returned by the call {@link Function} is made available to this workflow via the {@code andThen} method.
    * In the {@code andThen} method, we can use the result to update the workflow state and transition to the next step.
    * <p>
    * On failure, the step will be retried according to the default retry strategy or the one defined in the step configuration.
    *
    * @param callInputClass Input class for call factory.
-   * @param callFactory    Factory method for creating async call.
-   * @param <Input>        Input for async call factory, provided by transition method.
-   * @param <Output>       Output of async call.
+   * @param callFactory    Factory method for creating a call.
+   * @param <Input>        Input for the call factory, provided by transition method.
+   * @param <Output>       Output of the call.
    * @return Step builder.
    */
   public <Input, Output> CallStepBuilder<Input, Output> call(Class<Input> callInputClass, Function<Input, Output> callFactory) {
@@ -45,18 +44,31 @@ public class StepBuilder {
   /**
    * Build a step action with a call.
    * <p>
-   * The {@link Supplier} function passed to this method should return a {@link CompletionStage}.
-   * On successful completion, its result is made available to this workflow via the {@code andThen} method.
+   * The value returned by the {@link Supplier} is made available to this workflow via the {@code andThen} method.
    * In the {@code andThen} method, we can use the result to update the workflow state and transition to the next step.
    * <p>
    * On failure, the step will be retried according to the default retry strategy or the one defined in the step configuration.
    *
-   * @param callSupplier Factory method for creating async call.
-   * @param <Output>     Output of async call.
+   * @param callSupplier Factory method for creating a call.
+   * @param <Output>     Output of the call.
    * @return Step builder.
    */
   public <Output> CallStepBuilder<Void, Output> call(Supplier<Output> callSupplier) {
     return new CallStepBuilder<>(name, Void.class, (Void v) -> callSupplier.get());
+  }
+
+  /**
+   * Build a step action with a call.
+   * <p>
+   * The {@link Runnable} passed to this method is executed and if successful, the {@code andThen} method is called.
+   * In the {@code andThen} method, we can update the workflow state and transition to the next step.
+   * <p>
+   * On failure, the step will be retried according to the default retry strategy or the one defined in the step configuration.
+   *
+   * @return Step builder.
+   */
+  public RunnableStepBuilder call(Runnable runnable) {
+    return new RunnableStepBuilder(name,runnable);
   }
 
   /**
@@ -125,6 +137,35 @@ public class StepBuilder {
      */
     public Workflow.CallStep<CallInput, CallOutput, ?> andThen(Class<CallOutput> transitionInputClass, Function<CallOutput, Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
       return new Workflow.CallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
+    }
+  }
+
+  public static class RunnableStepBuilder {
+    final private String name;
+
+    final private Runnable runnable;
+
+    RunnableStepBuilder(String name, Runnable runnable) {
+      this.name = name;
+      this.runnable = runnable;
+    }
+
+    /**
+     * Transition to the next step after the step call completes.
+     * <p>
+     * The {@link Supplier} passed to this method should return
+     * an {@link Workflow.Effect.TransitionalEffect} describing the next step to transition to.
+     * <p>
+     * When defining the Effect, you can update the workflow state and indicate the next step to transition to.
+     * This can be another step, or a pause or end of the workflow.
+     * <p>
+     * When transition to another step, you can also pass an input parameter to the next step.
+     *
+     * @param transitionFunc       Supplier of{@link Workflow.Effect.TransitionalEffect}
+     * @return AsyncCallStep
+     */
+    public Workflow.RunnableStep andThen(Supplier<Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
+      return new Workflow.RunnableStep(name, runnable, transitionFunc);
     }
   }
 

--- a/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
@@ -525,6 +525,43 @@ public abstract class Workflow<S> {
     }
   }
 
+  public static final class RunnableStep implements Step {
+
+    final private String _name;
+    final public Runnable runnable;
+    final public Supplier<Effect.TransitionalEffect<Void>> transitionFunc;
+    private Optional<Duration> _timeout = Optional.empty();
+
+    /**
+     * Not for direct user construction, instances are created through the workflow DSL
+     */
+    public RunnableStep(String name,
+                        Runnable runnable,
+                        Supplier<Effect.TransitionalEffect<Void>> transitionFunc) {
+      _name = name;
+      this.runnable = runnable;
+      this.transitionFunc = transitionFunc;
+    }
+
+    @Override
+    public String name() {
+      return this._name;
+    }
+
+    @Override
+    public Optional<Duration> timeout() {
+      return this._timeout;
+    }
+
+    /**
+     * Define a step timeout.
+     */
+    public RunnableStep timeout(Duration timeout) {
+      this._timeout = Optional.of(timeout);
+      return this;
+    }
+  }
+
   public static class AsyncCallStep<CallInput, CallOutput, FailoverInput> implements Step {
 
     final private String _name;

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -10,7 +10,6 @@ import java.lang.reflect.Method
 import java.util
 import java.util.Optional
 import java.util.concurrent.CompletionStage
-
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
@@ -78,6 +77,7 @@ import akka.javasdk.timedaction.TimedAction
 import akka.javasdk.timer.TimerScheduler
 import akka.javasdk.view.View
 import akka.javasdk.workflow.Workflow
+import akka.javasdk.workflow.Workflow.RunnableStep
 import akka.javasdk.workflow.WorkflowContext
 import akka.runtime.sdk.spi
 import akka.runtime.sdk.spi.ComponentClients
@@ -443,6 +443,7 @@ private final class Sdk(
               List(asyncCallStep.callInputClass, asyncCallStep.transitionInputClass)
             case callStep: Workflow.CallStep[_, _, _] =>
               List(callStep.callInputClass, callStep.transitionInputClass)
+            case runnable: RunnableStep => List.empty
           }
           .foreach(serializer.registerTypeHints)
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -440,9 +440,11 @@ private final class Sdk(
           .asScala
           .flatMap {
             case asyncCallStep: Workflow.AsyncCallStep[_, _, _] =>
-              List(asyncCallStep.callInputClass, asyncCallStep.transitionInputClass)
+              if (asyncCallStep.transitionInputClass == null) List(asyncCallStep.callInputClass)
+              else List(asyncCallStep.callInputClass, asyncCallStep.transitionInputClass)
             case callStep: Workflow.CallStep[_, _, _] =>
-              List(callStep.callInputClass, callStep.transitionInputClass)
+              if (callStep.transitionInputClass == null) List(callStep.callInputClass)
+              else List(callStep.callInputClass, callStep.transitionInputClass)
             case runnable: RunnableStep => List.empty
           }
           .foreach(serializer.registerTypeHints)


### PR DESCRIPTION
Adds support for passing a `Runnable` in a synchronous calls. 

When using a `Runnable` the corresponding `andThen` will accepts a `Supplier` only. 

