### PR TITLE
docs: glossary format

### DIFF
--- a/docs/src/modules/reference/pages/glossary.adoc
+++ b/docs/src/modules/reference/pages/glossary.adoc
@@ -1,9 +1,10 @@
- Glossary of Terms
+= Glossary of Terms
+
 include::ROOT:partial$include.adoc[]
 
 [glossary]
 
-[[agent]]Agent::A component that interacts with an AI model to perform a specific task. It is typically backed by a large language model (LLM). It maintains contextual history in a session memory, which may be shared between multiple agents that are collaborating on the same goal. It may provide function tools and call them as requested by the model.
+[[agent]]Agent:: A component that interacts with an AI model to perform a specific task. It is typically backed by a large language model (LLM). It maintains contextual history in a session memory, which may be shared between multiple agents that are collaborating on the same goal. It may provide function tools and call them as requested by the model.
 
 [[CICD]]CI/CD:: You can deploy <<service>>s using a Continuous Integration/Continuous Delivery service. See xref:operations:integrating-cicd/index.adoc[] for instructions.
 


### PR DESCRIPTION
Fixes formatting of the glossary page.
- https://doc.akka.io/reference/glossary.html