### PR TITLE
add chatlio div for inserting widget

### DIFF
--- a/docs/supplemental_ui/layouts/default.hbs
+++ b/docs/supplemental_ui/layouts/default.hbs
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+{{> head defaultPageTitle='Untitled'}}
+  </head>
+  <body class="bg-white text-akka-black dark:bg-black dark:text-white article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
+  <chatlio-widget widgetid="b611b988-9e2b-4e36-566e-01a6d042121c"></chatlio-widget>
+{{> header}}
+{{> body}}
+{{> footer}}
+  </body>
+</html>


### PR DESCRIPTION
@beritou this adds the `default.hbs` file into the supplemental ui folder, and we add the `<chatlio-widget widgetid="b611b988-9e2b-4e36-566e-01a6d042121c"></chatlio-widget>` div to the site in preparation for a Chat widget that Nash is going to be testing out on the SDK docs.
