### PR TITLE
feat: resolve repository with akka-token variable

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -1,27 +1,15 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
     <profiles>
         <profile>
-            <id>akka-github-actions</id>
-            <repositories>
-              <repository>
-                  <id>akka-repository</id>
-                  <name>Akka library repository</name>
-                  <!-- This only works for Akka's internal CI/CD -->
-                  <url>https://repo.akka.io/maven/github_actions</url>
-              </repository>
-          </repositories>
-          <pluginRepositories>
-              <pluginRepository>
-                  <id>akka-repository</id>
-                  <name>Akka library repository</name>
-                  <!-- This only works for Akka's internal CI/CD -->
-                  <url>https://repo.akka.io/maven/github_actions</url>
-              </pluginRepository>
-          </pluginRepositories>
+        <id>akka-default</id>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+        </activation>
+        <properties>
+            <akka-secure-repo>https://repo.akka.io/maven/github_actions</akka-secure-repo>
+        </properties>
         </profile>
     </profiles>
-    <activeProfiles>
-        <activeProfile>akka-github-actions</activeProfile>
-    </activeProfiles>
-  </settings>
+</settings>

--- a/akka-javasdk-maven/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-maven/akka-javasdk-parent/pom.xml
@@ -54,22 +54,24 @@
         <maven-failsafe-plugin.version>3.1.2</maven-failsafe-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
-
+        <akka-token>invalid-token</akka-token>
+        <akka-secure-repo>https://repo.akka.io/${akka-token}/secure</akka-secure-repo>
     </properties>
 
 
     <pluginRepositories>
         <pluginRepository>
-            <id>akka-repository</id>
-            <url>https://repo.akka.io/maven</url>
+            <id>akka-secure</id>
+            <name>Akka Secure</name>
+            <url>${akka-secure-repo}</url>
         </pluginRepository>
     </pluginRepositories>
 
     <repositories>
         <repository>
-            <id>akka-repository</id>
-            <name>Akka repository</name>
-            <url>https://repo.akka.io/maven</url>
+            <id>akka-secure</id>
+            <name>Akka Secure</name>
+            <url>${akka-secure-repo}</url>
         </repository>
     </repositories>
 

--- a/akka-javasdk-maven/pom.xml
+++ b/akka-javasdk-maven/pom.xml
@@ -45,6 +45,8 @@
      docs/build/src/managed/modules/java/partials/attributes.adoc#L4
     -->
     <maven.version>3.9.0</maven.version>
+    <akka-token>invalid-token</akka-token>
+    <akka-secure-repo>https://repo.akka.io/${akka-token}/secure</akka-secure-repo>
   </properties>
 
   
@@ -118,17 +120,17 @@
 
   <pluginRepositories>
     <pluginRepository>
-      <id>akka-repository</id>
-      <name>Akka repository</name>
-      <url>https://repo.akka.io/maven</url>
+        <id>akka-secure</id>
+        <name>Akka Secure</name>
+        <url>${akka-secure-repo}</url>
     </pluginRepository>
   </pluginRepositories>
 
   <repositories>
     <repository>
-      <id>akka-repository</id>
-      <name>Akka repository</name>
-      <url>https://repo.akka.io/maven</url>
+        <id>akka-secure</id>
+        <name>Akka Secure</name>
+        <url>${akka-secure-repo}</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Draft: just exploring some ideas to easy the the token retrieval. 

Some extra information that will help understand how this will work. 

The precedence order to resolve properties is the following:

* Command line properties (-Dproperty=value) (also anything in `~/.mvn/maven.config`)
* User settings.xml properties 
* Project POM properties
* Parent POM properties (lowest priority)

This PR is changing the parent pom to have the following:

```xml
<properties>
  <akka-token>invalid-token</akka-token>
  <akka-secure-repo>https://repo.akka.io/${akka-token}/secure</akka-secure-repo>
</properties>

<repositories>
    <repository>
        <id>akka-secure</id>
        <name>Akka Secure</name>
        <url>${akka-secure-repo}</url>
    </repository>
</repositories>
```

If no changes are made, the resulting URL will be `https://repo.akka.io/invalid-token/secure`. The most effective solution is to detect this scenario and display a clear, informative message to the user.

When a user obtains a token via the CLI, it will be added to their `~/.mvn/maven.config` as `-Dakka-token=user-token`. Alternatively, users can choose to add the token directly to their `settings.xml` if they prefer.

This approach works well for us because it centralizes the repository configuration in the parent POM, giving us greater control. For instance, if we need to migrate the repository URL, we can simply update the parent POM, rather than asking users to modify their settings.xml files individually.

