### PR TITLE
feat: ValueAlias to reduce annotation verbosity

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/FunctionTool.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/FunctionTool.java
@@ -16,5 +16,9 @@ import java.lang.annotation.Target;
 public @interface FunctionTool {
 
   String name() default "";
-  String description();
+
+  String value() default "";
+
+  @ValueAlias
+  String description() default "";;
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/ValueAlias.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/ValueAlias.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021-2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated annotation method serves as an alias for the {@code value()} method.
+ * <p>
+ * When used in a custom annotation, this marker allows a field to act as an alternative to the {@code value()} field.
+ * Only one of {@code value()} or the field annotated with {@code @ValueAlias} should be set at a time.
+ * If both are set, an {@link IllegalArgumentException} should be thrown by utilities processing the annotation.
+ * </p>
+ *
+ * <p>
+ * Example usage:
+ * <pre>
+ * &#64;interface MyAnnotation {
+ *     String value() default "";
+ *     &#64;ValueAlias
+ *     String name() default "";
+ * }
+ * </pre>
+ * </p>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ValueAlias {}

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/ValueAlias.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/ValueAlias.java
@@ -32,4 +32,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface ValueAlias {}
+public @interface ValueAlias {
+  boolean required() default true;
+}

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ToolDescriptors.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ToolDescriptors.scala
@@ -7,6 +7,7 @@ package akka.javasdk.impl.agent
 import akka.annotation.InternalApi
 import akka.javasdk.annotations.FunctionTool
 import akka.javasdk.impl.JsonSchema
+import akka.javasdk.impl.reflection.Reflect
 import akka.javasdk.impl.reflection.Reflect.Syntax.AnnotatedElementOps
 import akka.runtime.sdk.spi.SpiAgent
 
@@ -32,7 +33,8 @@ object ToolDescriptors {
           else toolAnno.name()
         val objSchema = JsonSchema.jsonSchemaFor(method)
 
-        new SpiAgent.ToolDescriptor(name, toolAnno.description(), schema = objSchema)
+        val description = Reflect.valueOrAlias(toolAnno)
+        new SpiAgent.ToolDescriptor(name, description, schema = objSchema)
 
       }
       .toSeq

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/reflection/Reflect.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/reflection/Reflect.scala
@@ -98,6 +98,16 @@ private[impl] object Reflect {
 
     if (valueSet && aliasSet)
       throw new IllegalArgumentException("Both value() and alias are set. Only one must be set.")
+
+    // Check a required flag on ValueAlias
+    val aliasRequired = aliasMethodOpt.exists { m =>
+      val va = m.getAnnotation(classOf[ValueAlias])
+      va != null && va.required()
+    }
+
+    if (!valueSet && !aliasSet && aliasRequired)
+      throw new IllegalArgumentException("At least one of value() or alias must be set (required = true).")
+
     if (valueSet) value.asInstanceOf[T]
     else if (aliasSet) aliasValue.asInstanceOf[T]
     else null.asInstanceOf[T]

--- a/akka-javasdk/src/test/java/akka/javasdk/annotations/OptionalDescription.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/annotations/OptionalDescription.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2021-2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.annotations;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// test annotation (written in java) to test Reflect.valueOrAlias
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface OptionalDescription {
+
+  String value() default "";
+
+  @ValueAlias(required = false)
+  String description() default "";
+}

--- a/samples/multi-agent/src/main/java/demo/multiagent/application/agents/WeatherAgent.java
+++ b/samples/multi-agent/src/main/java/demo/multiagent/application/agents/WeatherAgent.java
@@ -52,7 +52,7 @@ public class WeatherAgent extends Agent {
 
 
   // tag::weather-tool[]
-  @FunctionTool(description = "Returns the weather forecast for a given city.") // <1>
+  @FunctionTool("Returns the weather forecast for a given city.") // <1>
   private String getWeather(
       @Description("A location or city name.") String location, // <2>
       @Description("Forecast for a given date, in yyyy-MM-dd format. Leave empty to use current date.") String date) {
@@ -65,7 +65,7 @@ public class WeatherAgent extends Agent {
   }
   // end::weather-tool[]
 
-  @FunctionTool(description = "Return current date in yyyy-MM-dd format")
+  @FunctionTool("Return current date in yyyy-MM-dd format")
   private String getCurrentDate() {
     return LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
   }


### PR DESCRIPTION
This is an experiment inspired on AliasFor annotation from Spring. 
The original Spring annotation is much more generic. This impl is much simpler and covers a single use case.

The main goal is to be able to define an annotation with a `value()` and another field, eg: `description()` where `description` is an alias for `value`.

### The problem

When an annotation has a `value` field, it's possible to use it as: 

```java
@FunctionTool("this is the value")
```

But that's only possible if we want to fill only one field. The following is not possible:

```java
@FunctionTool(name = "my-method", "this is the value")
```

When filling more than one field, we need to write:

```java
@FunctionTool(name = "my-method", value = "this is the value")
```

However, now it becomes weird. What is `value`?

In the case of `@FunctionTool` the main field is called `description`, but then we are always forced to name it each time. Like in

```java
@FunctionTool(description = "this is the value")
```

### The Solution

With a `@ValueAlias` we can make `description` an alias for `value` and use the annotation in both ways.

```java
// description filed is treated as if it was value field
@FunctionTool(name = "my-method", description = "this is the value")
```

or

```java
@FunctionTool("this is the value")
```

### The drawback

We can't enforce at compile time that one of the two must be set. 
