### PR TITLE
making the AI model provider config page more dev friendly

### DIFF
--- a/docs/src/modules/java/nav.adoc
+++ b/docs/src/modules/java/nav.adoc
@@ -22,5 +22,6 @@
 *** xref:java:access-control.adoc[]
 *** xref:java:auth-with-jwts.adoc[]
 *** xref:java:running-locally.adoc[]
+*** xref:java:model-provider-details.adoc[]
 ** xref:java:dev-best-practices.adoc[]
 ** xref:java:ai-coding-assistant.adoc[]

--- a/docs/src/modules/java/pages/model-provider-details.adoc
+++ b/docs/src/modules/java/pages/model-provider-details.adoc
@@ -1,73 +1,296 @@
-= AI Model Provider Details
+= AI model provider configuration
 
 include::ROOT:partial$include.adoc[]
 
-Akka provides integration with several backend AI models, and you have to select which model to use. xref:agents.adoc#_configuring_the_model[Configuring the model] gives an overview of how to specify the model to use. This page describes the configuration for each model provider in more detail. Each model provider may have different settings.
+Akka provides integration with several backend AI models. You are responsible for configuring the AI model provider for every agent you build, whether you do so with configuration settings or via code.
 
-== Anthropic
+As discussed in the xref:agents.adoc#model[Configuring the model] section of the Agent documentation, supplying a model provider through code will override the model provider configured through `application.conf` settings. You can also have multiple model providers configured and then use the `fromConfig` method of the `ModelProvider` class to load a specific one.
 
-Configuration properties:
+This page provides a detailed list of all of the configuration values available to each provider. As with all Akka configuration, the model configuration is declared using the https://github.com/lightbend/config/blob/main/HOCON.md[HOCON] format.
 
+== Definitions
+The following are a few definitions that might not be familiar to you. Not all models support these properties, but when they do, their definition remains the same.
+
+=== Temperature
+A value from 0.0 to 1.0 that indicates the amount of randomness in the model output. Often described as controlling how "creative" a model can get. The lower the value, the more precise and strict you want the model to behave. The higher the value, the more you expect it to improvise and the less deterministic it will be.
+
+=== top-p
+This property refers to the "Nucleus sampling parameter". Controls text generation by only considering the most likely tokens whose cumulative probability
+exceeds the threshold value. It helps balance between diversity and
+quality of outputs—lower values (like 0.3) produce more focused,
+predictable text while higher values (like 0.9) allow more creativity
+and variation.
+
+=== top-k
+Top-k sampling limits text generation to only the k most probable
+tokens at each step, discarding all other possibilities regardless
+of their probability. It provides a simpler way to control randomness,
+smaller k values (like 10) produce more focused outputs while larger
+values (like 50) allow for more diversity.
+
+=== max-tokens
+If this value is supplied and the model supports this property, then it will stop operations in mid flight if the token quota runs out. It's important to check _how_ the model counts tokens, as some may count differently. Be aware of the fact that this parameter name frequently varies from one provider to the next. Make sure you're using the right property name.
+
+== Model configuration
+The following is a list of all natively supported model configurations. Remember that if you don't see your model or model format here, you can always create your own custom configuration and still use all of the Agent-related components.
+
+=== Anthropic
+
+[cols="1m,1,4"]
+|===
+| Property | Type | Description
+
+| provider 
+| "anthropic" 
+| Name of the provider. Must always be `anthropic`
+
+| api-key
+| String 
+| The API key. Defaults to the value of the `ANTHROPIC_API_KEY` environment variable
+
+| model-name
+| String
+| The name of the model to use. See vendor documentation for a list of available models
+
+| base-url
+| Url
+| Optional override to the base URL for the API
+
+| temperature
+| Float
+| Model randomness. The default is not supplied so check with the model documentation for default behavior
+
+| top-p
+| Float
+| Nucleus sampling parameter
+
+| top-k
+| Integer
+| Top-k sampling parameter
+
+| max-tokens
+| Integer
+| Max token quota. Leave as -1 for model default
+
+|===
+
+
+See link:_attachments/api/akka/javasdk/agent/ModelProvider.Anthropic.html[`ModelProvider.Anthropic`] for programmatic settings.
+
+=== Gemini
+
+[cols="1m,1,4"]
+|===
+| Property | Type | Description
+
+| provider 
+| "googleai-gemini" 
+| Name of the provider. Must always be `googleai-gemini`
+
+| api-key
+| String 
+| The API key. Defaults to the value of the `GOOGLE_AI_GEMINI_API_KEY` environment variable
+
+| model-name
+| String
+| The name of the model to use. See vendor documentation for a list of available models
+
+| base-url
+| Url
+| Optional override to the base URL for the API
+
+| temperature
+| Float
+| Model randomness. The default is not supplied so check with the model documentation for default behavior
+
+| top-p
+| Float
+| Nucleus sampling parameter
+
+| max-output-tokens
+| Integer
+| Max token _output_ quota. Leave as -1 for model default
+
+|===
+
+See link:_attachments/api/akka/javasdk/agent/ModelProvider.GoogleAIGemini.html[`ModelProvider.GoogleAIGemini`] for programmatic settings.
+
+=== Hugging Face
+
+[cols="1m,1,4"]
+|===
+| Property | Type | Description
+
+| provider 
+| "hugging-face" 
+| Name of the provider. Must always be `hugging-face`
+
+| access-token
+| String
+| The access token for authentication with the Hugging Face API
+
+| model-id
+| String
+| The ID of the model to use. See vendor documentation for a list of available models
+
+| base-url
+| Url
+| Optional override to the base URL for the API
+
+| temperature
+| Float
+| Model randomness. The default is not supplied so check with the model documentation for default behavior
+
+| top-p
+| Float
+| Nucleus sampling parameter
+
+| max-new-tokens
+| Integer
+| Max number of tokens to generate (-1 for model default)
+
+|===
+
+See link:_attachments/api/akka/javasdk/agent/ModelProvider.HuggingFace.html[`ModelProvider.HuggingFace`] for programmatic settings.
+
+=== Local AI
+
+[cols="1m,1,4"]
+|===
+| Property | Type | Description
+
+| provider 
+| "local-ai" 
+| Name of the provider. Must always be `local-ai`
+
+| model-name
+| String
+| The name of the model to use. See vendor documentation for a list of available models
+
+| base-url
+| Url
+| Optional override to the base URL for the API (default `http://localhost:8080/v1`)
+
+| temperature
+| Float
+| Model randomness. The default is not supplied so check with the model documentation for default behavior
+
+| top-p
+| Float
+| Nucleus sampling parameter
+
+| max-tokens
+| Integer
+| Max number of tokens to generate (-1 for model default)
+
+|===
+
+See link:_attachments/api/akka/javasdk/agent/ModelProvider.LocalAI.html[`ModelProvider.LocalAI`] for programmatic settings.
+
+=== Ollama
+
+[cols="1m,1,4"]
+|===
+| Property | Type | Description
+
+| provider 
+| "ollama" 
+| Name of the provider. Must always be `ollama`
+
+| model-name
+| String
+| The name of the model to use. See vendor documentation for a list of available models
+
+| base-url
+| Url
+| Optional override to the base URL for the API (default `http://localhost:11434`)
+
+| temperature
+| Float
+| Model randomness. The default is not supplied so check with the model documentation for default behavior
+
+| top-p
+| Float
+| Nucleus sampling parameter
+
+|===
+
+See link:_attachments/api/akka/javasdk/agent/ModelProvider.Ollama.html[`ModelProvider.Ollama`] for programmatic settings.
+
+=== OpenAI
+
+[cols="1m,1,4"]
+|===
+| Property | Type | Description
+
+| provider 
+| "openai" 
+| Name of the provider. Must always be `openai`
+
+| api-key
+| String 
+| The API key. Defaults to the value of the `OPENAI_API_KEY` environment variable
+
+| model-name
+| String
+| The name of the model to use (e.g. "gpt-4" or "gpt-3.5-turbo"). See vendor documentation for a list of available models
+
+| base-url
+| Url
+| Optional override to the base URL for the API
+
+| temperature
+| Float
+| Model randomness. The default is not supplied so check with the model documentation for default behavior
+
+| top-p
+| Float
+| Nucleus sampling parameter
+
+| max-tokens
+| Integer
+| Max token quota. Leave as -1 for model default
+
+|===
+
+See link:_attachments/api/akka/javasdk/agent/ModelProvider.OpenAi.html[`ModelProvider.OpenAi`] for programmatic settings.
+
+== Reference configurations
+The following is a list of the various reference configurations for each of the AI models
+
+=== Anthropic
 [source,hocon,indent=0]
 ----
 include::example$resources/reference.conf[tag=anthropic]
 ----
 
-See link:_attachments/api/akka/javasdk/agent/ModelProvider.Anthropic.html[`ModelProvider.Anthropic`] for programmatic settings.
-
-== GoogleAIGemini
-
-Configuration properties:
-
+=== Gemini
 [source,hocon,indent=0]
 ----
 include::example$resources/reference.conf[tag=googleai-gemini]
 ----
 
-See link:_attachments/api/akka/javasdk/agent/ModelProvider.GoogleAIGemini.html[`ModelProvider.GoogleAIGemini`] for programmatic settings.
-
-== HuggingFace
-
-Configuration properties:
-
+=== Hugging face
 [source,hocon,indent=0]
 ----
 include::example$resources/reference.conf[tag=hugging-face]
 ----
 
-See link:_attachments/api/akka/javasdk/agent/ModelProvider.HuggingFace.html[`ModelProvider.HuggingFace`] for programmatic settings.
-
-
-== LocalAI
-
-Configuration properties:
-
+=== Local AI
 [source,hocon,indent=0]
 ----
 include::example$resources/reference.conf[tag=local-ai]
 ----
 
-See link:_attachments/api/akka/javasdk/agent/ModelProvider.LocalAI.html[`ModelProvider.LocalAI`] for programmatic settings.
-
-== Ollama
-
-Configuration properties:
-
+=== Ollama
 [source,hocon,indent=0]
 ----
 include::example$resources/reference.conf[tag=ollama]
 ----
 
-See link:_attachments/api/akka/javasdk/agent/ModelProvider.Ollama.html[`ModelProvider.Ollama`] for programmatic settings.
-
-== OpenAi
-
-Configuration properties:
-
+=== OpenAI
 [source,hocon,indent=0]
 ----
 include::example$resources/reference.conf[tag=openai]
 ----
-
-See link:_attachments/api/akka/javasdk/agent/ModelProvider.OpenAi.html[`ModelProvider.OpenAi`] for programmatic settings.
 

--- a/docs/src/modules/java/pages/model-provider-details.adoc
+++ b/docs/src/modules/java/pages/model-provider-details.adoc
@@ -15,7 +15,7 @@ The following are a few definitions that might not be familiar to you. Not all m
 A value from 0.0 to 1.0 that indicates the amount of randomness in the model output. Often described as controlling how "creative" a model can get. The lower the value, the more precise and strict you want the model to behave. The higher the value, the more you expect it to improvise and the less deterministic it will be.
 
 === top-p
-This property refers to the "Nucleus sampling parameter". Controls text generation by only considering the most likely tokens whose cumulative probability
+This property refers to the "Nucleus sampling parameter." Controls text generation by only considering the most likely tokens whose cumulative probability
 exceeds the threshold value. It helps balance between diversity and
 quality of outputs—lower values (like 0.3) produce more focused,
 predictable text while higher values (like 0.9) allow more creativity
@@ -54,7 +54,7 @@ The following is a list of all natively supported model configurations. Remember
 
 | base-url
 | Url
-| Optional override to the base URL for the API
+| Optional override to the base URL of the API
 
 | temperature
 | Float
@@ -70,7 +70,7 @@ The following is a list of all natively supported model configurations. Remember
 
 | max-tokens
 | Integer
-| Max token quota. Leave as -1 for model default
+| Max token quota. Leave as –1 for model default
 
 |===
 
@@ -97,7 +97,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.Anthropic.html[`Model
 
 | base-url
 | Url
-| Optional override to the base URL for the API
+| Optional override to the base URL of the API
 
 | temperature
 | Float
@@ -109,7 +109,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.Anthropic.html[`Model
 
 | max-output-tokens
 | Integer
-| Max token _output_ quota. Leave as -1 for model default
+| Max token _output_ quota. Leave as –1 for model default
 
 |===
 
@@ -135,7 +135,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.GoogleAIGemini.html[`
 
 | base-url
 | Url
-| Optional override to the base URL for the API
+| Optional override to the base URL of the API
 
 | temperature
 | Float
@@ -147,7 +147,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.GoogleAIGemini.html[`
 
 | max-new-tokens
 | Integer
-| Max number of tokens to generate (-1 for model default)
+| Max number of tokens to generate (–1 for model default)
 
 |===
 
@@ -169,7 +169,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.HuggingFace.html[`Mod
 
 | base-url
 | Url
-| Optional override to the base URL for the API (default `http://localhost:8080/v1`)
+| Optional override to the base URL of the API (default `http://localhost:8080/v1`)
 
 | temperature
 | Float
@@ -181,7 +181,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.HuggingFace.html[`Mod
 
 | max-tokens
 | Integer
-| Max number of tokens to generate (-1 for model default)
+| Max number of tokens to generate (–1 for model default)
 
 |===
 
@@ -203,7 +203,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.LocalAI.html[`ModelPr
 
 | base-url
 | Url
-| Optional override to the base URL for the API (default `http://localhost:11434`)
+| Optional override to the base URL of the API (default `http://localhost:11434`)
 
 | temperature
 | Float
@@ -237,7 +237,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.Ollama.html[`ModelPro
 
 | base-url
 | Url
-| Optional override to the base URL for the API
+| Optional override to the base URL of the API
 
 | temperature
 | Float
@@ -249,7 +249,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.Ollama.html[`ModelPro
 
 | max-tokens
 | Integer
-| Max token quota. Leave as -1 for model default
+| Max token quota. Leave as –1 for model default
 
 |===
 

--- a/docs/src/modules/java/pages/setup-and-configuration/index.adoc
+++ b/docs/src/modules/java/pages/setup-and-configuration/index.adoc
@@ -9,3 +9,4 @@ Akka provides several built-in features for dependency injection, data serializa
 * xref:java:access-control.adoc[Access Control]
 * xref:java:auth-with-jwts.adoc[Authentication with JWTs]
 * xref:java:running-locally.adoc[Running Locally]
+* xref:java:model-provider-details.adoc[Configuring AI Agent Model Providers]

--- a/docs/styles/config/vocabularies/Akka/accept.txt
+++ b/docs/styles/config/vocabularies/Akka/accept.txt
@@ -118,6 +118,7 @@ O'Reilly
 OAuth
 Okta
 [Oo]llama
+[Oo]pen[Aa]i
 onboarding
 operationalized
 (?i)OpenID


### PR DESCRIPTION
This makes a significant improvement to the page, making it easier for developers to scan and find the configuration they're looking for and moves the "noise" of the raw configuration text to their own sections at the bottom.

This page also didn't have a position on the left nav, so I've added it to the Setup and Configuration section.