### PR TITLE
ci: checkout to respect workflow trigger branch

### DIFF
--- a/.github/workflows/pr-akka-samples.yml
+++ b/.github/workflows/pr-akka-samples.yml
@@ -76,7 +76,8 @@ jobs:
           repository: ${{ matrix.sampleRepo }}
           path: akka-samples-${{ matrix.sample }}
           token: ${{ secrets.AKKA_SAMPLES_RW_ACCESS_TOKEN }}
-          ref: main
+          # Use the same branch/commit as the original workflow when triggered by workflow_run
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
 
       - name: Open PR with changes
         env:


### PR DESCRIPTION
This 2nd checkout should also respect the original branch as in https://github.com/akka/akka-sdk/blob/06edf3a546cb1d3ac4d69e87df17610ab13792d0/.github/workflows/pr-akka-samples.yml#L47