### PR TITLE
chore: use Instant and remove orphans messages from memory

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SessionMemoryEntityTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SessionMemoryEntityTest.java
@@ -11,6 +11,7 @@ import akka.javasdk.agent.SessionMemoryEntity.AddInteractionCmd;
 import akka.javasdk.agent.SessionMessage;
 import akka.javasdk.agent.SessionMessage.AiMessage;
 import akka.javasdk.agent.SessionMessage.UserMessage;
+import akka.javasdk.eventsourcedentity.EventSourcedEntityContext;
 import akka.javasdk.testkit.EventSourcedResult;
 import akka.javasdk.testkit.EventSourcedTestKit;
 import com.typesafe.config.Config;
@@ -35,7 +36,7 @@ public class SessionMemoryEntityTest {
   @Test
   public void shouldAddMessageToHistory() {
     // given
-    var testKit = EventSourcedTestKit.of(() -> new SessionMemoryEntity(config));
+    var testKit = EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
     var timestamp = Instant.now();
     String userMsg = "Hello, how are you?";
     String aiMsg = "I'm fine, thanks for asking!";
@@ -79,7 +80,7 @@ public class SessionMemoryEntityTest {
   @Test
   public void shouldAddMultipleMessagesToHistory() {
     // given
-    var testKit = EventSourcedTestKit.of(() -> new SessionMemoryEntity(config));
+    var testKit = EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
     var timestamp = Instant.now();
     String userMsg1 = "Hello";
     String aiMsg1 = "Hi there!";
@@ -115,7 +116,7 @@ public class SessionMemoryEntityTest {
   @Test
   public void shouldBeCompactable() {
     // given
-    var testKit = EventSourcedTestKit.of(() -> new SessionMemoryEntity(config));
+    var testKit = EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
     var timestamp = Instant.now();
 
     var userMessage1 = new UserMessage(timestamp, "Hello", COMPONENT_ID);
@@ -162,7 +163,7 @@ public class SessionMemoryEntityTest {
   @Test
   public void shouldHandleConcurrentUpdatesWhenCompacting() {
     // given
-    var testKit = EventSourcedTestKit.of(() -> new SessionMemoryEntity(config));
+    var testKit = EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
     var timestamp = Instant.now();
 
     var userMessage1 = new UserMessage(timestamp, "Hello", COMPONENT_ID);
@@ -211,7 +212,7 @@ public class SessionMemoryEntityTest {
   @Test
   public void shouldBeDeletable() {
     // given
-    var testKit = EventSourcedTestKit.of(() -> new SessionMemoryEntity(config));
+    var testKit = EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
     var timestamp = Instant.now();
     String userMsg = "Hello";
     String aiMsg = "Hi there!";
@@ -244,7 +245,7 @@ public class SessionMemoryEntityTest {
   @Test
   public void shouldGetEmptyHistoryWhenNoMessagesAdded() {
     // given
-    var testKit = EventSourcedTestKit.of(() -> new SessionMemoryEntity(config));
+    var testKit = EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
 
     // when
     EventSourcedResult<SessionHistory> historyResult =
@@ -257,7 +258,7 @@ public class SessionMemoryEntityTest {
   @Test
   public void shouldRemoveOldestMessagesWhenLimitIsReached() {
     // given
-    var testKit = EventSourcedTestKit.of(() -> new SessionMemoryEntity(config));
+    var testKit = EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
     var timestamp = Instant.now();
 
     // Calculate the total bytes needed for each message
@@ -300,7 +301,7 @@ public class SessionMemoryEntityTest {
   @Test
   public void shouldMaintainCorrectSizeAfterMultipleOperations() {
     // given
-    var testKit = EventSourcedTestKit.of(() -> new SessionMemoryEntity(config));
+    var testKit = EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
     var timestamp = Instant.now();
 
     // Calculate the total bytes needed for each message
@@ -367,7 +368,7 @@ public class SessionMemoryEntityTest {
   @Test
   public void shouldRejectInvalidBufferSize() {
     // given
-    var testKit = EventSourcedTestKit.of(() -> new SessionMemoryEntity(config));
+    var testKit = EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
     var invalidBuffer = new SessionMemoryEntity.LimitedWindow(0);
 
     // when
@@ -380,7 +381,7 @@ public class SessionMemoryEntityTest {
 
   @Test
   public void shouldSkipWhenFirstMessageGreaterBySize() {
-    var testKit = EventSourcedTestKit.of(() -> new SessionMemoryEntity(config));
+    var testKit = EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
     var timestamp = Instant.now();
     // Create a message larger than the buffer
     String largeUserMsg = "A".repeat(100);
@@ -407,7 +408,7 @@ public class SessionMemoryEntityTest {
   @Test
   public void shouldTrackTotalTokenUsage() {
     // given
-    var testKit = EventSourcedTestKit.of(() -> new SessionMemoryEntity(config));
+    var testKit = EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
     var timestamp = Instant.now();
     String userMsg1 = "Hello";
     String aiMsg1 = "Hi!";
@@ -441,7 +442,7 @@ public class SessionMemoryEntityTest {
   public void shouldReturnOnlyLastNMessages() {
     // Create test kit with the configuration
     EventSourcedTestKit<SessionMemoryEntity.State, SessionMemoryEntity.Event, SessionMemoryEntity> testKit =
-      EventSourcedTestKit.of(() -> new SessionMemoryEntity(config));
+      EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
     var timestamp = Instant.now();
 
     // Add several interactions
@@ -474,7 +475,7 @@ public class SessionMemoryEntityTest {
   @Test
   public void shouldReturnEmptyHistoryWithLastN() {
     EventSourcedTestKit<SessionMemoryEntity.State, SessionMemoryEntity.Event, SessionMemoryEntity> testKit =
-      EventSourcedTestKit.of(() -> new SessionMemoryEntity(config));
+      EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
 
     var lastN = 4;
     EventSourcedResult<SessionHistory> result = testKit

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMessage.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMessage.java
@@ -10,12 +10,16 @@ import akka.javasdk.agent.SessionMessage.UserMessage;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import java.time.Instant;
 import java.util.List;
 
 
+/**
+ * Interface for message representation used inside SessionMemoryEntity state.
+ */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "@type")
 @JsonSubTypes({
-    @JsonSubTypes.Type(value = UserMessage.class, name = "UM"),
+  @JsonSubTypes.Type(value = UserMessage.class, name = "UM"),
   @JsonSubTypes.Type(value = AiMessage.class, name = "AIM"),
   @JsonSubTypes.Type(value = ToolCallResponse.class, name = "TCR")})
 public sealed interface SessionMessage {
@@ -24,7 +28,7 @@ public sealed interface SessionMessage {
 
   String text();
 
-  record UserMessage(long timestamp, String text, String componentId) implements SessionMessage {
+  record UserMessage(Instant timestamp, String text, String componentId) implements SessionMessage {
 
     @Override
     public int size() {
@@ -35,14 +39,14 @@ public sealed interface SessionMessage {
   record ToolCallRequest(String id, String name, String arguments)  {
   }
 
-  record AiMessage(long timestamp,
+  record AiMessage(Instant timestamp,
                    String text,
                    String componentId,
                    int inputTokens,
                    int outputTokens,
                    List<ToolCallRequest> toolCallRequests) implements SessionMessage {
 
-    public AiMessage(long timestamp, String text, String componentId, int inputTokens, int   outputTokens) {
+    public AiMessage(Instant timestamp, String text, String componentId, int inputTokens, int outputTokens) {
       this(timestamp, text, componentId, inputTokens, outputTokens, List.of());
     }
 
@@ -59,7 +63,7 @@ public sealed interface SessionMessage {
     }
   }
 
-  record ToolCallResponse(long timestamp, String componentId, String id, String name, String text) implements SessionMessage {
+  record ToolCallResponse(Instant timestamp, String componentId, String id, String name, String text) implements SessionMessage {
     @Override
     public int size() {
       return text.length();

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
@@ -50,6 +50,7 @@ import io.opentelemetry.api.trace.Tracer
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 
+import java.time.Instant
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -254,7 +255,7 @@ private[impl] final class AgentImpl[A <: Agent](
       userMessage: String,
       responses: Seq[SpiAgent.Response]): Unit = {
 
-    val timestamp = System.currentTimeMillis()
+    val timestamp = Instant.now()
 
     // AiMessages and ToolCallResponses
     val responseMessages: Seq[SessionMessage] =

--- a/samples/ask-akka-agent/src/main/java/akka/ask/agent/application/ConversationHistoryView.java
+++ b/samples/ask-akka-agent/src/main/java/akka/ask/agent/application/ConversationHistoryView.java
@@ -49,13 +49,13 @@ public class ConversationHistoryView extends View {
     }
 
     private Effect<Session> aiMessage(SessionMemoryEntity.Event.AiMessageAdded added) {
-      Message newMessage = new Message(added.message(), "ai", added.timestamp());
+      Message newMessage = new Message(added.message(), "ai", added.timestamp().toEpochMilli());
       var rowState = rowStateOrNew(userId(), sessionId());
       return effects().updateRow(rowState.add(newMessage));
     }
 
     private Effect<Session> userMessage(SessionMemoryEntity.Event.UserMessageAdded added) {
-      Message newMessage = new Message(added.message(), "user", added.timestamp());
+      Message newMessage = new Message(added.message(), "user", added.timestamp().toEpochMilli());
       var rowState = rowStateOrNew(userId(), sessionId());
       return effects().updateRow(rowState.add(newMessage));
     }

--- a/samples/doc-snippets/src/main/java/com/example/application/SessionMemoryConsumer.java
+++ b/samples/doc-snippets/src/main/java/com/example/application/SessionMemoryConsumer.java
@@ -9,6 +9,7 @@ import akka.javasdk.consumer.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.Optional;
 
 // tag::consumer[]
@@ -49,7 +50,7 @@ public class SessionMemoryConsumer extends Consumer {
                   .method(CompactionAgent::summarizeSessionHistory) // <3>
                   .invoke(history);
 
-          var now = System.currentTimeMillis();
+          var now = Instant.now();
           componentClient
               .forEventSourcedEntity(sessionId)
               .method(SessionMemoryEntity::compactHistory) // <4>

--- a/samples/doc-snippets/src/test/java/com/example/application/CompactionAgentIntegrationTest.java
+++ b/samples/doc-snippets/src/test/java/com/example/application/CompactionAgentIntegrationTest.java
@@ -5,6 +5,7 @@ import akka.javasdk.agent.SessionMessage;
 import akka.javasdk.testkit.TestKitSupport;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.UUID;
@@ -127,9 +128,9 @@ public class CompactionAgentIntegrationTest extends TestKitSupport {
           .forEventSourcedEntity(sessionId)
           .method(SessionMemoryEntity::addInteraction)
           .invoke(new SessionMemoryEntity.AddInteractionCmd(
-              new SessionMessage.UserMessage(System.currentTimeMillis(), userMessages.get(i), "my-agent"),
+              new SessionMessage.UserMessage(Instant.now(), userMessages.get(i), "my-agent"),
               new SessionMessage.AiMessage(
-                System.currentTimeMillis(),
+                  Instant.now(),
                 aiMessages.get(i),
                 "my-agent",
                 userMessages.get(i).length(), // simulated input tokens


### PR DESCRIPTION
This PR:
- uses Instant instead of long for timestamps in SessionMemory
- makes sure that the first message on the session memory is always a UserMessage.. important when we do auto truncation.

Refs:
- https://github.com/lightbend/kalix-runtime/issues/3831