### PR TITLE
chore: langchain deps bump

### DIFF
--- a/project/SamplesCompilationProject.scala
+++ b/project/SamplesCompilationProject.scala
@@ -13,13 +13,13 @@ import sbt.Test
 
 object SamplesCompilationProject {
 
-  private val LangChain4JVersion = "1.0.0-beta1"
+  private val LangChain4JVersion = "1.1.0"
   private val additionalDeps = Map(
     "spring-dependency-injection" -> Seq("org.springframework" % "spring-context" % "6.2.8"),
     "ask-akka-agent" -> Seq(
       "dev.langchain4j" % "langchain4j-open-ai" % LangChain4JVersion,
       "dev.langchain4j" % "langchain4j" % LangChain4JVersion,
-      "dev.langchain4j" % "langchain4j-mongodb-atlas" % LangChain4JVersion))
+      "dev.langchain4j" % "langchain4j-mongodb-atlas" % "1.1.0-beta7"))
 
   def compilationProject(configureFunc: Project => Project): CompositeProject = {
     val pathToSample = "samples"

--- a/samples/ask-akka-agent/pom.xml
+++ b/samples/ask-akka-agent/pom.xml
@@ -18,7 +18,7 @@
 
     <name>ask-akka</name>
     <properties>
-        <langchain4j.version>1.0.0</langchain4j.version>
+        <langchain4j.version>1.1.0</langchain4j.version>
     </properties>
     <dependencies>
         <dependency>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-mongodb-atlas</artifactId>
-            <version>1.0.0-beta5</version>
+            <version>1.1.0-beta7</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Otherwise running locally will fail with:
```
16:04:03.632 ERROR akka.actor.ActorSystemImpl - Uncaught error from thread [kalix-proxy-akka.runtime.embedded-sdk-dispatcher]: Class dev.langchain4j.model.chat.request.DefaultChatRequestParameters does not have member field 'dev.langchain4j.model.chat.request.ChatRequestParameters EMPTY', shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[kalix-proxy]
java.lang.NoSuchFieldError: Class dev.langchain4j.model.chat.request.DefaultChatRequestParameters does not have member field 'dev.langchain4j.model.chat.request.ChatRequestParameters EMPTY'
	at dev.langchain4j.model.openai.OpenAiChatModel.<init>(OpenAiChatModel.java:79)
	at dev.langchain4j.model.openai.OpenAiChatModel$OpenAiChatModelBuilder.build(OpenAiChatModel.java:386)
	at kalix.runtime.agent.OpenAiChatModelFactory.createChatModel(ChatModelFactory.scala:120)
	at kalix.runtime.agent.Agent.$anonfun$requestModel$1(Agent.scala:330)
	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:687)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:64)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:101)
```
