### PR TITLE
build: Use original branch for workflow_run

### DIFF
--- a/.github/workflows/pr-akka-samples.yml
+++ b/.github/workflows/pr-akka-samples.yml
@@ -43,6 +43,8 @@ jobs:
         # v4.1.1
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
+          # Use the same branch/commit as the original workflow when triggered by workflow_run
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
@@ -117,6 +119,8 @@ jobs:
         # v4.1.1
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
+          # Use the same branch/commit as the original workflow when triggered by workflow_run
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 

--- a/.github/workflows/publish-sample-images.yml
+++ b/.github/workflows/publish-sample-images.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
+          # Use the same branch/commit as the original workflow when triggered by workflow_run
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
           fetch-depth: 0
 
       - name: Check latest tag pattern
@@ -51,6 +53,8 @@ jobs:
         # v4.1.1
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
+          # Use the same branch/commit as the original workflow when triggered by workflow_run
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 


### PR DESCRIPTION
https://github.com/akka/akka-sdk/pull/494 didn't work as intended when publishing 3.4.0-M1 because it was running from main and therefore the tag was 3.3.2. I think that was harmless, since that image from main should be fine.

This change will make it use the same branch as the original workflow.