### PR TITLE
fix: typo in javadoc

### DIFF
--- a/samples/ask-akka-agent/src/main/java/akka/ask/agent/api/UiEndpoint.java
+++ b/samples/ask-akka-agent/src/main/java/akka/ask/agent/api/UiEndpoint.java
@@ -7,7 +7,7 @@ import akka.javasdk.annotations.http.HttpEndpoint;
 import akka.javasdk.http.HttpResponses;
 
 /**
- * This Http endpoint return the static UI page located under
+ * This Http endpoint returns the static UI page located under
  * src/main/resources/static-resources/
  */
 // tag::endpoint[]


### PR DESCRIPTION
Sorry for the PR overhead, but I spotted this typo en passant and couldn't let it go.