### PR TITLE
docs: cross link securing endpoints

### DIFF
--- a/docs/src/modules/java/pages/grpc-endpoints.adoc
+++ b/docs/src/modules/java/pages/grpc-endpoints.adoc
@@ -61,7 +61,7 @@ id and the response message only includes the correlation id to not leak service
 
 == Securing gRPC endpoints ==
 
-Akka's HTTP endpoints can be secured by multiple approaches:
+Akka's gRPC endpoints can be secured by multiple approaches:
 
 . xref:java:access-control.adoc[]
 . xref:security:jwts.adoc[]

--- a/docs/src/modules/java/pages/grpc-endpoints.adoc
+++ b/docs/src/modules/java/pages/grpc-endpoints.adoc
@@ -59,6 +59,14 @@ In addition to the special `GrpcServiceException` and `StatusRuntimeException`, 
 id and the response message only includes the correlation id to not leak service internals to an untrusted client.
 ** In local development and integration tests the full exception is returned as response body.
 
+== Securing gRPC endpoints ==
+
+Akka's HTTP endpoints can be secured by multiple approaches:
+
+. xref:java:access-control.adoc[]
+. xref:security:jwts.adoc[]
+. xref:security:tls-certificates.adoc[]
+
 == Interacting with other components ==
 
 Endpoints are commonly used to interact with other components in a service. This is done through
@@ -177,3 +185,8 @@ Dropping fields will not be _source compatible_, since the generated Java class 
 along with the protobuf message change, once a protocol file with name changes is introduced in a service it will need
 updates to the code wherever it is accessing the old field.
 
+== See also
+
+- xref:java:access-control.adoc[]
+- xref:security:jwts.adoc[]
+- xref:security:tls-certificates.adoc[]

--- a/docs/src/modules/java/pages/http-endpoints.adoc
+++ b/docs/src/modules/java/pages/http-endpoints.adoc
@@ -141,6 +141,14 @@ In addition to the special `HttpException`s, exceptions are handled like this:
 id and the response message only includes the correlation id to not leak service internals to an untrusted client.
 ** In local development and integration tests the full exception is returned as response body.
 
+== Securing HTTP endpoints ==
+
+Akka's HTTP endpoints can be secured by multiple approaches:
+
+. xref:java:access-control.adoc[]
+. xref:security:jwts.adoc[]
+. xref:security:tls-certificates.adoc[]
+. xref:operations:services/invoke-service.adoc#_http_basic_authentication[HTTP Basic authentication]
 
 == Interacting with other components ==
 
@@ -354,4 +362,6 @@ This uses more advanced Akka stream operators, you can find more details of thos
 == See also
 
 - xref:java:access-control.adoc[]
+- xref:security:jwts.adoc[]
 - xref:security:tls-certificates.adoc[]
+- xref:operations:services/invoke-service.adoc#_http_basic_authentication[HTTP Basic authentication]


### PR DESCRIPTION
Users had a hard time to discover the means to protect endpoints. Cross linking should help.