### PR TITLE
docs: overhaul landing page for agentic AI

### DIFF
--- a/docs/src/modules/ROOT/pages/index.adoc
+++ b/docs/src/modules/ROOT/pages/index.adoc
@@ -1,66 +1,75 @@
-= Welcome to Akka
+= Build Agentic AI Systems with Akka
 
-Akka is designed for building and running responsive applications. It adheres to the *Reactive Principles*, which promote creating services and systems that are elastic, agile, and resilient.
+Akka is a platform for designing, building, operating and continuously reasoning about AI systems composed of autonomous, stateful agents that embrace uncertainty and randomness by design.
 
-== Key Principles
-* *Elastic*: Akka applications automatically scale to varying workloads and position active-active replicas close to users.
-* *Agile*: Akka allows for updates, rebalancing, and repartitioning of workloads, enabling no-downtime maintenance.
-* *Resilient*: Akka applications function as self-managed in-memory databases, ensuring recoverability and replicability to handle potential failures.
+[.akka-docs-homepage-grid]
+====
 
-== Development and Operations
-Akka Platform simplifies the development and operation of responsive applications by providing libraries, components, sandboxes, buildpacks, and a cloud runtime. Akka Platform manages infrastructure to ensure elasticity, agility, and resilience, allowing applications to achieve their Service Level Agreement (SLA) goals. This includes managing database persistence, networking, clustering, and orchestration.
+[.grid-item]
+--
+[discrete]
+== 📘 Start with a tutorial
 
-Alternatively, Akka applications written with the Akka SDK or the Akka Libraries can run self-hosted on any infrastructure.
+Quick, hands-on paths to build your first agentic service.
 
-Akka applications are inherently event-driven, allowing developers to focus on building durable, stateful services without needing to navigate complex messaging or asynchronous programming issues. A new developer can design and implement stateful services within a day, achieving low latency and burstable performance of up to 1 million input/output operations per second (IOPS). This is made possible by integrating microservices best practices into the application and runtime transparently.
+* xref:java:author-your-first-service.adoc[Author your first agentic service]: Start from scratch with the Akka SDK.
+* xref:java:shopping-cart/quickstart.adoc[Explore a complete example]: Learn from a real-world agentic system.
+* https://console.akka.io/register[Try Akka in the browser]: Deploy and replicate a sample service in minutes.
+* xref:java:running-locally.adoc[Run and debug locally]: Use the local console, inspect memory, and trace behavior.
+--
 
-== Building Akka Applications
-There are two ways to build applications with Akka:
+[.grid-item]
+--
+[discrete]
+== 🛠 Solve a specific task
 
-=== Akka SDK
-The Akka software development kit (SDK) includes components with a local console, debugger, and runtime. The components let you build durable, transactional, real-time services. It enforces separation of domain logic from infrastructure concerns.
+Step-by-step guides for common development and operations workflows.
 
-Applications built with the Akka SDK can -- _without any changes_ -- operate simultaneously across **multiple regions**, even across **multiple cloud providers**. Customers can also set up private regions operating in their cloud accounts.
+* Generate agents from prompts using LLMs and the Akka AI Coding Kit.
+* Add memory to agents (session-based, persistent, or shared).
+* Deploy agents across regions and cloud environments.
+* Integrate LLMs, external tools, and orchestrate workflows.
+* Visualize and evaluate agent behavior using Akka EvalOps.
+--
 
-=== Akka Libraries
-* *Overview*: The libraries are open-source modules that are foundational for creating distributed systems including actors, networking, streams, persistence, and clustering.
-* *Operations*: Services built with these libraries are self-managed with DevOps packaging them into microservices runtime bundles. They do not operate within Akka's Serverless, BYOC, or Self-Hosted environments.
+[.grid-item]
+--
+[discrete]
+== 📑 Explore APIs and components
 
-== Developer Experience
-Developers need only Java 21 and Maven as dependencies. The Akka SDK build process automatically pulls the necessary modules, enabling inter-service communication without complex orchestration. Local services include an embedded persistence store for creating distributed entities.
+Documentation for building, deploying, and evaluating agentic systems.
 
-Developers can access a local console that replicates runtime observability, tracing, and debugging capabilities. Applications can be pushed directly to a cloud runtime or deployed via a Continuous Integration/Continuous Deployment (CI/CD) pipeline.
+* SDK components: `Agent`, `Entity`, `Workflow`, `Timer`, `View`, `Consumer`, `Endpoint`
+* Memory models and evaluation hooks
+* A2A (Agent-to-Agent) protocol support
+* EvalOps: metrics, traces, reasoning paths
+* Runtime and deployment configurations
+* Akka libraries: Actors, Streams, Clustering, Persistence
+--
 
-== DevOps Operations
-Operators can configure application elasticity without deep architectural knowledge. Akka Platform automates instance management to meet traffic needs while preserving performance SLAs. Services can be replicated xref:concepts:multi-region.adoc[across multiple regions], spanning different geographies and environments.
-Stateful services can be read-replicated or write-replicated with conflict resolution options. Services can migrate between locations without downtime and can be restarted from specific points in time.
-Developers have access to a component library for creating various application types, including transactional, durable, Artificial Intelligence (AI), Retrieval-Augmented Generation (RAG), analytics, edge, event-sourced, and streaming applications.
+[.grid-item]
+--
+[discrete]
+== 💡 Understand the Akka agentic model
 
-== Key Components
-* *Entities*: Act as in-memory databases, either event-sourced or key-value.
-* *Endpoints*: Expose your services to the outside world, functioning similarly to Cloudflare Workers when deployed xref:concepts:multi-region.adoc[across multiple regions].
-* *Timed Actions*: Scheduled executions that are reliable and guaranteed to run at least once.
-* *Views*: Streaming projections that implement the Command Query Responsibility Segregation (CQRS) pattern, separating reads from writes across multiple services.
-* *Workflows*: Durable, long-running processes orchestrated through Saga patterns.
+Key concepts and the vision behind the Agentic AI Platform.
 
-== Interoperability and Integration
-Akka applications seamlessly integrate into larger service ecosystems. Components communicate via a typed _Component_ _Client_, and services can advertise state changes through events, ensuring reliable data replication and decoupled messaging.
+* *What is Agentic AI?*  
+  Agents making decisions from distributed state and LLM output.
 
-== Streaming
-Akka's event-sourced model is fundamentally streaming-based, providing a robust framework for handling events. Akka integrates with many messaging brokers to both interface with the outside world and to bring the benefits of Akka to non-Akka platforms and software. 
+* *The Akka advantage:*  
+  Most platforms lack memory models, reasoning observability, or evaluation tools.
 
-== Getting Started with Akka
-There are multiple ways to get started with Akka.
+* *DevEx: from vibe to power:*  
+  Start with a prompt, evolve with AI assistance, or build in code.
 
-* Hands-on
-** *Deploy, scale, and replicate a pre-built service.* Take the 5 minute walk-through by creating a free account at https://console.akka.io/register[akka.io].
-** *Implement a "Hello World" service.* xref:java:author-your-first-service.adoc[].
-** *Review a pre-built service implementation.* See some Akka components in the xref:java:shopping-cart/quickstart.adoc[].
+* *The Akka component model:*  
+  Components for building, operating, and evaluating intelligent, adaptive systems where uncertainty is a first-class concern.
 
-* Understand
-** ... the Akka xref:concepts:architecture-model.adoc[] for architects and developers.
-** ... the Akka xref:concepts:deployment-model.adoc[] for operators.
-** ... the Akka xref:concepts:development-process.adoc[].
-* *Start a local development environment* Getting started with Integrated Development Environment (IDE) integration, local debugging, and packing services into images. See xref:java:running-locally.adoc[].
-* *Setup* CI/CD pipelines, external Docker repositories, external messaging brokers, or 3rd party observability.
-See xref:operations:index.adoc[Operating Services] for more information.
+* *OpsEx and EvalOps:*  
+  Tools for resilience, observability, and debugging across the system.
+--
+
+====
+
+Ready to build? xref:java:author-your-first-service.adoc[Start here →]

--- a/docs/src/modules/ROOT/pages/index.adoc
+++ b/docs/src/modules/ROOT/pages/index.adoc
@@ -41,7 +41,8 @@ Documentation for building, deploying, and evaluating agentic systems.
 
 * SDK components: `Agent`, `Entity`, `Workflow`, `Timer`, `View`, `Consumer`, `Endpoint`
 * Memory models and evaluation hooks
-* A2A (Agent-to-Agent) protocol support
+* Model Context Protocol (MCP) support
+* Agent2Agent (A2A) protocol support
 * EvalOps: metrics, traces, reasoning paths
 * Runtime and deployment configurations
 * Akka libraries: Actors, Streams, Clustering, Persistence

--- a/docs/src/modules/ROOT/pages/index.adoc
+++ b/docs/src/modules/ROOT/pages/index.adoc
@@ -26,7 +26,7 @@ Quick, hands-on paths to build your first agentic service.
 Step-by-step guides for common development and operations workflows.
 
 * Generate agents from prompts using LLMs and the Akka AI Coding Kit.
-* Add memory to agents (session-based, persistent, or shared).
+* Add memory to agents (session-based, persistent and shared).
 * Deploy agents across regions and cloud environments.
 * Integrate LLMs, external tools, and orchestrate workflows.
 * Visualize and evaluate agent behavior using Akka EvalOps.


### PR DESCRIPTION
Reframe opening headline and introduction.

Replace legacy sections about reactive principles and traditional deployment with new sections.

Emphasize lifecycle support from prompt, to production, to evaluation.

Refs: lightbend/kalix#13504

![image](https://github.com/user-attachments/assets/5ae0d64e-625a-4a58-ac6d-c8a9b64ffc7a)