### PR TITLE
chore: add prettier-ignore for format control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,8 @@ examples: prepare
 	mkdir -p "${java_managed_examples}"
 	rsync -a --exclude-from=docs/.examplesignore samples/* "${java_managed_examples}/"
 	rsync -a akka-javasdk/src/main/resources "${java_managed_examples}/"
+	# Remove prettier-ignore comments from copied examples
+	docs/bin/remove-prettier-ignore.sh "${java_managed_examples}"
 
 bundles:
 	./docs/bin/bundle.sh --zip "${java_managed_attachments}/shopping-cart-quickstart.zip" samples/shopping-cart-quickstart

--- a/docs/PRETTIER_IGNORE_REMOVAL.md
+++ b/docs/PRETTIER_IGNORE_REMOVAL.md
@@ -1,0 +1,66 @@
+# Prettier-Ignore Comment Removal
+
+This directory contains a shell script to remove lines containing `prettier-ignore` comments from the documentation source files while leaving the original source code untouched.
+
+## Overview
+
+During development, `// prettier-ignore` comments are used to prevent Prettier from formatting specific code sections. However, these comments should not appear in the final documentation.
+
+## Implementation
+
+**File:** `docs/bin/remove-prettier-ignore.sh`
+
+This is a shell script that removes any line containing `prettier-ignore` from files after they are copied to the `docs/src-managed` directory but before Antora processes them.
+
+**Integration:** The script is automatically run as part of the `examples` target in the Makefile, which copies sample code to the managed documentation directory.
+
+## How It Works
+
+1. The `make examples` command copies sample code to `docs/src-managed`
+2. The script runs automatically and finds all `.java` files
+3. It removes any line containing `prettier-ignore` using `sed`
+4. Antora then processes the cleaned files to generate the final documentation
+
+## Integration
+
+The script runs automatically when you build the documentation:
+
+```bash
+# Local development
+make local
+
+# Production build
+make prod
+```
+
+The script runs during the `examples` phase and logs basic information about its execution.
+
+## Testing
+
+To verify the script is working:
+
+1. Add some `// prettier-ignore` comments to Java files in the samples directory
+2. Build the documentation: `make local`
+3. Check the files in `docs/src-managed/modules/java/examples/` - lines with prettier-ignore should be removed
+4. Check the generated HTML files in `target/site` - they should not contain prettier-ignore comments
+5. Verify the original source files in `samples/` still contain the comments
+
+## Manual Usage
+
+You can also run the script manually:
+
+```bash
+# Process files in docs/src-managed
+./docs/bin/remove-prettier-ignore.sh docs/src-managed
+
+# Process a specific directory
+./docs/bin/remove-prettier-ignore.sh path/to/directory
+```
+
+## Troubleshooting
+
+If prettier-ignore comments still appear in the generated documentation:
+
+1. Check that the script ran during the build (look for the log message)
+2. Verify that the files in `docs/src-managed` have had the prettier-ignore lines removed
+3. Make sure the `examples` target completed successfully before Antora runs

--- a/docs/bin/remove-prettier-ignore.sh
+++ b/docs/bin/remove-prettier-ignore.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Simple script to remove lines containing prettier-ignore comments
+# Usage: ./remove-prettier-ignore.sh <directory>
+
+TARGET_DIR="${1:-docs/src-managed}"
+
+if [ ! -d "$TARGET_DIR" ]; then
+    echo "Directory $TARGET_DIR does not exist. Skipping prettier-ignore removal."
+    exit 0
+fi
+
+echo "Removing prettier-ignore lines from Java files in: $TARGET_DIR"
+
+# Find all Java files and remove lines containing prettier-ignore
+find "$TARGET_DIR" -type f -name "*.java" -exec sed -i '' '/prettier-ignore/d' {} \;
+
+echo "Removed prettier-ignore lines from Java files in $TARGET_DIR"

--- a/samples/doc-snippets/src/main/java/com/example/api/ExampleEndpoint.java
+++ b/samples/doc-snippets/src/main/java/com/example/api/ExampleEndpoint.java
@@ -33,7 +33,6 @@ import java.util.concurrent.CompletionStage;
 public class ExampleEndpoint extends AbstractHttpEndpoint { // <1>
 
   // end::header-access[]
-
   // end::basic-endpoint[]
   private final Materializer materializer;
 
@@ -43,7 +42,6 @@ public class ExampleEndpoint extends AbstractHttpEndpoint { // <1>
 
   // end::lower-level-request[]
   // tag::basic-endpoint[]
-
   @Get("/hello") // <3>
   public String hello() {
     return "Hello World"; // <4>
@@ -66,24 +64,19 @@ public class ExampleEndpoint extends AbstractHttpEndpoint { // <1>
   // tag::request-body[]
   public record GreetingRequest(String name, int age) {} // <1>
 
+  // prettier-ignore
   @Post("/hello")
   public String hello(GreetingRequest greetingRequest) { // <2>
-    return (
-      "Hello " + greetingRequest.name + "! " + "You are " + greetingRequest.age + " years old"
-    );
+    return "Hello " + greetingRequest.name + "! " + 
+           "You are " + greetingRequest.age + " years old";
+    
   }
 
+  // prettier-ignore
   @Post("/hello/{number}") // <3>
   public String hello(int number, GreetingRequest greetingRequest) { // <4>
-    return (
-      number +
-      " Hello " +
-      greetingRequest.name +
-      "! " +
-      "You are " +
-      greetingRequest.age +
-      " years old"
-    );
+    return number + " Hello " + greetingRequest.name + "! " +
+           "You are " + greetingRequest.age + " years old";
   }
 
   // end::request-body[]
@@ -101,9 +94,10 @@ public class ExampleEndpoint extends AbstractHttpEndpoint { // <1>
   // tag::error-exceptions[]
   @Get("/hello-code/{name}/{age}")
   public String helloWithValidation(String name, int age) {
-    if (age > 130) throw HttpException.badRequest(
-      "It is unlikely that you are " + age + " years old"
-    ); // <1>
+    // prettier-ignore
+    if (age > 130)
+      throw HttpException
+        .badRequest("It is unlikely that you are " + age + " years old"); // <1>
     else return " Hello " + name + "!"; // <2>
   }
 
@@ -114,9 +108,10 @@ public class ExampleEndpoint extends AbstractHttpEndpoint { // <1>
 
   @Get("/hello-low-level-response/{name}/{age}")
   public HttpResponse lowLevelResponseHello(String name, int age) { // <1>
-    if (age > 130) return HttpResponses.badRequest(
-      "It is unlikely that you are " + age + " years old"
-    ); // <2>
+    // prettier-ignore
+    if (age > 130)
+      return HttpResponses
+        .badRequest("It is unlikely that you are " + age + " years old"); // <2>
     else return HttpResponses.ok(new HelloResponse("Hello " + name + "!")); // <3>
   }
 

--- a/samples/doc-snippets/src/main/java/com/example/jwt/HelloJwtEndpoint.java
+++ b/samples/doc-snippets/src/main/java/com/example/jwt/HelloJwtEndpoint.java
@@ -2,7 +2,6 @@ package com.example.jwt;
 
 import akka.javasdk.annotations.Acl;
 import akka.javasdk.annotations.JWT;
-import akka.javasdk.annotations.http.Get;
 import akka.javasdk.annotations.http.HttpEndpoint;
 import akka.javasdk.annotations.http.Post;
 import akka.javasdk.http.AbstractHttpEndpoint;

--- a/samples/doc-snippets/src/test/java/com/example/MyIntegrationTest.java
+++ b/samples/doc-snippets/src/test/java/com/example/MyIntegrationTest.java
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.Test;
 // tag::test-di-provider[]
 public class MyIntegrationTest extends TestKitSupport {
 
-  private static final DependencyProvider mockDependencyProvider = new DependencyProvider() { // <1>
+  // prettier-ignore
+  private static final DependencyProvider mockDependencyProvider =
+    new DependencyProvider() { // <1>
     @SuppressWarnings("unchecked")
     @Override
     public <T> T getDependency(Class<T> clazz) {

--- a/samples/endpoint-jwt/src/main/java/hellojwt/api/HelloJwtEndpoint.java
+++ b/samples/endpoint-jwt/src/main/java/hellojwt/api/HelloJwtEndpoint.java
@@ -21,12 +21,14 @@ import akka.javasdk.http.AbstractHttpEndpoint;
 @JWT(validate = JWT.JwtMethodMode.BEARER_TOKEN, bearerTokenIssuers = "my-issuer") // <1>
 // tag::accessing-claims[]
 public class HelloJwtEndpoint extends AbstractHttpEndpoint {
+
   // end::bearer-token[]
   // end::accessing-claims[]
   @Get("/")
   public String hello() {
     return "Hello, World!";
   }
+
   // tag::accessing-claims[]
   // tag::multiple-bearer-token-issuers[]
   @JWT(

--- a/samples/endpoint-jwt/src/main/java/hellojwt/api/HelloJwtEndpoint.java
+++ b/samples/endpoint-jwt/src/main/java/hellojwt/api/HelloJwtEndpoint.java
@@ -21,17 +21,13 @@ import akka.javasdk.http.AbstractHttpEndpoint;
 @JWT(validate = JWT.JwtMethodMode.BEARER_TOKEN, bearerTokenIssuers = "my-issuer") // <1>
 // tag::accessing-claims[]
 public class HelloJwtEndpoint extends AbstractHttpEndpoint {
-
   // end::bearer-token[]
   // end::accessing-claims[]
-
   @Get("/")
   public String hello() {
     return "Hello, World!";
   }
-
   // tag::accessing-claims[]
-
   // tag::multiple-bearer-token-issuers[]
   @JWT(
     validate = JWT.JwtMethodMode.BEARER_TOKEN,
@@ -47,7 +43,6 @@ public class HelloJwtEndpoint extends AbstractHttpEndpoint {
     return "issuer: " + issuer + ", subject: " + sub;
   }
   // tag::bearer-token[]
-
 }
 // end::accessing-claims[]
 // end::bearer-token[]

--- a/samples/helloworld-agent/src/main/java/com/example/application/HelloWorldAgent.java
+++ b/samples/helloworld-agent/src/main/java/com/example/application/HelloWorldAgent.java
@@ -25,7 +25,11 @@ public class HelloWorldAgent extends Agent {
     """.stripIndent();
 
   public Effect<String> greet(String userGreeting) {
-    return effects().systemMessage(SYSTEM_MESSAGE).userMessage(userGreeting).thenReply();
+    // prettier-ignore
+    return effects()
+      .systemMessage(SYSTEM_MESSAGE)
+      .userMessage(userGreeting)
+      .thenReply();
   }
 }
 // end::class[]

--- a/samples/reliable-timers/src/main/java/com/example/application/OrderEntity.java
+++ b/samples/reliable-timers/src/main/java/com/example/application/OrderEntity.java
@@ -101,7 +101,9 @@ public class OrderEntity extends KeyValueEntity<Order> {
     if (!currentState().placed()) {
       return effects().reply(Result.NotFound.of("No order found for " + orderId)); // <1>
     } else if (currentState().confirmed()) {
-      return effects().reply(Result.Invalid.of("Cannot cancel an already confirmed order")); // <2>
+      // prettier-ignore
+      return effects()
+        .reply(Result.Invalid.of("Cannot cancel an already confirmed order")); // <2>
     } else {
       return effects().updateState(emptyState()).thenReply(ok); // <3>
     }

--- a/samples/shopping-cart-quickstart/src/main/java/shoppingcart/application/ShoppingCartEntity.java
+++ b/samples/shopping-cart-quickstart/src/main/java/shoppingcart/application/ShoppingCartEntity.java
@@ -14,10 +14,12 @@ import shoppingcart.domain.ShoppingCartEvent;
 
 // end::top[]
 
+// prettier-ignore
 // tag::all[]
 // tag::class[]
 @ComponentId("shopping-cart") // <2>
-public class ShoppingCartEntity extends EventSourcedEntity<ShoppingCart, ShoppingCartEvent> { // <1>
+public class ShoppingCartEntity 
+  extends EventSourcedEntity<ShoppingCart, ShoppingCartEvent> { // <1>
 
   // end::class[]
 

--- a/samples/shopping-cart-quickstart/src/test/java/shoppingcart/application/ShoppingCartTest.java
+++ b/samples/shopping-cart-quickstart/src/test/java/shoppingcart/application/ShoppingCartTest.java
@@ -1,21 +1,19 @@
 package shoppingcart.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static shoppingcart.domain.ShoppingCartEvent.ItemAdded;
 
 import akka.Done;
 import akka.javasdk.testkit.EventSourcedTestKit;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import shoppingcart.domain.ShoppingCart;
+import shoppingcart.domain.ShoppingCartEvent.ItemAdded;
 
 public class ShoppingCartTest {
 
-  private final ShoppingCart.LineItem akkaTshirt = new ShoppingCart.LineItem(
-    "akka-tshirt",
-    "Akka Tshirt",
-    10
-  );
+  // prettier-ignore
+  private final ShoppingCart.LineItem akkaTshirt = 
+    new ShoppingCart.LineItem("akka-tshirt", "Akka Tshirt", 10);
 
   @Test
   public void testAddLineItem() {

--- a/samples/spring-dependency-injection/src/main/java/com/example/CounterSetup.java
+++ b/samples/spring-dependency-injection/src/main/java/com/example/CounterSetup.java
@@ -38,7 +38,9 @@ public class CounterSetup implements ServiceSetup {
   @Override
   public DependencyProvider createDependencyProvider() {
     try {
-      AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(); // <1>
+      // prettier-ignore
+      AnnotationConfigApplicationContext context =
+        new AnnotationConfigApplicationContext(); // <1>
       ResourcePropertySource resourcePropertySource = new ResourcePropertySource(
         new ClassPathResource("application.properties")
       );


### PR DESCRIPTION
Using comment with `prettier-ignore` to disable formatting in some specific situations. 

And added a script to remove those lines from the generated site. 
