### PR TITLE
chore: simplify tranistional effect signature

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflowWithFraudDetection.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflowWithFraudDetection.java
@@ -4,50 +4,23 @@
 
 package akkajavasdk.components.workflowentities;
 
+import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.client.ComponentClient;
+import akka.javasdk.workflow.Workflow;
 import akkajavasdk.components.actions.echo.Message;
 import akkajavasdk.components.workflowentities.FraudDetectionResult.TransferRejected;
 import akkajavasdk.components.workflowentities.FraudDetectionResult.TransferRequiresManualAcceptation;
 import akkajavasdk.components.workflowentities.FraudDetectionResult.TransferVerified;
-import akka.javasdk.annotations.ComponentId;
-import akka.javasdk.client.ComponentClient;
-import akka.javasdk.workflow.Workflow;
 
 @ComponentId("transfer-workflow-with-fraud-detection")
 public class TransferWorkflowWithFraudDetection extends Workflow<TransferState> {
 
-  private final String fraudDetectionStepName = "fraud-detection";
-  private final String withdrawStepName = "withdraw";
-  private final String depositStepName = "deposit";
-
-  private ComponentClient componentClient;
+  private final ComponentClient componentClient;
 
   public TransferWorkflowWithFraudDetection(ComponentClient componentClient) {
     this.componentClient = componentClient;
   }
 
-  @Override
-  public WorkflowDef<TransferState> definition() {
-    var fraudDetection =
-        step(fraudDetectionStepName)
-            .call(Transfer.class, this::checkFrauds)
-            .andThen(FraudDetectionResult.class, this::processFraudDetectionResult);
-
-    var withdraw =
-        step(withdrawStepName)
-            .call(Withdraw.class, cmd ->
-                componentClient.forKeyValueEntity(cmd.from).method(WalletEntity::withdraw).invoke(cmd.amount))
-            .andThen(String.class, this::moveToDeposit);
-
-    var deposit =
-        step(depositStepName)
-            .call(Deposit.class, cmd -> componentClient.forKeyValueEntity(cmd.to).method(WalletEntity::deposit).invoke(cmd.amount))
-            .andThen(String.class, this::finishWithSuccess);
-
-    return workflow()
-        .addStep(fraudDetection)
-        .addStep(withdraw)
-        .addStep(deposit);
-  }
 
   public Effect<Message> startTransfer(Transfer transfer) {
     if (transfer.amount() <= 0) {
@@ -56,7 +29,8 @@ public class TransferWorkflowWithFraudDetection extends Workflow<TransferState> 
       if (currentState() == null) {
         return effects()
             .updateState(new TransferState(transfer, "started"))
-            .transitionTo(fraudDetectionStepName, transfer)
+            .transitionTo(TransferWorkflowWithFraudDetection::detectFraud)
+            .withInput(transfer)
             .thenReply(new Message("transfer started"));
       } else {
         return effects().reply(new Message("transfer started already"));
@@ -64,15 +38,20 @@ public class TransferWorkflowWithFraudDetection extends Workflow<TransferState> 
     }
   }
 
+
   public Effect<Message> acceptTransfer() {
     if (currentState() == null) {
       return effects().reply(new Message("transfer not started"));
     } else if (!currentState().accepted() && !currentState().finished()) {
+
       var withdrawInput = new Withdraw(currentState().transfer().from(), currentState().transfer().amount());
+
       return effects()
           .updateState(currentState().asAccepted())
-          .transitionTo(withdrawStepName, withdrawInput)
+          .transitionTo(TransferWorkflowWithFraudDetection::withdraw)
+          .withInput(withdrawInput)
           .thenReply(new Message("transfer accepted"));
+
     } else {
       return effects().reply(new Message("transfer cannot be accepted"));
     }
@@ -86,21 +65,6 @@ public class TransferWorkflowWithFraudDetection extends Workflow<TransferState> 
     }
   }
 
-  private Effect.TransitionalEffect<Void> finishWithSuccess(String response) {
-    var state = currentState().withLastStep(depositStepName);
-    return effects().updateState(state).end();
-  }
-
-  private Effect.TransitionalEffect<Void> moveToDeposit(String response) {
-    var state = currentState().withLastStep(withdrawStepName);
-
-    var depositInput = new Deposit(currentState().transfer().to(), currentState().transfer().amount());
-
-    return effects()
-        .updateState(state)
-        .transitionTo(depositStepName, depositInput);
-  }
-
   private FraudDetectionResult checkFrauds(Transfer transfer) {
     if (transfer.amount() >= 1000 && transfer.amount() < 1000000) {
       return new TransferRequiresManualAcceptation(transfer);
@@ -111,27 +75,60 @@ public class TransferWorkflowWithFraudDetection extends Workflow<TransferState> 
     }
   }
 
-  private Effect.TransitionalEffect<Void> processFraudDetectionResult(FraudDetectionResult result) {
-    var state = currentState().withLastStep(fraudDetectionStepName);
+  private StepEffect detectFraud(Transfer transfer) {
+
+    var result = checkFrauds(transfer);
+    var state = currentState().withLastStep("fraud-detection");
 
     switch (result) {
       case TransferVerified transferVerified -> {
         var withdrawInput = new Withdraw(transferVerified.transfer.from(), transferVerified.transfer.amount());
 
-        return effects()
-            .updateState(state)
-            .transitionTo(withdrawStepName, withdrawInput);
+        return stepEffects()
+          .updateState(state)
+          .thenTransitionTo(TransferWorkflowWithFraudDetection::withdraw)
+          .withInput(withdrawInput);
       }
-      case TransferRequiresManualAcceptation transferRequiresManualAcceptation -> {
-        return effects()
-            .updateState(state)
-            .pause();
+      case TransferRequiresManualAcceptation __ -> {
+        return stepEffects()
+          .updateState(state)
+          .thenPause();
       }
-      case TransferRejected transferRejected -> {
-        return effects()
-            .updateState(state.asFinished())
-            .end();
+      case TransferRejected __ -> {
+        return stepEffects()
+          .updateState(state.asFinished())
+          .thenEnd();
       }
     }
+  }
+
+  private StepEffect withdraw(Withdraw withdraw) {
+
+    componentClient
+      .forKeyValueEntity(withdraw.from)
+      .method(WalletEntity::withdraw)
+      .invoke(withdraw.amount);
+
+    var state = currentState().withLastStep("withdraw");
+    var depositInput = new Deposit(currentState().transfer().to(), currentState().transfer().amount());
+
+    return stepEffects()
+      .updateState(state)
+      .thenTransitionTo(TransferWorkflowWithFraudDetection::deposit)
+      .withInput(depositInput);
+  }
+
+  private StepEffect deposit(Deposit deposit) {
+
+    componentClient
+      .forKeyValueEntity(deposit.to)
+      .method(WalletEntity::deposit)
+      .invoke(deposit.amount);
+
+    var state = currentState().withLastStep("deposit");
+
+    return stepEffects()
+      .updateState(state)
+      .thenEnd();
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
@@ -217,7 +217,7 @@ public abstract class Workflow<S> {
       /**
        * Pause the workflow execution and wait for an external input, e.g. via command handler.
        */
-      TransitionalEffect<Void> pause();
+      Transitional pause();
 
       /**
        * Defines the next step to which the workflow should transition to.
@@ -231,7 +231,7 @@ public abstract class Workflow<S> {
        * @deprecated use {@link Builder#transitionTo(akka.japi.function.Function2)} instead.
        */
       @Deprecated
-      <I> TransitionalEffect<Void> transitionTo(String stepName, I input);
+      <I> Transitional transitionTo(String stepName, I input);
 
       /**
        * Defines the next step to which the workflow should transition to.
@@ -243,24 +243,24 @@ public abstract class Workflow<S> {
        * @deprecated use {@link Builder#transitionTo(akka.japi.function.Function)} instead.
        */
       @Deprecated
-      TransitionalEffect<Void> transitionTo(String stepName);
+      Transitional transitionTo(String stepName);
 
-      <W> TransitionalEffect<Void> transitionTo(akka.japi.function.Function <W, StepEffect> methodRef);
+      <W> Transitional transitionTo(akka.japi.function.Function <W, StepEffect> methodRef);
 
-      <W, I> CallWithInput<I, TransitionalEffect<Void> > transitionTo(akka.japi.function.Function2<W, I, StepEffect> methodRef);
+      <W, I> CallWithInput<I, Transitional> transitionTo(akka.japi.function.Function2<W, I, StepEffect> methodRef);
 
       /**
        * Finish the workflow execution.
        * After transition to {@code end}, no more transitions are allowed.
        */
-      TransitionalEffect<Void> end();
+      Transitional end();
 
       /**
        * Finish and delete the workflow execution.
        * After transition to {@code delete}, no more transitions are allowed.
        * The actual workflow state deletion is done with a configurable delay to allow downstream consumers to observe that fact.
        */
-      TransitionalEffect<Void> delete();
+      Transitional delete();
 
       /**
        * Create a message reply.
@@ -319,13 +319,35 @@ public abstract class Workflow<S> {
       <R> Effect<R> thenReply(R message, Metadata metadata);
     }
 
+    interface Transitional extends TransitionalEffect<Void> {
+
+      /**
+       * Reply after for example {@code updateState}.
+       *
+       * @param message The payload of the reply.
+       * @param <R>     The type of the message that must be returned by this call.
+       * @return A message reply.
+       */
+      <R> Effect<R> thenReply(R message);
+
+      /**
+       * Reply after for example {@code updateState}.
+       *
+       * @param message  The payload of the reply.
+       * @param metadata The metadata for the message.
+       * @param <R>      The type of the message that must be returned by this call.
+       * @return A message reply.
+       */
+      <R> Effect<R> thenReply(R message, Metadata metadata);
+    }
+
 
     interface PersistenceEffectBuilder<T> {
 
       /**
        * Pause the workflow execution and wait for an external input, e.g. via command handler.
        */
-      TransitionalEffect<Void> pause();
+      Transitional pause();
 
       /**
        * Defines the next step to which the workflow should transition to.
@@ -339,7 +361,7 @@ public abstract class Workflow<S> {
        * @deprecated use {@link PersistenceEffectBuilder#transitionTo(akka.japi.function.Function2)} instead.
        */
       @Deprecated
-      <I> TransitionalEffect<Void> transitionTo(String stepName, I input);
+      <I> Transitional transitionTo(String stepName, I input);
 
       /**
        * Defines the next step to which the workflow should transition to.
@@ -351,25 +373,25 @@ public abstract class Workflow<S> {
        * @deprecated use {@link PersistenceEffectBuilder#transitionTo(akka.japi.function.Function)} instead.
        */
       @Deprecated
-      TransitionalEffect<Void> transitionTo(String stepName);
+      Transitional transitionTo(String stepName);
 
 
-      <W>   TransitionalEffect<Void> transitionTo(akka.japi.function.Function <W, StepEffect> lambda);
+      <W> Transitional transitionTo(akka.japi.function.Function <W, StepEffect> lambda);
 
-      <W, I> CallWithInput<I, TransitionalEffect<Void> > transitionTo(akka.japi.function.Function2<W, I, StepEffect> lambda);
+      <W, I> CallWithInput<I, Transitional> transitionTo(akka.japi.function.Function2<W, I, StepEffect> lambda);
 
       /**
        * Finish the workflow execution.
        * After transition to {@code end}, no more transitions are allowed.
        */
-      TransitionalEffect<Void> end();
+      Transitional end();
 
       /**
        * Finish and delete the workflow execution.
        * After transition to {@code delete}, no more transitions are allowed.
        * The actual workflow state deletion is done with a configurable delay to allow downstream consumers to observe that fact.
        */
-      TransitionalEffect<Void> delete();
+      Transitional delete();
     }
 
   }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/ReflectiveWorkflowRouter.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/ReflectiveWorkflowRouter.scala
@@ -320,7 +320,7 @@ class ReflectiveWorkflowRouter[S, W <: Workflow[S]](
 
   private def toSpiTransitionalEffect(effect: Workflow.Effect.TransitionalEffect[_]) =
     effect match {
-      case trEff: TransitionalEffectImpl[_, _] =>
+      case trEff: TransitionalEffectImpl[_] =>
         new SpiWorkflow.TransitionalOnlyEffect(handleState(trEff.persistence), toSpiTransition(trEff.transition))
     }
 


### PR DESCRIPTION
`Effect.TransitionalEffect<Void>` deprecated in favour of `Effect.Transitional`

Refactored `TransferWorkflowWithFraudDetection` for the fun