### PR TITLE
docs: Improve JavaDoc of McpEndpoint

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/agent/McpToolCallExecutionException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/McpToolCallExecutionException.java
@@ -5,8 +5,20 @@
 package akka.javasdk.agent;
 
 /**
- * Exception thrown when there is a failure executing an MCP (Model Context Protocol) tool call.
- * This includes the name of the tool and the endpoint that failed.
+ * Exception thrown when an MCP (Model Context Protocol) tool call fails during execution.
+ * <p>
+ * This exception is thrown by agents when they attempt to call MCP tools from remote servers
+ * and the tool execution fails. It provides detailed information about which tool and endpoint
+ * failed to help with debugging and error handling.
+ * <p>
+ * <strong>Context Information:</strong>
+ * The exception includes the tool name and endpoint URL to help identify the source of the failure.
+ * This is particularly useful when agents are using multiple MCP servers or when debugging
+ * tool integration issues.
+ * <p>
+ * <strong>Error Handling:</strong>
+ * Agents can catch this exception in their {@code onFailure} handlers to provide fallback
+ * behavior or alternative responses when MCP tools are unavailable.
  */
 final public class McpToolCallExecutionException extends RuntimeException {
 

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpEndpoint.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpEndpoint.java
@@ -7,21 +7,43 @@ package akka.javasdk.annotations.mcp;
 import java.lang.annotation.*;
 
 /**
- * Mark a class to be made available as an MCP server. The annotated class should be public and have a public
- * constructor.
+ * Annotation to mark a class as an MCP (Model Context Protocol) server endpoint.
  * <p>
- * Annotated classes can accept the following types to the constructor:
+ * MCP endpoints expose services to MCP clients such as LLM chat agent desktop applications and agents
+ * running on other services. They provide tools, resources, and prompts that AI models can use to
+ * extend their capabilities.
+ * <p>
+ * <strong>Endpoint Capabilities:</strong>
  * <ul>
- *   <li>{@link akka.javasdk.client.ComponentClient}</li>
- *   <li>{@link akka.javasdk.http.HttpClientProvider}</li>
+ *   <li><strong>Tools:</strong> Methods annotated with {@link McpTool} that clients can call</li>
+ *   <li><strong>Resources:</strong> Methods annotated with {@link McpResource} that provide data</li>
+ *   <li><strong>Prompts:</strong> Methods annotated with {@link McpPrompt} that generate prompts</li>
+ * </ul>
+ * <p>
+ * <strong>Requirements:</strong>
+ * The annotated class must be public and have a public constructor. It should also be annotated
+ * with appropriate {@link akka.javasdk.annotations.Acl} annotations to control access.
+ * <p>
+ * <strong>Constructor Injection:</strong>
+ * Annotated classes can accept the following types in their constructor:
+ * <ul>
+ *   <li>{@link akka.javasdk.client.ComponentClient} - for calling other components</li>
+ *   <li>{@link akka.javasdk.http.HttpClientProvider} - for HTTP service calls</li>
+ *   <li>{@link akka.javasdk.mcp.McpRequestContext} - for request context access</li>
  *   <li>{@link akka.javasdk.timer.TimerScheduler}</li>
  *   <li>{@link akka.stream.Materializer}</li>
  *   <li>{@link com.typesafe.config.Config}</li>
  *   <li>{@link io.opentelemetry.api.trace.Span}</li>
- *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider} from the service setup</li>
+ *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider}</li>
  * </ul>
- * <p>If the annotated class extends {@link akka.javasdk.http.AbstractHttpEndpoint} the request context
- * is available without constructor injection.
+ * <p>
+ * <strong>Request Context Access:</strong>
+ * If the annotated class extends {@link akka.javasdk.mcp.AbstractMcpEndpoint}, the request context
+ * is available via {@code requestContext()} without constructor injection.
+ * <p>
+ * <strong>Transport:</strong>
+ * MCP endpoints use a stateless streamable HTTP transport as defined by the MCP specification.
+ * The endpoint is served at the specified path (default: {@code /mcp}).
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpPrompt.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpPrompt.java
@@ -7,12 +7,35 @@ package akka.javasdk.annotations.mcp;
 import java.lang.annotation.*;
 
 /**
- * Marks a method that can construct an LLM prompt that clients can fetch.
+ * Annotation to expose a method as an MCP prompt that clients can fetch and use.
  * <p>
- * The prompt method can have zero or more parameters used as prompt "arguments". All parameters must be either {@code String} for required parameters
- * or {@code Optional<String>} for optional parameters.
+ * MCP prompts provide template prompts that can be customized with input parameters. They help
+ * standardize common prompting patterns and make them reusable across different AI interactions.
  * <p>
- *
+ * <strong>Method Requirements:</strong>
+ * <ul>
+ *   <li>Must be public</li>
+ *   <li>Must return a {@code String}</li>
+ *   <li>Can have zero or more parameters</li>
+ *   <li>Must be in a class annotated with {@link McpEndpoint}</li>
+ * </ul>
+ * <p>
+ * <strong>Parameter Types:</strong>
+ * All parameters must be either {@code String} for required parameters or {@code Optional<String>}
+ * for optional parameters. Use {@link akka.javasdk.annotations.Description} annotations to describe
+ * the purpose of each parameter.
+ * <p>
+ * <strong>Prompt Roles:</strong>
+ * Prompts can be designated as "user" prompts (default) or "assistant" prompts using the {@link #role()}
+ * attribute. This helps clients understand how to use the prompt in their conversation flow.
+ * <p>
+ * <strong>Use Cases:</strong>
+ * <ul>
+ *   <li>Code review templates</li>
+ *   <li>Analysis frameworks</li>
+ *   <li>Structured questioning patterns</li>
+ *   <li>Domain-specific prompt templates</li>
+ * </ul>
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpResource.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpResource.java
@@ -8,15 +8,40 @@ package akka.javasdk.annotations.mcp;
 import java.lang.annotation.*;
 
 /**
- * Marks a method that returns an MCP resource that clients can fetch.
+ * Annotation to expose a method as an MCP resource that clients can fetch.
  * <p>
- * If {@code uri} is defined the annotated method must have no parameters.
- * If {@code uriTemplate} is defined the method must take one string parameter, which will be fed the suffix of the template.
+ * MCP resources provide static or dynamic content that AI models can access to gather information.
+ * Resources can be static files, configuration data, or dynamically generated content based on parameters.
  * <p>
- * If the method returns {@code String} an MCP text resource is returned (implicitly UTF-8 encoded).
- * If the method returns {@code byte[]} a binary resource is returned, with the payload base64 encoded.
- * For all other returned types, the value is encoded to JSON using jackson and is returned as a text resource with
- * default mime type {@code application/json}.
+ * <strong>Resource Types:</strong>
+ * <ul>
+ *   <li><strong>Static Resources:</strong> Use {@link #uri()} for fixed content with no parameters</li>
+ *   <li><strong>Dynamic Resources:</strong> Use {@link #uriTemplate()} for parameterized content</li>
+ * </ul>
+ * <p>
+ * <strong>Method Requirements:</strong>
+ * <ul>
+ *   <li>Must be public</li>
+ *   <li>For static resources ({@code uri}): no parameters allowed</li>
+ *   <li>For dynamic resources ({@code uriTemplate}): parameters must match template placeholders</li>
+ *   <li>Must be in a class annotated with {@link McpEndpoint}</li>
+ * </ul>
+ * <p>
+ * <strong>Return Types:</strong>
+ * <ul>
+ *   <li>{@code String}: Returns as UTF-8 encoded text resource</li>
+ *   <li>{@code byte[]}: Returns as base64 encoded binary resource</li>
+ *   <li>Other types: Encoded to JSON with {@code application/json} MIME type</li>
+ * </ul>
+ * <p>
+ * <strong>URI Templates:</strong>
+ * Templates can contain named placeholders for entire path segments only. Each placeholder must match
+ * a method parameter name. For example: {@code "file:///images/{category}/{file}"} matches
+ * {@code file:///images/bicycles/tall_bike.jpg} and passes {@code "bicycles"} as {@code category}
+ * and {@code "tall_bike.jpg"} as {@code file}.
+ * <p>
+ * <strong>Security:</strong>
+ * Always validate input parameters to prevent path traversal attacks or unauthorized access.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpTool.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpTool.java
@@ -7,9 +7,36 @@ package akka.javasdk.annotations.mcp;
 import java.lang.annotation.*;
 
 /**
- * Marks a public method on a {@link McpEndpoint} a tool that can be called by MCP clients.
+ * Annotation to expose a method as an MCP tool that can be called by MCP clients.
  * <p>
- * The method may accept 0 or more parameters, but must return a {@code String}.
+ * MCP tools are functions that AI models can invoke to perform specific tasks or retrieve information.
+ * The LLM determines which tools to call based on the tool descriptions and the user's request.
+ * <p>
+ * <strong>Method Requirements:</strong>
+ * <ul>
+ *   <li>Must be public</li>
+ *   <li>Must return a {@code String}</li>
+ *   <li>Can accept 0 or more parameters</li>
+ *   <li>Must be in a class annotated with {@link McpEndpoint}</li>
+ * </ul>
+ * <p>
+ * <strong>Parameter Types:</strong>
+ * Only simple parameter types are supported. Fields must be primitive types, boxed Java primitives,
+ * or strings. All parameters are required by default; use {@code Optional<T>} for optional parameters.
+ * <p>
+ * <strong>Schema Generation:</strong>
+ * The input schema is automatically generated from method parameters unless a manual schema is provided
+ * via {@link #inputSchema()}. Use {@link akka.javasdk.annotations.Description} annotations on parameters
+ * to help the LLM understand their purpose.
+ * <p>
+ * <strong>Best Practices:</strong>
+ * <ul>
+ *   <li>Provide clear, descriptive tool descriptions</li>
+ *   <li>Use {@link akka.javasdk.annotations.Description} on all parameters</li>
+ *   <li>Keep tools focused on single, well-defined tasks</li>
+ *   <li>Validate input parameters for security</li>
+ *   <li>Use {@link ToolAnnotation} to describe tool behavior characteristics</li>
+ * </ul>
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/ToolAnnotation.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/ToolAnnotation.java
@@ -6,27 +6,26 @@ package akka.javasdk.annotations.mcp;
 
 /**
  * Behavioral annotations that describe MCP tool characteristics to clients.
- * <p>
- * These annotations provide hints about tool behavior to help AI models make informed decisions
- * about when and how to use tools. They describe properties like whether a tool modifies data,
- * can be called repeatedly safely, or interacts with external systems.
- * <p>
- * <strong>Usage:</strong>
- * Apply these annotations to {@link McpTool} methods via the {@link McpTool#annotations()} attribute
- * to help clients understand tool behavior patterns.
- * <p>
- * <strong>Security Note:</strong>
- * All values are <strong>hints only</strong> and are not guaranteed to provide a faithful description
- * of actual tool behavior. Clients should never make security-critical tool use decisions based on
- * ToolAnnotations received from untrusted servers.
- * <p>
- * <strong>Annotation Pairs:</strong>
- * Annotations are defined as opposites to allow clear specification in Java annotations:
+ *
+ * <p>These annotations provide hints about tool behavior to help AI models make informed decisions
+ * about when and how to use tools. They describe properties like whether a tool modifies data, can
+ * be called repeatedly safely, or interacts with external systems.
+ *
+ * <p><strong>Usage:</strong> Apply these annotations to {@link McpTool} methods via the {@link
+ * McpTool#annotations()} attribute to help clients understand tool behavior patterns.
+ *
+ * <p><strong>Security Note:</strong> All values are <strong>hints only</strong> and are not
+ * guaranteed to provide a faithful description of actual tool behavior. Clients should never make
+ * security-critical tool use decisions based on ToolAnnotations received from untrusted servers.
+ *
+ * <p><strong>Annotation Pairs:</strong> Annotations are defined as opposites to allow clear
+ * specification in Java annotations:
+ *
  * <ul>
- *   <li>{@link #Destructive} vs {@link #NonDestructive}</li>
- *   <li>{@link #Idempotent} vs {@link #NonIdempotent}</li>
- *   <li>{@link #OpenWorld} vs {@link #ClosedWorld}</li>
- *   <li>{@link #ReadOnly} vs {@link #Mutating}</li>
+ *   <li>{@link #Destructive} vs {@link #NonDestructive}
+ *   <li>{@link #Idempotent} vs {@link #NonIdempotent}
+ *   <li>{@link #OpenWorld} vs {@link #ClosedWorld}
+ *   <li>{@link #ReadOnly} vs {@link #Mutating}
  * </ul>
  */
 public enum ToolAnnotation {

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/ToolAnnotation.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/ToolAnnotation.java
@@ -5,13 +5,29 @@
 package akka.javasdk.annotations.mcp;
 
 /**
- * Additional annotations describing a Tool to clients.
- *
- * <p>NOTE: all values are **hints**. They are not guaranteed to provide a faithful description of
- * tool behavior.
- *
- * <p>Clients should never make tool use decisions based on ToolAnnotations received from untrusted
- * servers.
+ * Behavioral annotations that describe MCP tool characteristics to clients.
+ * <p>
+ * These annotations provide hints about tool behavior to help AI models make informed decisions
+ * about when and how to use tools. They describe properties like whether a tool modifies data,
+ * can be called repeatedly safely, or interacts with external systems.
+ * <p>
+ * <strong>Usage:</strong>
+ * Apply these annotations to {@link McpTool} methods via the {@link McpTool#annotations()} attribute
+ * to help clients understand tool behavior patterns.
+ * <p>
+ * <strong>Security Note:</strong>
+ * All values are <strong>hints only</strong> and are not guaranteed to provide a faithful description
+ * of actual tool behavior. Clients should never make security-critical tool use decisions based on
+ * ToolAnnotations received from untrusted servers.
+ * <p>
+ * <strong>Annotation Pairs:</strong>
+ * Annotations are defined as opposites to allow clear specification in Java annotations:
+ * <ul>
+ *   <li>{@link #Destructive} vs {@link #NonDestructive}</li>
+ *   <li>{@link #Idempotent} vs {@link #NonIdempotent}</li>
+ *   <li>{@link #OpenWorld} vs {@link #ClosedWorld}</li>
+ *   <li>{@link #ReadOnly} vs {@link #Mutating}</li>
+ * </ul>
  */
 public enum ToolAnnotation {
   // Note: defined as enum with opposites to allow usage in Java annotations

--- a/akka-javasdk/src/main/java/akka/javasdk/mcp/AbstractMcpEndpoint.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/mcp/AbstractMcpEndpoint.java
@@ -31,16 +31,6 @@ import akka.annotation.InternalApi;
  *   public String add(@Description("First number") int a, @Description("Second number") int b) {
  *     return String.valueOf(a + b);
  *   }
- * 
- *   @McpResource(uri = "file:///config.json", name = "Configuration")
- *   public String getConfig() {
- *     return "{ \"setting\": \"value\" }";
- *   }
- * 
- *   @McpPrompt(description = "Code review prompt")
- *   public String reviewPrompt(@Description("Code to review") String code) {
- *     return "Please review this code: " + code;
- *   }
  * }
  * }</pre>
  * <p>

--- a/akka-javasdk/src/main/java/akka/javasdk/mcp/AbstractMcpEndpoint.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/mcp/AbstractMcpEndpoint.java
@@ -7,7 +7,54 @@ package akka.javasdk.mcp;
 import akka.annotation.InternalApi;
 
 /**
- * Optional base class for MCP endpoints giving access to a request context without additional constructor parameters
+ * Optional base class for MCP (Model Context Protocol) endpoints providing convenient access to request context.
+ * <p>
+ * MCP endpoints expose services to MCP clients such as LLM chat agent desktop applications and agents running
+ * on other services. They can provide tools, resources, and prompts that AI models can use to extend their capabilities.
+ * <p>
+ * <strong>MCP Capabilities:</strong>
+ * <ul>
+ *   <li><strong>Tools:</strong> Functions/logic that MCP clients can call on behalf of the LLM</li>
+ *   <li><strong>Resources:</strong> Static resources or dynamic resource templates that clients can fetch</li>
+ *   <li><strong>Prompts:</strong> Template prompts created from input parameters</li>
+ * </ul>
+ * <p>
+ * <strong>Basic Usage:</strong>
+ * <pre>{@code
+ * @Acl(allow = @Acl.Matcher(principal = Acl.Principal.ALL))
+ * @McpEndpoint(
+ *     serverName = "my-service-mcp",
+ *     serverVersion = "1.0.0")
+ * public class MyMcpEndpoint extends AbstractMcpEndpoint {
+ * 
+ *   @McpTool(description = "Adds two numbers")
+ *   public String add(@Description("First number") int a, @Description("Second number") int b) {
+ *     return String.valueOf(a + b);
+ *   }
+ * 
+ *   @McpResource(uri = "file:///config.json", name = "Configuration")
+ *   public String getConfig() {
+ *     return "{ \"setting\": \"value\" }";
+ *   }
+ * 
+ *   @McpPrompt(description = "Code review prompt")
+ *   public String reviewPrompt(@Description("Code to review") String code) {
+ *     return "Please review this code: " + code;
+ *   }
+ * }
+ * }</pre>
+ * <p>
+ * <strong>Request Context:</strong>
+ * Extending this class provides access to {@link McpRequestContext} via {@link #requestContext()} without
+ * requiring constructor injection. The context provides access to request headers, JWT claims, principals,
+ * and tracing information.
+ * <p>
+ * <strong>Alternative Approach:</strong>
+ * Instead of extending this class, you can inject {@link McpRequestContext} directly into your endpoint
+ * constructor or use dependency injection for other services like {@link akka.javasdk.client.ComponentClient}.
+ * <p>
+ * MCP endpoints are made available using a stateless streamable HTTP transport as defined by the
+ * MCP specification. By default, endpoints are served at the {@code /mcp} path.
  */
 abstract public class AbstractMcpEndpoint {
 

--- a/akka-javasdk/src/main/java/akka/javasdk/mcp/McpRequestContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/mcp/McpRequestContext.java
@@ -16,26 +16,26 @@ import java.util.Optional;
 
 /**
  * Context information available during MCP endpoint request processing.
- * <p>
- * Provides access to request metadata including headers, authentication information, and tracing capabilities
- * for MCP endpoint methods. This context is available during the processing of MCP tool calls, resource
- * requests, and prompt requests.
- * <p>
- * <strong>Access Methods:</strong>
+ *
+ * <p>Provides access to request metadata including headers, authentication information, and tracing
+ * capabilities for MCP endpoint methods. This context is available during the processing of MCP
+ * tool calls, resource requests, and prompt requests.
+ *
+ * <p><strong>Access Methods:</strong>
+ *
  * <ul>
- *   <li>Extend {@link AbstractMcpEndpoint} and use {@code requestContext()}</li>
- *   <li>Inject as constructor parameter into MCP endpoint classes</li>
+ *   <li>Extend {@link AbstractMcpEndpoint} and use {@code requestContext()}
+ *   <li>Inject as constructor parameter into MCP endpoint classes
  * </ul>
- * <p>
- * <strong>Authentication & Authorization:</strong>
- * Use {@link #getPrincipals()} and {@link #getJwtClaims()} to access authentication information
- * for custom authorization logic. MCP endpoints support ACL annotations and JWT validation.
- * <p>
- * <strong>Custom Headers:</strong>
- * Access request headers via {@link #requestHeader(String)} for custom authentication schemes
- * or client-specific metadata.
- * <p>
- * Not for user extension, implementation provided by the SDK.
+ *
+ * <p><strong>Authentication & Authorization:</strong> Use {@link #getPrincipals()} and {@link
+ * #getJwtClaims()} to access authentication information for custom authorization logic. MCP
+ * endpoints support ACL annotations and JWT validation.
+ *
+ * <p><strong>Custom Headers:</strong> Access request headers via {@link #requestHeader(String)} for
+ * custom authentication schemes or client-specific metadata.
+ *
+ * <p>Not for user extension, implementation provided by the SDK.
  */
 @DoNotInherit
 public interface McpRequestContext {

--- a/akka-javasdk/src/main/java/akka/javasdk/mcp/McpRequestContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/mcp/McpRequestContext.java
@@ -14,7 +14,29 @@ import akka.javasdk.Tracing;
 import java.util.List;
 import java.util.Optional;
 
-/** Not for user extension, can be injected as constructor parameter into MCP endpoint components */
+/**
+ * Context information available during MCP endpoint request processing.
+ * <p>
+ * Provides access to request metadata including headers, authentication information, and tracing capabilities
+ * for MCP endpoint methods. This context is available during the processing of MCP tool calls, resource
+ * requests, and prompt requests.
+ * <p>
+ * <strong>Access Methods:</strong>
+ * <ul>
+ *   <li>Extend {@link AbstractMcpEndpoint} and use {@code requestContext()}</li>
+ *   <li>Inject as constructor parameter into MCP endpoint classes</li>
+ * </ul>
+ * <p>
+ * <strong>Authentication & Authorization:</strong>
+ * Use {@link #getPrincipals()} and {@link #getJwtClaims()} to access authentication information
+ * for custom authorization logic. MCP endpoints support ACL annotations and JWT validation.
+ * <p>
+ * <strong>Custom Headers:</strong>
+ * Access request headers via {@link #requestHeader(String)} for custom authentication schemes
+ * or client-specific metadata.
+ * <p>
+ * Not for user extension, implementation provided by the SDK.
+ */
 @DoNotInherit
 public interface McpRequestContext {
   /**


### PR DESCRIPTION
Mostly AI updates based on prompt:
```
Read the documentation from akka-context/java/mcp-endpoints.html.md

Improve the javadoc of the @mcp  classes based on the other documentation.

Don't include multi-line code snippets (<pre>) in JavaDoc aside from one single example in the AbstractMcpEndpoint class javadoc.
```