### PR TITLE
docs: Include akka code init in getting started

### DIFF
--- a/docs/src/modules/ROOT/partials/cli-install-short.adoc
+++ b/docs/src/modules/ROOT/partials/cli-install-short.adoc
@@ -1,6 +1,4 @@
-Install the Akka CLI:
-
-NOTE: In case there is any trouble with installing the CLI when following these instructions, please check xref:operations:cli/installation.adoc[].
+NOTE: In case there is any trouble with installing the CLI when following these instructions, please check the xref:operations:cli/installation.adoc[detailed CLI installation instructions].
 
 [.tabset]
 Linux::

--- a/docs/src/modules/getting-started/pages/author-your-first-service.adoc
+++ b/docs/src/modules/getting-started/pages/author-your-first-service.adoc
@@ -41,6 +41,17 @@ git clone https://github.com/akka-samples/helloworld-agent.git --depth 1
 
 . Open it in your preferred IDE / Editor.
 
+[sidebar]
+****
+Another convenient way to download this and other samples is to use the Akka CLI. See xref:quick-install-cli.adoc[installation instructions].
+
+[source, command line]
+----
+akka code init
+----
+****
+
+
 == Explore the Agent
 
 An _Agent_ interacts with an AI model and maintains contextual history in a session memory.
@@ -215,7 +226,6 @@ The Akka local console is a web-based tool that comes bundled with the Akka CLI.
 Starting the local console requires using the Akka CLI.
 
 include::ROOT:partial$cli-install-short.adoc[]
-
 
 === Start the local console
 

--- a/docs/src/modules/getting-started/pages/planner-agent/activity.adoc
+++ b/docs/src/modules/getting-started/pages/planner-agent/activity.adoc
@@ -21,7 +21,7 @@ include::ROOT:partial$local-dev-prerequisites.adoc[]
 
 == Create the empty project
 
-You already learned how to create an empty Akka project when you went through the guide to xref:getting-started:author-your-first-service.adoc#clone_sample[author your first service].
+You already learned how to create an empty Akka project when you went through the guide to xref:getting-started:author-your-first-service.adoc#clone_sample[author your first service]. You can continue from the `helloworld-agent` project.
 
 [NOTE]
 ====

--- a/docs/src/modules/getting-started/pages/quick-install-cli.adoc
+++ b/docs/src/modules/getting-started/pages/quick-install-cli.adoc
@@ -1,0 +1,3 @@
+= Install the Akka CLI
+
+include::ROOT:partial$cli-install-short.adoc[]

--- a/docs/src/modules/getting-started/pages/samples.adoc
+++ b/docs/src/modules/getting-started/pages/samples.adoc
@@ -4,7 +4,7 @@ include::ROOT:partial$include.adoc[]
 
 include::ROOT:partial$new-to-akka-start-here.adoc[]
 
-Samples are available that demonstrate important patterns and abstractions. These can be cloned from their respective repositories. Please refer to the `README` file in each repository for setup and usage instructions.
+Samples are available that demonstrate important patterns and abstractions. Full sources for the samples can be downloaded with `akka code init` or cloned from their respective GitHub repositories. Please refer to the `README` file in each repository for setup and usage instructions.
 
 [sidebar]
 It is also possible to deploy a pre-built sample project in https://console.akka.io[the Akka console, window="new"], eliminating the need for local development.


### PR DESCRIPTION
Still not making it mandatory to use CLI first.