### PR TITLE
fix: langchain version bump

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
   // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L31
   val JacksonVersion = "2.19.0"
   val JacksonDatabindVersion = JacksonVersion
-  val Langchain4jVersion = "1.0.0"
+  val Langchain4jVersion = "1.1.0"
   val LogbackVersion = "1.5.18"
   val LogbackContribVersion = "0.1.5"
   val JUnitVersion = "4.13.2"


### PR DESCRIPTION
fixes:
```
Uncaught error from thread [kalix-proxy-akka.runtime.embedded-sdk-dispatcher]: Class dev.langchain4j.model.chat.request.DefaultChatRequestParameters does not have member field 'dev.langchain4j.model.chat.request.ChatRequestParameters EMPTY', shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[kalix-proxy]
java.lang.NoSuchFieldError: Class dev.langchain4j.model.chat.request.DefaultChatRequestParameters does not have member field 'dev.langchain4j.model.chat.request.ChatRequestParameters EMPTY'
	at dev.langchain4j.model.openai.OpenAiChatModel.<init>(OpenAiChatModel.java:79)
	at dev.langchain4j.model.openai.OpenAiChatModel$OpenAiChatModelBuilder.build(OpenAiChatModel.java:386)
	at kalix.runtime.agent.OpenAiChatModelFactory.createChatModel(ChatModelFactory.scala:120)
	at kalix.runtime.agent.Agent.$anonfun$requestModel$1(Agent.scala:330)
	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:687)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:64)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:101)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:101)
```