### PR TITLE
chore: make collision of typename with user less likely

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/agent/PromptTemplate.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/PromptTemplate.java
@@ -31,11 +31,11 @@ public final class PromptTemplate extends EventSourcedEntity<PromptTemplate.Prom
   }
 
   public sealed interface Event {
-    @TypeName("updated")
+    @TypeName("akka-prompt-updated")
     record Updated(String prompt) implements Event {
     }
 
-    @TypeName("deleted")
+    @TypeName("akka-prompt-deleted")
     record Deleted() implements Event {
     }
   }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMemoryEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMemoryEntity.java
@@ -30,7 +30,7 @@ import static akka.Done.done;
  * The maximum number of entries in the history can be set dynamically with command setLimitedWindow.
  * {@link akka.javasdk.client.ComponentClient} can be used to interact directly with this entity.
  */
-@ComponentId("akka-conversation-memory")
+@ComponentId("akka-session-memory")
 public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> {
 
   private static final Logger log = LoggerFactory.getLogger(SessionMemoryEntity.class);


### PR DESCRIPTION
I mentioned this issue before but didn't raise an issue and now I would rather fix it before we do a 1st release of the Agent things.

For the long run, I think we can now automatically scope the type names using the componentId as prefix but maybe that was not possible when we first implemented this.