### PR TITLE
fix(docs): shopping-cart sample setup instructions

### DIFF
--- a/docs/src/modules/ROOT/partials/create-the-empty-project.adoc
+++ b/docs/src/modules/ROOT/partials/create-the-empty-project.adoc
@@ -1,0 +1,3 @@
+== Create the empty project
+
+You already learned how to create an empty Akka project when you went through the guide to xref:getting-started:author-your-first-service.adoc#clone_sample[author your first service].

--- a/docs/src/modules/getting-started/pages/ask-akka-agent/the-agent.adoc
+++ b/docs/src/modules/getting-started/pages/ask-akka-agent/the-agent.adoc
@@ -22,9 +22,7 @@ include::ROOT:partial$local-dev-prerequisites.adoc[]
 
 include::ROOT:partial$recommend-ai-video.adoc[]
 
-== Create the empty project
-
-You already learned how to create an empty Akka project when you went through the guide to xref:getting-started:author-your-first-service.adoc#clone_sample[author your first service].
+include::ROOT:partial$create-the-empty-project.adoc[]
 
 [NOTE]
 ====

--- a/docs/src/modules/getting-started/pages/planner-agent/activity.adoc
+++ b/docs/src/modules/getting-started/pages/planner-agent/activity.adoc
@@ -19,9 +19,8 @@ In this part of the guide you will:
 include::ROOT:partial$local-dev-prerequisites.adoc[]
 * https://platform.openai.com/api-keys[OpenAI API key, window="new"]
 
-== Create the empty project
-
-You already learned how to create an empty Akka project when you went through the guide to xref:getting-started:author-your-first-service.adoc#clone_sample[author your first service]. You can continue from the `helloworld-agent` project.
+include::ROOT:partial$create-the-empty-project.adoc[]
+You can continue from the `helloworld-agent` project.
 
 [NOTE]
 ====

--- a/docs/src/modules/getting-started/pages/shopping-cart/build-and-deploy-shopping-cart.adoc
+++ b/docs/src/modules/getting-started/pages/shopping-cart/build-and-deploy-shopping-cart.adoc
@@ -23,16 +23,12 @@ In this guide you will:
 
 include::ROOT:partial$cloud-dev-prerequisites.adoc[]
 
-== Clone the sample
+include::ROOT:partial$create-the-empty-project.adoc[]
 
-. Clone the full source code of the Shopping Cart sample from link:https://github.com/akka-samples/shopping-cart-quickstart[GitHub], or use the Akka CLI command below to download and unzip this quickstart project.
-+
-[source,bash]
-----
-akka quickstart download shopping-cart
-----
-
-. Open the project in your favorite editor.
+[NOTE]
+====
+This guide is written assuming you will follow it as a tutorial to walk through all of the components, building them on your own. If at any time you want to compare your solution with the official sample, check out the link:https://github.com/akka-samples/shopping-cart-quickstart[GitHub Repository, window="new"].
+====
 
 == Understanding the shopping cart
 


### PR DESCRIPTION
Replace outdated Akka CLI download steps with reusable project creation partial.

Ensure consistency across samples and align with initial getting started flow.
    
Closes: #837