### PR TITLE
docs: Improve JavaDoc of KeyValueEntity

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/CommandContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/CommandContext.java
@@ -7,32 +7,45 @@ package akka.javasdk.keyvalueentity;
 import akka.javasdk.MetadataContext;
 import akka.javasdk.Tracing;
 
-/** A value based entity command context. */
+/**
+ * Context information available to Key Value Entity command handlers during command processing.
+ * Provides access to command metadata, entity identification, and tracing capabilities.
+ * 
+ * <p>This context is automatically provided by the Akka runtime and can be accessed within
+ * command handlers using {@link KeyValueEntity#commandContext()}.
+ */
 public interface CommandContext extends MetadataContext {
 
   /**
-   * The name of the command being executed.
+   * Returns the name of the command currently being executed. This corresponds to the
+   * method name of the command handler being invoked.
    *
-   * @return The name of the command.
+   * @return the name of the command being processed
    */
   String commandName();
 
   /**
-   * The id of the command being executed.
+   * Returns the command ID for the current command.
    *
-   * @return The id of the command.
-   * @deprecated not used anymore
+   * @return the command ID
+   * @deprecated This method is no longer used and will be removed in a future version
    */
   @Deprecated
   long commandId();
 
   /**
-   * The id of the entity that this context is for.
+   * Returns the unique identifier of the entity instance that this command is being executed on.
+   * This is the same ID used when calling the entity through a component client.
    *
-   * @return The entity id.
+   * @return the unique entity ID for this entity instance
    */
   String entityId();
 
-  /** Access to tracing for custom app specific tracing. */
+  /**
+   * Provides access to tracing functionality for adding custom application-specific tracing
+   * information to the current command processing.
+   * 
+   * @return the tracing context for custom tracing operations
+   */
   Tracing tracing();
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/CommandContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/CommandContext.java
@@ -25,9 +25,9 @@ public interface CommandContext extends MetadataContext {
   String commandName();
 
   /**
-   * Returns the command ID for the current command.
+   * Returns the command id for the current command.
    *
-   * @return the command ID
+   * @return the command id
    * @deprecated This method is no longer used and will be removed in a future version
    */
   @Deprecated
@@ -35,9 +35,9 @@ public interface CommandContext extends MetadataContext {
 
   /**
    * Returns the unique identifier of the entity instance that this command is being executed on.
-   * This is the same ID used when calling the entity through a component client.
+   * This is the same id used when calling the entity through a component client.
    *
-   * @return the unique entity ID for this entity instance
+   * @return the unique entity id for this entity instance
    */
   String entityId();
 

--- a/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/KeyValueEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/KeyValueEntity.java
@@ -11,32 +11,78 @@ import akka.javasdk.impl.keyvalueentity.KeyValueEntityEffectImpl;
 import java.util.Optional;
 
 /**
- * Key Value Entities persist their state on every change. You can think of them as a Key-Value entity where
- * the key is the entity id and the value is the state of the entity.
- * <p>
- *
- * When implementing a Key Value Entity, you first define what will be its internal state (your domain model),
- * and the commands it will handle (mutation requests).
- * <p>
- * Each command is handled by a command handler. Command handlers are methods returning an {@link Effect}.
- * When handling a command, you use the Effect API to:
- * <p>
+ * Key Value Entities are stateful components that persist their complete state on every change.
+ * Unlike Event Sourced Entities, only the latest state is stored without access to historical changes.
+ * 
+ * <p>Key Value Entities provide strong consistency guarantees through entity sharding, where each
+ * entity instance is identified by a unique ID and distributed across the service cluster. Only one
+ * instance of each entity exists in the cluster at any time, ensuring sequential message processing
+ * without concurrency concerns.
+ * 
+ * <p>The entity state is kept in memory while active and can serve read requests or command validation
+ * without additional reads from durable storage. Inactive entities are passivated and recover their
+ * state from durable storage when accessed again.
+ * 
+ * <h2>Implementation Steps</h2>
+ * <ol>
+ *   <li>Define the API and model the entity's state</li>
+ *   <li>Create and initialize the Entity with {@code @ComponentId}</li>
+ *   <li>Implement behavior in command handlers</li>
+ * </ol>
+ * 
+ * <h2>Command Handlers</h2>
+ * Command handlers are methods that return an {@link Effect} and define how the entity responds to commands.
+ * The Effect API allows you to:
  * <ul>
- *   <li>update the entity state and send a reply to the caller
- *   <li>directly reply to the caller if the command is not requesting any state change
- *   <li>rejected the command by returning an error
- *   <li>instruct the runtime to delete the entity
+ *   <li>Update the entity state and send a reply to the caller</li>
+ *   <li>Reply directly without state changes</li>
+ *   <li>Return an error message</li>
+ *   <li>Delete the entity</li>
  * </ul>
- * <p>
- * Concrete classes can accept the following types to the constructor:
+ * 
+ * <h2>Multi-region Replication</h2>
+ * Key Value Entities support multi-region replication for resilience and performance. Write requests
+ * are handled by the primary region, while read requests can be served from any region. Use
+ * {@link ReadOnlyEffect} for read-only operations that can be served from replicas.
+ * 
+ * <h2>Example Implementation</h2>
+ * <pre>{@code
+ * @ComponentId("counter")
+ * public class CounterEntity extends KeyValueEntity<Counter> {
+ *   
+ *   public CounterEntity(KeyValueEntityContext context) {
+ *     // Constructor can accept KeyValueEntityContext and custom dependency types
+ *   }
+ *   
+ *   @Override
+ *   public Counter emptyState() {
+ *     return new Counter(0);
+ *   }
+ *   
+ *   public Effect<Counter> set(int value) {
+ *     Counter newCounter = new Counter(value);
+ *     return effects()
+ *         .updateState(newCounter)
+ *         .thenReply(newCounter);
+ *   }
+ *   
+ *   public ReadOnlyEffect<Counter> get() {
+ *     return effects().reply(currentState());
+ *   }
+ * }
+ * }</pre>
+ * 
+ * <p>Concrete classes can accept the following types in the constructor:
  * <ul>
- *   <li>{@link akka.javasdk.keyvalueentity.KeyValueEntityContext}</li>
+ *   <li>{@link KeyValueEntityContext} - provides entity context information</li>
  *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider} from the service setup</li>
  * </ul>
- * <p>
- * Concrete class must be annotated with {@link akka.javasdk.annotations.ComponentId}.
+ * 
+ * <p>Concrete classes must be annotated with {@link akka.javasdk.annotations.ComponentId} with a
+ * stable, unique identifier that cannot be changed after production deployment.
  *
- * @param <S> The type of the state for this entity. */
+ * @param <S> The type of the state for this entity
+ */
 public abstract class KeyValueEntity<S> {
 
   private Optional<CommandContext> commandContext = Optional.empty();
@@ -48,24 +94,30 @@ public abstract class KeyValueEntity<S> {
   private boolean handlingCommands = false;
 
   /**
-   * Implement by returning the initial empty state object. This object will be passed into the
-   * command handlers, until a new state replaces it.
+   * Returns the initial empty state object for this entity. This state is used when the entity
+   * is first created and before any commands have been processed.
    *
-   * <p>Also known as "zero state" or "neutral state".
+   * <p>Also known as "zero state" or "neutral state". This method is called when the entity
+   * is instantiated for the first time or when recovering from storage without any persisted state.
    *
-   * <p>The default implementation of this method returns {@code null}. It can be overridden to
-   * return a more sensible initial state.
+   * <p>The default implementation returns {@code null}. Override this method to provide a more
+   * meaningful initial state for your entity.
+   *
+   * @return the initial state object, or {@code null} if no initial state is needed
    */
   public S emptyState() {
     return null;
   }
 
   /**
-   * Additional context and metadata for a command handler.
+   * Provides access to additional context and metadata for the current command being processed.
+   * This includes information such as the command name, entity ID, and tracing context.
    *
-   * <p>It will throw an exception if accessed from constructor.
+   * <p>This method can only be called from within a command handler method. Attempting to access
+   * it from the constructor or outside of command processing will result in an exception.
    *
-   * @throws IllegalStateException if accessed outside a handler method
+   * @return the command context for the current command
+   * @throws IllegalStateException if accessed outside a command handler method
    */
   protected final CommandContext commandContext() {
     return commandContext.orElseThrow(
@@ -104,15 +156,18 @@ public abstract class KeyValueEntity<S> {
   }
 
   /**
-   * Returns the state as currently stored.
+   * Returns the current state of this entity as stored in memory. This represents the latest
+   * persisted state and any updates made during the current command processing.
    *
-   * <p>Note that modifying the state directly will not update it in storage. To save the state, you
-   * must call {{@code effects().updateState()}}.
+   * <p><strong>Important:</strong> Modifying the returned state object directly will not persist
+   * the changes. To save state changes, you must use {@code effects().updateState(newState)} in
+   * your command handler's return value.
    *
-   * <p>This method can only be called when handling a command. Calling it outside a method (eg: in
-   * the constructor) will raise a IllegalStateException exception.
+   * <p>This method can only be called from within a command handler method. Attempting to access
+   * it from the constructor or outside of command processing will result in an exception.
    *
-   * @throws IllegalStateException if accessed outside a handler method
+   * @return the current state of the entity, which may be {@code null} if no state has been set
+   * @throws IllegalStateException if accessed outside a command handler method
    */
   protected final S currentState() {
     // user may call this method inside a command handler and get a null because it's legal
@@ -123,7 +178,15 @@ public abstract class KeyValueEntity<S> {
   }
 
   /**
-   * Returns true if the entity has been deleted.
+   * Returns whether this entity has been marked for deletion. When an entity is deleted using
+   * {@code effects().deleteEntity()}, it will still exist with an empty state for some time
+   * before being completely removed.
+   *
+   * <p>After deletion, the entity can still handle read requests but will have an empty state.
+   * No further state changes are allowed after deletion. The entity will be completely cleaned
+   * up after a default period of one week.
+   *
+   * @return {@code true} if the entity has been deleted, {@code false} otherwise
    */
   protected boolean isDeleted() {
     return deleted;
@@ -134,90 +197,110 @@ public abstract class KeyValueEntity<S> {
   }
 
   /**
-   * An Effect is a description of what the runtime needs to do after the command is handled.
-   * You can think of it as a set of instructions you are passing to the runtime, which will process
-   * the instructions on your behalf.
-   * <p>
-   * Each component defines its own effects, which are a set of predefined
-   * operations that match the capabilities of that component.
-   * <p>
-   * a KeyValueEntity Effect can either:
-   * <p>
+   * An Effect describes the actions that the Akka runtime should perform after a command handler
+   * completes. Effects are declarative instructions that tell the runtime how to update state,
+   * send replies, or handle errors.
+   * 
+   * <p>Key Value Entity effects can:
    * <ul>
-   *   <li>update the entity state and send a reply to the caller
-   *   <li>directly reply to the caller if the command is not requesting any state change
-   *   <li>rejected the command by returning an error
-   *   <li>instruct the runtime to delete the entity
+   *   <li>Update the entity state and send a reply to the caller</li>
+   *   <li>Reply directly to the caller without state changes</li>
+   *   <li>Return an error message to reject the command</li>
+   *   <li>Delete the entity from storage</li>
    * </ul>
    *
-   * @param <T> The type of the message that must be returned by this call.
+   * @param <T> The type of the message that must be returned by this call
    */
   public interface Effect<T> {
 
     /**
-     * Construct the effect that is returned by the command handler. The effect describes next
-     * processing actions, such as updating state and sending a reply.
+     * Builder for constructing effects that describe the actions to be performed after
+     * command processing. Use this to create effects that update state, reply to callers,
+     * or handle errors.
      *
-     * @param <S> The type of the state for this entity.
+     * @param <S> The type of the state for this entity
      */
     interface Builder<S> {
 
+      /**
+       * Updates the entity state with the provided new state. This is the only way to persist
+       * state changes in a Key Value Entity. The new state will replace the current state entirely.
+       *
+       * @param newState the new state to persist, replacing the current state
+       * @return a builder for chaining additional effects like replies
+       */
       OnSuccessBuilder<S> updateState(S newState);
 
       /**
-       * Delete the entity. No additional updates are allowed afterwards.
+       * Marks the entity for deletion. After deletion, the entity will still exist with an empty
+       * state for some time before being completely removed. No additional state updates are
+       * allowed after deletion.
+       *
+       * @return a builder for chaining additional effects like replies
        */
       OnSuccessBuilder<S> deleteEntity();
 
-
       /**
-       * Create a message reply.
+       * Creates a reply message to send back to the caller without updating the entity state.
+       * Use this for read-only operations or when the command doesn't require state changes.
        *
-       * @param message The payload of the reply.
-       * @param <T> The type of the message that must be returned by this call.
-       * @return A message reply.
+       * @param message the payload of the reply message
+       * @param <T> the type of the reply message
+       * @return a read-only effect containing the reply
        */
       <T> ReadOnlyEffect<T> reply(T message);
 
       /**
-       * Create a message reply.
+       * Creates a reply message with additional metadata to send back to the caller without
+       * updating the entity state.
        *
-       * @param message The payload of the reply.
-       * @param metadata The metadata for the message.
-       * @param <T> The type of the message that must be returned by this call.
-       * @return A message reply.
+       * @param message the payload of the reply message
+       * @param metadata additional metadata to include with the reply
+       * @param <T> the type of the reply message
+       * @return a read-only effect containing the reply
        */
       <T> ReadOnlyEffect<T> reply(T message, Metadata metadata);
 
       /**
-       * Create an error reply.
+       * Creates an error reply to reject the command and inform the caller of the failure.
+       * The entity state will not be modified when returning an error.
        *
-       * @param description The description of the error.
-       * @param <T> The type of the message that must be returned by this call.
-       * @return An error reply.
+       * @param description a description of the error that occurred
+       * @param <T> the type of the expected reply message
+       * @return a read-only effect containing the error
        */
       <T> ReadOnlyEffect<T> error(String description);
 
     }
 
+    /**
+     * Builder for chaining a reply after a successful state operation like {@code updateState}
+     * or {@code deleteEntity}. This allows you to both modify the entity and send a response
+     * to the caller in a single effect.
+     *
+     * @param <S> The type of the state for this entity
+     */
     interface OnSuccessBuilder<S> {
 
       /**
-       * Reply after for example {@code updateState}.
+       * Sends a reply message to the caller after the state operation (update or delete) completes
+       * successfully. This is typically used to confirm the operation and return the new state
+       * or operation result.
        *
-       * @param message The payload of the reply.
-       * @param <T> The type of the message that must be returned by this call.
-       * @return A message reply.
+       * @param message the payload of the reply message
+       * @param <T> the type of the reply message
+       * @return an effect that will perform the state operation and then send the reply
        */
       <T> Effect<T> thenReply(T message);
 
       /**
-       * Reply after for example {@code updateState}.
+       * Sends a reply message with additional metadata to the caller after the state operation
+       * completes successfully.
        *
-       * @param message The payload of the reply.
-       * @param metadata The metadata for the message.
-       * @param <T> The type of the message that must be returned by this call.
-       * @return A message reply.
+       * @param message the payload of the reply message
+       * @param metadata additional metadata to include with the reply
+       * @param <T> the type of the reply message
+       * @return an effect that will perform the state operation and then send the reply
        */
       <T> Effect<T> thenReply(T message, Metadata metadata);
 
@@ -226,7 +309,13 @@ public abstract class KeyValueEntity<S> {
   }
 
   /**
-   * An effect that is known to be read only and does not update the state of the entity.
+   * A read-only effect that does not modify the entity state. These effects are used for
+   * operations that only read data or send replies without persisting any changes.
+   * 
+   * <p>Read-only effects are important for multi-region replication as they can be served
+   * from any region, not just the primary region where writes are handled.
+   *
+   * @param <T> The type of the message that will be returned by this effect
    */
   public interface ReadOnlyEffect<T> extends Effect<T> {
   }

--- a/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/KeyValueEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/KeyValueEntity.java
@@ -30,6 +30,31 @@ import java.util.Optional;
  *   <li>Implement behavior in command handlers</li>
  * </ol>
  * 
+ * <h2>State Management</h2>
+ * <p>It is recommended to use immutable state objects, such as Java records, for the entity state.
+ * Immutable state ensures thread safety and prevents accidental modifications that could lead to
+ * inconsistent state or concurrency issues.
+ * 
+ * <p>While mutable state classes are supported, they require careful handling:
+ * <ul>
+ *   <li>Mutable state should not be shared outside the entity</li>
+ *   <li>Mutable state should not be passed to other threads, such as in {@code CompletionStage} operations</li>
+ *   <li>Any modifications to mutable state must be done within the entity's command handlers</li>
+ * </ul>
+ * 
+ * <p><strong>Collections in State:</strong> Collections (such as {@code List}, {@code Set}, {@code Map}) are 
+ * typically mutable even when contained within immutable objects. When updating state that contains collections,
+ * you should create copies of the collections rather than modifying them in place. This ensures that the
+ * previous state remains unchanged and prevents unintended side effects.
+ * 
+ * <p><strong>Performance Considerations:</strong> Defensive copying of collections can introduce performance 
+ * overhead, especially for large collections or frequent updates. In performance-critical scenarios, this 
+ * recommendation can be carefully tuned by using mutable state with strict adherence to the safety guidelines 
+ * mentioned above.
+ * 
+ * <p>Using immutable records with defensive copying of collections eliminates concurrency concerns and is the 
+ * preferred approach for state modeling in most cases.
+ * 
  * <h2>Command Handlers</h2>
  * Command handlers are methods that return an {@link Effect} and define how the entity responds to commands.
  * The Effect API allows you to:

--- a/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/KeyValueEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/KeyValueEntity.java
@@ -103,7 +103,7 @@ public abstract class KeyValueEntity<S> {
    * <p>The default implementation returns {@code null}. Override this method to provide a more
    * meaningful initial state for your entity.
    *
-   * @return the initial state object, or {@code null} if no initial state is needed
+   * @return the initial state object, or {@code null} if no initial state is defined
    */
   public S emptyState() {
     return null;
@@ -166,7 +166,8 @@ public abstract class KeyValueEntity<S> {
    * <p>This method can only be called from within a command handler method. Attempting to access
    * it from the constructor or outside of command processing will result in an exception.
    *
-   * @return the current state of the entity, which may be {@code null} if no state has been set
+   * @return the current state of the entity, which may initially be {@code null} if
+   *   {@link #emptyState} has not been defined
    * @throws IllegalStateException if accessed outside a command handler method
    */
   protected final S currentState() {

--- a/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/KeyValueEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/KeyValueEntity.java
@@ -15,7 +15,7 @@ import java.util.Optional;
  * Unlike Event Sourced Entities, only the latest state is stored without access to historical changes.
  * 
  * <p>Key Value Entities provide strong consistency guarantees through entity sharding, where each
- * entity instance is identified by a unique ID and distributed across the service cluster. Only one
+ * entity instance is identified by a unique id and distributed across the service cluster. Only one
  * instance of each entity exists in the cluster at any time, ensuring sequential message processing
  * without concurrency concerns.
  * 
@@ -136,7 +136,7 @@ public abstract class KeyValueEntity<S> {
 
   /**
    * Provides access to additional context and metadata for the current command being processed.
-   * This includes information such as the command name, entity ID, and tracing context.
+   * This includes information such as the command name, entity id, and tracing context.
    *
    * <p>This method can only be called from within a command handler method. Attempting to access
    * it from the constructor or outside of command processing will result in an exception.

--- a/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/KeyValueEntityContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/KeyValueEntityContext.java
@@ -6,5 +6,15 @@ package akka.javasdk.keyvalueentity;
 
 import akka.javasdk.EntityContext;
 
-/** Root context for all value based entity contexts. */
+/**
+ * Context information available during Key Value Entity construction and initialization.
+ * This context provides access to entity metadata and configuration that is available
+ * throughout the entity's lifecycle.
+ * 
+ * <p>The KeyValueEntityContext is typically injected into the entity constructor and can be
+ * used to access the entity ID and other contextual information needed during entity setup.
+ * 
+ * <p>Unlike {@link CommandContext}, this context is available during entity construction
+ * and is not limited to command processing.
+ */
 public interface KeyValueEntityContext extends EntityContext {}

--- a/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/KeyValueEntityContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/KeyValueEntityContext.java
@@ -12,7 +12,7 @@ import akka.javasdk.EntityContext;
  * throughout the entity's lifecycle.
  * 
  * <p>The KeyValueEntityContext is typically injected into the entity constructor and can be
- * used to access the entity ID and other contextual information needed during entity setup.
+ * used to access the entity id and other contextual information needed during entity setup.
  * 
  * <p>Unlike {@link CommandContext}, this context is available during entity construction
  * and is not limited to command processing.

--- a/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/package-info.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/package-info.java
@@ -1,2 +1,17 @@
-/** {@link akka.javasdk.keyvalueentity.KeyValueEntity} component. */
+/**
+ * Key Value Entity components for building stateful services that persist complete state on every change.
+ * 
+ * <p>Key Value Entities are stateful components that store their entire state with each update,
+ * unlike Event Sourced Entities which store a sequence of events. This makes them suitable for
+ * use cases where you need simple state management without event history.
+ * 
+ * <p>The main classes in this package are:
+ * <ul>
+ *   <li>{@link akka.javasdk.keyvalueentity.KeyValueEntity} - The base class for implementing Key Value Entities</li>
+ *   <li>{@link akka.javasdk.keyvalueentity.CommandContext} - Context available during command processing</li>
+ *   <li>{@link akka.javasdk.keyvalueentity.KeyValueEntityContext} - Context available during entity construction</li>
+ * </ul>
+ * 
+ * @see akka.javasdk.keyvalueentity.KeyValueEntity
+ */
 package akka.javasdk.keyvalueentity;


### PR DESCRIPTION
Mostly AI updates from the prompt:

```
Read the documentation from akka-context/java/key-value-entities.html.md

Improve the javadoc of the @keyvalueentity  classes based on the other documentation.

Don't include multi-line code snippets (<pre>) in JavaDoc aside from one single example in the KeyValueEntity class javadoc.
```

If we like this I can do the same for some of the other.