### PR TITLE
docs: Improve JavaDoc of EventSourcedEntity

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/CommandContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/CommandContext.java
@@ -7,40 +7,59 @@ package akka.javasdk.eventsourcedentity;
 import akka.javasdk.MetadataContext;
 import akka.javasdk.Tracing;
 
-/** An event sourced command context. */
+/**
+ * Context information available to Event Sourced Entity command handlers during command processing.
+ * Provides access to command metadata, entity identification, sequence information, and tracing capabilities.
+ * 
+ * <p>This context is automatically provided by the Akka runtime and can be accessed within
+ * command handlers using {@link EventSourcedEntity#commandContext()}.
+ */
 public interface CommandContext extends MetadataContext {
   /**
-   * The current sequence number of events in this entity.
+   * Returns the current sequence number of events in this entity. This represents the number
+   * of events that have been persisted for this entity instance.
    *
-   * @return The current sequence number.
+   * @return the current sequence number of persisted events
    */
   long sequenceNumber();
 
   /**
-   * The name of the command being executed.
+   * Returns the name of the command currently being executed. This corresponds to the
+   * method name of the command handler being invoked.
    *
-   * @return The name of the command.
+   * @return the name of the command being processed
    */
   String commandName();
 
   /**
-   * The id of the command being executed.
+   * Returns the command ID for the current command.
    *
-   * @return The id of the command.
-   * @deprecated not used anymore
+   * @return the command ID
+   * @deprecated This method is no longer used and will be removed in a future version
    */
   @Deprecated
   long commandId();
 
   /**
-   * The id of the entity that this context is for.
+   * Returns the unique identifier of the entity instance that this command is being executed on.
+   * This is the same ID used when calling the entity through a component client.
    *
-   * @return The entity id.
+   * @return the unique entity ID for this entity instance
    */
   String entityId();
 
+  /**
+   * Returns whether this entity has been marked for deletion.
+   *
+   * @return {@code true} if the entity has been deleted, {@code false} otherwise
+   */
   boolean isDeleted();
 
-  /** Access to tracing for custom app specific tracing. */
+  /**
+   * Provides access to tracing functionality for adding custom application-specific tracing
+   * information to the current command processing.
+   * 
+   * @return the tracing context for custom tracing operations
+   */
   Tracing tracing();
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/CommandContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/CommandContext.java
@@ -9,23 +9,24 @@ import akka.javasdk.Tracing;
 
 /**
  * Context information available to Event Sourced Entity command handlers during command processing.
- * Provides access to command metadata, entity identification, sequence information, and tracing capabilities.
- * 
- * <p>This context is automatically provided by the Akka runtime and can be accessed within
- * command handlers using {@link EventSourcedEntity#commandContext()}.
+ * Provides access to command metadata, entity identification, sequence information, and tracing
+ * capabilities.
+ *
+ * <p>This context is automatically provided by the Akka runtime and can be accessed within command
+ * handlers using {@link EventSourcedEntity#commandContext()}.
  */
 public interface CommandContext extends MetadataContext {
   /**
-   * Returns the current sequence number of events in this entity. This represents the number
-   * of events that have been persisted for this entity instance.
+   * Returns the current sequence number of events in this entity. This represents the number of
+   * events that have been persisted for this entity instance.
    *
    * @return the current sequence number of persisted events
    */
   long sequenceNumber();
 
   /**
-   * Returns the name of the command currently being executed. This corresponds to the
-   * method name of the command handler being invoked.
+   * Returns the name of the command currently being executed. This corresponds to the method name
+   * of the command handler being invoked.
    *
    * @return the name of the command being processed
    */
@@ -58,7 +59,7 @@ public interface CommandContext extends MetadataContext {
   /**
    * Provides access to tracing functionality for adding custom application-specific tracing
    * information to the current command processing.
-   * 
+   *
    * @return the tracing context for custom tracing operations
    */
   Tracing tracing();

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/CommandContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/CommandContext.java
@@ -32,9 +32,9 @@ public interface CommandContext extends MetadataContext {
   String commandName();
 
   /**
-   * Returns the command ID for the current command.
+   * Returns the command id for the current command.
    *
-   * @return the command ID
+   * @return the command id
    * @deprecated This method is no longer used and will be removed in a future version
    */
   @Deprecated
@@ -42,9 +42,9 @@ public interface CommandContext extends MetadataContext {
 
   /**
    * Returns the unique identifier of the entity instance that this command is being executed on.
-   * This is the same ID used when calling the entity through a component client.
+   * This is the same id used when calling the entity through a component client.
    *
-   * @return the unique entity ID for this entity instance
+   * @return the unique entity id for this entity instance
    */
   String entityId();
 

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventContext.java
@@ -5,16 +5,16 @@
 package akka.javasdk.eventsourcedentity;
 
 /**
- * Context information available when processing events in the {@link EventSourcedEntity#applyEvent} method.
- * Provides access to event metadata and sequence information.
- * 
- * <p>This context is automatically provided by the Akka runtime and can be accessed within
- * the {@link EventSourcedEntity#applyEvent} method using {@link EventSourcedEntity#eventContext()}.
+ * Context information available when processing events in the {@link EventSourcedEntity#applyEvent}
+ * method. Provides access to event metadata and sequence information.
+ *
+ * <p>This context is automatically provided by the Akka runtime and can be accessed within the
+ * {@link EventSourcedEntity#applyEvent} method using {@link EventSourcedEntity#eventContext()}.
  */
 public interface EventContext extends EventSourcedEntityContext {
   /**
-   * Returns the sequence number of the current event being processed. This represents the
-   * position of this event in the entity's event journal.
+   * Returns the sequence number of the current event being processed. This represents the position
+   * of this event in the entity's event journal.
    *
    * @return the sequence number of the current event
    */

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventContext.java
@@ -4,12 +4,19 @@
 
 package akka.javasdk.eventsourcedentity;
 
-/** Context for an event. */
+/**
+ * Context information available when processing events in the {@link EventSourcedEntity#applyEvent} method.
+ * Provides access to event metadata and sequence information.
+ * 
+ * <p>This context is automatically provided by the Akka runtime and can be accessed within
+ * the {@link EventSourcedEntity#applyEvent} method using {@link EventSourcedEntity#eventContext()}.
+ */
 public interface EventContext extends EventSourcedEntityContext {
   /**
-   * The sequence number of the current event being processed.
+   * Returns the sequence number of the current event being processed. This represents the
+   * position of this event in the entity's event journal.
    *
-   * @return The sequence number.
+   * @return the sequence number of the current event
    */
   long sequenceNumber();
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntity.java
@@ -105,6 +105,31 @@ import java.util.function.Function;
  * <p>Concrete classes must be annotated with {@link akka.javasdk.annotations.ComponentId} with a
  * stable, unique identifier that cannot be changed after production deployment.
  *
+ * <h2>Immutable state record</h2>
+ * <p>It is recommended to use immutable state objects, such as Java records, for the entity state.
+ * Immutable state ensures thread safety and prevents accidental modifications that could lead to
+ * inconsistent state or concurrency issues.
+ *
+ * <p>While mutable state classes are supported, they require careful handling:
+ * <ul>
+ *   <li>Mutable state should not be shared outside the entity</li>
+ *   <li>Mutable state should not be passed to other threads, such as in {@code CompletionStage} operations</li>
+ *   <li>Any modifications to mutable state must be done within the entity's event handler</li>
+ * </ul>
+ *
+ * <p><strong>Collections in State:</strong> Collections (such as {@code List}, {@code Set}, {@code Map}) are
+ * typically mutable even when contained within immutable objects. When updating state that contains collections,
+ * you should create copies of the collections rather than modifying them in place. This ensures that the
+ * previous state remains unchanged and prevents unintended side effects.
+ *
+ * <p><strong>Performance Considerations:</strong> Defensive copying of collections can introduce performance
+ * overhead, especially for large collections or frequent updates. In performance-critical scenarios, this
+ * recommendation can be carefully tuned by using mutable state with strict adherence to the safety guidelines
+ * mentioned above.
+ *
+ * <p>Using immutable records with defensive copying of collections eliminates concurrency concerns and is the
+ * preferred approach for state modeling in most cases.
+ *
  * @param <S> The type of the state for this entity
  * @param <E> The parent type of the event hierarchy for this entity, required to be a sealed interface
  */

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntity.java
@@ -63,29 +63,33 @@ import java.util.function.Function;
  * <pre>{@code
  * @ComponentId("shopping-cart")
  * public class ShoppingCartEntity extends EventSourcedEntity<ShoppingCart, ShoppingCartEvent> {
- *   
+ *   private final String entityId;
+ *
  *   public ShoppingCartEntity(EventSourcedEntityContext context) {
- *     // Constructor can accept EventSourcedEntityContext and custom dependency types
+ *     this.entityId = context.entityId();
  *   }
- *   
+ *
  *   @Override
  *   public ShoppingCart emptyState() {
  *     return new ShoppingCart(entityId, Collections.emptyList(), false);
  *   }
- *   
+ *
  *   public Effect<Done> addItem(LineItem item) {
  *     var event = new ShoppingCartEvent.ItemAdded(item);
+ *
  *     return effects()
  *         .persist(event)
  *         .thenReply(newState -> Done.getInstance());
  *   }
- *   
+ *
+ *   public ReadOnlyEffect<ShoppingCart> getCart() {
+ *     return effects().reply(currentState());
+ *   }
  *   @Override
  *   public ShoppingCart applyEvent(ShoppingCartEvent event) {
  *     return switch (event) {
- *       case ShoppingCartEvent.ItemAdded evt -> currentState().onItemAdded(evt);
- *       case ShoppingCartEvent.ItemRemoved evt -> currentState().onItemRemoved(evt);
- *       case ShoppingCartEvent.CheckedOut evt -> currentState().onCheckedOut();
+ *       case ShoppingCartEvent.ItemAdded evt -> currentState().addItem(evt.item());
+ *       // handle all events ...
  *     };
  *   }
  * }

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntity.java
@@ -37,7 +37,7 @@ import java.util.function.Function;
  * <ul>
  *   <li>Commands validate business rules and persist events representing state changes</li>
  *   <li>Events are applied to update the entity state through the {@link #applyEvent(E)} method</li>
- *   <li>The current state is always derived from the complete sequence of events</li>
+ *   <li>The current state is always derived from the complete sequence of events (and snapshot, if exists)</li>
  * </ul>
  * 
  * <h2>Command Handlers</h2>

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntity.java
@@ -58,12 +58,7 @@ import java.util.function.Function;
  * <p>Akka automatically creates snapshots as an optimization to avoid replaying all events during
  * entity recovery. Snapshots are created after a configurable number of events and are handled
  * transparently without requiring specific code.
- * 
- * <h2>Multi-region Replication</h2>
- * Event Sourced Entities support multi-region replication for resilience and performance. Write requests
- * are handled by the primary region, while read requests can be served from any region. Use
- * {@link ReadOnlyEffect} for read-only operations that can be served from replicas.
- * 
+ *
  * <h2>Example Implementation</h2>
  * <pre>{@code
  * @ComponentId("shopping-cart")
@@ -104,6 +99,11 @@ import java.util.function.Function;
  * 
  * <p>Concrete classes must be annotated with {@link akka.javasdk.annotations.ComponentId} with a
  * stable, unique identifier that cannot be changed after production deployment.
+ *
+ * <h2>Multi-region Replication</h2>
+ * Event Sourced Entities support multi-region replication for resilience and performance. Write requests
+ * are handled by the primary region, while read requests can be served from any region. Use
+ * {@link ReadOnlyEffect} for read-only operations that can be served from replicas.
  *
  * <h2>Immutable state record</h2>
  * <p>It is recommended to use immutable state objects, such as Java records, for the entity state.

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntity.java
@@ -18,7 +18,7 @@ import java.util.function.Function;
  * This approach provides a complete audit trail and enables reliable state replication.
  * 
  * <p>Event Sourced Entities provide strong consistency guarantees through entity sharding, where each
- * entity instance is identified by a unique ID and distributed across the service cluster. Only one
+ * entity instance is identified by a unique id and distributed across the service cluster. Only one
  * instance of each entity exists in the cluster at any time, ensuring sequential message processing
  * without concurrency concerns.
  * 
@@ -159,7 +159,7 @@ public abstract class EventSourcedEntity<S, E> {
 
   /**
    * Provides access to additional context and metadata for the current command being processed.
-   * This includes information such as the command name, entity ID, sequence number, and tracing context.
+   * This includes information such as the command name, entity id, sequence number, and tracing context.
    *
    * <p>This method can only be called from within a command handler method. Attempting to access
    * it from the constructor or inside the {@link #applyEvent(E)} method will result in an exception.

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntityContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntityContext.java
@@ -7,13 +7,13 @@ package akka.javasdk.eventsourcedentity;
 import akka.javasdk.EntityContext;
 
 /**
- * Context information available during Event Sourced Entity construction and initialization.
- * This context provides access to entity metadata and configuration that is available
- * throughout the entity's lifecycle.
- * 
+ * Context information available during Event Sourced Entity construction and initialization. This
+ * context provides access to entity metadata and configuration that is available throughout the
+ * entity's lifecycle.
+ *
  * <p>The EventSourcedEntityContext is typically injected into the entity constructor and can be
  * used to access the entity id and other contextual information needed during entity setup.
- * 
+ *
  * <p>Unlike {@link CommandContext} and {@link EventContext}, this context is available during
  * entity construction and is not limited to command or event processing.
  */

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntityContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntityContext.java
@@ -12,7 +12,7 @@ import akka.javasdk.EntityContext;
  * throughout the entity's lifecycle.
  * 
  * <p>The EventSourcedEntityContext is typically injected into the entity constructor and can be
- * used to access the entity ID and other contextual information needed during entity setup.
+ * used to access the entity id and other contextual information needed during entity setup.
  * 
  * <p>Unlike {@link CommandContext} and {@link EventContext}, this context is available during
  * entity construction and is not limited to command or event processing.

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntityContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntityContext.java
@@ -6,5 +6,15 @@ package akka.javasdk.eventsourcedentity;
 
 import akka.javasdk.EntityContext;
 
-/** Root context for all event sourcing contexts. */
+/**
+ * Context information available during Event Sourced Entity construction and initialization.
+ * This context provides access to entity metadata and configuration that is available
+ * throughout the entity's lifecycle.
+ * 
+ * <p>The EventSourcedEntityContext is typically injected into the entity constructor and can be
+ * used to access the entity ID and other contextual information needed during entity setup.
+ * 
+ * <p>Unlike {@link CommandContext} and {@link EventContext}, this context is available during
+ * entity construction and is not limited to command or event processing.
+ */
 public interface EventSourcedEntityContext extends EntityContext {}

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/package-info.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/package-info.java
@@ -1,18 +1,25 @@
 /**
- * Event Sourced Entity components for building stateful services that persist changes as events in a journal.
- * 
- * <p>Event Sourced Entities store a sequence of events rather than the current state directly. The current
- * state is derived by replaying all events from the journal. This approach provides a complete audit trail,
- * enables reliable state replication, and allows for sophisticated event-driven architectures.
- * 
+ * Event Sourced Entity components for building stateful services that persist changes as events in
+ * a journal.
+ *
+ * <p>Event Sourced Entities store a sequence of events rather than the current state directly. The
+ * current state is derived by replaying all events from the journal. This approach provides a
+ * complete audit trail, enables reliable state replication, and allows for sophisticated
+ * event-driven architectures.
+ *
  * <p>The main classes in this package are:
+ *
  * <ul>
- *   <li>{@link akka.javasdk.eventsourcedentity.EventSourcedEntity} - The base class for implementing Event Sourced Entities</li>
- *   <li>{@link akka.javasdk.eventsourcedentity.CommandContext} - Context available during command processing</li>
- *   <li>{@link akka.javasdk.eventsourcedentity.EventContext} - Context available during event processing</li>
- *   <li>{@link akka.javasdk.eventsourcedentity.EventSourcedEntityContext} - Context available during entity construction</li>
+ *   <li>{@link akka.javasdk.eventsourcedentity.EventSourcedEntity} - The base class for
+ *       implementing Event Sourced Entities
+ *   <li>{@link akka.javasdk.eventsourcedentity.CommandContext} - Context available during command
+ *       processing
+ *   <li>{@link akka.javasdk.eventsourcedentity.EventContext} - Context available during event
+ *       processing
+ *   <li>{@link akka.javasdk.eventsourcedentity.EventSourcedEntityContext} - Context available
+ *       during entity construction
  * </ul>
- * 
+ *
  * @see akka.javasdk.eventsourcedentity.EventSourcedEntity
  */
 package akka.javasdk.eventsourcedentity;

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/package-info.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/package-info.java
@@ -1,2 +1,18 @@
-/** {@link akka.javasdk.eventsourcedentity.EventSourcedEntity} component. */
+/**
+ * Event Sourced Entity components for building stateful services that persist changes as events in a journal.
+ * 
+ * <p>Event Sourced Entities store a sequence of events rather than the current state directly. The current
+ * state is derived by replaying all events from the journal. This approach provides a complete audit trail,
+ * enables reliable state replication, and allows for sophisticated event-driven architectures.
+ * 
+ * <p>The main classes in this package are:
+ * <ul>
+ *   <li>{@link akka.javasdk.eventsourcedentity.EventSourcedEntity} - The base class for implementing Event Sourced Entities</li>
+ *   <li>{@link akka.javasdk.eventsourcedentity.CommandContext} - Context available during command processing</li>
+ *   <li>{@link akka.javasdk.eventsourcedentity.EventContext} - Context available during event processing</li>
+ *   <li>{@link akka.javasdk.eventsourcedentity.EventSourcedEntityContext} - Context available during entity construction</li>
+ * </ul>
+ * 
+ * @see akka.javasdk.eventsourcedentity.EventSourcedEntity
+ */
 package akka.javasdk.eventsourcedentity;


### PR DESCRIPTION
See #735 

Mostly AI updates from the prompt:
```
Read the documentation from akka-context/java/event-sourced-entities.html.md

Improve the javadoc of the @eventsourcedentity classes based on the other documentation.

Don't include multi-line code snippets (<pre>) in JavaDoc aside from one single example in the EventSourcedEntity class javadoc.
```