### PR TITLE
fix: map tool request and responses to context msg

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMessage.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMessage.java
@@ -48,7 +48,14 @@ public sealed interface SessionMessage {
 
     @Override
     public int size() {
-      return text.length();
+      var textLength = text == null ? 0 : text.length();
+      // calculating the length of tool call requests arguments
+      // NOTE: not accounting for the real payload, only the arguments
+      int argsLength = toolCallRequests == null ? 0 : toolCallRequests.stream()
+          .mapToInt(req -> req.arguments() == null ? 0 : req.arguments().length())
+          .sum();
+
+      return textLength + argsLength;
     }
   }
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
@@ -163,7 +163,7 @@ private[impl] final class AgentImpl[A <: Agent](
               systemMessage,
               req.userMessage,
               additionalContext,
-              functionDescriptors,
+              toolDescriptors,
               Seq.empty, // FIXME mcp tool endpoints
               req.responseType,
               req.responseMapping,


### PR DESCRIPTION
Maps the tool request and responses from session memory back to runtime SPI format.

Draft because waiting for runtime pre-release.