### PR TITLE
docs: fix formatting issue in session memory

### DIFF
--- a/docs/src/modules/java/pages/agents.adoc
+++ b/docs/src/modules/java/pages/agents.adoc
@@ -234,16 +234,14 @@ akka.javasdk.agent.memory {
 
 Or you can configure memory behavior for specific agent interactions using the `MemoryProvider` API.
 
-* Example with `limitedWindow` memory provider:
-+
+Example with `limitedWindow` memory provider:
 [source,java]
 ----
 include::example$doc-snippets/src/main/java/com/example/application/MyAgent.java[tag=read-last]
 ----
 
 
-* Example disabling session memory for the agent:
-+
+Example disabling session memory for the agent:
 [source,java]
 ----
 include::example$doc-snippets/src/main/java/com/example/application/MyAgent.java[tag=no-memory]


### PR DESCRIPTION
Fix this:
<img width="520" alt="Screenshot 2025-06-11 at 15 28 58" src="https://github.com/user-attachments/assets/0ebfe04c-e831-465c-acd6-937845c32b18" />
