### PR TITLE
chore: pass the sessionId to the memory store

### DIFF
--- a/samples/ask-akka-agent/src/main/java/akka/ask/agent/application/AskAkkaAgent.java
+++ b/samples/ask-akka-agent/src/main/java/akka/ask/agent/application/AskAkkaAgent.java
@@ -121,6 +121,7 @@ public class AskAkkaAgent {
     var chatMemory = MessageWindowChatMemory.builder()
         .maxMessages(2000)
         .chatMemoryStore(chatMemoryStore)
+        .id(sessionId)
         .build();
 
     return AiServices.builder(Assistant.class)


### PR DESCRIPTION
We need to pass the `sessionId` to the chat memory so it can call the store with it. 

Otherwise, it will use `default`, but that won't work because we added the chat history using `sessionId`. 

Basically, when calling the LLM, we were not using the previous chat history.