### PR TITLE
chore: Remove AgentInfoCollection

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/AgentIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/AgentIntegrationTest.java
@@ -120,9 +120,9 @@ public class AgentIntegrationTest extends TestKitSupport {
 
   @Test
   public void shouldIncludeAgentsInRegistry() {
-    assertThat(testKit.getAgentRegistry().allAgents().agents().stream().map(AgentRegistry.AgentInfo::id).toList())
+    assertThat(testKit.getAgentRegistry().allAgents().stream().map(AgentRegistry.AgentInfo::id).toList())
         .contains("some-agent", "some-streaming-agent", "structured-response-agent");
-    assertThat(testKit.getAgentRegistry().agentsWithRole("streaming").agents().stream().map(AgentRegistry.AgentInfo::id).toList())
+    assertThat(testKit.getAgentRegistry().agentsWithRole("streaming").stream().map(AgentRegistry.AgentInfo::id).toList())
         .isEqualTo(List.of("some-streaming-agent"));
 
     var someStructuredInfo = testKit.getAgentRegistry().agentInfo("structured-response-agent");

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/AgentRegistry.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/AgentRegistry.java
@@ -36,15 +36,13 @@ public interface AgentRegistry {
     }
   }
 
-  record AgentInfoCollection(Set<AgentInfo> agents) {}
-
   /**
    * Information about All agents. The agent id is defined with the {@link
    * akka.javasdk.annotations.ComponentId} annotation on the agent class.
    * Additional information is defined with the {@link akka.javasdk.annotations.AgentDescription}
    * annotation on the agent class.
    */
-  AgentInfoCollection allAgents();
+  Set<AgentInfo> allAgents();
 
   /**
    * Agent identifiers of agents with a certain role. The role is defined with {@link
@@ -53,7 +51,7 @@ public interface AgentRegistry {
    * Additional information is defined with the {@link akka.javasdk.annotations.AgentDescription}
    * annotation on the agent class.
    */
-  AgentInfoCollection agentsWithRole(String role);
+  Set<AgentInfo> agentsWithRole(String role);
 
   /**
    * Information about a given agent. The agent id is defined with the {@link

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentRegistryImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentRegistryImpl.scala
@@ -4,13 +4,14 @@
 
 package akka.javasdk.impl.agent
 
+import java.util.{ Set => JSet }
+
 import scala.jdk.CollectionConverters._
 
 import akka.annotation.InternalApi
 import akka.javasdk.agent.Agent
 import akka.javasdk.agent.AgentRegistry
 import akka.javasdk.agent.AgentRegistry.AgentInfo
-import akka.javasdk.agent.AgentRegistry.AgentInfoCollection
 
 /**
  * INTERNAL API
@@ -32,11 +33,11 @@ import akka.javasdk.agent.AgentRegistry.AgentInfoCollection
 
   val agentClassById: Map[String, Class[Agent]] = agents.iterator.map(a => a.id -> a.agentClass).toMap
 
-  override def allAgents(): AgentInfoCollection =
-    new AgentInfoCollection(agentInfoById.values.toSet.asJava)
+  override def allAgents(): JSet[AgentInfo] =
+    agentInfoById.values.toSet.asJava
 
-  override def agentsWithRole(role: String): AgentInfoCollection =
-    new AgentInfoCollection(agentInfoById.values.iterator.filter(_.hasRole(role)).toSet.asJava)
+  override def agentsWithRole(role: String): JSet[AgentInfo] =
+    agentInfoById.values.iterator.filter(_.hasRole(role)).toSet.asJava
 
   override def agentInfo(agentId: String): AgentInfo = {
     agentInfoById.getOrElse(


### PR DESCRIPTION
* I had the wrong impression that Jackson couldn't format a generic collection
