### PR TITLE
chore: Self service resolution in integration tests

### DIFF
--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -296,6 +296,7 @@
                         </excludes>
                         <systemPropertyVariables>
                             <logback.configurationFile>${logback.configurationFile}</logback.configurationFile>
+                            <akka.javasdk.dev-mode.project-artifact-id>${project.artifactId}</akka.javasdk.dev-mode.project-artifact-id>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/HttpEndpointTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/HttpEndpointTest.java
@@ -67,6 +67,13 @@ public class HttpEndpointTest extends TestKitSupport {
 
 
   @Test
+  public void resolveSelfServiceNameInIntegrationTest() {
+    var response = testKit.getHttpClientProvider().httpClientFor("sdk-tests").GET("/index.html").invoke();
+    assertThat(response.status()).isEqualTo(StatusCodes.OK);
+  }
+
+
+  @Test
   public void shouldServeWildcardResources() throws Exception {
     var htmlResponse = httpClient.GET("/static/index.html").invoke();
     assertThat(htmlResponse.status()).isEqualTo(StatusCodes.OK);


### PR DESCRIPTION
Previous to this change, calls from the test or the service itself using the service name in Http client, gRPC client or MCP client would fail with a resolution error.

Depends on upstream SPI change in https://github.com/lightbend/kalix-runtime/pull/3987
