### PR TITLE
docs: Clarify workflow docs

### DIFF
--- a/docs/src/modules/java/pages/workflows.adoc
+++ b/docs/src/modules/java/pages/workflows.adoc
@@ -24,8 +24,25 @@ A Workflow Effect can either:
 * fail the step or reject a command by returning an error
 * reply to incoming commands
 
-
 For additional details, refer to xref:concepts:declarative-effects.adoc[Declarative Effects].
+
+== Skeleton
+
+A Workflow implementation has the following code structure.
+
+[source,java]
+.{sample-base-url}/doc-snippets/src/main/java/com/example/application/TransferWorkflow.java[TransferWorkflow.java]
+----
+include::example$doc-snippets/src/main/java/com/example/application/TransferWorkflow.java[tag=class]
+----
+<1> Annotate the class with `@ComponentId` and pass a unique identifier for this workflow type.
+<2> Class that extends `Workflow`.
+<3> Define the workflow steps.
+<4> Each step has a name.
+<5> The step consists of a call, which is a lambda that will be called to execute the step.
+<6> When the call has completed successfully the `andThen` lambda is called, and here you can update the state and transition to next step.
+<7> The workflow has methods that can be called with the component client.
+<8> Those methods return an effect, which can be instructions to update the state and transition to a certain step.
 
 == Modeling state
 
@@ -109,13 +126,19 @@ ifdef::todo[TODO: add some diagram or sth]
 ----
 include::example$transfer-workflow/src/main/java/com/example/transfer/application/TransferWorkflow.java[tag=definition]
 ----
-<1> Each step should have a unique name.
-<2> Using the xref:component-and-service-calls.adoc#_component_client[ComponentClient], which is injected in the constructor.
-<3> We instruct Akka to run a given call to withdraw funds from a wallet.
-<4> After successful withdrawal we return an `Effect` that will update the workflow state and move to the next step called "deposit." An input parameter for this step is a `Deposit` record.
-<5> Another workflow step action to deposit funds to a given wallet.
-<6> This time we return an effect that will stop workflow processing, by using the special `end` method.
-<7> We collect all steps to form a workflow definition.
+<1> We collect all steps to form a workflow definition.
+<2> Each step should have a unique name.
+<3> Using the xref:component-and-service-calls.adoc#_component_client[ComponentClient], which is injected in the constructor.
+<4> We instruct Akka to run a given call to withdraw funds from a wallet.
+<5> After successful withdrawal we return an `Effect` that will update the workflow state and move to the next step called "deposit." An input parameter for this step is a `Deposit` record.
+<6> Another workflow step action to deposit funds to a given wallet.
+<7> This time we return an effect that will stop workflow processing, by using the special `end` method.
+
+The step consists of two parts, a lambda that is called to execute the step, and a second lambda that is run when the call has completed successfully. In the `call` lamda you implement what should be executed in the step, and this may be retried until successful. In the `andThen` lambda you can update the state and transition to next step.
+
+The workflow will automatically execute the steps in a reliable and durable way. This means that if a call in a step fails, it will be retried until it succeeds or the retry limit of the recovery strategy is reached and separate error handling can be performed. The state machine of the workflow is durable, which means that if the workflow is restarted for some reason it will continue from where it left off, i.e. execute the current non-completed step again.
+
+It is possible to pass input from `transitionTo` to the call in the next step. It's also possible to pass the result from the call to the `andThen`. These inputs and outputs are optional, and you can use supplier lambdas without parameter, e.g. `call(() -> {})`. The state of the workflow can be accessed with `currentState()` from both the `call` and the `andThen` lambdas, but it can only be updated from `andThen`.
 
 IMPORTANT: In the following example all `WalletEntity` interactions are not idempotent. It means that if the workflow step retries, it will make the deposit or withdraw again. In a real-world scenario, you should consider making all interactions idempotent with a proper deduplication mechanism. A very basic example of handling retries for workflows can be found in https://github.com/akka/akka-sdk/blob/main/samples/transfer-workflow-compensation/src/main/java/com/example/wallet/domain/Wallet.java[this] sample.
 

--- a/samples/doc-snippets/src/main/java/com/example/application/TransferWorkflow.java
+++ b/samples/doc-snippets/src/main/java/com/example/application/TransferWorkflow.java
@@ -1,0 +1,62 @@
+package com.example.application;
+
+import akka.Done;
+import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.workflow.Workflow;
+import com.example.domain.TransferState;
+import com.example.domain.TransferState.Transfer;
+
+import static akka.Done.done;
+import static com.example.domain.TransferState.TransferStatus.COMPLETED;
+import static com.example.domain.TransferState.TransferStatus.WITHDRAW_SUCCEED;
+
+// tag::class[]
+@ComponentId("transfer") // <1>
+public class TransferWorkflow extends Workflow<TransferState> { // <2>
+  public record Withdraw(String from, int amount) {
+  }
+
+  @Override
+  public WorkflowDef<TransferState> definition() { // <3>
+    return workflow()
+        .addStep(withdrawStep())
+        .addStep(depositStep());
+  }
+
+  private Step withdrawStep() {
+    return
+        step("withdraw") // <4>
+            .call(() -> {// <5>
+              return null; // FIXME implement this
+            })
+            .andThen(() -> { // <6>
+              return effects()
+                  .updateState(currentState().withStatus(WITHDRAW_SUCCEED))
+                  .transitionTo("deposit");
+            });
+  }
+
+  private Step depositStep() {
+    return
+        step("deposit")
+            .call(() -> {
+              return null; // FIXME implement this
+            })
+            .andThen(() -> {
+              return effects()
+                  .updateState(currentState().withStatus(COMPLETED))
+                  .end();
+            });
+  }
+
+  public Effect<Done> startTransfer(Transfer transfer) { // <7>
+    TransferState initialState = new TransferState(transfer);
+
+    return effects()// <8>
+        .updateState(initialState)
+        .transitionTo("withdraw")
+        .thenReply(done());
+  }
+
+}
+// end::class[]

--- a/samples/doc-snippets/src/main/java/com/example/domain/TransferState.java
+++ b/samples/doc-snippets/src/main/java/com/example/domain/TransferState.java
@@ -1,0 +1,19 @@
+package com.example.domain;
+
+public record TransferState(Transfer transfer, TransferStatus status) {
+
+  public record Transfer(String from, String to, int amount) {
+  }
+
+  public enum TransferStatus {
+    STARTED, WITHDRAW_SUCCEED, COMPLETED
+  }
+
+  public TransferState(Transfer transfer) {
+    this(transfer, TransferStatus.STARTED);
+  }
+
+  public TransferState withStatus(TransferStatus newStatus) {
+    return new TransferState(transfer, newStatus);
+  }
+}

--- a/samples/transfer-workflow-compensation/src/main/java/com/example/transfer/application/TransferWorkflow.java
+++ b/samples/transfer-workflow-compensation/src/main/java/com/example/transfer/application/TransferWorkflow.java
@@ -12,6 +12,7 @@ import com.example.wallet.application.WalletEntity.WalletResult.Failure;
 import com.example.wallet.application.WalletEntity.WalletResult.Success;
 import com.example.wallet.domain.WalletCommand.Deposit;
 import com.example.wallet.domain.WalletCommand.Withdraw;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,126 +41,6 @@ public class TransferWorkflow extends Workflow<TransferState> {
   // tag::definition[]
   @Override
   public WorkflowDef<TransferState> definition() {
-    Step withdraw =
-      step("withdraw")
-        .call(Withdraw.class, cmd -> {
-          logger.info("Running withdraw: {}", cmd);
-
-          // cancelling the timer in case it was scheduled
-          timers().delete("acceptationTimout-" + currentState().transferId());
-
-          return componentClient.forEventSourcedEntity(currentState().transfer().from())
-              .method(WalletEntity::withdraw)
-              .invoke(cmd);
-        })
-        .andThen(WalletResult.class, result -> {
-          switch (result) {
-            case Success __ -> {
-              Deposit depositInput = new Deposit(currentState().depositId(), currentState().transfer().amount());
-              return effects()
-                .updateState(currentState().withStatus(WITHDRAW_SUCCEED))
-                .transitionTo("deposit", depositInput);
-            }
-            case Failure failure -> {
-              logger.warn("Withdraw failed with msg: {}", failure.errorMsg());
-              return effects()
-                .updateState(currentState().withStatus(WITHDRAW_FAILED))
-                .end();
-
-            }
-          }
-        });
-
-    // tag::compensation[]
-    Step deposit =
-      step("deposit")
-        .call(Deposit.class, cmd -> {
-          // end::compensation[]
-          logger.info("Running deposit: {}", cmd);
-          // tag::compensation[]
-          return componentClient.forEventSourcedEntity(currentState().transfer().to())
-            .method(WalletEntity::deposit)
-            .invoke(cmd);
-        })
-        .andThen(WalletResult.class, result -> { // <1>
-          switch (result) {
-            case Success __ -> {
-              return effects()
-                .updateState(currentState().withStatus(COMPLETED))
-                .end(); // <2>
-            }
-            case Failure failure -> {
-              // end::compensation[]
-              logger.warn("Deposit failed with msg: {}", failure.errorMsg());
-              // tag::compensation[]
-              return effects()
-                .updateState(currentState().withStatus(DEPOSIT_FAILED))
-                .transitionTo("compensate-withdraw"); // <3>
-            }
-          }
-        });
-
-    Step compensateWithdraw =
-      step("compensate-withdraw") // <4>
-        .call(() -> {
-          // end::compensation[]
-          logger.info("Running withdraw compensation");
-          // tag::compensation[]
-          var transfer = currentState().transfer();
-          // end::compensation[]
-          // depositId is reused for the compensation, just to have a stable commandId and simplify the example
-          // tag::compensation[]
-          String commandId = currentState().depositId();
-          return componentClient.forEventSourcedEntity(transfer.from())
-            .method(WalletEntity::deposit)
-            .invoke(new Deposit(commandId, transfer.amount()));
-        })
-        .andThen(WalletResult.class, result -> {
-          switch (result) {
-            case Success __ -> {
-              return effects()
-                .updateState(currentState().withStatus(COMPENSATION_COMPLETED))
-                .end(); // <5>
-            }
-            case Failure __ -> { // <6>
-              throw new IllegalStateException("Expecting succeed operation but received: " + result);
-            }
-          }
-        });
-    // end::compensation[]
-
-    // tag::step-timeout[]
-    Step failoverHandler =
-      step("failover-handler")
-        .call(() -> {
-          // end::step-timeout[]
-          logger.info("Running workflow failed step");
-          // tag::step-timeout[]
-          return "handling failure";
-        })
-        .andThen(String.class, __ -> effects()
-          .updateState(currentState().withStatus(REQUIRES_MANUAL_INTERVENTION))
-          .end())
-        .timeout(ofSeconds(1)); // <1>
-    // end::step-timeout[]
-
-    // tag::pausing[]
-    Step waitForAcceptation =
-      step("wait-for-acceptation")
-        .call(() -> {
-          String transferId = currentState().transferId();
-          timers().createSingleTimer(
-            "acceptationTimeout-" + transferId,
-            ofHours(8),
-            componentClient.forWorkflow(transferId)
-              .method(TransferWorkflow::acceptationTimeout)
-              .deferred()); // <1>
-          return Done.done();
-        })
-        .andThen(Done.class, __ ->
-          effects().pause()); // <2>
-    // end::pausing[]
-
     // tag::timeouts[]
     // tag::recover-strategy[]
     return workflow()
@@ -172,13 +53,146 @@ public class TransferWorkflow extends Workflow<TransferState> {
       // tag::recover-strategy[]
       .failoverTo("failover-handler", maxRetries(0)) // <1>
       .defaultStepRecoverStrategy(maxRetries(1).failoverTo("failover-handler")) // <2>
-      .addStep(withdraw)
-      .addStep(deposit, maxRetries(2).failoverTo("compensate-withdraw")) // <3>
+      .addStep(withdrawStep())
+      .addStep(depositStep(), maxRetries(2).failoverTo("compensate-withdraw")) // <3>
       // end::recover-strategy[]
-      .addStep(compensateWithdraw)
-      .addStep(waitForAcceptation)
-      .addStep(failoverHandler);
+      .addStep(compensateWithdrawStep())
+      .addStep(waitForAcceptationStep())
+      .addStep(failoverHandlerStep());
   }
+  // end::definition[]
+
+  private Step withdrawStep() {
+    return
+        step("withdraw")
+            .call(Withdraw.class, cmd -> {
+              logger.info("Running withdraw: {}", cmd);
+
+              // cancelling the timer in case it was scheduled
+              timers().delete("acceptationTimout-" + currentState().transferId());
+
+              return componentClient.forEventSourcedEntity(currentState().transfer().from())
+                  .method(WalletEntity::withdraw)
+                  .invoke(cmd);
+            })
+            .andThen(WalletResult.class, result -> {
+              switch (result) {
+                case Success __ -> {
+                  Deposit depositInput = new Deposit(currentState().depositId(), currentState().transfer().amount());
+                  return effects()
+                      .updateState(currentState().withStatus(WITHDRAW_SUCCEED))
+                      .transitionTo("deposit", depositInput);
+                }
+                case Failure failure -> {
+                  logger.warn("Withdraw failed with msg: {}", failure.errorMsg());
+                  return effects()
+                      .updateState(currentState().withStatus(WITHDRAW_FAILED))
+                      .end();
+
+                }
+              }
+            });
+  }
+
+  // tag::compensation[]
+  private Step depositStep() {
+    return
+        step("deposit")
+            .call(Deposit.class, cmd -> {
+              // end::compensation[]
+              logger.info("Running deposit: {}", cmd);
+              // tag::compensation[]
+              return componentClient.forEventSourcedEntity(currentState().transfer().to())
+                  .method(WalletEntity::deposit)
+                  .invoke(cmd);
+            })
+            .andThen(WalletResult.class, result -> { // <1>
+              switch (result) {
+                case Success __ -> {
+                  return effects()
+                      .updateState(currentState().withStatus(COMPLETED))
+                      .end(); // <2>
+                }
+                case Failure failure -> {
+                  // end::compensation[]
+                  logger.warn("Deposit failed with msg: {}", failure.errorMsg());
+                  // tag::compensation[]
+                  return effects()
+                      .updateState(currentState().withStatus(DEPOSIT_FAILED))
+                      .transitionTo("compensate-withdraw"); // <3>
+                }
+              }
+            });
+  }
+  // end::compensation[]
+
+  private Step compensateWithdrawStep() {
+    return
+        step("compensate-withdraw") // <4>
+            .call(() -> {
+              // end::compensation[]
+              logger.info("Running withdraw compensation");
+              // tag::compensation[]
+              var transfer = currentState().transfer();
+              // end::compensation[]
+              // depositId is reused for the compensation, just to have a stable commandId and simplify the example
+              // tag::compensation[]
+              String commandId = currentState().depositId();
+              return componentClient.forEventSourcedEntity(transfer.from())
+                  .method(WalletEntity::deposit)
+                  .invoke(new Deposit(commandId, transfer.amount()));
+            })
+            .andThen(WalletResult.class, result -> {
+              switch (result) {
+                case Success __ -> {
+                  return effects()
+                      .updateState(currentState().withStatus(COMPENSATION_COMPLETED))
+                      .end(); // <5>
+                }
+                case Failure __ -> { // <6>
+                  throw new IllegalStateException("Expecting succeed operation but received: " + result);
+                }
+              }
+            });
+  }
+
+  // tag::pausing[]
+  private Step waitForAcceptationStep() {
+    Step waitForAcceptation =
+        step("wait-for-acceptation")
+            .call(() -> {
+              String transferId = currentState().transferId();
+              timers().createSingleTimer(
+                  "acceptationTimeout-" + transferId,
+                  ofHours(8),
+                  componentClient.forWorkflow(transferId)
+                      .method(TransferWorkflow::acceptationTimeout)
+                      .deferred()); // <1>
+              return Done.done();
+            })
+            .andThen(Done.class, __ ->
+                effects().pause()); // <2>
+    return waitForAcceptation;
+  }
+  // end::pausing[]
+
+  // tag::step-timeout[]
+  private Step failoverHandlerStep() {
+    Step failoverHandler =
+        step("failover-handler")
+            .call(() -> {
+              // end::step-timeout[]
+              logger.info("Running workflow failed step");
+              // tag::step-timeout[]
+              return "handling failure";
+            })
+            .andThen(String.class, __ -> effects()
+                .updateState(currentState().withStatus(REQUIRES_MANUAL_INTERVENTION))
+                .end())
+            .timeout(ofSeconds(1)); // <1>
+    return failoverHandler;
+  }
+  // end::step-timeout[]
 
   public Effect<String> startTransfer(Transfer transfer) {
     if (currentState() != null) {


### PR DESCRIPTION
* Add a skeleton template at the beginning
* Explain that step consists of two parts
* Clarify input parameters to the step lambdas
* Refactor the step definition in samples

Closes https://github.com/lightbend/kalix-runtime/issues/3977