### PR TITLE
feat: Mandatory sessionId

### DIFF
--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -40,7 +40,7 @@
 
         <!-- These are dependent on runtime environment and cannot be customized by users -->
         <maven.compiler.release>21</maven.compiler.release>
-        <akka-runtime.version>1.4.12-8a1cf3db0-1-fc2a9c87-SNAPSHOT</akka-runtime.version>
+        <akka-runtime.version>1.4.12-544d5c162</akka-runtime.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skip.docker>false</skip.docker>

--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -40,7 +40,7 @@
 
         <!-- These are dependent on runtime environment and cannot be customized by users -->
         <maven.compiler.release>21</maven.compiler.release>
-        <akka-runtime.version>1.4.12-8a1cf3db0</akka-runtime.version>
+        <akka-runtime.version>1.4.12-8a1cf3db0-1-fc2a9c87-SNAPSHOT</akka-runtime.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skip.docker>false</skip.docker>

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/AgentContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/AgentContext.java
@@ -10,9 +10,7 @@ import akka.javasdk.Tracing;
 import java.util.Optional;
 
 public interface AgentContext extends MetadataContext {
-  /**
-   * The agent participates in a session, which is used for the agent's conversational memory.
-   */
+  /** The agent participates in a session, which is used for the agent's conversational memory. */
   String sessionId();
 
   /** Access to tracing for custom app specific tracing. */

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/AgentContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/AgentContext.java
@@ -11,9 +11,9 @@ import java.util.Optional;
 
 public interface AgentContext extends MetadataContext {
   /**
-   * The agent may participate in a session, which is used for the agent's conversational memory.
+   * The agent participates in a session, which is used for the agent's conversational memory.
    */
-  Optional<String> sessionId();
+  String sessionId();
 
   /** Access to tracing for custom app specific tracing. */
   Tracing tracing();

--- a/akka-javasdk/src/main/java/akka/javasdk/client/AgentClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/AgentClient.java
@@ -5,9 +5,6 @@
 package akka.javasdk.client;
 
 import akka.annotation.DoNotInherit;
-import akka.japi.function.Function;
-import akka.japi.function.Function2;
-import akka.javasdk.agent.Agent;
 
 /**
  * Not for user extension
@@ -16,14 +13,8 @@ import akka.javasdk.agent.Agent;
 public interface AgentClient {
 
   /**
-   * Pass in an Agent command handler method reference, e.g. {@code SummarizerAgent::summarizeSession}
+   * The agent participates in a session, which is used for the agent's conversational memory.
    */
-  <T, R> ComponentMethodRef<R> method(Function<T, Agent.Effect<R>> methodRef);
-
-  /**
-   * Pass in an Agent command handler method reference, e.g. {@code PlannerAgent::plan}
-   */
-  <T, A1, R> ComponentMethodRef1<A1, R> method(Function2<T, A1, Agent.Effect<R>> methodRef);
-
+  AgentClientInSession inSession(String sessionId);
 
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/client/AgentClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/AgentClient.java
@@ -6,15 +6,10 @@ package akka.javasdk.client;
 
 import akka.annotation.DoNotInherit;
 
-/**
- * Not for user extension
- */
+/** Not for user extension */
 @DoNotInherit
 public interface AgentClient {
 
-  /**
-   * The agent participates in a session, which is used for the agent's conversational memory.
-   */
+  /** The agent participates in a session, which is used for the agent's conversational memory. */
   AgentClientInSession inSession(String sessionId);
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/client/AgentClientInSession.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/AgentClientInSession.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2021-2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.client;
+
+import akka.annotation.DoNotInherit;
+import akka.japi.function.Function;
+import akka.japi.function.Function2;
+import akka.javasdk.agent.Agent;
+
+/**
+ * Not for user extension
+ */
+@DoNotInherit
+public interface AgentClientInSession {
+
+  /**
+   * Pass in an Agent command handler method reference, e.g. {@code SummarizerAgent::summarizeSession}
+   */
+  <T, R> ComponentMethodRef<R> method(Function<T, Agent.Effect<R>> methodRef);
+
+  /**
+   * Pass in an Agent command handler method reference, e.g. {@code PlannerAgent::plan}
+   */
+  <T, A1, R> ComponentMethodRef1<A1, R> method(Function2<T, A1, Agent.Effect<R>> methodRef);
+
+}

--- a/akka-javasdk/src/main/java/akka/javasdk/client/ComponentClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/ComponentClient.java
@@ -62,10 +62,7 @@ public interface ComponentClient {
 
   /**
    * Select {@link Agent} as a call target component.
-   *
-   * @param sessionId - The agent participates in a session, which is used for the agent's
-   *     conversational memory.
    */
-  AgentClient forAgent(String sessionId);
+  AgentClient forAgent();
 
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/client/ComponentClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/ComponentClient.java
@@ -60,9 +60,6 @@ public interface ComponentClient {
   /** Select {@link akka.javasdk.view.View} as a call target component. */
   ViewClient forView();
 
-  /**
-   * Select {@link Agent} as a call target component.
-   */
+  /** Select {@link Agent} as a call target component. */
   AgentClient forAgent();
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/client/ComponentClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/ComponentClient.java
@@ -7,8 +7,6 @@ package akka.javasdk.client;
 import akka.annotation.DoNotInherit;
 import akka.javasdk.agent.Agent;
 
-import java.util.Optional;
-
 /**
  * Utility to send requests to other components by composing a call that can be executed by the
  * runtime. To compose a call:
@@ -65,16 +63,9 @@ public interface ComponentClient {
   /**
    * Select {@link Agent} as a call target component.
    *
-   * @param sessionId - The agent may participate in a session, which is used for the agent's
-   *     conversational memory.
-   */
-  AgentClient forAgent(Optional<String> sessionId);
-
-  /**
-   * Select {@link Agent} as a call target component.
-   *
-   * @param sessionId - The agent will participate in this session, which is used for the agent's
+   * @param sessionId - The agent participates in a session, which is used for the agent's
    *     conversational memory.
    */
   AgentClient forAgent(String sessionId);
+
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -638,7 +638,7 @@ private final class Sdk(
         val instanceFactory: SpiAgent.FactoryContext => SpiAgent = { factoryContext =>
           new AgentImpl(
             componentId,
-            factoryContext.sessionId.toJava,
+            factoryContext.sessionId,
             context =>
               wiredInstance(agentClass) {
                 (sideEffectingComponentInjects(None)).orElse {

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
@@ -4,8 +4,6 @@
 
 package akka.javasdk.impl.agent
 
-import java.util.Optional
-
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
@@ -51,7 +49,7 @@ private[impl] object AgentImpl {
   private val log = LoggerFactory.getLogger(classOf[AgentImpl[_]])
 
   private class AgentContextImpl(
-      override val sessionId: Optional[String],
+      override val sessionId: String,
       override val selfRegion: String,
       override val metadata: Metadata,
       span: Option[Span],
@@ -69,7 +67,7 @@ private[impl] object AgentImpl {
 @InternalApi
 private[impl] final class AgentImpl[A <: Agent](
     componentId: String,
-    sessionId: Optional[String],
+    sessionId: String,
     val factory: AgentContext => A,
     tracerFactory: () => Tracer,
     serializer: JsonSerializer,

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AgentClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AgentClientImpl.scala
@@ -32,7 +32,7 @@ private[javasdk] final case class AgentClientImpl(
     agentClient: RuntimeAgentClient,
     serializer: JsonSerializer,
     callMetadata: Option[Metadata],
-    sessionId: Option[String])(implicit val executionContext: ExecutionContext, system: ActorSystem[_])
+    sessionId: String)(implicit val executionContext: ExecutionContext, system: ActorSystem[_])
     extends AgentClient {
 
   override def method[T, R](methodRef: function.Function[T, Agent.Effect[R]]): ComponentMethodRef[R] =

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AgentClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AgentClientImpl.scala
@@ -13,6 +13,7 @@ import akka.japi.function
 import akka.javasdk.Metadata
 import akka.javasdk.agent.Agent
 import akka.javasdk.client.AgentClient
+import akka.javasdk.client.AgentClientInSession
 import akka.javasdk.client.ComponentMethodRef
 import akka.javasdk.client.ComponentMethodRef1
 import akka.javasdk.impl.ComponentDescriptorFactory
@@ -33,7 +34,14 @@ private[javasdk] final case class AgentClientImpl(
     serializer: JsonSerializer,
     callMetadata: Option[Metadata],
     sessionId: String)(implicit val executionContext: ExecutionContext, system: ActorSystem[_])
-    extends AgentClient {
+    extends AgentClient
+    with AgentClientInSession {
+
+  override def inSession(sessionId: String): AgentClientInSession = {
+    if ((sessionId eq null) || sessionId.trim.isBlank)
+      throw new IllegalArgumentException("sessionId must be defined")
+    AgentClientImpl(agentClient, serializer, callMetadata, sessionId)
+  }
 
   override def method[T, R](methodRef: function.Function[T, Agent.Effect[R]]): ComponentMethodRef[R] =
     createMethodRef[R](methodRef)
@@ -107,4 +115,5 @@ private[javasdk] final case class AgentClientImpl(
       .asInstanceOf[ComponentMethodRefImpl[A1, R]]
 
   }
+
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ComponentClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ComponentClientImpl.scala
@@ -4,9 +4,6 @@
 
 package akka.javasdk.impl.client
 
-import java.util.Optional
-import scala.jdk.OptionConverters._
-
 import akka.annotation.InternalApi
 import akka.javasdk.Metadata
 import akka.javasdk.client.ComponentClient
@@ -72,13 +69,10 @@ private[javasdk] final case class ComponentClientImpl(
 
   override def forView(): ViewClient = ViewClientImpl(runtimeComponentClients.viewClient, serializer, callMetadata)
 
-  override def forAgent(sessionId: Optional[String]): AgentClient =
-    AgentClientImpl(runtimeComponentClients.agentClient, serializer, callMetadata, sessionId.toScala)
-
   override def forAgent(sessionId: String): AgentClient = {
     if ((sessionId eq null) || sessionId.trim.isBlank)
-      forAgent(sessionId = Optional.empty[String])
-    else
-      forAgent(Optional.ofNullable(sessionId))
+      throw new IllegalArgumentException("sessionId must be defined")
+    AgentClientImpl(runtimeComponentClients.agentClient, serializer, callMetadata, sessionId)
   }
+
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ComponentClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ComponentClientImpl.scala
@@ -69,10 +69,7 @@ private[javasdk] final case class ComponentClientImpl(
 
   override def forView(): ViewClient = ViewClientImpl(runtimeComponentClients.viewClient, serializer, callMetadata)
 
-  override def forAgent(sessionId: String): AgentClient = {
-    if ((sessionId eq null) || sessionId.trim.isBlank)
-      throw new IllegalArgumentException("sessionId must be defined")
-    AgentClientImpl(runtimeComponentClients.agentClient, serializer, callMetadata, sessionId)
-  }
+  override def forAgent(): AgentClient =
+    AgentClientImpl(runtimeComponentClients.agentClient, serializer, callMetadata, sessionId = "")
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val ProtocolVersionMinor = 1
   }
   // Remember to bump akka-runtime.version in akka-javasdk-maven/akka-javasdk-parent if bumping this
-  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.4.12-8a1cf3db0-1-fc2a9c87-SNAPSHOT")
+  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.4.12-544d5c162")
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned
   // for prod code, they are marked as Provided, but testkit still requires the alignment

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val ProtocolVersionMinor = 1
   }
   // Remember to bump akka-runtime.version in akka-javasdk-maven/akka-javasdk-parent if bumping this
-  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.4.12-8a1cf3db0")
+  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.4.12-8a1cf3db0-1-fc2a9c87-SNAPSHOT")
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned
   // for prod code, they are marked as Provided, but testkit still requires the alignment

--- a/samples/ask-akka-agent/pom.xml
+++ b/samples/ask-akka-agent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.akka</groupId>
         <artifactId>akka-javasdk-parent</artifactId>
-        <version>3.3.1-31-01f449b0-SNAPSHOT</version>
+        <version>3.3.1-25-caff44f3-dev-SNAPSHOT</version>
     </parent>
 
     <groupId>akka.ask</groupId>

--- a/samples/ask-akka-agent/src/main/java/akka/ask/agent/api/AskHttpEndpoint.java
+++ b/samples/ask-akka-agent/src/main/java/akka/ask/agent/api/AskHttpEndpoint.java
@@ -48,7 +48,7 @@ public class AskHttpEndpoint {
   @Post("/new-ask") // FIXME
   public String newAsk(QueryRequest request) {
     return componentClient
-        .forAgent(Optional.of(request.sessionId()))
+        .forAgent(request.sessionId())
         .method(NewAskAkkaAgent::ask)
         .invoke(request.question);
   }
@@ -56,7 +56,7 @@ public class AskHttpEndpoint {
   @Post("/new-ask-structured") // FIXME
   public StructuredAskAkkaAgent.Response newAskStructured(QueryRequest request) {
     return componentClient
-        .forAgent(Optional.of(request.sessionId()))
+        .forAgent(request.sessionId())
         .method(StructuredAskAkkaAgent::ask)
         .invoke(request.question);
   }

--- a/samples/ask-akka-agent/src/main/java/akka/ask/agent/api/AskHttpEndpoint.java
+++ b/samples/ask-akka-agent/src/main/java/akka/ask/agent/api/AskHttpEndpoint.java
@@ -48,7 +48,8 @@ public class AskHttpEndpoint {
   @Post("/new-ask") // FIXME
   public String newAsk(QueryRequest request) {
     return componentClient
-        .forAgent(request.sessionId())
+        .forAgent()
+        .inSession(request.sessionId())
         .method(NewAskAkkaAgent::ask)
         .invoke(request.question);
   }
@@ -56,7 +57,8 @@ public class AskHttpEndpoint {
   @Post("/new-ask-structured") // FIXME
   public StructuredAskAkkaAgent.Response newAskStructured(QueryRequest request) {
     return componentClient
-        .forAgent(request.sessionId())
+        .forAgent()
+        .inSession(request.sessionId())
         .method(StructuredAskAkkaAgent::ask)
         .invoke(request.question);
   }


### PR DESCRIPTION
* and another way of defining the sessionId in the agent component client

With the session we can correlate agents and conversations that participate in the same overall task. That is important for understanding what is going on and for eval. A standalone agent that is not having a conversation or collaboration should be extremely rare. If that is still needed it's just a matter of creating a new uuid for that call.

We intend to use the sessionId for connecting to our built in conversational memory, but that is not the reason why I want to make it mandatory. It's the above tracking that is most important.