### PR TITLE
build: fix java formatting

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,7 @@
+# for google-java-format
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/akka-javasdk-annotation-processor/src/main/java/akka/javasdk/tooling/processor/ComponentAnnotationProcessor.java
+++ b/akka-javasdk-annotation-processor/src/main/java/akka/javasdk/tooling/processor/ComponentAnnotationProcessor.java
@@ -7,19 +7,6 @@ package akka.javasdk.tooling.processor;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
-
-import javax.annotation.processing.AbstractProcessor;
-import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.DeclaredType;
-import javax.lang.model.util.ElementFilter;
-import javax.tools.Diagnostic;
-import javax.tools.FileObject;
-import javax.tools.StandardLocation;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -32,229 +19,297 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.util.ElementFilter;
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
 
-
-@SupportedAnnotationTypes(
-        {
-                "akka.javasdk.annotations.http.HttpEndpoint",
-                "akka.javasdk.annotations.GrpcEndpoint",
-                "akka.javasdk.annotations.mcp.McpEndpoint",
-                // all components will have this
-                "akka.javasdk.annotations.ComponentId",
-                // central config/lifecycle class
-                "akka.javasdk.annotations.Setup"
-        })
+@SupportedAnnotationTypes({
+  "akka.javasdk.annotations.http.HttpEndpoint",
+  "akka.javasdk.annotations.GrpcEndpoint",
+  "akka.javasdk.annotations.mcp.McpEndpoint",
+  // all components will have this
+  "akka.javasdk.annotations.ComponentId",
+  // central config/lifecycle class
+  "akka.javasdk.annotations.Setup"
+})
 @SupportedSourceVersion(SourceVersion.RELEASE_21)
 public class ComponentAnnotationProcessor extends AbstractProcessor {
 
-    private static final String COMPONENT_DESCRIPTOR_FILE_PATH = "META-INF/akka-javasdk-components.conf";
+  private static final String COMPONENT_DESCRIPTOR_FILE_PATH =
+      "META-INF/akka-javasdk-components.conf";
 
-    // parent path in hoconf
-    private static final String DESCRIPTOR_ENTRY_BASE_PATH = "akka.javasdk.";
-    private static final String DESCRIPTOR_COMPONENT_ENTRY_BASE_PATH = DESCRIPTOR_ENTRY_BASE_PATH + "components.";
+  // parent path in hoconf
+  private static final String DESCRIPTOR_ENTRY_BASE_PATH = "akka.javasdk.";
+  private static final String DESCRIPTOR_COMPONENT_ENTRY_BASE_PATH =
+      DESCRIPTOR_ENTRY_BASE_PATH + "components.";
 
-    // key of each component type under that parent path, containing a string list of concrete component classes
-    private static final String HTTP_ENDPOINT_KEY = "http-endpoint";
-    private static final String GRPC_ENDPOINT_KEY = "grpc-endpoint";
-    private static final String MCP_ENDPOINT_KEY = "mcp-endpoint";
-    private static final String EVENT_SOURCED_ENTITY_KEY = "event-sourced-entity";
-    private static final String VALUE_ENTITY_KEY = "key-value-entity";
-    private static final String TIMED_ACTION_KEY = "timed-action";
-    private static final String CONSUMER_KEY = "consumer";
-    private static final String VIEW_KEY = "view";
-    private static final String WORKFLOW_KEY = "workflow";
-    private static final String AGENT_KEY = "agent";
-    private static final String SERVICE_SETUP_KEY = "service-setup";
+  // key of each component type under that parent path, containing a string list of concrete
+  // component classes
+  private static final String HTTP_ENDPOINT_KEY = "http-endpoint";
+  private static final String GRPC_ENDPOINT_KEY = "grpc-endpoint";
+  private static final String MCP_ENDPOINT_KEY = "mcp-endpoint";
+  private static final String EVENT_SOURCED_ENTITY_KEY = "event-sourced-entity";
+  private static final String VALUE_ENTITY_KEY = "key-value-entity";
+  private static final String TIMED_ACTION_KEY = "timed-action";
+  private static final String CONSUMER_KEY = "consumer";
+  private static final String VIEW_KEY = "view";
+  private static final String WORKFLOW_KEY = "workflow";
+  private static final String AGENT_KEY = "agent";
+  private static final String SERVICE_SETUP_KEY = "service-setup";
 
-    private static final List<String> ALL_COMPONENT_TYPES = List.of(HTTP_ENDPOINT_KEY, GRPC_ENDPOINT_KEY, MCP_ENDPOINT_KEY,
-        EVENT_SOURCED_ENTITY_KEY, VALUE_ENTITY_KEY, TIMED_ACTION_KEY, CONSUMER_KEY, VIEW_KEY, WORKFLOW_KEY,
-        AGENT_KEY, SERVICE_SETUP_KEY);
+  private static final List<String> ALL_COMPONENT_TYPES =
+      List.of(
+          HTTP_ENDPOINT_KEY,
+          GRPC_ENDPOINT_KEY,
+          MCP_ENDPOINT_KEY,
+          EVENT_SOURCED_ENTITY_KEY,
+          VALUE_ENTITY_KEY,
+          TIMED_ACTION_KEY,
+          CONSUMER_KEY,
+          VIEW_KEY,
+          WORKFLOW_KEY,
+          AGENT_KEY,
+          SERVICE_SETUP_KEY);
 
+  private final boolean debugEnabled;
+  private boolean alreadyRan = false;
 
-    private final boolean debugEnabled;
-    private boolean alreadyRan = false;
+  public ComponentAnnotationProcessor() {
+    // can be passed to compiler: `mvn compile -Dakka-component-processor.debug=true`
+    debugEnabled = Boolean.getBoolean("akka-component-processor.debug");
+  }
 
-    public ComponentAnnotationProcessor() {
-        // can be passed to compiler: `mvn compile -Dakka-component-processor.debug=true`
-        debugEnabled = Boolean.getBoolean("akka-component-processor.debug");
-    }
+  @Override
+  public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    if (!alreadyRan) {
+      // processor may be invoked several times - only run this on the first iteration (or else we
+      // get errors
+      // from trying to open the descriptor files multiple times)
+      alreadyRan = true;
 
-    @Override
-    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-        if (!alreadyRan) {
-            // processor may be invoked several times - only run this on the first iteration (or else we get errors
-            // from trying to open the descriptor files multiple times)
-            alreadyRan = true;
+      Map<String, List<String>> componentTypeToConcreteComponents = new HashMap<>();
+      for (TypeElement annotation : annotations) {
+        Set<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(annotation);
+        var elementsPerComponentType =
+            ElementFilter.typesIn(annotatedElements).stream()
+                .collect(Collectors.groupingBy(element -> componentTypeFor(element, annotation)));
+        elementsPerComponentType.forEach(
+            (componentType, elements) -> {
+              var classNames =
+                  new ArrayList<>(
+                      elements.stream()
+                          .map(
+                              element ->
+                                  processingEnv
+                                      .getElementUtils()
+                                      .getBinaryName((TypeElement) element)
+                                      .toString())
+                          .toList());
+              if (componentTypeToConcreteComponents.containsKey(componentType)) {
+                // the same component might have multiple annotations, deduplication happens when
+                // creating config later
+                classNames.addAll(componentTypeToConcreteComponents.get(componentType));
+              }
+              debug(
+                  "Found "
+                      + classNames.size()
+                      + " components of type "
+                      + componentType
+                      + " annotated with "
+                      + annotation
+                      + ": "
+                      + String.join(", ", classNames));
+              componentTypeToConcreteComponents.put(componentType, classNames);
+            });
+      }
 
-            Map<String, List<String>> componentTypeToConcreteComponents = new HashMap<>();
-            for (TypeElement annotation : annotations) {
-                Set<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(annotation);
-                var elementsPerComponentType = ElementFilter.typesIn(annotatedElements)
-                  .stream()
-                  .collect(Collectors.groupingBy(element -> componentTypeFor(element, annotation)));
-                elementsPerComponentType.forEach((componentType, elements) -> {
-                    var classNames = new ArrayList<>(elements.stream().map(element ->
-                        processingEnv.getElementUtils().getBinaryName((TypeElement) element).toString()).toList());
-                    if (componentTypeToConcreteComponents.containsKey(componentType)) {
-                        // the same component might have multiple annotations, deduplication happens when creating config later
-                        classNames.addAll(componentTypeToConcreteComponents.get(componentType));
-                    }
-                    debug("Found "  + classNames.size() + " components of type " + componentType + " annotated with " + annotation + ": " + String.join(", ", classNames));
-                    componentTypeToConcreteComponents.put(componentType, classNames);
-                });
-            }
+      var service = componentTypeToConcreteComponents.get(SERVICE_SETUP_KEY);
+      if (service != null && service.size() > 1) {
+        error(
+            "More than one class annotated with @Setup, only one is allowed. Annotated classes: "
+                + String.join(", ", service));
+      }
 
-            var service = componentTypeToConcreteComponents.get(SERVICE_SETUP_KEY);
-            if (service != null && service.size() > 1) {
-                error("More than one class annotated with @Setup, only one is allowed. Annotated classes: " + String.join(", ", service));
-            }
-
-            try {
-                if (!componentTypeToConcreteComponents.isEmpty()) {
-                    var summary = String.join(", ", componentTypeToConcreteComponents.entrySet().stream().map(mapEntry ->
-                        mapEntry.getValue().size() + " " + mapEntry.getKey()
-                    ).toList());
-                    info("Akka SDK annotation processor detected components: " + summary);
-                    createComponentServiceDescriptor(componentTypeToConcreteComponents);
-                } else {
-                    debug("Akka SDK annotation processor found no annotated components");
-                }
-            } catch (IOException ex) {
-                error("Akka SDK annotation processor failed to create component descriptor: " + ex.getMessage());
-                throw new RuntimeException(ex);
-            }
-            return true;
+      try {
+        if (!componentTypeToConcreteComponents.isEmpty()) {
+          var summary =
+              String.join(
+                  ", ",
+                  componentTypeToConcreteComponents.entrySet().stream()
+                      .map(mapEntry -> mapEntry.getValue().size() + " " + mapEntry.getKey())
+                      .toList());
+          info("Akka SDK annotation processor detected components: " + summary);
+          createComponentServiceDescriptor(componentTypeToConcreteComponents);
         } else {
-            return false;
+          debug("Akka SDK annotation processor found no annotated components");
         }
+      } catch (IOException ex) {
+        error(
+            "Akka SDK annotation processor failed to create component descriptor: "
+                + ex.getMessage());
+        throw new RuntimeException(ex);
+      }
+      return true;
+    } else {
+      return false;
     }
+  }
 
-    private String componentTypeFor(Element annotatedClass, TypeElement annotation) {
-        return switch (annotation.getQualifiedName().toString()) {
-            case "akka.javasdk.annotations.http.HttpEndpoint" -> HTTP_ENDPOINT_KEY;
-            case "akka.javasdk.annotations.GrpcEndpoint" -> GRPC_ENDPOINT_KEY;
-            case "akka.javasdk.annotations.Setup" -> SERVICE_SETUP_KEY;
-            case "akka.javasdk.annotations.mcp.McpEndpoint" -> MCP_ENDPOINT_KEY;
-            case "akka.javasdk.annotations.ComponentId" -> componentType(annotatedClass);
-            default -> throw new IllegalArgumentException("Unknown annotation type: " + annotation.getQualifiedName());
-        };
-    }
+  private String componentTypeFor(Element annotatedClass, TypeElement annotation) {
+    return switch (annotation.getQualifiedName().toString()) {
+      case "akka.javasdk.annotations.http.HttpEndpoint" -> HTTP_ENDPOINT_KEY;
+      case "akka.javasdk.annotations.GrpcEndpoint" -> GRPC_ENDPOINT_KEY;
+      case "akka.javasdk.annotations.Setup" -> SERVICE_SETUP_KEY;
+      case "akka.javasdk.annotations.mcp.McpEndpoint" -> MCP_ENDPOINT_KEY;
+      case "akka.javasdk.annotations.ComponentId" -> componentType(annotatedClass);
+      default ->
+          throw new IllegalArgumentException(
+              "Unknown annotation type: " + annotation.getQualifiedName());
+    };
+  }
 
-    /**
-     * Entities share the same annotation, so we need to look at class supertypes
-     */
-    private String componentType(Element annotatedClass) {
-        return recurseForComponentType(annotatedClass, annotatedClass);
-    }
+  /** Entities share the same annotation, so we need to look at class supertypes */
+  private String componentType(Element annotatedClass) {
+    return recurseForComponentType(annotatedClass, annotatedClass);
+  }
 
-    private String recurseForComponentType(Element annotatedClass, Element current) {
-        var superClassTypeMirror = ((TypeElement) current).getSuperclass();
-        var superClassElement = ((DeclaredType) superClassTypeMirror).asElement();
+  private String recurseForComponentType(Element annotatedClass, Element current) {
+    var superClassTypeMirror = ((TypeElement) current).getSuperclass();
+    var superClassElement = ((DeclaredType) superClassTypeMirror).asElement();
 
-        var superClassName = superClassTypeMirror.toString();
+    var superClassName = superClassTypeMirror.toString();
 
-        // cut out type params if any
-        int typeParams = superClassName.indexOf("<");
-        var classNameWithoutTypeParams = typeParams > 0 ? superClassName.substring(0, typeParams) : superClassName;
-        debug("Determining component type trough supertype: " +  classNameWithoutTypeParams);
+    // cut out type params if any
+    int typeParams = superClassName.indexOf("<");
+    var classNameWithoutTypeParams =
+        typeParams > 0 ? superClassName.substring(0, typeParams) : superClassName;
+    debug("Determining component type trough supertype: " + classNameWithoutTypeParams);
 
-        return switch (classNameWithoutTypeParams) {
-            case "akka.javasdk.eventsourcedentity.EventSourcedEntity" -> EVENT_SOURCED_ENTITY_KEY;
-            case "akka.javasdk.keyvalueentity.KeyValueEntity" -> VALUE_ENTITY_KEY;
-            case "akka.javasdk.workflow.Workflow" -> WORKFLOW_KEY;
-            case "akka.javasdk.timedaction.TimedAction" -> TIMED_ACTION_KEY;
-            case "akka.javasdk.consumer.Consumer" -> CONSUMER_KEY;
-            case "akka.javasdk.view.View" -> VIEW_KEY;
-            case "akka.javasdk.agent.Agent" -> AGENT_KEY;
-            case "java.lang.Object" -> throw new IllegalArgumentException("Unknown supertype for class [" + annotatedClass + "] annotated with @ComponentId: [" + superClassName + "]");
-            default ->
-                // go through hierarchy
-                recurseForComponentType(annotatedClass, superClassElement);
-        };
-    }
+    return switch (classNameWithoutTypeParams) {
+      case "akka.javasdk.eventsourcedentity.EventSourcedEntity" -> EVENT_SOURCED_ENTITY_KEY;
+      case "akka.javasdk.keyvalueentity.KeyValueEntity" -> VALUE_ENTITY_KEY;
+      case "akka.javasdk.workflow.Workflow" -> WORKFLOW_KEY;
+      case "akka.javasdk.timedaction.TimedAction" -> TIMED_ACTION_KEY;
+      case "akka.javasdk.consumer.Consumer" -> CONSUMER_KEY;
+      case "akka.javasdk.view.View" -> VIEW_KEY;
+      case "akka.javasdk.agent.Agent" -> AGENT_KEY;
+      case "java.lang.Object" ->
+          throw new IllegalArgumentException(
+              "Unknown supertype for class ["
+                  + annotatedClass
+                  + "] annotated with @ComponentId: ["
+                  + superClassName
+                  + "]");
+      default ->
+          // go through hierarchy
+          recurseForComponentType(annotatedClass, superClassElement);
+    };
+  }
 
-    private void createComponentServiceDescriptor(Map<String, List<String>> componentTypeToConcreteComponents) throws IOException {
-        var filer = processingEnv.getFiler();
+  private void createComponentServiceDescriptor(
+      Map<String, List<String>> componentTypeToConcreteComponents) throws IOException {
+    var filer = processingEnv.getFiler();
 
-        Config existingConfig;
-        try {
-            var existingDescriptorResource = filer.getResource(StandardLocation.CLASS_OUTPUT, "", COMPONENT_DESCRIPTOR_FILE_PATH);
+    Config existingConfig;
+    try {
+      var existingDescriptorResource =
+          filer.getResource(StandardLocation.CLASS_OUTPUT, "", COMPONENT_DESCRIPTOR_FILE_PATH);
 
-            try(var in = existingDescriptorResource.openReader(true)) {
-                // this could be both user defined existing config, and a previous compile without clean inbetween
-                debug("Existing kalix component descriptor found, will merge with discovered components");
-                try (in) {
-                    existingConfig = ConfigFactory.parseReader(in);
-                }
-            }
-            existingDescriptorResource.delete();
-        } catch (NoSuchFileException ex) {
-            // no existing file
-            debug("No existing kalix component descriptor found");
-            existingConfig = ConfigFactory.empty();
+      try (var in = existingDescriptorResource.openReader(true)) {
+        // this could be both user defined existing config, and a previous compile without clean
+        // inbetween
+        debug("Existing kalix component descriptor found, will merge with discovered components");
+        try (in) {
+          existingConfig = ConfigFactory.parseReader(in);
         }
+      }
+      existingDescriptorResource.delete();
+    } catch (NoSuchFileException ex) {
+      // no existing file
+      debug("No existing kalix component descriptor found");
+      existingConfig = ConfigFactory.empty();
+    }
 
-        final Config foundExistingConfig = existingConfig;
-        final Map<String, Object> config = new HashMap<>();
-        ALL_COMPONENT_TYPES.forEach(componentType -> {
-            var foundComponentClasses = componentTypeToConcreteComponents.getOrDefault(componentType, List.of());
-            if (componentType.equals(SERVICE_SETUP_KEY)) {
-                // only one kalix service annotated class
-                String serviceSetupPath = DESCRIPTOR_ENTRY_BASE_PATH + SERVICE_SETUP_KEY;
-                if (foundComponentClasses.isEmpty()) {
-                    if (foundExistingConfig.hasPath(serviceSetupPath)) {
-                        //use the old value
-                        config.put(serviceSetupPath, foundExistingConfig.getString(serviceSetupPath));
-                    }
-                } else {
-                    config.put(serviceSetupPath, foundComponentClasses.getFirst());
-                }
+    final Config foundExistingConfig = existingConfig;
+    final Map<String, Object> config = new HashMap<>();
+    ALL_COMPONENT_TYPES.forEach(
+        componentType -> {
+          var foundComponentClasses =
+              componentTypeToConcreteComponents.getOrDefault(componentType, List.of());
+          if (componentType.equals(SERVICE_SETUP_KEY)) {
+            // only one kalix service annotated class
+            String serviceSetupPath = DESCRIPTOR_ENTRY_BASE_PATH + SERVICE_SETUP_KEY;
+            if (foundComponentClasses.isEmpty()) {
+              if (foundExistingConfig.hasPath(serviceSetupPath)) {
+                // use the old value
+                config.put(serviceSetupPath, foundExistingConfig.getString(serviceSetupPath));
+              }
             } else {
-                Set<String> components = new HashSet<>();
-                var componentTypeConfigPath = DESCRIPTOR_COMPONENT_ENTRY_BASE_PATH + componentType;
-                //add existing ones
-                if (foundExistingConfig.hasPath(componentTypeConfigPath))
-                    components.addAll(foundExistingConfig.getStringList(componentTypeConfigPath));
-                //add new ones (could be empty)
-                components.addAll(foundComponentClasses);
-                if (!components.isEmpty()) {
-                    debug("Adding " + components.size() + " components of type " + componentType +  ": " + String.join(", ", components) + " to descriptor");
-                    config.put(componentTypeConfigPath, components.stream().toList());
-                }
+              config.put(serviceSetupPath, foundComponentClasses.getFirst());
             }
+          } else {
+            Set<String> components = new HashSet<>();
+            var componentTypeConfigPath = DESCRIPTOR_COMPONENT_ENTRY_BASE_PATH + componentType;
+            // add existing ones
+            if (foundExistingConfig.hasPath(componentTypeConfigPath))
+              components.addAll(foundExistingConfig.getStringList(componentTypeConfigPath));
+            // add new ones (could be empty)
+            components.addAll(foundComponentClasses);
+            if (!components.isEmpty()) {
+              debug(
+                  "Adding "
+                      + components.size()
+                      + " components of type "
+                      + componentType
+                      + ": "
+                      + String.join(", ", components)
+                      + " to descriptor");
+              config.put(componentTypeConfigPath, components.stream().toList());
+            }
+          }
         });
 
-        var newDescriptorResource = filer.createResource(StandardLocation.CLASS_OUTPUT, "", COMPONENT_DESCRIPTOR_FILE_PATH);
-        debug("Akka SDK annotation processor writing component descriptor " + new File(newDescriptorResource.toUri()));
-        writeConfig(newDescriptorResource, ConfigFactory.parseMap(config));
-    }
+    var newDescriptorResource =
+        filer.createResource(StandardLocation.CLASS_OUTPUT, "", COMPONENT_DESCRIPTOR_FILE_PATH);
+    debug(
+        "Akka SDK annotation processor writing component descriptor "
+            + new File(newDescriptorResource.toUri()));
+    writeConfig(newDescriptorResource, ConfigFactory.parseMap(config));
+  }
 
-    private void writeConfig(FileObject descriptorResource, Config config) throws IOException {
-        try (Writer out = descriptorResource.openWriter()) {
-            var writer = new BufferedWriter(out);
-            var configAsString = config.root().render(
-                    ConfigRenderOptions.concise()
-                            .setFormatted(true)
-                            .setJson(false));
-            writer.write(configAsString);
-            writer.flush();
-        }
+  private void writeConfig(FileObject descriptorResource, Config config) throws IOException {
+    try (Writer out = descriptorResource.openWriter()) {
+      var writer = new BufferedWriter(out);
+      var configAsString =
+          config.root().render(ConfigRenderOptions.concise().setFormatted(true).setJson(false));
+      writer.write(configAsString);
+      writer.flush();
     }
+  }
 
-    private void debug(Object msg) {
-        if (debugEnabled)
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, msg.toString());
-    }
+  private void debug(Object msg) {
+    if (debugEnabled)
+      processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, msg.toString());
+  }
 
-    private void info(Object msg) {
-        processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, msg.toString());
-    }
+  private void info(Object msg) {
+    processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, msg.toString());
+  }
 
-    private void warning(Object msg) {
-        processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, msg.toString());
-    }
+  private void warning(Object msg) {
+    processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, msg.toString());
+  }
 
-    private void error(Object msg) {
-        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg.toString());
-    }
+  private void error(Object msg) {
+    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg.toString());
+  }
 }

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/AsyncCallsSupport.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/AsyncCallsSupport.java
@@ -4,15 +4,14 @@
 
 package akka.javasdk.testkit;
 
-import akka.javasdk.impl.ErrorHandling;
+import static java.time.temporal.ChronoUnit.SECONDS;
 
+import akka.javasdk.impl.ErrorHandling;
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import static java.time.temporal.ChronoUnit.SECONDS;
 
 public abstract class AsyncCallsSupport {
 
@@ -32,9 +31,9 @@ public abstract class AsyncCallsSupport {
     }
   }
 
-
   /**
-   * If completed with an exception, returns the exception. If completed successfully, fail with runtime exception.
+   * If completed with an exception, returns the exception. If completed successfully, fail with
+   * runtime exception.
    */
   public <O> Exception failed(CompletionStage<O> stage) {
     try {

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/DeferredCallDetails.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/DeferredCallDetails.java
@@ -7,15 +7,23 @@ package akka.javasdk.testkit;
 import akka.javasdk.Metadata;
 
 public interface DeferredCallDetails<I, O> {
-  /** @return The forwarded message */
+  /**
+   * @return The forwarded message
+   */
   I getMessage();
 
-  /** @return Any metadata attached to the call */
+  /**
+   * @return Any metadata attached to the call
+   */
   Metadata getMetadata();
 
-  /** @return The name of the service being called */
+  /**
+   * @return The name of the service being called
+   */
   String getServiceName();
 
-  /** @return The method name being called */
+  /**
+   * @return The method name being called
+   */
   String getMethodName();
 }

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EntitySerializationChecker.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EntitySerializationChecker.java
@@ -6,7 +6,6 @@ package akka.javasdk.testkit;
 
 import akka.javasdk.impl.serialization.JsonSerializer;
 import akka.runtime.sdk.spi.BytesPayload;
-
 import java.lang.reflect.Type;
 
 final class EntitySerializationChecker {
@@ -22,9 +21,7 @@ final class EntitySerializationChecker {
     }
   }
 
-  /**
-   * different deserialization for responses, state, and commands
-   */
+  /** different deserialization for responses, state, and commands */
   static void verifySerDerWithExpectedType(Class<?> expectedClass, Object object, Object entity) {
     try {
       BytesPayload bytesPayload = jsonSerializer.toBytes(object);
@@ -34,9 +31,7 @@ final class EntitySerializationChecker {
     }
   }
 
-  /**
-   * different deserialization for responses, state, and commands
-   */
+  /** different deserialization for responses, state, and commands */
   static void verifySerDerWithExpectedType(Type expectedType, Object object, Object entity) {
     try {
       BytesPayload bytesPayload = jsonSerializer.toBytes(object);
@@ -47,6 +42,11 @@ final class EntitySerializationChecker {
   }
 
   private static void fail(Object object, Object entity, Exception e) {
-    throw new RuntimeException("Failed to serialize or deserialize " + object.getClass().getName() + ". Make sure that all events, commands, responses and state are serializable for " + entity.getClass().getName(), e);
+    throw new RuntimeException(
+        "Failed to serialize or deserialize "
+            + object.getClass().getName()
+            + ". Make sure that all events, commands, responses and state are serializable for "
+            + entity.getClass().getName(),
+        e);
   }
 }

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventSourcedEntityEffectsRunner.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventSourcedEntityEffectsRunner.java
@@ -4,21 +4,20 @@
 
 package akka.javasdk.testkit;
 
+import static akka.javasdk.testkit.EntitySerializationChecker.verifySerDer;
+import static akka.javasdk.testkit.EntitySerializationChecker.verifySerDerWithExpectedType;
+
 import akka.javasdk.Metadata;
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
 import akka.javasdk.impl.reflection.Reflect;
 import akka.javasdk.testkit.impl.EventSourcedResultImpl;
 import akka.javasdk.testkit.impl.TestKitEventSourcedEntityCommandContext;
 import akka.javasdk.testkit.impl.TestKitEventSourcedEntityEventContext;
-
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
-
-import static akka.javasdk.testkit.EntitySerializationChecker.verifySerDer;
-import static akka.javasdk.testkit.EntitySerializationChecker.verifySerDerWithExpectedType;
 
 /** Extended by generated code, not meant for user extension */
 abstract class EventSourcedEntityEffectsRunner<S, E> {
@@ -51,22 +50,32 @@ abstract class EventSourcedEntityEffectsRunner<S, E> {
     playEventsForEntity(initialEvents);
   }
 
-  /** @return The current state of the entity after applying the event */
+  /**
+   * @return The current state of the entity after applying the event
+   */
   protected abstract S handleEvent(S state, E event);
 
-  protected EventSourcedEntity<S, E> entity() { return entity; }
+  protected EventSourcedEntity<S, E> entity() {
+    return entity;
+  }
 
-  /** @return The current state of the entity */
+  /**
+   * @return The current state of the entity
+   */
   public S getState() {
     return _state;
   }
 
-  /** @return true if the entity is deleted */
+  /**
+   * @return true if the entity is deleted
+   */
   public boolean isDeleted() {
     return deleted;
   }
 
-  /** @return All events persisted by command handlers of this entity up to now */
+  /**
+   * @return All events persisted by command handlers of this entity up to now
+   */
   public List<E> getAllEvents() {
     return events;
   }
@@ -79,9 +88,13 @@ abstract class EventSourcedEntityEffectsRunner<S, E> {
    * @return the result of the side effects
    */
   protected <R> EventSourcedResult<R> interpretEffects(
-      Supplier<EventSourcedEntity.Effect<R>> effect, String entityId, Metadata metadata, Optional<Type> returnType) {
+      Supplier<EventSourcedEntity.Effect<R>> effect,
+      String entityId,
+      Metadata metadata,
+      Optional<Type> returnType) {
     var sequenceNumber = this.events.size();
-    var commandContext = new TestKitEventSourcedEntityCommandContext(entityId, metadata, sequenceNumber);
+    var commandContext =
+        new TestKitEventSourcedEntityCommandContext(entityId, metadata, sequenceNumber);
     EventSourcedEntity.Effect<R> effectExecuted;
     try {
       entity._internalSetCommandContext(Optional.of(commandContext));

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventSourcedResult.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventSourcedResult.java
@@ -5,7 +5,6 @@
 package akka.javasdk.testkit;
 
 import io.grpc.Status;
-
 import java.util.List;
 
 /**
@@ -18,7 +17,9 @@ import java.util.List;
  */
 public interface EventSourcedResult<R> {
 
-  /** @return true if the call had an effect with a reply, false if not */
+  /**
+   * @return true if the call had an effect with a reply, false if not
+   */
   boolean isReply();
 
   /**
@@ -27,7 +28,9 @@ public interface EventSourcedResult<R> {
    */
   R getReply();
 
-  /** @return true if the call was an error, false if not */
+  /**
+   * @return true if the call was an error, false if not
+   */
   boolean isError();
 
   /** The error description. If the result was not an error an exception is thrown */
@@ -56,7 +59,9 @@ public interface EventSourcedResult<R> {
    */
   boolean didPersistEvents();
 
-  /** @return All the events that were emitted by handling this command. */
+  /**
+   * @return All the events that were emitted by handling this command.
+   */
   List<Object> getAllEvents();
 
   /**
@@ -67,5 +72,4 @@ public interface EventSourcedResult<R> {
    * @return The next event if it is of type E, for additional assertions.
    */
   <E> E getNextEventOfType(Class<E> expectedClass);
-
 }

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventSourcedTestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventSourcedTestKit.java
@@ -4,21 +4,19 @@
 
 package akka.javasdk.testkit;
 
+import static akka.javasdk.testkit.EntitySerializationChecker.verifySerDerWithExpectedType;
+
 import akka.javasdk.Metadata;
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
 import akka.javasdk.eventsourcedentity.EventSourcedEntityContext;
 import akka.javasdk.impl.client.MethodRefResolver;
 import akka.javasdk.impl.reflection.Reflect;
 import akka.javasdk.testkit.impl.TestKitEventSourcedEntityContext;
-
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
-import static akka.javasdk.testkit.EntitySerializationChecker.verifySerDerWithExpectedType;
 
 /**
  * EventSourced Testkit for use in unit tests for EventSourced entities.
@@ -66,8 +64,8 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
    *
    * <p>A default test entity id will be automatically provided.
    */
-  public static <S, E, ES extends EventSourcedEntity<S, E>> EventSourcedTestKit<S, E, ES> ofEntityWithState(
-      Supplier<ES> entityFactory, S initialState) {
+  public static <S, E, ES extends EventSourcedEntity<S, E>>
+      EventSourcedTestKit<S, E, ES> ofEntityWithState(Supplier<ES> entityFactory, S initialState) {
     return ofEntityWithState(DEFAULT_TEST_ENTITY_ID, entityFactory, initialState);
   }
 
@@ -77,8 +75,9 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
    *
    * <p>A default test entity id will be automatically provided.
    */
-  public static <S, E, ES extends EventSourcedEntity<S, E>> EventSourcedTestKit<S, E, ES> ofEntityFromEvents(
-      Supplier<ES> entityFactory, List<E> initialEvents) {
+  public static <S, E, ES extends EventSourcedEntity<S, E>>
+      EventSourcedTestKit<S, E, ES> ofEntityFromEvents(
+          Supplier<ES> entityFactory, List<E> initialEvents) {
     return ofEntityFromEvents(DEFAULT_TEST_ENTITY_ID, entityFactory, initialEvents);
   }
 
@@ -98,8 +97,9 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
    *
    * <p>A default test entity id will be automatically provided.
    */
-  public static <S, E, ES extends EventSourcedEntity<S, E>> EventSourcedTestKit<S, E, ES> ofEntityWithState(
-      Function<EventSourcedEntityContext, ES> entityFactory, S initialState) {
+  public static <S, E, ES extends EventSourcedEntity<S, E>>
+      EventSourcedTestKit<S, E, ES> ofEntityWithState(
+          Function<EventSourcedEntityContext, ES> entityFactory, S initialState) {
     return ofEntityWithState(DEFAULT_TEST_ENTITY_ID, entityFactory, initialState);
   }
 
@@ -109,8 +109,9 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
    *
    * <p>A default test entity id will be automatically provided.
    */
-  public static <S, E, ES extends EventSourcedEntity<S, E>> EventSourcedTestKit<S, E, ES> ofEntityFromEvents(
-      Function<EventSourcedEntityContext, ES> entityFactory, List<E> initialEvents) {
+  public static <S, E, ES extends EventSourcedEntity<S, E>>
+      EventSourcedTestKit<S, E, ES> ofEntityFromEvents(
+          Function<EventSourcedEntityContext, ES> entityFactory, List<E> initialEvents) {
     return ofEntityFromEvents(DEFAULT_TEST_ENTITY_ID, entityFactory, initialEvents);
   }
 
@@ -127,8 +128,9 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
    * Creates a new testkit instance from a user defined entity id, a Supplier of EventSourcedEntity,
    * and a state into which the supplied entity will be placed for tests.
    */
-  public static <S, E, ES extends EventSourcedEntity<S, E>> EventSourcedTestKit<S, E, ES> ofEntityWithState(
-      String entityId, Supplier<ES> entityFactory, S initialState) {
+  public static <S, E, ES extends EventSourcedEntity<S, E>>
+      EventSourcedTestKit<S, E, ES> ofEntityWithState(
+          String entityId, Supplier<ES> entityFactory, S initialState) {
     return ofEntityWithState(entityId, ctx -> entityFactory.get(), initialState);
   }
 
@@ -136,8 +138,9 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
    * Creates a new testkit instance from a user defined entity id, a Supplier of EventSourcedEntity,
    * and events from which to derive a state for the generated entity for tests.
    */
-  public static <S, E, ES extends EventSourcedEntity<S, E>> EventSourcedTestKit<S, E, ES> ofEntityFromEvents(
-      String entityId, Supplier<ES> entityFactory, List<E> initialEvents) {
+  public static <S, E, ES extends EventSourcedEntity<S, E>>
+      EventSourcedTestKit<S, E, ES> ofEntityFromEvents(
+          String entityId, Supplier<ES> entityFactory, List<E> initialEvents) {
     return ofEntityFromEvents(entityId, ctx -> entityFactory.get(), initialEvents);
   }
 
@@ -154,8 +157,9 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
    * Creates a new testkit instance from a user defined entity id, a factory function for
    * EventSourcedEntity, and a state into which the built entity will be placed for tests.
    */
-  public static <S, E, ES extends EventSourcedEntity<S, E>> EventSourcedTestKit<S, E, ES> ofEntityWithState(
-      String entityId, Function<EventSourcedEntityContext, ES> entityFactory, S initialState) {
+  public static <S, E, ES extends EventSourcedEntity<S, E>>
+      EventSourcedTestKit<S, E, ES> ofEntityWithState(
+          String entityId, Function<EventSourcedEntityContext, ES> entityFactory, S initialState) {
     return new EventSourcedTestKit<>(entityWithId(entityId, entityFactory), entityId, initialState);
   }
 
@@ -163,16 +167,21 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
    * Creates a new testkit instance from a user defined entity id, a factory function for
    * EventSourcedEntity, and events from which to derive a state for the generated entity for tests.
    */
-  public static <S, E, ES extends EventSourcedEntity<S, E>> EventSourcedTestKit<S, E, ES> ofEntityFromEvents(
-      String entityId, Function<EventSourcedEntityContext, ES> entityFactory, List<E> initialEvents) {
-    return new EventSourcedTestKit<>(entityWithId(entityId, entityFactory), entityId, initialEvents);
+  public static <S, E, ES extends EventSourcedEntity<S, E>>
+      EventSourcedTestKit<S, E, ES> ofEntityFromEvents(
+          String entityId,
+          Function<EventSourcedEntityContext, ES> entityFactory,
+          List<E> initialEvents) {
+    return new EventSourcedTestKit<>(
+        entityWithId(entityId, entityFactory), entityId, initialEvents);
   }
 
   public final class MethodRef<R> {
     private final akka.japi.function.Function<ES, EventSourcedEntity.Effect<R>> func;
     private final Metadata metadata;
 
-    public MethodRef(akka.japi.function.Function<ES, EventSourcedEntity.Effect<R>> func, Metadata metadata) {
+    public MethodRef(
+        akka.japi.function.Function<ES, EventSourcedEntity.Effect<R>> func, Metadata metadata) {
       this.func = func;
       this.metadata = metadata;
     }
@@ -192,7 +201,8 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
     private final akka.japi.function.Function2<ES, I, EventSourcedEntity.Effect<R>> func;
     private final Metadata metadata;
 
-    public MethodRef1(akka.japi.function.Function2<ES, I, EventSourcedEntity.Effect<R>> func, Metadata metadata) {
+    public MethodRef1(
+        akka.japi.function.Function2<ES, I, EventSourcedEntity.Effect<R>> func, Metadata metadata) {
       this.func = func;
       this.metadata = metadata;
     }
@@ -208,27 +218,34 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
 
       verifySerDerWithExpectedType(inputType, input, entity);
 
-      return EventSourcedTestKit.this.call(es -> {
-        try {
-          return func.apply(es, input);
-        } catch (Exception e) {
-          throw new RuntimeException(e);
-        }
-      }, metadata, Optional.of(returnType));
+      return EventSourcedTestKit.this.call(
+          es -> {
+            try {
+              return func.apply(es, input);
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          },
+          metadata,
+          Optional.of(returnType));
     }
   }
 
   /**
-   * Pass in an Event Sourced Entity command handler method reference without parameters, e.g. {@code UserEntity::create}
+   * Pass in an Event Sourced Entity command handler method reference without parameters, e.g.
+   * {@code UserEntity::create}
    */
-  public <R> MethodRef<R> method(akka.japi.function.Function<ES, EventSourcedEntity.Effect<R>> func) {
+  public <R> MethodRef<R> method(
+      akka.japi.function.Function<ES, EventSourcedEntity.Effect<R>> func) {
     return new MethodRef<>(func, Metadata.EMPTY);
   }
 
   /**
-   * Pass in an Event Sourced Entity command handler method reference with a single parameter, e.g. {@code UserEntity::create}
+   * Pass in an Event Sourced Entity command handler method reference with a single parameter, e.g.
+   * {@code UserEntity::create}
    */
-  public <I, R> MethodRef1<I, R> method(akka.japi.function.Function2<ES, I, EventSourcedEntity.Effect<R>> func) {
+  public <I, R> MethodRef1<I, R> method(
+      akka.japi.function.Function2<ES, I, EventSourcedEntity.Effect<R>> func) {
     return new MethodRef1<>(func, Metadata.EMPTY);
   }
 
@@ -243,7 +260,8 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
    * @deprecated Use "method(MyEntity::myCommandHandler).invoke()" instead
    */
   @Deprecated(since = "3.2.1", forRemoval = true)
-  public <R> EventSourcedResult<R> call(akka.japi.function.Function<ES, EventSourcedEntity.Effect<R>> func) {
+  public <R> EventSourcedResult<R> call(
+      akka.japi.function.Function<ES, EventSourcedEntity.Effect<R>> func) {
     return call(func, Metadata.EMPTY);
   }
 
@@ -252,26 +270,34 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
    * lambda should return an EventSourcedEntity.Effect. The Effect is interpreted into an
    * EventSourcedResult that can be used in test assertions.
    *
-   * @param func     A function from EventSourcedEntity to EventSourcedEntity.Effect.
+   * @param func A function from EventSourcedEntity to EventSourcedEntity.Effect.
    * @param metadata A metadata passed as a call context.
-   * @param <R>      The type of reply that is expected from invoking a command handler
+   * @param <R> The type of reply that is expected from invoking a command handler
    * @return a EventSourcedResult
    * @deprecated Use "method(MyEntity::myCommandHandler).withMetadata(metadata).invoke()" instead
    */
   @SuppressWarnings("unchecked") // entity() returns the entity we were constructed with
   @Deprecated(since = "3.2.1", forRemoval = true)
-  public <R> EventSourcedResult<R> call(akka.japi.function.Function<ES, EventSourcedEntity.Effect<R>> func, Metadata metadata) {
+  public <R> EventSourcedResult<R> call(
+      akka.japi.function.Function<ES, EventSourcedEntity.Effect<R>> func, Metadata metadata) {
     return call(func, metadata, Optional.empty());
   }
 
-  private <R> EventSourcedResult<R> call(akka.japi.function.Function<ES, EventSourcedEntity.Effect<R>> func, Metadata metadata, Optional<Type> returnType) {
-    return interpretEffects(() -> {
-      try {
-        return func.apply((ES) entity());
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    }, entityId, metadata,returnType);
+  private <R> EventSourcedResult<R> call(
+      akka.japi.function.Function<ES, EventSourcedEntity.Effect<R>> func,
+      Metadata metadata,
+      Optional<Type> returnType) {
+    return interpretEffects(
+        () -> {
+          try {
+            return func.apply((ES) entity());
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        },
+        entityId,
+        metadata,
+        returnType);
   }
 
   @Override

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventingTestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventingTestKit.java
@@ -6,24 +6,21 @@ package akka.javasdk.testkit;
 
 import akka.actor.typed.ActorSystem;
 import akka.annotation.InternalApi;
-import akka.javasdk.impl.serialization.JsonSerializer;
-import com.google.protobuf.ByteString;
 import akka.javasdk.Metadata;
+import akka.javasdk.impl.serialization.JsonSerializer;
 import akka.javasdk.testkit.impl.EventingTestKitImpl;
 import akka.javasdk.testkit.impl.OutgoingMessagesImpl;
 import akka.javasdk.testkit.impl.TestKitMessageImpl;
-
+import com.google.protobuf.ByteString;
 import java.time.Duration;
 import java.util.List;
 
-
 public interface EventingTestKit {
 
-  /**
-   * INTERNAL API
-   */
+  /** INTERNAL API */
   @InternalApi
-  static EventingTestKit start(ActorSystem<?> system, String host, int port, JsonSerializer serializer) {
+  static EventingTestKit start(
+      ActorSystem<?> system, String host, int port, JsonSerializer serializer) {
     return EventingTestKitImpl.start(system, host, port, serializer);
   }
 
@@ -39,15 +36,12 @@ public interface EventingTestKit {
 
   IncomingMessages getStreamIncomingMessages(String service, String streamId);
 
-  /**
-   * Allows to simulate publishing messages for the purposes of testing incoming message flow.
-   */
+  /** Allows to simulate publishing messages for the purposes of testing incoming message flow. */
   interface IncomingMessages {
     /**
      * Simulate the publishing of a raw message.
      *
      * @param message raw protobuf bytestring to be published
-     *
      * @deprecated Use publish with byte array parameter
      */
     @Deprecated
@@ -56,9 +50,8 @@ public interface EventingTestKit {
     /**
      * Simulate the publishing of a raw message.
      *
-     * @param message  raw protobuf bytestring to be published
+     * @param message raw protobuf bytestring to be published
      * @param metadata associated with the message
-     *
      * @deprecated Use publish with byte array parameter
      */
     @Deprecated
@@ -74,7 +67,7 @@ public interface EventingTestKit {
     /**
      * Simulate the publishing of a raw message.
      *
-     * @param message  raw byte array to be published
+     * @param message raw byte array to be published
      * @param metadata associated with the message
      */
     void publish(byte[] message, Metadata metadata);
@@ -103,42 +96,42 @@ public interface EventingTestKit {
     void publish(List<Message<?>> messages);
 
     /**
-     * Publish a predefined delete message. Supported only in case of KeyValueEntity incoming message flow.
+     * Publish a predefined delete message. Supported only in case of KeyValueEntity incoming
+     * message flow.
      *
      * @param subject to identify the entity
      */
     void publishDelete(String subject);
   }
 
-  /**
-   * Allows to assert published messages for the purposes of testing outgoing message flow.
-   */
+  /** Allows to assert published messages for the purposes of testing outgoing message flow. */
   interface OutgoingMessages {
     /**
-     * Waits for predefined amount of time (see {@link OutgoingMessagesImpl#DefaultTimeout()} for default value). If a message arrives in the meantime or
-     * has arrived before but was not consumed, the test fails.
+     * Waits for predefined amount of time (see {@link OutgoingMessagesImpl#DefaultTimeout()} for
+     * default value). If a message arrives in the meantime or has arrived before but was not
+     * consumed, the test fails.
      */
     void expectNone();
 
     /**
-     * Waits for given amount of time. If a message arrives in the meantime or
-     * has arrived before but was not consumed, the test fails.
+     * Waits for given amount of time. If a message arrives in the meantime or has arrived before
+     * but was not consumed, the test fails.
      *
      * @param timeout amount of time to wait for a message
      */
     void expectNone(Duration timeout);
 
     /**
-     * Waits and returns the next unread message. Note the message might have been received before this
-     * method was called. If no message is received, a timeout exception is thrown.
+     * Waits and returns the next unread message. Note the message might have been received before
+     * this method was called. If no message is received, a timeout exception is thrown.
      *
      * @return a Message with a ByteString payload
      */
     Message<ByteString> expectOneRaw();
 
     /**
-     * Waits and returns the next unread message. Note the message might have been received before this
-     * method was called. If no message is received, a timeout exception is thrown.
+     * Waits and returns the next unread message. Note the message might have been received before
+     * this method was called. If no message is received, a timeout exception is thrown.
      *
      * @param timeout amount of time to wait for a message
      * @return a Message with a ByteString payload
@@ -146,18 +139,18 @@ public interface EventingTestKit {
     Message<ByteString> expectOneRaw(Duration timeout);
 
     /**
-     * Waits for predefined amount of time (see {@link OutgoingMessagesImpl#DefaultTimeout()} for default value) and returns the next unread message.
-     * Note the message might have been received before this method was called.
-     * If no message is received, a timeout exception is thrown.
+     * Waits for predefined amount of time (see {@link OutgoingMessagesImpl#DefaultTimeout()} for
+     * default value) and returns the next unread message. Note the message might have been received
+     * before this method was called. If no message is received, a timeout exception is thrown.
      *
      * @return message including ByteString payload and metadata
      */
     Message<?> expectOne();
 
     /**
-     * Waits for a specific amount and returns the next unread message.
-     * Note the message might have been received before this method was called.
-     * If no message is received, a timeout exception is thrown.
+     * Waits for a specific amount and returns the next unread message. Note the message might have
+     * been received before this method was called. If no message is received, a timeout exception
+     * is thrown.
      *
      * @param timeout amount of time to wait for a message if it was not received already
      * @return message including ByteString payload and metadata
@@ -165,20 +158,19 @@ public interface EventingTestKit {
     Message<?> expectOne(Duration timeout);
 
     /**
-     * Waits and returns the next unread message and automatically parses
-     * and casts it to the specified given type.
+     * Waits and returns the next unread message and automatically parses and casts it to the
+     * specified given type.
      *
      * @param instance class type to cast the received message bytes to
-     * @param <T>      a given domain type
+     * @param <T> a given domain type
      * @return a Message of type T
      */
     <T> Message<T> expectOneTyped(Class<T> instance);
 
     /**
-     * Waits and returns the next unread message and automatically parses
-     * and casts it to the specified given type.
-     * Note the message might have been received before this method was called.
-     * If no message is received, a timeout exception is thrown.
+     * Waits and returns the next unread message and automatically parses and casts it to the
+     * specified given type. Note the message might have been received before this method was
+     * called. If no message is received, a timeout exception is thrown.
      *
      * @param timeout amount of time to wait for a message if it was not received already
      * @return message including ByteString payload and metadata
@@ -186,16 +178,16 @@ public interface EventingTestKit {
     <T> Message<T> expectOneTyped(Class<T> instance, Duration timeout);
 
     /**
-     * Waits for a default amount of time before returning all unread messages.
-     * If no message is received, a timeout exception is thrown.
+     * Waits for a default amount of time before returning all unread messages. If no message is
+     * received, a timeout exception is thrown.
      *
      * @return list of messages, each message including the deserialized payload object and metadata
      */
     List<Message<?>> expectN();
 
     /**
-     * Waits for a given amount of unread messages to be received before returning.
-     * If no message is received, a timeout exception is thrown.
+     * Waits for a given amount of unread messages to be received before returning. If no message is
+     * received, a timeout exception is thrown.
      *
      * @param total number of messages to wait for before returning
      * @return list of messages, each message including the deserialized payload object and metadata
@@ -203,10 +195,10 @@ public interface EventingTestKit {
     List<Message<?>> expectN(int total);
 
     /**
-     * Waits for a given amount of unread messages to be received before returning up to a given timeout.
-     * If no message is received, a timeout exception is thrown.
+     * Waits for a given amount of unread messages to be received before returning up to a given
+     * timeout. If no message is received, a timeout exception is thrown.
      *
-     * @param total   number of messages to wait for before returning
+     * @param total number of messages to wait for before returning
      * @param timeout maximum amount of time to wait for the messages
      * @return list of messages, each message including the deserialized payload object and metadata
      */
@@ -228,8 +220,8 @@ public interface EventingTestKit {
     }
 
     /**
-     * Create a message from a payload plus a subject (that is, the entity id).
-     * Automatically adds required default metadata for a CloudEvent.
+     * Create a message from a payload plus a subject (that is, the entity id). Automatically adds
+     * required default metadata for a CloudEvent.
      *
      * @param payload the message payload
      * @param subject the entity id of which the message is concerned about
@@ -237,11 +229,13 @@ public interface EventingTestKit {
      * @return a Message object to be used in the context of the Testkit
      */
     public <T> Message<T> of(T payload, String subject) {
-      return new TestKitMessageImpl<>(payload, TestKitMessageImpl.defaultMetadata(payload, subject, serializer));
+      return new TestKitMessageImpl<>(
+          payload, TestKitMessageImpl.defaultMetadata(payload, subject, serializer));
     }
 
     /**
      * Create a default metadata a given payload and subject.
+     *
      * @param payload the message payload
      * @param subject the entity id to associate with the payload
      * @return
@@ -253,7 +247,7 @@ public interface EventingTestKit {
     /**
      * Create a message object from a payload plus metadata.
      *
-     * @param payload  the message payload
+     * @param payload the message payload
      * @param metadata the metadata associated with the message
      * @param <T>
      * @return a Message object to be used in the context of the Testkit
@@ -273,7 +267,7 @@ public interface EventingTestKit {
      * Otherwise, throws an exception.
      *
      * @param clazz expected class type for the payload of the message
-     * @param <T>   the type of the payload
+     * @param <T> the type of the payload
      * @return a typed object from the payload
      */
     <T> T expectType(Class<T> clazz);

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/KeyValueEntityResult.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/KeyValueEntityResult.java
@@ -13,7 +13,9 @@ package akka.javasdk.testkit;
  */
 public interface KeyValueEntityResult<R> {
 
-  /** @return true if the call had an effect with a reply, false if not */
+  /**
+   * @return true if the call had an effect with a reply, false if not
+   */
   boolean isReply();
 
   /**
@@ -22,18 +24,26 @@ public interface KeyValueEntityResult<R> {
    */
   R getReply();
 
-  /** @return true if the call was an error, false if not */
+  /**
+   * @return true if the call was an error, false if not
+   */
   boolean isError();
 
   /** The error description. If the result was not an error an exception is thrown */
   String getError();
 
-  /** @return true if the call updated the entity state */
+  /**
+   * @return true if the call updated the entity state
+   */
   boolean stateWasUpdated();
 
-  /** @return The updated state. If the state was not updated an exception is thrown */
+  /**
+   * @return The updated state. If the state was not updated an exception is thrown
+   */
   Object getUpdatedState();
 
-  /** @return true if the call deleted the entity */
+  /**
+   * @return true if the call deleted the entity
+   */
   boolean stateWasDeleted();
 }

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/KeyValueEntityTestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/KeyValueEntityTestKit.java
@@ -4,6 +4,8 @@
 
 package akka.javasdk.testkit;
 
+import static akka.javasdk.testkit.EntitySerializationChecker.verifySerDerWithExpectedType;
+
 import akka.javasdk.Metadata;
 import akka.javasdk.impl.client.MethodRefResolver;
 import akka.javasdk.impl.reflection.Reflect;
@@ -12,19 +14,16 @@ import akka.javasdk.keyvalueentity.KeyValueEntityContext;
 import akka.javasdk.testkit.impl.KeyValueEntityResultImpl;
 import akka.javasdk.testkit.impl.TestKitKeyValueEntityCommandContext;
 import akka.javasdk.testkit.impl.TestKitKeyValueEntityContext;
-
 import java.lang.reflect.Type;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static akka.javasdk.testkit.EntitySerializationChecker.verifySerDerWithExpectedType;
-
 /**
  * KeyValueEntity Testkit for use in unit tests for Value entities.
  *
- * <p>To test a KeyValueEntity create a testkit instance by calling one of the available
- * {@code KeyValueEntityTestKit.of} methods. The returned testkit is stateful, and it holds internally the
+ * <p>To test a KeyValueEntity create a testkit instance by calling one of the available {@code
+ * KeyValueEntityTestKit.of} methods. The returned testkit is stateful, and it holds internally the
  * state of the entity.
  *
  * <p>Use the {@code call} methods to interact with the testkit.
@@ -53,7 +52,7 @@ public class KeyValueEntityTestKit<S, E extends KeyValueEntity<S>> {
    * <p>A default test entity id will be automatically provided.
    */
   public static <S, E extends KeyValueEntity<S>> KeyValueEntityTestKit<S, E> of(
-    Supplier<E> entityFactory) {
+      Supplier<E> entityFactory) {
     return of(ctx -> entityFactory.get());
   }
 
@@ -63,24 +62,22 @@ public class KeyValueEntityTestKit<S, E extends KeyValueEntity<S>> {
    * <p>A default test entity id will be automatically provided.
    */
   public static <S, E extends KeyValueEntity<S>> KeyValueEntityTestKit<S, E> of(
-    Function<KeyValueEntityContext, E> entityFactory) {
+      Function<KeyValueEntityContext, E> entityFactory) {
     return of("testkit-entity-id", entityFactory);
   }
 
-  /**
-   * Creates a new testkit instance from a user defined entity id and a KeyValueEntity Supplier.
-   */
+  /** Creates a new testkit instance from a user defined entity id and a KeyValueEntity Supplier. */
   public static <S, E extends KeyValueEntity<S>> KeyValueEntityTestKit<S, E> of(
-    String entityId, Supplier<E> entityFactory) {
+      String entityId, Supplier<E> entityFactory) {
     return of(entityId, ctx -> entityFactory.get());
   }
 
   /**
-   * Creates a new testkit instance from a user defined entity id and a function KeyValueEntityContext
-   * to KeyValueEntity.
+   * Creates a new testkit instance from a user defined entity id and a function
+   * KeyValueEntityContext to KeyValueEntity.
    */
   public static <S, E extends KeyValueEntity<S>> KeyValueEntityTestKit<S, E> of(
-    String entityId, Function<KeyValueEntityContext, E> entityFactory) {
+      String entityId, Function<KeyValueEntityContext, E> entityFactory) {
     TestKitKeyValueEntityContext context = new TestKitKeyValueEntityContext(entityId);
     return new KeyValueEntityTestKit<>(entityId, entityFactory.apply(context));
   }
@@ -103,7 +100,8 @@ public class KeyValueEntityTestKit<S, E extends KeyValueEntity<S>> {
     private final akka.japi.function.Function<E, KeyValueEntity.Effect<R>> func;
     private final Metadata metadata;
 
-    public MethodRef(akka.japi.function.Function<E, KeyValueEntity.Effect<R>> func, Metadata metadata) {
+    public MethodRef(
+        akka.japi.function.Function<E, KeyValueEntity.Effect<R>> func, Metadata metadata) {
       this.func = func;
       this.metadata = metadata;
     }
@@ -123,7 +121,8 @@ public class KeyValueEntityTestKit<S, E extends KeyValueEntity<S>> {
     private final akka.japi.function.Function2<E, I, KeyValueEntity.Effect<R>> func;
     private final Metadata metadata;
 
-    public MethodRef1(akka.japi.function.Function2<E, I, KeyValueEntity.Effect<R>> func, Metadata metadata) {
+    public MethodRef1(
+        akka.japi.function.Function2<E, I, KeyValueEntity.Effect<R>> func, Metadata metadata) {
       this.func = func;
       this.metadata = metadata;
     }
@@ -139,32 +138,39 @@ public class KeyValueEntityTestKit<S, E extends KeyValueEntity<S>> {
 
       verifySerDerWithExpectedType(inputType, input, entity);
 
-      return KeyValueEntityTestKit.this.call(kve -> {
-        try {
-          return func.apply(kve, input);
-        } catch (Exception e) {
-          throw new RuntimeException(e);
-        }
-      }, metadata, Optional.of(returnType));
+      return KeyValueEntityTestKit.this.call(
+          kve -> {
+            try {
+              return func.apply(kve, input);
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          },
+          metadata,
+          Optional.of(returnType));
     }
   }
 
   /**
-   * Pass in a Key Value Entity command handler method reference without parameters, e.g. {@code UserEntity::create}
+   * Pass in a Key Value Entity command handler method reference without parameters, e.g. {@code
+   * UserEntity::create}
    */
   public <R> MethodRef<R> method(akka.japi.function.Function<E, KeyValueEntity.Effect<R>> func) {
     return new MethodRef<>(func, Metadata.EMPTY);
   }
 
   /**
-   * Pass in a Key Value Entity command handler method reference with a single parameter, e.g. {@code UserEntity::create}
+   * Pass in a Key Value Entity command handler method reference with a single parameter, e.g.
+   * {@code UserEntity::create}
    */
-  public <I, R> MethodRef1<I, R> method(akka.japi.function.Function2<E, I, KeyValueEntity.Effect<R>> func) {
+  public <I, R> MethodRef1<I, R> method(
+      akka.japi.function.Function2<E, I, KeyValueEntity.Effect<R>> func) {
     return new MethodRef1<>(func, Metadata.EMPTY);
   }
 
   @SuppressWarnings("unchecked")
-  private <Reply> KeyValueEntityResult<Reply> interpretEffects(Supplier<KeyValueEntity.Effect<Reply>> effect, Optional<Type> returnType) {
+  private <Reply> KeyValueEntityResult<Reply> interpretEffects(
+      Supplier<KeyValueEntity.Effect<Reply>> effect, Optional<Type> returnType) {
     KeyValueEntityResultImpl<Reply> result = new KeyValueEntityResultImpl<>(effect.get());
     if (result.stateWasUpdated()) {
       this.state = (S) result.getUpdatedState();
@@ -181,46 +187,53 @@ public class KeyValueEntityTestKit<S, E extends KeyValueEntity<S>> {
 
   /**
    * The call method can be used to simulate a call to the KeyValueEntity. The passed java lambda
-   * should return a KeyValueEntity.Effect. The Effect is interpreted into a KeyValueEntityResult that can
-   * be used in test assertions.
+   * should return a KeyValueEntity.Effect. The Effect is interpreted into a KeyValueEntityResult
+   * that can be used in test assertions.
    *
    * @param func A function from KeyValueEntity to KeyValueEntity.Effect.
-   * @param <R>  The type of reply that is expected from invoking a command handler
+   * @param <R> The type of reply that is expected from invoking a command handler
    * @return a KeyValueEntityResult
    * @deprecated Use "method(MyEntity::myCommandHandler).invoke()" instead
    */
   @Deprecated(since = "3.2.1", forRemoval = true)
-  public <R> KeyValueEntityResult<R> call(akka.japi.function.Function<E, KeyValueEntity.Effect<R>> func) {
+  public <R> KeyValueEntityResult<R> call(
+      akka.japi.function.Function<E, KeyValueEntity.Effect<R>> func) {
     return call(func, Metadata.EMPTY);
   }
 
   /**
    * The call method can be used to simulate a call to the KeyValueEntity. The passed java lambda
-   * should return a KeyValueEntity.Effect. The Effect is interpreted into a KeyValueEntityResult that can
-   * be used in test assertions.
+   * should return a KeyValueEntity.Effect. The Effect is interpreted into a KeyValueEntityResult
+   * that can be used in test assertions.
    *
-   * @param func     A function from KeyValueEntity to KeyValueEntity.Effect.
+   * @param func A function from KeyValueEntity to KeyValueEntity.Effect.
    * @param metadata A metadata passed as a call context.
-   * @param <R>      The type of reply that is expected from invoking a command handler
+   * @param <R> The type of reply that is expected from invoking a command handler
    * @return a KeyValueEntityResult
    * @deprecated Use "method(MyEntity::myCommandHandler).withMetadata(metadata).invoke()" instead
    */
   @Deprecated(since = "3.2.1", forRemoval = true)
-  public <R> KeyValueEntityResult<R> call(akka.japi.function.Function<E, KeyValueEntity.Effect<R>> func, Metadata metadata) {
+  public <R> KeyValueEntityResult<R> call(
+      akka.japi.function.Function<E, KeyValueEntity.Effect<R>> func, Metadata metadata) {
     return call(func, metadata, Optional.empty());
   }
 
-  private <R> KeyValueEntityResult<R> call(akka.japi.function.Function<E, KeyValueEntity.Effect<R>> func, Metadata metadata, Optional<Type> returnType) {
+  private <R> KeyValueEntityResult<R> call(
+      akka.japi.function.Function<E, KeyValueEntity.Effect<R>> func,
+      Metadata metadata,
+      Optional<Type> returnType) {
     TestKitKeyValueEntityCommandContext commandContext =
-      new TestKitKeyValueEntityCommandContext(entityId, metadata);
+        new TestKitKeyValueEntityCommandContext(entityId, metadata);
     entity._internalSetCommandContext(Optional.of(commandContext));
     entity._internalSetCurrentState(this.state, this.deleted);
-    return interpretEffects(() -> {
-      try {
-        return func.apply(entity);
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    }, returnType);
+    return interpretEffects(
+        () -> {
+          try {
+            return func.apply(entity);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        },
+        returnType);
   }
 }

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/SerializationTestkit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/SerializationTestkit.java
@@ -8,23 +8,19 @@ import akka.javasdk.impl.serialization.JsonSerializer;
 import akka.runtime.sdk.spi.BytesPayload;
 import akka.util.ByteString;
 import com.fasterxml.jackson.core.JsonProcessingException;
-
 import java.io.IOException;
 
-/**
- * Helper class for serializing and deserializing objects for testing schema migration.
- *
- */
+/** Helper class for serializing and deserializing objects for testing schema migration. */
 public final class SerializationTestkit {
 
-  private record SerializedPayload(String contentType, byte[] bytes) {
-  }
+  private record SerializedPayload(String contentType, byte[] bytes) {}
 
   private static final JsonSerializer jsonSerializer = new JsonSerializer();
 
   public static <T> byte[] serialize(T value) {
     BytesPayload bytesPayload = jsonSerializer.toBytes(value);
-    SerializedPayload serializedPayload = new SerializedPayload(bytesPayload.contentType(), bytesPayload.bytes().toArray());
+    SerializedPayload serializedPayload =
+        new SerializedPayload(bytesPayload.contentType(), bytesPayload.bytes().toArray());
     try {
       return jsonSerializer.objectMapper().writeValueAsBytes(serializedPayload);
     } catch (JsonProcessingException e) {
@@ -34,8 +30,12 @@ public final class SerializationTestkit {
 
   public static <T> T deserialize(Class<T> valueClass, byte[] bytes) {
     try {
-      SerializedPayload serializedPayload = jsonSerializer.objectMapper().readValue(bytes, SerializedPayload.class);
-      return jsonSerializer.fromBytes(valueClass, new BytesPayload(ByteString.fromArray(serializedPayload.bytes), serializedPayload.contentType));
+      SerializedPayload serializedPayload =
+          jsonSerializer.objectMapper().readValue(bytes, SerializedPayload.class);
+      return jsonSerializer.fromBytes(
+          valueClass,
+          new BytesPayload(
+              ByteString.fromArray(serializedPayload.bytes), serializedPayload.contentType));
     } catch (IOException e) {
       throw new RuntimeException("Unexpected deserialization error", e);
     }

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -4,6 +4,8 @@
 
 package akka.javasdk.testkit;
 
+import static akka.javasdk.testkit.TestKit.Settings.EventingSupport.TEST_BROKER;
+
 import akka.actor.typed.ActorSystem;
 import akka.grpc.javadsl.AkkaGrpcClient;
 import akka.http.javadsl.Http;
@@ -42,14 +44,6 @@ import akka.stream.Materializer;
 import akka.stream.SystemMaterializer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import kalix.runtime.AkkaRuntimeMain;
-import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import scala.Option;
-import scala.Some;
-import scala.concurrent.duration.FiniteDuration;
-
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.time.Duration;
@@ -65,15 +59,19 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
-
-import static akka.javasdk.testkit.TestKit.Settings.EventingSupport.TEST_BROKER;
+import kalix.runtime.AkkaRuntimeMain;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Option;
+import scala.Some;
+import scala.concurrent.duration.FiniteDuration;
 
 /**
  * Testkit for running services locally.
  *
- * <p>Create a TestKit and then {@link #start} the
- * testkit before testing the service with HTTP clients. Call {@link #stop} after tests are
- * complete.
+ * <p>Create a TestKit and then {@link #start} the testkit before testing the service with HTTP
+ * clients. Call {@link #stop} after tests are complete.
  */
 public class TestKit {
 
@@ -83,14 +81,16 @@ public class TestKit {
     public static final String WORKFLOW = "workflow";
     public static final String STREAM = "stream";
     public static final String TOPIC = "topic";
-    private final Map<String, Set<String>> mockedIncomingEvents; //Subscriptions
-    private final Map<String, Set<String>> mockedOutgoingEvents; //Destination
+    private final Map<String, Set<String>> mockedIncomingEvents; // Subscriptions
+    private final Map<String, Set<String>> mockedOutgoingEvents; // Destination
 
     private MockedEventing() {
       this(new HashMap<>(), new HashMap<>());
     }
 
-    private MockedEventing(Map<String, Set<String>> mockedIncomingEvents, Map<String, Set<String>> mockedOutgoingEvents) {
+    private MockedEventing(
+        Map<String, Set<String>> mockedIncomingEvents,
+        Map<String, Set<String>> mockedOutgoingEvents) {
       this.mockedIncomingEvents = mockedIncomingEvents;
       this.mockedOutgoingEvents = mockedOutgoingEvents;
     }
@@ -133,7 +133,7 @@ public class TestKit {
     private BiFunction<String, Set<String>, Set<String>> updateValues(String componentId) {
       return (key, currentValues) -> {
         if (currentValues == null) {
-          LinkedHashSet<String> values = new LinkedHashSet<>(); //order is relevant only for tests
+          LinkedHashSet<String> values = new LinkedHashSet<>(); // order is relevant only for tests
           values.add(componentId);
           return values;
         } else {
@@ -145,10 +145,12 @@ public class TestKit {
 
     @Override
     public String toString() {
-      return "MockedEventing{" +
-          "mockedIncomingEvents=" + mockedIncomingEvents +
-          ", mockedOutgoingEvents=" + mockedOutgoingEvents +
-          '}';
+      return "MockedEventing{"
+          + "mockedIncomingEvents="
+          + mockedIncomingEvents
+          + ", mockedOutgoingEvents="
+          + mockedOutgoingEvents
+          + '}';
     }
 
     public boolean hasIncomingConfig() {
@@ -174,10 +176,12 @@ public class TestKit {
     private String toConfig(Map<String, Set<String>> configs) {
       return configs.entrySet().stream()
           .sorted(Map.Entry.comparingByKey())
-          .flatMap(entry -> {
-            String subscriptionType = entry.getKey();
-            return entry.getValue().stream().map(name -> subscriptionType + "," + name);
-          }).collect(Collectors.joining(";"));
+          .flatMap(
+              entry -> {
+                String subscriptionType = entry.getKey();
+                return entry.getValue().stream().map(name -> subscriptionType + "," + name);
+              })
+          .collect(Collectors.joining(";"));
     }
 
     boolean hasKeyValueEntitySubscription(String componentId) {
@@ -196,7 +200,6 @@ public class TestKit {
       return checkExistence(STREAM, service + "/" + streamId);
     }
 
-
     boolean hasTopicSubscription(String topic) {
       return checkExistence(TOPIC, topic);
     }
@@ -212,23 +215,24 @@ public class TestKit {
     }
   }
 
-  /**
-   * Settings for testkit.
-   */
+  /** Settings for testkit. */
   public static class Settings {
-    /**
-     * Default settings for testkit.
-     */
-    public static Settings DEFAULT = new Settings("", true, TEST_BROKER, MockedEventing.EMPTY, Optional.empty(), ConfigFactory.empty(), Set.of(), new HashMap<>());
+    /** Default settings for testkit. */
+    public static Settings DEFAULT =
+        new Settings(
+            "",
+            true,
+            TEST_BROKER,
+            MockedEventing.EMPTY,
+            Optional.empty(),
+            ConfigFactory.empty(),
+            Set.of(),
+            new HashMap<>());
 
-    /**
-     * The name of this service when deployed.
-     */
+    /** The name of this service when deployed. */
     public final String serviceName;
 
-    /**
-     * Whether ACL checking is enabled.
-     */
+    /** Whether ACL checking is enabled. */
     public final boolean aclEnabled;
 
     public final EventingSupport eventingSupport;
@@ -245,36 +249,35 @@ public class TestKit {
 
     public enum EventingSupport {
       /**
-       * This is the default type used and allows the testing eventing integrations without an external broker dependency
-       * running.
+       * This is the default type used and allows the testing eventing integrations without an
+       * external broker dependency running.
        */
       TEST_BROKER,
 
       /**
        * Used if you want to use an external Google PubSub (or its Emulator) on your tests.
-       * <p>
-       * Note: the Google PubSub broker instance needs to be started independently.
+       *
+       * <p>Note: the Google PubSub broker instance needs to be started independently.
        */
       GOOGLE_PUBSUB,
 
       /**
        * Used if you want to use an external Kafka broker on your tests.
-       * <p>
-       * Note: the Kafka broker instance needs to be started independently.
+       *
+       * <p>Note: the Kafka broker instance needs to be started independently.
        */
       KAFKA
     }
 
     private Settings(
-      String serviceName,
-      boolean aclEnabled,
-      EventingSupport eventingSupport,
-      MockedEventing mockedEventing,
-      Optional<DependencyProvider> dependencyProvider,
-      Config additionalConfig,
-      Set<Class<?>> disabledComponents,
-      Map<String, ModelProvider> modelProvidersByAgentId
-    ) {
+        String serviceName,
+        boolean aclEnabled,
+        EventingSupport eventingSupport,
+        MockedEventing mockedEventing,
+        Optional<DependencyProvider> dependencyProvider,
+        Config additionalConfig,
+        Set<Class<?>> disabledComponents,
+        Map<String, ModelProvider> modelProvidersByAgentId) {
       this.serviceName = serviceName;
       this.aclEnabled = aclEnabled;
       this.eventingSupport = eventingSupport;
@@ -288,14 +291,22 @@ public class TestKit {
     /**
      * Set the name of this service. This will be used by the service when making calls on other
      * services run by the testkit to authenticate itself, allowing those services to apply ACLs
-     * based on that name. If not defined, the value from configuration key
-     * {@code akka.javasdk.dev-mode.service-name} will be used in the test.
+     * based on that name. If not defined, the value from configuration key {@code
+     * akka.javasdk.dev-mode.service-name} will be used in the test.
      *
      * @param serviceName The name of this service.
      * @return The updated settings.
      */
     public Settings withServiceName(final String serviceName) {
-      return new Settings(serviceName, aclEnabled, eventingSupport, mockedEventing, dependencyProvider, additionalConfig, disabledComponents, modelProvidersByAgentId);
+      return new Settings(
+          serviceName,
+          aclEnabled,
+          eventingSupport,
+          mockedEventing,
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          modelProvidersByAgentId);
     }
 
     /**
@@ -304,7 +315,15 @@ public class TestKit {
      * @return The updated settings.
      */
     public Settings withAclDisabled() {
-      return new Settings(serviceName, false, eventingSupport, mockedEventing, dependencyProvider, additionalConfig, disabledComponents, modelProvidersByAgentId);
+      return new Settings(
+          serviceName,
+          false,
+          eventingSupport,
+          mockedEventing,
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          modelProvidersByAgentId);
     }
 
     /**
@@ -313,47 +332,81 @@ public class TestKit {
      * @return The updated settings.
      */
     public Settings withAclEnabled() {
-      return new Settings(serviceName, true, eventingSupport, mockedEventing, dependencyProvider, additionalConfig, disabledComponents, modelProvidersByAgentId);
+      return new Settings(
+          serviceName,
+          true,
+          eventingSupport,
+          mockedEventing,
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          modelProvidersByAgentId);
     }
 
     /**
      * Mock the incoming messages flow from a KeyValueEntity.
+     *
      * @deprecated use {@link #withKeyValueEntityIncomingMessages(Class)} instead.
      */
     @Deprecated(since = "3.4.2", forRemoval = true)
     public Settings withKeyValueEntityIncomingMessages(String componentId) {
-      return new Settings(serviceName, aclEnabled, eventingSupport,
-          mockedEventing.withKeyValueEntityIncomingMessages(componentId), dependencyProvider, additionalConfig, disabledComponents, modelProvidersByAgentId);
+      return new Settings(
+          serviceName,
+          aclEnabled,
+          eventingSupport,
+          mockedEventing.withKeyValueEntityIncomingMessages(componentId),
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          modelProvidersByAgentId);
     }
 
-    public Settings withKeyValueEntityIncomingMessages(Class<? extends KeyValueEntity<?>> keyValueEntityClass) {
+    public Settings withKeyValueEntityIncomingMessages(
+        Class<? extends KeyValueEntity<?>> keyValueEntityClass) {
       String componentId = getComponentId(keyValueEntityClass);
       return withKeyValueEntityIncomingMessages(componentId);
     }
 
     /**
      * Mock the incoming events flow from an EventSourcedEntity.
+     *
      * @deprecated use {@link #withEventSourcedEntityIncomingMessages(Class)} instead.
      */
     @Deprecated(since = "3.4.2", forRemoval = true)
     public Settings withEventSourcedEntityIncomingMessages(String componentId) {
-      return new Settings(serviceName, aclEnabled, eventingSupport,
-          mockedEventing.withEventSourcedIncomingMessages(componentId), dependencyProvider, additionalConfig, disabledComponents, modelProvidersByAgentId);
+      return new Settings(
+          serviceName,
+          aclEnabled,
+          eventingSupport,
+          mockedEventing.withEventSourcedIncomingMessages(componentId),
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          modelProvidersByAgentId);
     }
 
-    public Settings withEventSourcedEntityIncomingMessages(Class<? extends EventSourcedEntity<?,?>> eventSourcedEntityClass) {
+    public Settings withEventSourcedEntityIncomingMessages(
+        Class<? extends EventSourcedEntity<?, ?>> eventSourcedEntityClass) {
       String componentId = getComponentId(eventSourcedEntityClass);
       return withEventSourcedEntityIncomingMessages(componentId);
     }
 
     /**
      * Mock the incoming state updates flow from a Workflow.
+     *
      * @deprecated use {@link #withWorkflowIncomingMessages(Class)} instead.
      */
     @Deprecated(since = "3.4.2", forRemoval = true)
     public Settings withWorkflowIncomingMessages(String componentId) {
-      return new Settings(serviceName, aclEnabled, eventingSupport,
-        mockedEventing.withWorkflowIncomingMessages(componentId), dependencyProvider, additionalConfig, disabledComponents, modelProvidersByAgentId);
+      return new Settings(
+          serviceName,
+          aclEnabled,
+          eventingSupport,
+          mockedEventing.withWorkflowIncomingMessages(componentId),
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          modelProvidersByAgentId);
     }
 
     public Settings withWorkflowIncomingMessages(Class<? extends Workflow<?>> workflowClass) {
@@ -365,77 +418,142 @@ public class TestKit {
      * Mock the incoming messages flow from a Stream (eventing.in.direct in case of protobuf SDKs).
      */
     public Settings withStreamIncomingMessages(String service, String streamId) {
-      return new Settings(serviceName, aclEnabled, eventingSupport,
-          mockedEventing.withStreamIncomingMessages(service, streamId), dependencyProvider, additionalConfig, disabledComponents, modelProvidersByAgentId);
+      return new Settings(
+          serviceName,
+          aclEnabled,
+          eventingSupport,
+          mockedEventing.withStreamIncomingMessages(service, streamId),
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          modelProvidersByAgentId);
     }
 
-    /**
-     * Mock the incoming events flow from a Topic.
-     */
+    /** Mock the incoming events flow from a Topic. */
     public Settings withTopicIncomingMessages(String topic) {
-      return new Settings(serviceName, aclEnabled, eventingSupport,
-          mockedEventing.withTopicIncomingMessages(topic), dependencyProvider, additionalConfig, disabledComponents, modelProvidersByAgentId);
+      return new Settings(
+          serviceName,
+          aclEnabled,
+          eventingSupport,
+          mockedEventing.withTopicIncomingMessages(topic),
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          modelProvidersByAgentId);
     }
 
-    /**
-     * Mock the outgoing events flow for a Topic.
-     */
+    /** Mock the outgoing events flow for a Topic. */
     public Settings withTopicOutgoingMessages(String topic) {
-      return new Settings(serviceName, aclEnabled, eventingSupport,
-          mockedEventing.withTopicOutgoingMessages(topic), dependencyProvider, additionalConfig, disabledComponents, modelProvidersByAgentId);
+      return new Settings(
+          serviceName,
+          aclEnabled,
+          eventingSupport,
+          mockedEventing.withTopicOutgoingMessages(topic),
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          modelProvidersByAgentId);
     }
 
     public Settings withEventingSupport(EventingSupport eventingSupport) {
-      return new Settings(serviceName, aclEnabled, eventingSupport, mockedEventing, dependencyProvider, additionalConfig, disabledComponents, modelProvidersByAgentId);
+      return new Settings(
+          serviceName,
+          aclEnabled,
+          eventingSupport,
+          mockedEventing,
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          modelProvidersByAgentId);
     }
 
     /**
-     * Specify additional config that will override the application-test.conf or application.conf configuration
-     * in a particular test.
+     * Specify additional config that will override the application-test.conf or application.conf
+     * configuration in a particular test.
      */
     public Settings withAdditionalConfig(Config additionalConfig) {
-      return new Settings(serviceName, aclEnabled, eventingSupport, mockedEventing, dependencyProvider, additionalConfig, disabledComponents, modelProvidersByAgentId);
+      return new Settings(
+          serviceName,
+          aclEnabled,
+          eventingSupport,
+          mockedEventing,
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          modelProvidersByAgentId);
     }
 
     /**
-     * Specify additional config that will override the application-test.conf or application.conf configuration
-     * in a particular test.
+     * Specify additional config that will override the application-test.conf or application.conf
+     * configuration in a particular test.
      */
     public Settings withAdditionalConfig(String additionalConfig) {
       return withAdditionalConfig(ConfigFactory.parseString(additionalConfig));
     }
 
     /**
-     * Set a dependency provider that will be used for looking up arbitrary dependencies, useful to provide mocks for
-     * production dependencies in tests rather than calling the real thing.
+     * Set a dependency provider that will be used for looking up arbitrary dependencies, useful to
+     * provide mocks for production dependencies in tests rather than calling the real thing.
      */
     public Settings withDependencyProvider(DependencyProvider dependencyProvider) {
-      return new Settings(serviceName, aclEnabled, eventingSupport, mockedEventing, Optional.of(dependencyProvider), additionalConfig, disabledComponents, modelProvidersByAgentId);
+      return new Settings(
+          serviceName,
+          aclEnabled,
+          eventingSupport,
+          mockedEventing,
+          Optional.of(dependencyProvider),
+          additionalConfig,
+          disabledComponents,
+          modelProvidersByAgentId);
     }
 
     /**
-     * Disable components from running, useful for testing components in isolation. This set of disabled components will be added to {@link ServiceSetup#disabledComponents()} if configured.
+     * Disable components from running, useful for testing components in isolation. This set of
+     * disabled components will be added to {@link ServiceSetup#disabledComponents()} if configured.
      */
     public Settings withDisabledComponents(Set<Class<?>> disabledComponents) {
-      return new Settings(serviceName, aclEnabled, eventingSupport, mockedEventing, dependencyProvider, additionalConfig, disabledComponents, modelProvidersByAgentId);
+      return new Settings(
+          serviceName,
+          aclEnabled,
+          eventingSupport,
+          mockedEventing,
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          modelProvidersByAgentId);
     }
 
-    public Settings withModelProvider(Class<? extends Agent> agentClass, ModelProvider modelProvider) {
+    public Settings withModelProvider(
+        Class<? extends Agent> agentClass, ModelProvider modelProvider) {
       var componentId = agentClass.getAnnotation(ComponentId.class).value();
       var newModelProvidersByAgentId = new HashMap<>(modelProvidersByAgentId);
       newModelProvidersByAgentId.put(componentId, modelProvider);
-      return new Settings(serviceName, aclEnabled, eventingSupport, mockedEventing, dependencyProvider, additionalConfig, disabledComponents, newModelProvidersByAgentId);
+      return new Settings(
+          serviceName,
+          aclEnabled,
+          eventingSupport,
+          mockedEventing,
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          newModelProvidersByAgentId);
     }
 
     @Override
     public String toString() {
-      return "Settings(" +
-          "serviceName='" + serviceName + '\'' +
-          ", aclEnabled=" + aclEnabled +
-          ", eventingSupport=" + eventingSupport +
-          ", mockedEventing=" + mockedEventing +
-          ", dependencyProvider=" + dependencyProvider +
-          ')';
+      return "Settings("
+          + "serviceName='"
+          + serviceName
+          + '\''
+          + ", aclEnabled="
+          + aclEnabled
+          + ", eventingSupport="
+          + eventingSupport
+          + ", mockedEventing="
+          + mockedEventing
+          + ", dependencyProvider="
+          + dependencyProvider
+          + ')';
     }
   }
 
@@ -460,9 +578,7 @@ public class TestKit {
   private Config applicationConfig;
   private String serviceName;
 
-  /**
-   * Create a new testkit for a service descriptor with the default settings.
-   */
+  /** Create a new testkit for a service descriptor with the default settings. */
   public TestKit() {
     this(Settings.DEFAULT);
   }
@@ -470,22 +586,20 @@ public class TestKit {
   /**
    * Create a new testkit for a service descriptor with custom settings.
    *
-   * @param settings     custom testkit settings
+   * @param settings custom testkit settings
    */
   public TestKit(final Settings settings) {
     this.settings = settings;
   }
 
   /**
-   * Start this testkit with default configuration.
-   * The default configuration is loaded from {@code application-test.conf} if that exists, otherwise
-   * from {@code application.conf}.
+   * Start this testkit with default configuration. The default configuration is loaded from {@code
+   * application-test.conf} if that exists, otherwise from {@code application.conf}.
    *
    * @return this TestKit instance
    */
   public TestKit start() {
-    if (started)
-      throw new IllegalStateException("Testkit already started");
+    if (started) throw new IllegalStateException("Testkit already started");
 
     eventingTestKitPort = availableLocalPort();
     startRuntime(settings.additionalConfig);
@@ -500,114 +614,148 @@ public class TestKit {
   private void startEventingTestkit() {
     if (settings.eventingSupport == TEST_BROKER || settings.mockedEventing.hasConfig()) {
       log.info("Eventing TestKit booting up on port: {}", eventingTestKitPort);
-      // actual message codec instance not available until runtime/sdk started, thus this is called after discovery happens
-      eventingTestKit = EventingTestKit.start(runtimeActorSystem, "0.0.0.0", eventingTestKitPort, new JsonSerializer());
+      // actual message codec instance not available until runtime/sdk started, thus this is called
+      // after discovery happens
+      eventingTestKit =
+          EventingTestKit.start(
+              runtimeActorSystem, "0.0.0.0", eventingTestKitPort, new JsonSerializer());
     }
   }
 
-  private void startRuntime(final Config config)  {
+  private void startRuntime(final Config config) {
     try {
       log.debug("Config from user: {}", config);
       runtimeHost = "localhost";
 
-      SdkRunner runner = new SdkRunner(settings.dependencyProvider, settings.disabledComponents) {
-        @Override
-        public Config applicationConfig() {
-          var userConfig = config.withFallback(super.applicationConfig());
-          runtimePort = userConfig.getInt("akka.javasdk.testkit.http-port");
+      SdkRunner runner =
+          new SdkRunner(settings.dependencyProvider, settings.disabledComponents) {
+            @Override
+            public Config applicationConfig() {
+              var userConfig = config.withFallback(super.applicationConfig());
+              runtimePort = userConfig.getInt("akka.javasdk.testkit.http-port");
 
-          if (settings.serviceName.isEmpty())
-            serviceName = userConfig.getString("akka.javasdk.dev-mode.service-name");
-          else
-            serviceName = settings.serviceName;
+              if (settings.serviceName.isEmpty())
+                serviceName = userConfig.getString("akka.javasdk.dev-mode.service-name");
+              else serviceName = settings.serviceName;
 
-          var grpcClientSelfConfigPrefix = "akka.javasdk.grpc.client." + serviceName;
-          var defaultConfigMap = Map.of(
-              "akka.javasdk.dev-mode.enabled", true,
-              // used by the gRPC endpoint test client to call itself
-              grpcClientSelfConfigPrefix + ".host", runtimeHost,
-              grpcClientSelfConfigPrefix + ".port", runtimePort,
-              grpcClientSelfConfigPrefix + ".use-tls", false
-          );
+              var grpcClientSelfConfigPrefix = "akka.javasdk.grpc.client." + serviceName;
+              var defaultConfigMap =
+                  Map.of(
+                      "akka.javasdk.dev-mode.enabled",
+                      true,
+                      // used by the gRPC endpoint test client to call itself
+                      grpcClientSelfConfigPrefix + ".host",
+                      runtimeHost,
+                      grpcClientSelfConfigPrefix + ".port",
+                      runtimePort,
+                      grpcClientSelfConfigPrefix + ".use-tls",
+                      false);
 
-          return ConfigFactory.parseMap(defaultConfigMap)
-              .withFallback(userConfig);
-        }
+              return ConfigFactory.parseMap(defaultConfigMap).withFallback(userConfig);
+            }
 
-        @Override
-        public SpiSettings getSettings() {
-          SpiSettings s = super.getSettings();
+            @Override
+            public SpiSettings getSettings() {
+              SpiSettings s = super.getSettings();
 
-          SpiEventingSupportSettings eventingSettings =
-              switch (settings.eventingSupport) {
-                case TEST_BROKER -> new SpiEventingSupportSettings.TestBroker(eventingTestKitPort);
-                case GOOGLE_PUBSUB -> SpiEventingSupportSettings.fromConfigValue("google-pubsub-emulator");
-                case KAFKA -> SpiEventingSupportSettings.fromConfigValue("kafka");
-              };
-          SpiMockedEventingSettings mockedEventingSettings =
-              SpiMockedEventingSettings.create(settings.mockedEventing.mockedIncomingEvents, settings.mockedEventing.mockedOutgoingEvents);
+              SpiEventingSupportSettings eventingSettings =
+                  switch (settings.eventingSupport) {
+                    case TEST_BROKER ->
+                        new SpiEventingSupportSettings.TestBroker(eventingTestKitPort);
+                    case GOOGLE_PUBSUB ->
+                        SpiEventingSupportSettings.fromConfigValue("google-pubsub-emulator");
+                    case KAFKA -> SpiEventingSupportSettings.fromConfigValue("kafka");
+                  };
+              SpiMockedEventingSettings mockedEventingSettings =
+                  SpiMockedEventingSettings.create(
+                      settings.mockedEventing.mockedIncomingEvents,
+                      settings.mockedEventing.mockedOutgoingEvents);
 
+              if (s.devMode().isEmpty())
+                throw new IllegalStateException(
+                    "dev-mode must be enabled"); // it's set from overridden applicationConfig
+              // method
 
-          if (s.devMode().isEmpty())
-            throw new IllegalStateException("dev-mode must be enabled"); // it's set from overridden applicationConfig method
+              SpiDevModeSettings devModeSettings =
+                  new SpiDevModeSettings(
+                      runtimePort,
+                      settings.aclEnabled,
+                      false,
+                      serviceName + "-IT-" + System.currentTimeMillis(),
+                      eventingSettings,
+                      mockedEventingSettings,
+                      true,
+                      Some.apply(serviceName));
 
-
-          SpiDevModeSettings devModeSettings = new SpiDevModeSettings(
-              runtimePort,
-              settings.aclEnabled,
-              false,
-              serviceName + "-IT-" + System.currentTimeMillis(),
-              eventingSettings,
-              mockedEventingSettings,
-              true,
-              Some.apply(serviceName));
-
-          return s.withDevMode(devModeSettings);
-        }
-
-      };
+              return s.withDevMode(devModeSettings);
+            }
+          };
 
       applicationConfig = runner.applicationConfig();
 
       Config runtimeConfig = ConfigFactory.empty();
       runtimeActorSystem = AkkaRuntimeMain.start(Some.apply(runtimeConfig), runner);
-      // wait for SDK to get on start callback (or fail starting), we need it to set up the component client
-      final Sdk.StartupContext startupContext = runner.started().toCompletableFuture().get(20, TimeUnit.SECONDS);
+      // wait for SDK to get on start callback (or fail starting), we need it to set up the
+      // component client
+      final Sdk.StartupContext startupContext =
+          runner.started().toCompletableFuture().get(20, TimeUnit.SECONDS);
       final ComponentClients componentClients = startupContext.componentClients();
       final JsonSerializer serializer = startupContext.serializer();
-      dependencyProvider = Optional.ofNullable(startupContext.dependencyProvider().getOrElse(() -> null));
+      dependencyProvider =
+          Optional.ofNullable(startupContext.dependencyProvider().getOrElse(() -> null));
 
-      settings.modelProvidersByAgentId.forEach((agentId, modelProvider) ->
-          startupContext.overrideModelProvider().setModelProviderForAgent(agentId, modelProvider));
+      settings.modelProvidersByAgentId.forEach(
+          (agentId, modelProvider) ->
+              startupContext
+                  .overrideModelProvider()
+                  .setModelProviderForAgent(agentId, modelProvider));
 
       startEventingTestkit();
 
       Http http = Http.get(runtimeActorSystem);
       log.info("Checking runtime status");
-      CompletionStage<String> checkingProxyStatus = Patterns.retry(() ->
-        http.singleRequest(HttpRequest.GET("http://" + runtimeHost + ":" + runtimePort + "/akka/dev-mode/health-check")).thenCompose(response -> {
-          int responseCode = response.status().intValue();
-          if (responseCode == 404) {
-            log.info("Runtime started");
-            return CompletableFuture.completedStage("Ok");
-          } else {
-            log.info("Waiting for runtime, current response code is {}", responseCode);
-            return CompletableFuture.failedFuture(new IllegalStateException("Runtime not started."));
-          }
-        })
-        .exceptionally(ex -> {
-          log.error("Failed to connect to runtime:", ex);
-          throw new IllegalStateException("Runtime not started.", ex);
-        }), 10, Duration.ofSeconds(1), runtimeActorSystem);
+      CompletionStage<String> checkingProxyStatus =
+          Patterns.retry(
+              () ->
+                  http.singleRequest(
+                          HttpRequest.GET(
+                              "http://"
+                                  + runtimeHost
+                                  + ":"
+                                  + runtimePort
+                                  + "/akka/dev-mode/health-check"))
+                      .thenCompose(
+                          response -> {
+                            int responseCode = response.status().intValue();
+                            if (responseCode == 404) {
+                              log.info("Runtime started");
+                              return CompletableFuture.completedStage("Ok");
+                            } else {
+                              log.info(
+                                  "Waiting for runtime, current response code is {}", responseCode);
+                              return CompletableFuture.failedFuture(
+                                  new IllegalStateException("Runtime not started."));
+                            }
+                          })
+                      .exceptionally(
+                          ex -> {
+                            log.error("Failed to connect to runtime:", ex);
+                            throw new IllegalStateException("Runtime not started.", ex);
+                          }),
+              10,
+              Duration.ofSeconds(1),
+              runtimeActorSystem);
 
       try {
-        CompletableFuture.anyOf(checkingProxyStatus.toCompletableFuture(),
-            runtimeActorSystem.getWhenTerminated().toCompletableFuture()).get(60, TimeUnit.SECONDS);
+        CompletableFuture.anyOf(
+                checkingProxyStatus.toCompletableFuture(),
+                runtimeActorSystem.getWhenTerminated().toCompletableFuture())
+            .get(60, TimeUnit.SECONDS);
       } catch (ExecutionException e) {
         RuntimeException cause = ErrorHandling.unwrapExecutionException(e);
         log.error("Failed to connect to Runtime with:", cause);
         throw cause;
-      } catch (InterruptedException| TimeoutException e) {
+      } catch (InterruptedException | TimeoutException e) {
         log.error("Failed to connect to Runtime with:", e);
         throw new RuntimeException(e);
       }
@@ -618,9 +766,17 @@ public class TestKit {
 
       // once runtime is started
 
-      componentClient = new ComponentClientImpl(componentClients, serializer, startupContext.agentRegistry().agentClassById(), Option.empty(), runtimeActorSystem.executionContext(), runtimeActorSystem);
+      componentClient =
+          new ComponentClientImpl(
+              componentClients,
+              serializer,
+              startupContext.agentRegistry().agentClassById(),
+              Option.empty(),
+              runtimeActorSystem.executionContext(),
+              runtimeActorSystem);
       agentRegistry = startupContext.agentRegistry();
-      selfHttpClient = new HttpClientImpl(runtimeActorSystem, "http://" + runtimeHost + ":" + runtimePort);
+      selfHttpClient =
+          new HttpClientImpl(runtimeActorSystem, "http://" + runtimeHost + ":" + runtimePort);
       httpClientProvider = startupContext.httpClientProvider();
       grpcClientProvider = startupContext.grpcClientProvider();
       timerScheduler = new TimerSchedulerImpl(componentClients.timerClient(), Metadata.EMPTY);
@@ -642,9 +798,7 @@ public class TestKit {
     return runtimeHost;
   }
 
-  /**
-   * Get the local port where the service is available.
-   */
+  /** Get the local port where the service is available. */
   public int getPort() {
     if (!started)
       throw new IllegalStateException("Need to start the testkit before accessing the port");
@@ -686,39 +840,42 @@ public class TestKit {
     return componentClient;
   }
 
-  /**
-   * Get a {@link TimerScheduler} for scheduling TimedAction.
-   */
+  /** Get a {@link TimerScheduler} for scheduling TimedAction. */
   public TimerScheduler getTimerScheduler() {
     return timerScheduler;
   }
 
   /**
-   * Get a {@link HttpClientProvider} for looking up HTTP clients to interact with other services than the current.
-   * Requests will appear as coming from this service from an ACL perspective.
+   * Get a {@link HttpClientProvider} for looking up HTTP clients to interact with other services
+   * than the current. Requests will appear as coming from this service from an ACL perspective.
    */
   public HttpClientProvider getHttpClientProvider() {
     return httpClientProvider;
   }
 
   /**
-   * Get a gRPC client for an endpoint provided by this service.
-   * Requests will appear as coming from this service itself from an ACL perspective.
+   * Get a gRPC client for an endpoint provided by this service. Requests will appear as coming from
+   * this service itself from an ACL perspective.
    *
-   * @param grpcClientClass The generated Akka gRPC client interface for a gRPC endpoint in this service
+   * @param grpcClientClass The generated Akka gRPC client interface for a gRPC endpoint in this
+   *     service
    */
   public <T extends AkkaGrpcClient> T getGrpcEndpointClient(Class<T> grpcClientClass) {
     return grpcClientProvider.grpcClientFor(grpcClientClass, serviceName);
   }
 
   /**
-   * Get a gRPC client for an endpoint provided by this service but specify the client principal for the ACLs.
+   * Get a gRPC client for an endpoint provided by this service but specify the client principal for
+   * the ACLs.
    *
-   * @param grpcClientClass The generated Akka gRPC client interface for a gRPC endpoint in this service
-   * @param requestPrincipal A principal that any request from the returned service will have when requests are handled in the endpoint.
+   * @param grpcClientClass The generated Akka gRPC client interface for a gRPC endpoint in this
+   *     service
+   * @param requestPrincipal A principal that any request from the returned service will have when
+   *     requests are handled in the endpoint.
    */
   @SuppressWarnings("unchecked")
-  public <T extends AkkaGrpcClient> T getGrpcEndpointClient(Class<T> grpcClientClass, Principal requestPrincipal) {
+  public <T extends AkkaGrpcClient> T getGrpcEndpointClient(
+      Class<T> grpcClientClass, Principal requestPrincipal) {
     var client = grpcClientProvider.createNewClientFor(grpcClientClass, serviceName, false);
     if (requestPrincipal == Principal.SELF) {
       // no need to use this method, but let's allow it
@@ -729,14 +886,17 @@ public class TestKit {
       // no principal / as from internet
       return client;
     } else {
-      throw new IllegalArgumentException("Specified principal [" + requestPrincipal + "] not supported by testkit");
+      throw new IllegalArgumentException(
+          "Specified principal [" + requestPrincipal + "] not supported by testkit");
     }
   }
-  // FIXME do we need a "get client with this principal" kind of method? Not sure that is useful (unlike in Kalix SDKs)
+
+  // FIXME do we need a "get client with this principal" kind of method? Not sure that is useful
+  // (unlike in Kalix SDKs)
 
   /**
-   * Get a {@link HttpClient} for interacting with the service itself, the client will not be authenticated
-   * and will appear to the service as a request with the internet principal.
+   * Get a {@link HttpClient} for interacting with the service itself, the client will not be
+   * authenticated and will appear to the service as a request with the internet principal.
    */
   public HttpClient getSelfHttpClient() {
     return selfHttpClient;
@@ -756,7 +916,8 @@ public class TestKit {
     return eventingTestKit.getKeyValueEntityIncomingMessages(componentId);
   }
 
-  public IncomingMessages getKeyValueEntityIncomingMessages(Class<? extends KeyValueEntity<?>> keyValueEntityClass) {
+  public IncomingMessages getKeyValueEntityIncomingMessages(
+      Class<? extends KeyValueEntity<?>> keyValueEntityClass) {
     String componentId = getComponentId(keyValueEntityClass);
     return getKeyValueEntityIncomingMessages(componentId);
   }
@@ -775,7 +936,8 @@ public class TestKit {
     return eventingTestKit.getEventSourcedEntityIncomingMessages(componentId);
   }
 
-  public IncomingMessages getEventSourcedEntityIncomingMessages(Class<? extends EventSourcedEntity<?,?>> eventSourcedEntityClass) {
+  public IncomingMessages getEventSourcedEntityIncomingMessages(
+      Class<? extends EventSourcedEntity<?, ?>> eventSourcedEntityClass) {
     String componentId = getComponentId(eventSourcedEntityClass);
     return getEventSourcedEntityIncomingMessages(componentId);
   }
@@ -806,7 +968,7 @@ public class TestKit {
   /**
    * Get incoming messages for Consume.ServiceStream.
    *
-   * @param service  service name
+   * @param service service name
    * @param streamId service stream id
    */
   public IncomingMessages getStreamIncomingMessages(String service, String streamId) {
@@ -841,21 +1003,23 @@ public class TestKit {
   }
 
   private void throwMissingConfigurationException(String hint) {
-    throw new IllegalStateException("Currently configured mocked eventing is [" + settings.mockedEventing +
-        "]. To use the MockedEventing API, to configure mocking of " + hint);
+    throw new IllegalStateException(
+        "Currently configured mocked eventing is ["
+            + settings.mockedEventing
+            + "]. To use the MockedEventing API, to configure mocking of "
+            + hint);
   }
 
   public AgentRegistry getAgentRegistry() {
     return agentRegistry;
   }
 
-  /**
-   * Stop the testkit and local runtime.
-   */
+  /** Stop the testkit and local runtime. */
   public void stop() {
     try {
       if (runtimeActorSystem != null) {
-        akka.testkit.javadsl.TestKit.shutdownActorSystem(runtimeActorSystem.classicSystem(), FiniteDuration.create(10, TimeUnit.SECONDS), true);
+        akka.testkit.javadsl.TestKit.shutdownActorSystem(
+            runtimeActorSystem.classicSystem(), FiniteDuration.create(10, TimeUnit.SECONDS), true);
       }
     } catch (Exception e) {
       log.error("TestKit runtime failed to terminate", e);
@@ -877,16 +1041,17 @@ public class TestKit {
   }
 
   /**
-   * Returns {@link EventingTestKit.MessageBuilder} utility
-   * to create {@link EventingTestKit.Message}s for the eventing testkit.
+   * Returns {@link EventingTestKit.MessageBuilder} utility to create {@link
+   * EventingTestKit.Message}s for the eventing testkit.
    */
   public EventingTestKit.MessageBuilder getMessageBuilder() {
     return messageBuilder;
   }
 
   /**
-   * @return The custom dependency provider used in this test, if one is defined, when overriding the dependency provided
-   *         through {@link Settings#withDependencyProvider(DependencyProvider)} the overridden provider is returned.
+   * @return The custom dependency provider used in this test, if one is defined, when overriding
+   *     the dependency provided through {@link Settings#withDependencyProvider(DependencyProvider)}
+   *     the overridden provider is returned.
    */
   public Optional<DependencyProvider> getDependencyProvider() {
     return dependencyProvider;

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKitSupport.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKitSupport.java
@@ -16,8 +16,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class provided the necessary infrastructure to run integration test for projects built
- * with the Java SDK. Users should let their test classes extend this class.
+ * This class provided the necessary infrastructure to run integration test for projects built with
+ * the Java SDK. Users should let their test classes extend this class.
  *
  * <p>This class wires-up a local service using the user's defined components.
  *
@@ -43,9 +43,7 @@ public abstract class TestKitSupport extends AsyncCallsSupport {
    */
   protected HttpClient httpClient;
 
-  /**
-   * Override this to use custom settings for an integration test
-   */
+  /** Override this to use custom settings for an integration test */
   protected TestKit.Settings testKitSettings() {
     return TestKit.Settings.DEFAULT;
   }
@@ -71,33 +69,39 @@ public abstract class TestKitSupport extends AsyncCallsSupport {
     }
   }
 
-
-  /**
-   * Lookup a specific object as provided by the service dependency provider
-   */
+  /** Lookup a specific object as provided by the service dependency provider */
   public <T> T getDependency(Class<T> clazz) {
-    return testKit.getDependencyProvider().map(provider -> provider.getDependency(clazz))
-      .orElseThrow(() -> new IllegalStateException("DependencyProvider not available, or not yet initialized."));
+    return testKit
+        .getDependencyProvider()
+        .map(provider -> provider.getDependency(clazz))
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "DependencyProvider not available, or not yet initialized."));
   }
 
   /**
-   * Get a gRPC client for an endpoint provided by this service.
-   * Requests will appear as coming from this service itself from an ACL perspective.
+   * Get a gRPC client for an endpoint provided by this service. Requests will appear as coming from
+   * this service itself from an ACL perspective.
    *
-   * @param grpcClientClass The generated Akka gRPC client interface for a gRPC endpoint in this service
+   * @param grpcClientClass The generated Akka gRPC client interface for a gRPC endpoint in this
+   *     service
    */
   public <T extends AkkaGrpcClient> T getGrpcEndpointClient(Class<T> grpcClientClass) {
     return testKit.getGrpcEndpointClient(grpcClientClass);
   }
 
   /**
-   * Get a gRPC client for an endpoint provided by this service but specify the client principal for the ACLs.
+   * Get a gRPC client for an endpoint provided by this service but specify the client principal for
+   * the ACLs.
    *
-   * @param grpcClientClass The generated Akka gRPC client interface for a gRPC endpoint in this service
-   * @param requestPrincipal A principal that any request from the returned service will have when requests are handled in the endpoint.
+   * @param grpcClientClass The generated Akka gRPC client interface for a gRPC endpoint in this
+   *     service
+   * @param requestPrincipal A principal that any request from the returned service will have when
+   *     requests are handled in the endpoint.
    */
-  public <T extends AkkaGrpcClient> T getGrpcEndpointClient(Class<T> grpcClientClass, Principal requestPrincipal) {
+  public <T extends AkkaGrpcClient> T getGrpcEndpointClient(
+      Class<T> grpcClientClass, Principal requestPrincipal) {
     return testKit.getGrpcEndpointClient(grpcClientClass, requestPrincipal);
   }
-
 }

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TimedActionResult.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TimedActionResult.java
@@ -11,13 +11,19 @@ package akka.javasdk.testkit;
  */
 public interface TimedActionResult {
 
-  /** @return true if the call had an effect with a reply, false if not */
+  /**
+   * @return true if the call had an effect with a reply, false if not
+   */
   boolean isDone();
 
-  /** @return true if the call was async, false if not */
+  /**
+   * @return true if the call was async, false if not
+   */
   boolean isAsync();
 
-  /** @return true if the call was an error, false if not */
+  /**
+   * @return true if the call was an error, false if not
+   */
   boolean isError();
 
   /**

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TimedActionTestkit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TimedActionTestkit.java
@@ -8,7 +8,6 @@ import akka.javasdk.Metadata;
 import akka.javasdk.testkit.impl.TestKitCommandContextTimed;
 import akka.javasdk.testkit.impl.TimedActionResultImpl;
 import akka.javasdk.timedaction.TimedAction;
-
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -17,8 +16,8 @@ import java.util.function.Supplier;
  * TimedAction Testkit for use in unit tests for TimedActions.
  *
  * <p>To test a TimedAction create a testkit instance by calling one of the available {@code
- * TimedActionTestkit.of} methods. The returned testkit can be used as many times as you want. It doesn't
- * preserve any state between invocations.
+ * TimedActionTestkit.of} methods. The returned testkit can be used as many times as you want. It
+ * doesn't preserve any state between invocations.
  *
  * <p>Use the {@code call or stream} methods to interact with the testkit.
  */
@@ -30,8 +29,7 @@ public class TimedActionTestkit<A extends TimedAction> {
     this.actionFactory = actionFactory;
   }
 
-  public static <A extends TimedAction> TimedActionTestkit<A> of(
-      Supplier<A> actionFactory) {
+  public static <A extends TimedAction> TimedActionTestkit<A> of(Supplier<A> actionFactory) {
     return new TimedActionTestkit<>(actionFactory);
   }
 
@@ -42,9 +40,9 @@ public class TimedActionTestkit<A extends TimedAction> {
   }
 
   /**
-   * The {@code call} method can be used to simulate a unary call to the Action. The passed java lambda should
-   * return an Action.Effect. The Effect is interpreted into an ActionResult that can be used in
-   * test assertions.
+   * The {@code call} method can be used to simulate a unary call to the Action. The passed java
+   * lambda should return an Action.Effect. The Effect is interpreted into an ActionResult that can
+   * be used in test assertions.
    *
    * @param func A function from Action to Action.Effect
    * @return an ActionResult
@@ -54,17 +52,17 @@ public class TimedActionTestkit<A extends TimedAction> {
   }
 
   /**
-   * The {@code call} method can be used to simulate a unary call to the Action. The passed java lambda should
-   * return an Action.Effect. The Effect is interpreted into an ActionResult that can be used in
-   * test assertions.
+   * The {@code call} method can be used to simulate a unary call to the Action. The passed java
+   * lambda should return an Action.Effect. The Effect is interpreted into an ActionResult that can
+   * be used in test assertions.
    *
-   * @param func     A function from Action to Action.Effect
+   * @param func A function from Action to Action.Effect
    * @param metadata A metadata passed as a call context
    * @return an ActionResult
    */
   public TimedActionResult call(Function<A, TimedAction.Effect> func, Metadata metadata) {
-    TestKitCommandContextTimed context = new TestKitCommandContextTimed(metadata, MockRegistry.EMPTY);
+    TestKitCommandContextTimed context =
+        new TestKitCommandContextTimed(metadata, MockRegistry.EMPTY);
     return new TimedActionResultImpl<>(func.apply(createTimedAction(context)));
   }
-
 }

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/junit/jupiter/TestkitExtension.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/junit/jupiter/TestkitExtension.java
@@ -7,12 +7,12 @@ package akka.javasdk.testkit.junit.jupiter;
 import akka.actor.typed.ActorSystem;
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
 import akka.javasdk.keyvalueentity.KeyValueEntity;
-import akka.javasdk.workflow.Workflow;
-import akka.stream.Materializer;
 import akka.javasdk.testkit.EventingTestKit;
 import akka.javasdk.testkit.EventingTestKit.IncomingMessages;
 import akka.javasdk.testkit.EventingTestKit.OutgoingMessages;
 import akka.javasdk.testkit.TestKit;
+import akka.javasdk.workflow.Workflow;
+import akka.stream.Materializer;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -29,27 +29,21 @@ public final class TestkitExtension implements BeforeAllCallback, AfterAllCallba
     this.testKit = new TestKit();
   }
 
-
   public TestkitExtension(TestKit.Settings settings) {
     this.testKit = new TestKit(settings);
   }
 
-  /**
-   * JUnit5 support - extension based
-   */
+  /** JUnit5 support - extension based */
   @Override
   public void afterAll(ExtensionContext extensionContext) throws Exception {
     testKit.stop();
   }
 
-  /**
-   * JUnit5 support - extension based
-   */
+  /** JUnit5 support - extension based */
   @Override
   public void beforeAll(ExtensionContext extensionContext) throws Exception {
     testKit.start();
   }
-
 
   /**
    * Get incoming messages for ValueEntity.
@@ -67,7 +61,8 @@ public final class TestkitExtension implements BeforeAllCallback, AfterAllCallba
    *
    * @param keyValueEntityClass class of the KeyValueEntity
    */
-  public IncomingMessages getValueEntityIncomingMessages(Class<? extends KeyValueEntity<?>> keyValueEntityClass) {
+  public IncomingMessages getValueEntityIncomingMessages(
+      Class<? extends KeyValueEntity<?>> keyValueEntityClass) {
     return testKit.getKeyValueEntityIncomingMessages(keyValueEntityClass);
   }
 
@@ -87,7 +82,8 @@ public final class TestkitExtension implements BeforeAllCallback, AfterAllCallba
    *
    * @param eventSourcedEntityClass class of the EventSourcedEntity
    */
-  public IncomingMessages getEventSourcedEntityIncomingMessages(Class<? extends EventSourcedEntity<?,?>> eventSourcedEntityClass) {
+  public IncomingMessages getEventSourcedEntityIncomingMessages(
+      Class<? extends EventSourcedEntity<?, ?>> eventSourcedEntityClass) {
     return testKit.getEventSourcedEntityIncomingMessages(eventSourcedEntityClass);
   }
 
@@ -103,7 +99,7 @@ public final class TestkitExtension implements BeforeAllCallback, AfterAllCallba
   /**
    * Get incoming messages for Stream (eventing.in.direct in case of protobuf SDKs).
    *
-   * @param service  service name
+   * @param service service name
    * @param streamId service stream id
    */
   public IncomingMessages getStreamIncomingMessages(String service, String streamId) {
@@ -129,8 +125,8 @@ public final class TestkitExtension implements BeforeAllCallback, AfterAllCallba
   }
 
   /**
-   * Returns {@link EventingTestKit.MessageBuilder} utility
-   * to create {@link EventingTestKit.Message}s for the eventing testkit.
+   * Returns {@link EventingTestKit.MessageBuilder} utility to create {@link
+   * EventingTestKit.Message}s for the eventing testkit.
    */
   public EventingTestKit.MessageBuilder getMessageBuilder() {
     return testKit.getMessageBuilder();
@@ -144,9 +140,7 @@ public final class TestkitExtension implements BeforeAllCallback, AfterAllCallba
     return testKit.getHost();
   }
 
-  /**
-   * Get the local port where the Kalix service is available.
-   */
+  /** Get the local port where the Kalix service is available. */
   public int getPort() {
     return testKit.getPort();
   }
@@ -168,6 +162,4 @@ public final class TestkitExtension implements BeforeAllCallback, AfterAllCallba
   public ActorSystem<?> getActorSystem() {
     return testKit.getActorSystem();
   }
-
-
 }

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/TestModelProviderTest.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/TestModelProviderTest.java
@@ -4,6 +4,10 @@
 
 package akka.javasdk.testkit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.ChatModel;
@@ -12,15 +16,10 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.FinishReason;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class TestModelProviderTest {
 
@@ -46,13 +45,16 @@ class TestModelProviderTest {
   @Test
   void testTokenizeWithMultipleSeparators() {
     List<String> tokens = testModelProvider.tokenize("Hello, world! How are you?");
-    assertThat(tokens).containsExactly("Hello", ",", " ", "world", "!", " ", "How", " ", "are", " ", "you", "?");
+    assertThat(tokens)
+        .containsExactly("Hello", ",", " ", "world", "!", " ", "How", " ", "are", " ", "you", "?");
   }
 
   @Test
   void testTokenizeWithAllSeparators() {
     List<String> tokens = testModelProvider.tokenize("a, b. c! d? e; f:");
-    assertThat(tokens).containsExactly("a", ",", " ", "b", ".", " ", "c", "!", " ", "d", "?", " ", "e", ";", " ", "f", ":");
+    assertThat(tokens)
+        .containsExactly(
+            "a", ",", " ", "b", ".", " ", "c", "!", " ", "d", "?", " ", "e", ";", " ", "f", ":");
   }
 
   @Test
@@ -82,15 +84,13 @@ class TestModelProviderTest {
   @Test
   void testCreateChatModel() {
     Object chatModel = testModelProvider.createChatModel();
-    assertThat(chatModel).isNotNull()
-        .isInstanceOf(ChatModel.class);
+    assertThat(chatModel).isNotNull().isInstanceOf(ChatModel.class);
   }
 
   @Test
   void testCreateStreamingChatModel() {
     Object streamingChatModel = testModelProvider.createStreamingChatModel();
-    assertThat(streamingChatModel).isNotNull()
-        .isInstanceOf(StreamingChatModel.class);
+    assertThat(streamingChatModel).isNotNull().isInstanceOf(StreamingChatModel.class);
   }
 
   @Test
@@ -98,9 +98,8 @@ class TestModelProviderTest {
     testModelProvider.fixedResponse("Test response");
 
     ChatModel chatModel = (ChatModel) testModelProvider.createChatModel();
-    ChatRequest request = ChatRequest.builder()
-        .messages(List.of(new UserMessage("Any question")))
-        .build();
+    ChatRequest request =
+        ChatRequest.builder().messages(List.of(new UserMessage("Any question"))).build();
 
     ChatResponse response = chatModel.doChat(request);
 
@@ -110,9 +109,8 @@ class TestModelProviderTest {
 
     // should be possible to update
     testModelProvider.fixedResponse("New response");
-    ChatRequest request2 = ChatRequest.builder()
-        .messages(List.of(new UserMessage("Another question")))
-        .build();
+    ChatRequest request2 =
+        ChatRequest.builder().messages(List.of(new UserMessage("Another question"))).build();
     ChatResponse response2 = chatModel.doChat(request);
 
     assertThat(response2.aiMessage().text()).isEqualTo("New response");
@@ -121,27 +119,21 @@ class TestModelProviderTest {
   @Test
   void testMockResponseWithPredicate() {
 
-    testModelProvider
-      .whenMessage(text -> text.contains("hello"))
-      .reply("Hello response");
+    testModelProvider.whenMessage(text -> text.contains("hello")).reply("Hello response");
 
-    testModelProvider
-      .whenMessage(text -> text.contains("goodbye"))
-      .reply("Goodbye response");
+    testModelProvider.whenMessage(text -> text.contains("goodbye")).reply("Goodbye response");
 
     ChatModel chatModel = (ChatModel) testModelProvider.createChatModel();
 
     // Test first predicate
-    ChatRequest helloRequest = ChatRequest.builder()
-        .messages(List.of(new UserMessage("Say hello to me")))
-        .build();
+    ChatRequest helloRequest =
+        ChatRequest.builder().messages(List.of(new UserMessage("Say hello to me"))).build();
     ChatResponse helloResponse = chatModel.doChat(helloRequest);
     assertThat(helloResponse.aiMessage().text()).isEqualTo("Hello response");
 
     // Test second predicate
-    ChatRequest goodbyeRequest = ChatRequest.builder()
-        .messages(List.of(new UserMessage("Say goodbye to me")))
-        .build();
+    ChatRequest goodbyeRequest =
+        ChatRequest.builder().messages(List.of(new UserMessage("Say goodbye to me"))).build();
     ChatResponse goodbyeResponse = chatModel.doChat(goodbyeRequest);
     assertThat(goodbyeResponse.aiMessage().text()).isEqualTo("Goodbye response");
   }
@@ -149,14 +141,11 @@ class TestModelProviderTest {
   @Test
   void testFailWhenActionIsMissing() {
 
-    var whenClause =
-    testModelProvider
-      .whenMessage("hello");
+    var whenClause = testModelProvider.whenMessage("hello");
 
     ChatModel chatModel = (ChatModel) testModelProvider.createChatModel();
-    ChatRequest helloRequest = ChatRequest.builder()
-      .messages(List.of(new UserMessage("hello")))
-      .build();
+    ChatRequest helloRequest =
+        ChatRequest.builder().messages(List.of(new UserMessage("hello"))).build();
 
     try {
       chatModel.doChat(helloRequest);
@@ -178,9 +167,8 @@ class TestModelProviderTest {
     testModelProvider.whenMessage("hello").failWith(new RuntimeException("I can't handle this"));
 
     ChatModel chatModel = (ChatModel) testModelProvider.createChatModel();
-    ChatRequest helloRequest = ChatRequest.builder()
-      .messages(List.of(new UserMessage("hello")))
-      .build();
+    ChatRequest helloRequest =
+        ChatRequest.builder().messages(List.of(new UserMessage("hello"))).build();
     try {
       chatModel.doChat(helloRequest);
       fail("Should have failed");
@@ -188,19 +176,15 @@ class TestModelProviderTest {
       assertThat(e.getMessage()).isEqualTo("I can't handle this");
       return;
     }
-
   }
 
   @Test
   void testMockResponseNoMatch() {
-    testModelProvider
-      .whenMessage(text -> text.contains("specific"))
-      .reply("Specific response");
+    testModelProvider.whenMessage(text -> text.contains("specific")).reply("Specific response");
 
     ChatModel chatModel = (ChatModel) testModelProvider.createChatModel();
-    ChatRequest request = ChatRequest.builder()
-        .messages(List.of(new UserMessage("Random question")))
-        .build();
+    ChatRequest request =
+        ChatRequest.builder().messages(List.of(new UserMessage("Random question"))).build();
 
     assertThatThrownBy(() -> chatModel.doChat(request))
         .isInstanceOf(IllegalArgumentException.class)
@@ -211,18 +195,17 @@ class TestModelProviderTest {
   void testStreamingChatModel() {
     testModelProvider.fixedResponse("Hello world!");
 
-    StreamingChatModel streamingChatModel = (StreamingChatModel) testModelProvider.createStreamingChatModel();
+    StreamingChatModel streamingChatModel =
+        (StreamingChatModel) testModelProvider.createStreamingChatModel();
     TestStreamingHandler handler = new TestStreamingHandler();
 
-    ChatRequest request = ChatRequest.builder()
-        .messages(List.of(new UserMessage("Test question")))
-        .build();
+    ChatRequest request =
+        ChatRequest.builder().messages(List.of(new UserMessage("Test question"))).build();
 
     streamingChatModel.doChat(request, handler);
 
     // Verify partial responses (tokens) - now separators are separate tokens
-    assertThat(handler.partialResponses).hasSize(4)
-        .containsExactly("Hello", " ", "world", "!");
+    assertThat(handler.partialResponses).hasSize(4).containsExactly("Hello", " ", "world", "!");
 
     // Verify complete response
     assertThat(handler.completeResponse).isNotNull();
@@ -236,9 +219,8 @@ class TestModelProviderTest {
     testModelProvider.fixedResponse("Initial response");
 
     ChatModel chatModel = (ChatModel) testModelProvider.createChatModel();
-    ChatRequest request = ChatRequest.builder()
-        .messages(List.of(new UserMessage("Test question")))
-        .build();
+    ChatRequest request =
+        ChatRequest.builder().messages(List.of(new UserMessage("Test question"))).build();
 
     // Verify initial response works
     ChatResponse response = chatModel.doChat(request);
@@ -257,9 +239,8 @@ class TestModelProviderTest {
     testModelProvider.fixedResponse("Test response");
 
     ChatModel chatModel = (ChatModel) testModelProvider.createChatModel();
-    ChatRequest request = ChatRequest.builder()
-        .messages(List.of(new AiMessage("AI message only")))
-        .build();
+    ChatRequest request =
+        ChatRequest.builder().messages(List.of(new AiMessage("AI message only"))).build();
 
     assertThatThrownBy(() -> chatModel.doChat(request))
         .isInstanceOf(RuntimeException.class)
@@ -268,18 +249,13 @@ class TestModelProviderTest {
 
   @Test
   void testMultipleResponsePredicatesLastMatch() {
-    testModelProvider
-      .whenMessage(text -> text.contains("first"))
-      .reply("First response");
+    testModelProvider.whenMessage(text -> text.contains("first")).reply("First response");
 
-    testModelProvider
-      .whenMessage(text -> text.contains("first"))
-      .reply("Second response");
+    testModelProvider.whenMessage(text -> text.contains("first")).reply("Second response");
 
     ChatModel chatModel = (ChatModel) testModelProvider.createChatModel();
-    ChatRequest request = ChatRequest.builder()
-        .messages(List.of(new UserMessage("This is the first test")))
-        .build();
+    ChatRequest request =
+        ChatRequest.builder().messages(List.of(new UserMessage("This is the first test"))).build();
 
     ChatResponse response = chatModel.doChat(request);
     assertThat(response.aiMessage().text()).isEqualTo("Second response");
@@ -289,36 +265,28 @@ class TestModelProviderTest {
   void testMixOfFixedAndWhen() {
     ChatModel chatModel = (ChatModel) testModelProvider.createChatModel();
 
-    testModelProvider
-        .whenMessage(text -> text.contains("first"))
-        .reply("First response");
+    testModelProvider.whenMessage(text -> text.contains("first")).reply("First response");
 
-    ChatRequest request1 = ChatRequest.builder()
-        .messages(List.of(new UserMessage("This is the first test")))
-        .build();
+    ChatRequest request1 =
+        ChatRequest.builder().messages(List.of(new UserMessage("This is the first test"))).build();
     ChatResponse response1 = chatModel.doChat(request1);
     assertThat(response1.aiMessage().text()).isEqualTo("First response");
 
     // changing to a fixed response that will take precedence
-    testModelProvider
-        .fixedResponse("Fixed response");
+    testModelProvider.fixedResponse("Fixed response");
     ChatResponse response2 = chatModel.doChat(request1);
     assertThat(response2.aiMessage().text()).isEqualTo("Fixed response");
 
     // adding another specific match
-    testModelProvider
-        .whenMessage(text -> text.contains("another"))
-        .reply("Another response");
-    ChatRequest request3 = ChatRequest.builder()
-        .messages(List.of(new UserMessage("This is another test")))
-        .build();
+    testModelProvider.whenMessage(text -> text.contains("another")).reply("Another response");
+    ChatRequest request3 =
+        ChatRequest.builder().messages(List.of(new UserMessage("This is another test"))).build();
     ChatResponse response3 = chatModel.doChat(request3);
     assertThat(response3.aiMessage().text()).isEqualTo("Another response");
 
     // and the fixed will still catch non-match
-    ChatRequest request4 = ChatRequest.builder()
-        .messages(List.of(new UserMessage("This is something else")))
-        .build();
+    ChatRequest request4 =
+        ChatRequest.builder().messages(List.of(new UserMessage("This is something else"))).build();
     ChatResponse response4 = chatModel.doChat(request4);
     assertThat(response4.aiMessage().text()).isEqualTo("Fixed response");
   }
@@ -327,18 +295,20 @@ class TestModelProviderTest {
   void testStreamingWithComplexTokenization() {
     testModelProvider.fixedResponse("Hello, world! How are you?");
 
-    StreamingChatModel streamingChatModel = (StreamingChatModel) testModelProvider.createStreamingChatModel();
+    StreamingChatModel streamingChatModel =
+        (StreamingChatModel) testModelProvider.createStreamingChatModel();
     TestStreamingHandler handler = new TestStreamingHandler();
 
-    ChatRequest request = ChatRequest.builder()
-        .messages(List.of(new UserMessage("Complex test")))
-        .build();
+    ChatRequest request =
+        ChatRequest.builder().messages(List.of(new UserMessage("Complex test"))).build();
 
     streamingChatModel.doChat(request, handler);
 
     // Verify all tokens are streamed correctly - now with separate separators
-    List<String> expectedTokens = List.of("Hello", ",", " ", "world", "!", " ", "How", " ", "are", " ", "you", "?");
-    assertThat(handler.partialResponses).hasSize(expectedTokens.size())
+    List<String> expectedTokens =
+        List.of("Hello", ",", " ", "world", "!", " ", "How", " ", "are", " ", "you", "?");
+    assertThat(handler.partialResponses)
+        .hasSize(expectedTokens.size())
         .containsExactlyElementsOf(expectedTokens);
 
     // Verify complete response
@@ -350,12 +320,12 @@ class TestModelProviderTest {
   void testStreamingWithEmptyResponse() {
     testModelProvider.fixedResponse("");
 
-    StreamingChatModel streamingChatModel = (StreamingChatModel) testModelProvider.createStreamingChatModel();
+    StreamingChatModel streamingChatModel =
+        (StreamingChatModel) testModelProvider.createStreamingChatModel();
     TestStreamingHandler handler = new TestStreamingHandler();
 
-    ChatRequest request = ChatRequest.builder()
-        .messages(List.of(new UserMessage("Empty test")))
-        .build();
+    ChatRequest request =
+        ChatRequest.builder().messages(List.of(new UserMessage("Empty test"))).build();
 
     streamingChatModel.doChat(request, handler);
 

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eventsourced/CounterEvent.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eventsourced/CounterEvent.java
@@ -6,12 +6,10 @@ package akka.javasdk.testkit.eventsourced;
 
 import com.google.common.collect.Multimap;
 
-
 public sealed interface CounterEvent {
 
-  record Increased(String counterId, int value) implements CounterEvent {
-  }
+  record Increased(String counterId, int value) implements CounterEvent {}
 
-  record Set(String counterId, int value, Multimap<String, String> notSerializableField) implements CounterEvent {
-  }
+  record Set(String counterId, int value, Multimap<String, String> notSerializableField)
+      implements CounterEvent {}
 }

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eventsourced/CounterEventSourcedEntity.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eventsourced/CounterEventSourcedEntity.java
@@ -5,10 +5,7 @@
 package akka.javasdk.testkit.eventsourced;
 
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
-import akka.javasdk.keyvalueentity.KeyValueEntity;
-import akka.javasdk.testkit.keyvalueentity.CounterValueEntity;
 import com.google.common.collect.HashMultimap;
-
 import java.util.List;
 
 public class CounterEventSourcedEntity extends EventSourcedEntity<Integer, CounterEvent> {
@@ -17,8 +14,12 @@ public class CounterEventSourcedEntity extends EventSourcedEntity<Integer, Count
 
   public Effect<String> increaseBy(Integer value) {
     if (value <= 0) return effects().error("Can't increase with a negative value");
-    else if (wouldOverflow(value)) return effects().error("Can't increase by [" + value + "] due to overflow");
-    else return effects().persist(new CounterEvent.Increased(commandContext().entityId(), value)).thenReply(__ -> "Ok");
+    else if (wouldOverflow(value))
+      return effects().error("Can't increase by [" + value + "] due to overflow");
+    else
+      return effects()
+          .persist(new CounterEvent.Increased(commandContext().entityId(), value))
+          .thenReply(__ -> "Ok");
   }
 
   public Effect<Response> commandHandlerWithResponse() {
@@ -31,11 +32,18 @@ public class CounterEventSourcedEntity extends EventSourcedEntity<Integer, Count
 
   public Effect<String> set(Integer value) {
     var map = HashMultimap.<String, String>create();
-    return effects().persist(new CounterEvent.Set(commandContext().entityId(), value, map)).thenReply(__ -> "Ok");
+    return effects()
+        .persist(new CounterEvent.Set(commandContext().entityId(), value, map))
+        .thenReply(__ -> "Ok");
   }
 
   public Effect<String> increaseFromMeta() {
-    return effects().persist(new CounterEvent.Increased(commandContext().entityId(), Integer.parseInt(commandContext().metadata().get("value").get()))).thenReply(__ -> "Ok");
+    return effects()
+        .persist(
+            new CounterEvent.Increased(
+                commandContext().entityId(),
+                Integer.parseInt(commandContext().metadata().get("value").get())))
+        .thenReply(__ -> "Ok");
   }
 
   public Effect<String> doubleIncreaseBy(Integer value) {
@@ -49,7 +57,10 @@ public class CounterEventSourcedEntity extends EventSourcedEntity<Integer, Count
   }
 
   public Effect<String> delete() {
-    return effects().persist(new CounterEvent.Increased(commandContext().entityId(), 0)).deleteEntity().thenReply(__ -> "Ok");
+    return effects()
+        .persist(new CounterEvent.Increased(commandContext().entityId(), 0))
+        .deleteEntity()
+        .thenReply(__ -> "Ok");
   }
 
   public ReadOnlyEffect<List<SomeRecord>> returnList() {

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eventsourced/CounterEventSourcedEntityTest.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eventsourced/CounterEventSourcedEntityTest.java
@@ -4,22 +4,19 @@
 
 package akka.javasdk.testkit.eventsourced;
 
-import akka.javasdk.Metadata;
-import akka.javasdk.eventsourcedentity.EventSourcedEntity;
-import akka.javasdk.testkit.EventSourcedResult;
-import akka.javasdk.testkit.EventSourcedTestKit;
-import akka.javasdk.testkit.KeyValueEntityTestKit;
-import akka.javasdk.testkit.keyvalueentity.CounterValueEntity;
-import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import akka.javasdk.Metadata;
+import akka.javasdk.eventsourcedentity.EventSourcedEntity;
+import akka.javasdk.testkit.EventSourcedResult;
+import akka.javasdk.testkit.EventSourcedTestKit;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
 
 public class CounterEventSourcedEntityTest {
 
@@ -30,8 +27,9 @@ public class CounterEventSourcedEntityTest {
   @Test
   public void testIncrease() {
     EventSourcedTestKit<Integer, CounterEvent, CounterEventSourcedEntity> testKit =
-      EventSourcedTestKit.of(ctx -> new CounterEventSourcedEntity());
-    EventSourcedResult<String> result = testKit.method(CounterEventSourcedEntity::increaseBy).invoke(10);
+        EventSourcedTestKit.of(ctx -> new CounterEventSourcedEntity());
+    EventSourcedResult<String> result =
+        testKit.method(CounterEventSourcedEntity::increaseBy).invoke(10);
     assertTrue(result.isReply());
     assertEquals("Ok", result.getReply());
     assertEquals(10, testKit.getState());
@@ -43,12 +41,15 @@ public class CounterEventSourcedEntityTest {
   public void testIncreaseWithMetadata() {
     String counterId = "123";
     EventSourcedTestKit<Integer, CounterEvent, CounterEventSourcedEntity> testKit =
-      EventSourcedTestKit.of(counterId, ctx -> new CounterEventSourcedEntity());
-    EventSourcedResult<String> result = testKit.method(CounterEventSourcedEntity::increaseFromMeta)
-      .withMetadata(Metadata.EMPTY.add("value", "10"))
-      .invoke();
+        EventSourcedTestKit.of(counterId, ctx -> new CounterEventSourcedEntity());
+    EventSourcedResult<String> result =
+        testKit
+            .method(CounterEventSourcedEntity::increaseFromMeta)
+            .withMetadata(Metadata.EMPTY.add("value", "10"))
+            .invoke();
     assertTrue(result.isReply());
-    assertEquals(new CounterEvent.Increased(counterId, 10), result.getNextEventOfType(CounterEvent.class));
+    assertEquals(
+        new CounterEvent.Increased(counterId, 10), result.getNextEventOfType(CounterEvent.class));
     assertEquals("Ok", result.getReply());
     assertEquals(10, testKit.getState());
     assertEquals(1, testKit.getAllEvents().size());
@@ -57,8 +58,9 @@ public class CounterEventSourcedEntityTest {
   @Test
   public void testDoubleIncrease() {
     EventSourcedTestKit<Integer, CounterEvent, CounterEventSourcedEntity> testKit =
-      EventSourcedTestKit.of(ctx -> new CounterEventSourcedEntity());
-    EventSourcedResult<String> result = testKit.method(CounterEventSourcedEntity::doubleIncreaseBy).invoke(10);
+        EventSourcedTestKit.of(ctx -> new CounterEventSourcedEntity());
+    EventSourcedResult<String> result =
+        testKit.method(CounterEventSourcedEntity::doubleIncreaseBy).invoke(10);
     assertTrue(result.isReply());
     assertEquals("Ok", result.getReply());
     assertEquals(20, testKit.getState());
@@ -68,7 +70,7 @@ public class CounterEventSourcedEntityTest {
   @Test
   public void testDelete() {
     EventSourcedTestKit<Integer, CounterEvent, CounterEventSourcedEntity> testKit =
-      EventSourcedTestKit.of(ctx -> new CounterEventSourcedEntity());
+        EventSourcedTestKit.of(ctx -> new CounterEventSourcedEntity());
     EventSourcedResult<String> result = testKit.method(CounterEventSourcedEntity::delete).invoke();
     assertTrue(result.isReply());
     assertEquals("Ok", result.getReply());
@@ -78,8 +80,9 @@ public class CounterEventSourcedEntityTest {
   @Test
   public void testIncreaseWithNegativeValue() {
     EventSourcedTestKit<Integer, CounterEvent, CounterEventSourcedEntity> testKit =
-      EventSourcedTestKit.of(ctx -> new CounterEventSourcedEntity());
-    EventSourcedResult<String> result = testKit.method(CounterEventSourcedEntity::increaseBy).invoke(-10);
+        EventSourcedTestKit.of(ctx -> new CounterEventSourcedEntity());
+    EventSourcedResult<String> result =
+        testKit.method(CounterEventSourcedEntity::increaseBy).invoke(-10);
     assertTrue(result.isError());
     assertEquals("Can't increase with a negative value", result.getError());
   }
@@ -87,8 +90,10 @@ public class CounterEventSourcedEntityTest {
   @Test
   public void testOverflowingIncrease() {
     EventSourcedTestKit<Integer, CounterEvent, CounterEventSourcedEntity> testKit =
-      EventSourcedTestKit.ofEntityWithState(ctx -> new CounterEventSourcedEntity(), Integer.MAX_VALUE - 10);
-    EventSourcedResult<String> result = testKit.method(CounterEventSourcedEntity::increaseBy).invoke(11);
+        EventSourcedTestKit.ofEntityWithState(
+            ctx -> new CounterEventSourcedEntity(), Integer.MAX_VALUE - 10);
+    EventSourcedResult<String> result =
+        testKit.method(CounterEventSourcedEntity::increaseBy).invoke(11);
     assertTrue(result.isError());
     assertEquals("Can't increase by [11] due to overflow", result.getError());
   }
@@ -103,9 +108,11 @@ public class CounterEventSourcedEntityTest {
     }
 
     EventSourcedTestKit<Integer, CounterEvent, CounterEventSourcedEntity> testKit =
-      EventSourcedTestKit.ofEntityFromEvents(ctx -> new CounterEventSourcedEntity(), previousEvents);
+        EventSourcedTestKit.ofEntityFromEvents(
+            ctx -> new CounterEventSourcedEntity(), previousEvents);
 
-    EventSourcedResult<String> result = testKit.method(CounterEventSourcedEntity::doubleIncreaseBy).invoke(10);
+    EventSourcedResult<String> result =
+        testKit.method(CounterEventSourcedEntity::doubleIncreaseBy).invoke(10);
     assertTrue(result.isError());
     assertEquals("Can't double-increase by [10] due to overflow", result.getError());
   }
@@ -116,45 +123,77 @@ public class CounterEventSourcedEntityTest {
         EventSourcedTestKit.of(ctx -> new CounterEventSourcedEntity());
     var result = testKit.method(CounterEventSourcedEntity::returnList).invoke();
     assertThat(result.getReply()).asList().hasSize(1);
-    assertThat(result.getReply().getFirst()).isEqualTo(new CounterEventSourcedEntity.SomeRecord("ok"));
+    assertThat(result.getReply().getFirst())
+        .isEqualTo(new CounterEventSourcedEntity.SomeRecord("ok"));
   }
 
   @Test
   public void failEventSerDes() {
     EventSourcedTestKit<Integer, CounterEvent, CounterEventSourcedEntity> testKit =
-      EventSourcedTestKit.ofEntityWithState(ctx -> new CounterEventSourcedEntity(), 0);
+        EventSourcedTestKit.ofEntityWithState(ctx -> new CounterEventSourcedEntity(), 0);
 
-    var ex = assertThrows(Exception.class, () -> testKit.method(CounterEventSourcedEntity::set).invoke(10));
-    assertThat(ex.getMessage()).isEqualTo("Failed to serialize or deserialize akka.javasdk.testkit.eventsourced.CounterEvent$Set. Make sure that all events, commands, responses and state are serializable for akka.javasdk.testkit.eventsourced.CounterEventSourcedEntity");
+    var ex =
+        assertThrows(
+            Exception.class, () -> testKit.method(CounterEventSourcedEntity::set).invoke(10));
+    assertThat(ex.getMessage())
+        .isEqualTo(
+            "Failed to serialize or deserialize akka.javasdk.testkit.eventsourced.CounterEvent$Set."
+                + " Make sure that all events, commands, responses and state are serializable for"
+                + " akka.javasdk.testkit.eventsourced.CounterEventSourcedEntity");
     assertThat(ex.getCause().getMessage()).contains("could not be decoded into");
   }
 
   @Test
   public void failResponseSerDes() {
     EventSourcedTestKit<Integer, CounterEvent, CounterEventSourcedEntity> testKit =
-      EventSourcedTestKit.ofEntityWithState(ctx -> new CounterEventSourcedEntity(), 0);
+        EventSourcedTestKit.ofEntityWithState(ctx -> new CounterEventSourcedEntity(), 0);
 
-    var ex = assertThrows(Exception.class, () -> testKit.method(CounterEventSourcedEntity::commandHandlerWithResponse).invoke());
-    assertThat(ex.getMessage()).isEqualTo("Failed to serialize or deserialize akka.javasdk.testkit.eventsourced.Response$Error. Make sure that all events, commands, responses and state are serializable for akka.javasdk.testkit.eventsourced.CounterEventSourcedEntity");
+    var ex =
+        assertThrows(
+            Exception.class,
+            () -> testKit.method(CounterEventSourcedEntity::commandHandlerWithResponse).invoke());
+    assertThat(ex.getMessage())
+        .isEqualTo(
+            "Failed to serialize or deserialize akka.javasdk.testkit.eventsourced.Response$Error."
+                + " Make sure that all events, commands, responses and state are serializable for"
+                + " akka.javasdk.testkit.eventsourced.CounterEventSourcedEntity");
     assertThat(ex.getCause().getMessage()).contains("could not be decoded into");
   }
 
   @Test
   public void failStateSerDes() {
-    var ex = assertThrows(Exception.class, () -> {
-        EventSourcedTestKit.ofEntityWithState(ctx -> new PolyStateESE(), new PolyState.StateA());
-    });
-    assertThat(ex.getMessage()).isEqualTo("Failed to serialize or deserialize akka.javasdk.testkit.eventsourced.PolyState$StateA. Make sure that all events, commands, responses and state are serializable for akka.javasdk.testkit.eventsourced.PolyStateESE");
+    var ex =
+        assertThrows(
+            Exception.class,
+            () -> {
+              EventSourcedTestKit.ofEntityWithState(
+                  ctx -> new PolyStateESE(), new PolyState.StateA());
+            });
+    assertThat(ex.getMessage())
+        .isEqualTo(
+            "Failed to serialize or deserialize akka.javasdk.testkit.eventsourced.PolyState$StateA."
+                + " Make sure that all events, commands, responses and state are serializable for"
+                + " akka.javasdk.testkit.eventsourced.PolyStateESE");
     assertThat(ex.getCause().getMessage()).contains("could not be decoded into");
   }
 
   @Test
   public void failInputSerDes() {
     EventSourcedTestKit<Integer, CounterEvent, CounterEventSourcedEntity> testKit =
-      EventSourcedTestKit.ofEntityWithState(ctx -> new CounterEventSourcedEntity(), 0);
+        EventSourcedTestKit.ofEntityWithState(ctx -> new CounterEventSourcedEntity(), 0);
 
-    var ex = assertThrows(Exception.class, () -> testKit.method(CounterEventSourcedEntity::commandHandlerWithPolyInput).invoke(new Response.OK()));
-    assertThat(ex.getMessage()).isEqualTo("Failed to serialize or deserialize akka.javasdk.testkit.eventsourced.Response$OK. Make sure that all events, commands, responses and state are serializable for akka.javasdk.testkit.eventsourced.CounterEventSourcedEntity");
+    var ex =
+        assertThrows(
+            Exception.class,
+            () ->
+                testKit
+                    .method(CounterEventSourcedEntity::commandHandlerWithPolyInput)
+                    .invoke(new Response.OK()));
+    assertThat(ex.getMessage())
+        .isEqualTo(
+            "Failed to serialize or deserialize akka.javasdk.testkit.eventsourced.Response$OK. Make"
+                + " sure that all events, commands, responses and state are serializable for"
+                + " akka.javasdk.testkit.eventsourced.CounterEventSourcedEntity");
     assertThat(ex.getCause().getMessage()).contains("could not be decoded into");
   }
 }

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eventsourced/PolyState.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eventsourced/PolyState.java
@@ -6,9 +6,7 @@ package akka.javasdk.testkit.eventsourced;
 
 public sealed interface PolyState {
 
-  record StateA() implements PolyState {
-  }
+  record StateA() implements PolyState {}
 
-  record StateB() implements PolyState {
-  }
+  record StateB() implements PolyState {}
 }

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eventsourced/Response.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eventsourced/Response.java
@@ -4,12 +4,9 @@
 
 package akka.javasdk.testkit.eventsourced;
 
-/**
- * Not serializable Response, missing Jackson annotations.
- */
+/** Not serializable Response, missing Jackson annotations. */
 public sealed interface Response {
-  record OK() implements Response {
-  }
-  record Error() implements Response {
-  }
+  record OK() implements Response {}
+
+  record Error() implements Response {}
 }

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/keyvalueentity/CounterKeyValueEntityTest.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/keyvalueentity/CounterKeyValueEntityTest.java
@@ -4,20 +4,17 @@
 
 package akka.javasdk.testkit.keyvalueentity;
 
-import akka.javasdk.Metadata;
-import akka.javasdk.testkit.EventSourcedTestKit;
-import akka.javasdk.testkit.KeyValueEntityResult;
-import akka.javasdk.testkit.KeyValueEntityTestKit;
-import akka.javasdk.testkit.eventsourced.PolyState;
-import akka.javasdk.testkit.eventsourced.PolyStateESE;
-import akka.javasdk.testkit.eventsourced.Response;
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import akka.javasdk.Metadata;
+import akka.javasdk.testkit.KeyValueEntityResult;
+import akka.javasdk.testkit.KeyValueEntityTestKit;
+import akka.javasdk.testkit.eventsourced.Response;
+import org.junit.jupiter.api.Test;
 
 public class CounterKeyValueEntityTest {
 
@@ -35,7 +32,11 @@ public class CounterKeyValueEntityTest {
   public void testIncreaseWithMetadata() {
     KeyValueEntityTestKit<Integer, CounterValueEntity> testKit =
         KeyValueEntityTestKit.of(ctx -> new CounterValueEntity());
-    KeyValueEntityResult<String> result = testKit.method(CounterValueEntity::increaseFromMeta).withMetadata(Metadata.EMPTY.add("value", "10")).invoke();
+    KeyValueEntityResult<String> result =
+        testKit
+            .method(CounterValueEntity::increaseFromMeta)
+            .withMetadata(Metadata.EMPTY.add("value", "10"))
+            .invoke();
     assertTrue(result.isReply());
     assertEquals(result.getReply(), "Ok");
     assertEquals(testKit.getState(), 10);
@@ -45,7 +46,8 @@ public class CounterKeyValueEntityTest {
   public void testIncreaseWithNegativeValue() {
     KeyValueEntityTestKit<Integer, CounterValueEntity> testKit =
         KeyValueEntityTestKit.of(ctx -> new CounterValueEntity());
-    KeyValueEntityResult<String> result = testKit.method(CounterValueEntity::increaseBy).invoke(-10);
+    KeyValueEntityResult<String> result =
+        testKit.method(CounterValueEntity::increaseBy).invoke(-10);
     assertTrue(result.isError());
     assertFalse(testKit.isDeleted());
     assertEquals(result.getError(), "Can't increase with a negative value");
@@ -76,22 +78,36 @@ public class CounterKeyValueEntityTest {
   @Test
   public void failResponseSerDes() {
     KeyValueEntityTestKit<Integer, CounterValueEntity> testKit =
-      KeyValueEntityTestKit.of(ctx -> new CounterValueEntity());
-    var ex = assertThrows(Exception.class, () -> {
-      testKit.method(CounterValueEntity::polyResponse).invoke();
-    });
-    assertThat(ex.getMessage()).isEqualTo("Failed to serialize or deserialize akka.javasdk.testkit.eventsourced.Response$Error. Make sure that all events, commands, responses and state are serializable for akka.javasdk.testkit.keyvalueentity.CounterValueEntity");
+        KeyValueEntityTestKit.of(ctx -> new CounterValueEntity());
+    var ex =
+        assertThrows(
+            Exception.class,
+            () -> {
+              testKit.method(CounterValueEntity::polyResponse).invoke();
+            });
+    assertThat(ex.getMessage())
+        .isEqualTo(
+            "Failed to serialize or deserialize akka.javasdk.testkit.eventsourced.Response$Error."
+                + " Make sure that all events, commands, responses and state are serializable for"
+                + " akka.javasdk.testkit.keyvalueentity.CounterValueEntity");
     assertThat(ex.getCause().getMessage()).contains("could not be decoded into");
   }
 
   @Test
   public void failInputSerDes() {
     KeyValueEntityTestKit<Integer, CounterValueEntity> testKit =
-      KeyValueEntityTestKit.of(ctx -> new CounterValueEntity());
-    var ex = assertThrows(Exception.class, () -> {
-      testKit.method(CounterValueEntity::polyHandler).invoke(new Response.OK());
-    });
-    assertThat(ex.getMessage()).isEqualTo("Failed to serialize or deserialize akka.javasdk.testkit.eventsourced.Response$OK. Make sure that all events, commands, responses and state are serializable for akka.javasdk.testkit.keyvalueentity.CounterValueEntity");
+        KeyValueEntityTestKit.of(ctx -> new CounterValueEntity());
+    var ex =
+        assertThrows(
+            Exception.class,
+            () -> {
+              testKit.method(CounterValueEntity::polyHandler).invoke(new Response.OK());
+            });
+    assertThat(ex.getMessage())
+        .isEqualTo(
+            "Failed to serialize or deserialize akka.javasdk.testkit.eventsourced.Response$OK. Make"
+                + " sure that all events, commands, responses and state are serializable for"
+                + " akka.javasdk.testkit.keyvalueentity.CounterValueEntity");
     assertThat(ex.getCause().getMessage()).contains("could not be decoded into");
   }
 }

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/keyvalueentity/CounterValueEntity.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/keyvalueentity/CounterValueEntity.java
@@ -6,7 +6,6 @@ package akka.javasdk.testkit.keyvalueentity;
 
 import akka.javasdk.keyvalueentity.KeyValueEntity;
 import akka.javasdk.testkit.eventsourced.Response;
-
 import java.util.List;
 
 public class CounterValueEntity extends KeyValueEntity<Integer> {
@@ -26,7 +25,9 @@ public class CounterValueEntity extends KeyValueEntity<Integer> {
 
   public Effect<String> increaseFromMeta() {
     Integer state = currentState();
-    return effects().updateState(state + Integer.parseInt(commandContext().metadata().get("value").get())).thenReply("Ok");
+    return effects()
+        .updateState(state + Integer.parseInt(commandContext().metadata().get("value").get()))
+        .thenReply("Ok");
   }
 
   public Effect<String> delete() {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/EventSourcedEntityTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/EventSourcedEntityTest.java
@@ -4,40 +4,41 @@
 
 package akkajavasdk;
 
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import akka.javasdk.CommandException;
+import akka.javasdk.client.EventSourcedEntityClient;
 import akka.javasdk.testkit.TestKit;
 import akka.javasdk.testkit.TestKitSupport;
 import akkajavasdk.components.MyException;
 import akkajavasdk.components.eventsourcedentities.counter.Counter;
 import akkajavasdk.components.eventsourcedentities.counter.CounterCommand;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEntity;
-import akka.javasdk.client.EventSourcedEntityClient;
 import akkajavasdk.components.eventsourcedentities.hierarchy.AbstractTextConsumer;
 import akkajavasdk.components.eventsourcedentities.hierarchy.TextEsEntity;
 import com.typesafe.config.ConfigFactory;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.Optional;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import static java.time.temporal.ChronoUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
-
 @ExtendWith(Junit5LogCapturing.class)
 public class EventSourcedEntityTest extends TestKitSupport {
 
   @Override
   protected TestKit.Settings testKitSettings() {
-    return TestKit.Settings.DEFAULT.withAdditionalConfig(ConfigFactory.parseString("""
-        akka.javasdk.event-sourced-entity.snapshot-every = 10
-        """));
+    return TestKit.Settings.DEFAULT.withAdditionalConfig(
+        ConfigFactory.parseString(
+            """
+            akka.javasdk.event-sourced-entity.snapshot-every = 10
+            """));
   }
 
   @Test
@@ -57,9 +58,11 @@ public class EventSourcedEntityTest extends TestKitSupport {
 
   @Test
   public void verifyEventSourcedEntityRunsOnVirtualThread() {
-    var result = componentClient.forEventSourcedEntity("hello")
-        .method(CounterEntity::commandHandlerIsOnVirtualThread)
-        .invoke();
+    var result =
+        componentClient
+            .forEventSourcedEntity("hello")
+            .method(CounterEntity::commandHandlerIsOnVirtualThread)
+            .invoke();
     assertThat(result).isTrue();
   }
 
@@ -81,9 +84,7 @@ public class EventSourcedEntityTest extends TestKitSupport {
   public void verifyCounterErrorEffect() {
     var counterId = "hello-error";
     var client = componentClient.forEventSourcedEntity(counterId);
-    assertThrows(IllegalArgumentException.class, () ->
-    increaseCounterWithError(client, -1)
-      );
+    assertThrows(IllegalArgumentException.class, () -> increaseCounterWithError(client, -1));
   }
 
   @Test
@@ -91,21 +92,18 @@ public class EventSourcedEntityTest extends TestKitSupport {
 
     var client = componentClient.forEventSourcedEntity("testing");
 
-    Result<CounterEntity.Error, Counter> result = await(client
-      .method(CounterEntity::increaseWithResult)
-      .invokeAsync(-10));
+    Result<CounterEntity.Error, Counter> result =
+        await(client.method(CounterEntity::increaseWithResult).invokeAsync(-10));
 
     assertThat(result.error()).isEqualTo(CounterEntity.Error.TOO_LOW);
 
-    Result<CounterEntity.Error, Counter> result2 = await(client
-      .method(CounterEntity::increaseWithResult)
-      .invokeAsync(1000001));
+    Result<CounterEntity.Error, Counter> result2 =
+        await(client.method(CounterEntity::increaseWithResult).invokeAsync(1000001));
 
     assertThat(result2.error()).isEqualTo(CounterEntity.Error.TOO_HIGH);
 
-    Result<CounterEntity.Error, Counter> result3 = await(client
-      .method(CounterEntity::increaseWithResult)
-      .invokeAsync(123));
+    Result<CounterEntity.Error, Counter> result3 =
+        await(client.method(CounterEntity::increaseWithResult).invokeAsync(123));
 
     assertThat(result3.success()).isEqualTo(new Counter(123));
   }
@@ -115,15 +113,17 @@ public class EventSourcedEntityTest extends TestKitSupport {
 
     var client = componentClient.forEventSourcedEntity("testing-generics");
 
-    Integer result1 = await(client
-        .method(CounterEntity::multiIncrease)
-        .invokeAsync(List.of(1, 5, 7)));
+    Integer result1 =
+        await(client.method(CounterEntity::multiIncrease).invokeAsync(List.of(1, 5, 7)));
 
     assertThat(result1).isEqualTo(13);
 
-    Integer result2 = await(client
-        .method(CounterEntity::multiIncreaseCommands)
-        .invokeAsync(List.of(new CounterEntity.DoIncrease(1), new CounterEntity.DoIncrease(5))));
+    Integer result2 =
+        await(
+            client
+                .method(CounterEntity::multiIncreaseCommands)
+                .invokeAsync(
+                    List.of(new CounterEntity.DoIncrease(1), new CounterEntity.DoIncrease(5))));
 
     assertThat(result2).isEqualTo(19);
   }
@@ -145,10 +145,9 @@ public class EventSourcedEntityTest extends TestKitSupport {
     // events should be replayed successfully and
     // counter value should be the same as previously
     Awaitility.await()
-            .ignoreExceptions()
-            .atMost(20, TimeUnit.SECONDS)
-            .until(() ->
-              getCounter(client), new IsEqual(30));
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.SECONDS)
+        .until(() -> getCounter(client), new IsEqual(30));
   }
 
   @Test
@@ -169,26 +168,20 @@ public class EventSourcedEntityTest extends TestKitSupport {
 
     // current state is based on snapshot and should be the same as previously
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .until(
-        () -> getCounter(client),
-        new IsEqual(10));
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .until(() -> getCounter(client), new IsEqual(10));
   }
 
   @Test
   public void verifyRequestWithSealedCommand() {
     var client = componentClient.forEventSourcedEntity("counter-with-sealed-command-handler");
-    await(client
-      .method(CounterEntity::handle)
-      .invokeAsync(new CounterCommand.Set(123)));
+    await(client.method(CounterEntity::handle).invokeAsync(new CounterCommand.Set(123)));
 
     Integer result1 = client.method(CounterEntity::get).invoke();
     assertThat(result1).isEqualTo(123);
 
-    await(client
-      .method(CounterEntity::handle)
-      .invokeAsync(new CounterCommand.Increase(123)));
+    await(client.method(CounterEntity::handle).invokeAsync(new CounterCommand.Increase(123)));
 
     Integer result2 = client.method(CounterEntity::get).invoke();
     assertThat(result2).isEqualTo(246);
@@ -212,75 +205,90 @@ public class EventSourcedEntityTest extends TestKitSupport {
     assertThat(result).isEqualTo(Optional.of("my text"));
 
     // also verify that hierarchy consumer works
-    Awaitility.await().untilAsserted(() ->
-        assertThat(StaticTestBuffer.getValue(AbstractTextConsumer.BUFFER_KEY)).isEqualTo("my text")
-    );
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(StaticTestBuffer.getValue(AbstractTextConsumer.BUFFER_KEY))
+                    .isEqualTo("my text"));
   }
 
   @Test
   public void shouldTestExceptions() {
-    var exc1 = Assertions.assertThrows(CommandException.class, () -> {
-      componentClient.forEventSourcedEntity("1")
-        .method(CounterEntity::run)
-        .invoke("errorMessage");
-    });
+    var exc1 =
+        Assertions.assertThrows(
+            CommandException.class,
+            () -> {
+              componentClient
+                  .forEventSourcedEntity("1")
+                  .method(CounterEntity::run)
+                  .invoke("errorMessage");
+            });
     assertThat(exc1.getMessage()).isEqualTo("errorMessage");
 
-    var exc2 = Assertions.assertThrows(CommandException.class, () -> {
-      componentClient.forEventSourcedEntity("1")
-        .method(CounterEntity::run)
-        .invoke("errorCommandException");
-    });
+    var exc2 =
+        Assertions.assertThrows(
+            CommandException.class,
+            () -> {
+              componentClient
+                  .forEventSourcedEntity("1")
+                  .method(CounterEntity::run)
+                  .invoke("errorCommandException");
+            });
     assertThat(exc2.getMessage()).isEqualTo("errorCommandException");
 
-    var exc3 = Assertions.assertThrows(MyException.class, () -> {
-      componentClient.forEventSourcedEntity("1")
-        .method(CounterEntity::run)
-        .invoke("errorMyException");
-    });
+    var exc3 =
+        Assertions.assertThrows(
+            MyException.class,
+            () -> {
+              componentClient
+                  .forEventSourcedEntity("1")
+                  .method(CounterEntity::run)
+                  .invoke("errorMyException");
+            });
     assertThat(exc3.getMessage()).isEqualTo("errorMyException");
     assertThat(exc3.getData()).isEqualTo(new MyException.SomeData("some data"));
 
-    var exc4 = Assertions.assertThrows(MyException.class, () -> {
-      componentClient.forEventSourcedEntity("1")
-        .method(CounterEntity::run)
-        .invoke("throwMyException");
-    });
+    var exc4 =
+        Assertions.assertThrows(
+            MyException.class,
+            () -> {
+              componentClient
+                  .forEventSourcedEntity("1")
+                  .method(CounterEntity::run)
+                  .invoke("throwMyException");
+            });
     assertThat(exc4.getMessage()).isEqualTo("throwMyException");
     assertThat(exc4.getData()).isEqualTo(new MyException.SomeData("some data"));
 
-    var exc5 = Assertions.assertThrows(RuntimeException.class, () -> {
-      componentClient.forEventSourcedEntity("1")
-        .method(CounterEntity::run)
-        .invoke("throwRuntimeException");
-    });
-    assertThat(exc5.getMessage()).contains("Unexpected error "); //it's not the original message, but the one from the runtime
+    var exc5 =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () -> {
+              componentClient
+                  .forEventSourcedEntity("1")
+                  .method(CounterEntity::run)
+                  .invoke("throwRuntimeException");
+            });
+    assertThat(exc5.getMessage())
+        .contains(
+            "Unexpected error "); // it's not the original message, but the one from the runtime
   }
 
-
   private Integer increaseCounter(EventSourcedEntityClient client, int value) {
-    return client
-      .method(CounterEntity::increase)
-      .invoke(value);
+    return client.method(CounterEntity::increase).invoke(value);
   }
 
   private Counter increaseCounterWithError(EventSourcedEntityClient client, int value) {
-    return client
-        .method(CounterEntity::increaseWithError)
-        .invoke(value);
+    return client.method(CounterEntity::increaseWithError).invoke(value);
   }
 
-
   private Integer multiplyCounter(EventSourcedEntityClient client, int value) {
-    return client
-      .method(CounterEntity::times)
-      .invoke(value);
+    return client.method(CounterEntity::times).invoke(value);
   }
 
   private void restartCounterEntity(EventSourcedEntityClient client) {
     try {
-      client
-        .method(CounterEntity::restart).invoke();
+      client.method(CounterEntity::restart).invoke();
       fail("This should not be reached");
     } catch (Exception ignored) {
     }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/GrpcEndpointTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/GrpcEndpointTest.java
@@ -4,18 +4,17 @@
 
 package akkajavasdk;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import akka.grpc.GrpcServiceException;
 import akka.grpc.javadsl.SingleBlockingResponseRequestBuilder;
-import akka.grpc.javadsl.SingleResponseRequestBuilder;
 import akka.javasdk.Principal;
 import akka.javasdk.testkit.TestKitSupport;
 import akkajavasdk.protocol.TestGrpcServiceClient;
 import akkajavasdk.protocol.TestGrpcServiceOuterClass;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 @ExtendWith(Junit5LogCapturing.class)
 public class GrpcEndpointTest extends TestKitSupport {
@@ -33,14 +32,14 @@ public class GrpcEndpointTest extends TestKitSupport {
 
   @Test
   public void shouldProvideAccessToRequestMetadata() {
-    var testClient = getGrpcEndpointClient(TestGrpcServiceClient.class).addRequestHeader("x-foo", "bar");
+    var testClient =
+        getGrpcEndpointClient(TestGrpcServiceClient.class).addRequestHeader("x-foo", "bar");
 
     var request = TestGrpcServiceOuterClass.In.newBuilder().setData("x-foo").build();
     var response = testClient.readMetadata(request);
 
     assertThat(response.getData()).isEqualTo("bar");
   }
-
 
   @Test
   public void shouldAllowExternalGrpcCall() {
@@ -107,7 +106,8 @@ public class GrpcEndpointTest extends TestKitSupport {
 
   @Test
   public void shouldAllowGrpcCallFromOtherService() {
-    var clientFromOtherService = getGrpcEndpointClient(TestGrpcServiceClient.class, Principal.localService("other-service"));
+    var clientFromOtherService =
+        getGrpcEndpointClient(TestGrpcServiceClient.class, Principal.localService("other-service"));
 
     var request = TestGrpcServiceOuterClass.In.newBuilder().setData("Hello world").build();
     var response = clientFromOtherService.aclService(request);
@@ -123,8 +123,9 @@ public class GrpcEndpointTest extends TestKitSupport {
     var testClient = getGrpcEndpointClient(TestGrpcServiceClient.class, Principal.INTERNET);
 
     // should inherit deny code defined at class level
-    expectFailWith(testClient.aclInheritedDenyCode()
-        .addHeader("impersonate-service", "other-service"), "NOT_FOUND");
+    expectFailWith(
+        testClient.aclInheritedDenyCode().addHeader("impersonate-service", "other-service"),
+        "NOT_FOUND");
 
     // should override deny code defined at class level
     expectFailWith(testClient.aclOverrideDenyCode(), "UNAVAILABLE");
@@ -133,7 +134,11 @@ public class GrpcEndpointTest extends TestKitSupport {
     expectFailWith(testClient.aclDefaultDenyCode(), "PERMISSION_DENIED");
   }
 
-  private void expectFailWith(SingleBlockingResponseRequestBuilder<TestGrpcServiceOuterClass.In, TestGrpcServiceOuterClass.Out> method, String expected) {
+  private void expectFailWith(
+      SingleBlockingResponseRequestBuilder<
+              TestGrpcServiceOuterClass.In, TestGrpcServiceOuterClass.Out>
+          method,
+      String expected) {
     try {
       var request = TestGrpcServiceOuterClass.In.newBuilder().setData("Hello world").build();
       method.invoke(request);
@@ -141,7 +146,5 @@ public class GrpcEndpointTest extends TestKitSupport {
     } catch (GrpcServiceException e) {
       assertThat(e.getMessage()).contains(expected);
     }
-
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/JwtEndpointTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/JwtEndpointTest.java
@@ -4,26 +4,25 @@
 
 package akkajavasdk;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
+
 import akka.grpc.GrpcServiceException;
 import akka.grpc.javadsl.SingleBlockingResponseRequestBuilder;
 import akka.http.javadsl.model.StatusCodes;
 import akka.javasdk.http.StrictResponse;
 import akka.javasdk.testkit.TestKitSupport;
-import akkajavasdk.protocol.TestJwtsGrpcServiceClient;
 import akkajavasdk.protocol.TestGrpcServiceOuterClass;
+import akkajavasdk.protocol.TestJwtsGrpcServiceClient;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.*;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(Junit5LogCapturing.class)
 public class JwtEndpointTest extends TestKitSupport {
@@ -31,10 +30,13 @@ public class JwtEndpointTest extends TestKitSupport {
   @Test
   public void shouldReturnIssuerAndSubject() {
     var token = bearerTokenWith(Map.of("iss", "my-issuer-123", "sub", "my-subject-123"));
-    
-    StrictResponse<String> call = httpClient.GET("/hello").addHeader("Authorization", token)
-        .responseBodyAs(String.class)
-        .invoke();
+
+    StrictResponse<String> call =
+        httpClient
+            .GET("/hello")
+            .addHeader("Authorization", token)
+            .responseBodyAs(String.class)
+            .invoke();
 
     assertThat(call.body()).isEqualTo("issuer: my-issuer-123, subject: my-subject-123");
   }
@@ -43,8 +45,7 @@ public class JwtEndpointTest extends TestKitSupport {
   public void shouldReturnForbidden() {
     var token = bearerTokenWith(Map.of("iss", "my-issuer-123"));
 
-    var call = httpClient.GET("/hello").addHeader("Authorization", token)
-        .invoke();
+    var call = httpClient.GET("/hello").addHeader("Authorization", token).invoke();
 
     assertThat(call.status()).isEqualTo(StatusCodes.FORBIDDEN);
   }
@@ -53,61 +54,84 @@ public class JwtEndpointTest extends TestKitSupport {
   public void shouldRaiseExceptionWhenAccessingJWT() {
     var token = bearerTokenWith(Map.of("iss", "my-issuer-123"));
 
-    var call = httpClient.GET("/missingjwt").addHeader("Authorization", token)
-        .responseBodyAs(String.class).invokeAsync().toCompletableFuture();
+    var call =
+        httpClient
+            .GET("/missingjwt")
+            .addHeader("Authorization", token)
+            .responseBodyAs(String.class)
+            .invokeAsync()
+            .toCompletableFuture();
 
     Awaitility.await()
         .atMost(5, TimeUnit.SECONDS)
-        .untilAsserted(() -> {
-          var exception = assertThrows(Exception.class, call::get);
-          assertThat(exception.getCause().getClass()).isEqualTo(RuntimeException.class);
-          assertTrue(exception.getCause().getMessage().contains(
-              "There are no JWT claims defined but trying accessing the JWT claims. The class or the method needs to be annotated with @JWT."));
-        });
-
+        .untilAsserted(
+            () -> {
+              var exception = assertThrows(Exception.class, call::get);
+              assertThat(exception.getCause().getClass()).isEqualTo(RuntimeException.class);
+              assertTrue(
+                  exception
+                      .getCause()
+                      .getMessage()
+                      .contains(
+                          "There are no JWT claims defined but trying accessing the JWT claims. The"
+                              + " class or the method needs to be annotated with @JWT."));
+            });
   }
 
-
   // from here down, JWT validation tests for gRPC endpoints
-  TestGrpcServiceOuterClass.In request = TestGrpcServiceOuterClass.In.newBuilder().setData("Hello world").build();
+  TestGrpcServiceOuterClass.In request =
+      TestGrpcServiceOuterClass.In.newBuilder().setData("Hello world").build();
 
   @Test
   public void shouldValidateJwtIssuer() {
     String bearerToken = bearerTokenWith(Map.of("iss", "my-issuer"));
-    var wrongIss = getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
-        .addRequestHeader("Authorization", bearerToken);
+    var wrongIss =
+        getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
+            .addRequestHeader("Authorization", bearerToken);
     expectFailWith(wrongIss.jwtIssuer(), "UNAUTHENTICATED: Bearer token from wrong issuer");
 
-    var correctIss = getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
-        .addRequestHeader("Authorization", bearerTokenWith(Map.of("iss", "my-issuer-123")));
+    var correctIss =
+        getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
+            .addRequestHeader("Authorization", bearerTokenWith(Map.of("iss", "my-issuer-123")));
     var response = correctIss.jwtIssuer().invoke(request);
     assertThat(response.getData()).isEqualTo(request.getData());
   }
 
   @Test
   public void shouldValidateJwtStaticClaim() {
-    String wrongSub = bearerTokenWith(
-        Map.of("iss", "my-issuer-123", "sub", "incorrect-subject"));
-    var client = getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
-        .addRequestHeader("Authorization", wrongSub);
-    expectFailWith(client.jwtStaticClaimValue(), "PERMISSION_DENIED: Bearer token does not contain required claims");
+    String wrongSub = bearerTokenWith(Map.of("iss", "my-issuer-123", "sub", "incorrect-subject"));
+    var client =
+        getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
+            .addRequestHeader("Authorization", wrongSub);
+    expectFailWith(
+        client.jwtStaticClaimValue(),
+        "PERMISSION_DENIED: Bearer token does not contain required claims");
 
-    var correctSub = getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
-        .addRequestHeader("Authorization", bearerTokenWith(Map.of("iss", "my-issuer-123", "sub", "my-subject-123")));
+    var correctSub =
+        getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
+            .addRequestHeader(
+                "Authorization",
+                bearerTokenWith(Map.of("iss", "my-issuer-123", "sub", "my-subject-123")));
     var response = correctSub.jwtStaticClaimValue().invoke(request);
     assertThat(response.getData()).isEqualTo(request.getData());
   }
 
   @Test
   public void shouldValidateJwtStaticClaimPattern() {
-    String wrongClaimFormat = bearerTokenWith(
-        Map.of("iss", "my-issuer-123", "sub", "not-my-subject-456"));
-    var client = getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
-        .addRequestHeader("Authorization", wrongClaimFormat);
-    expectFailWith(client.jwtStaticClaimPattern(), "PERMISSION_DENIED: Bearer token does not contain required claims");
+    String wrongClaimFormat =
+        bearerTokenWith(Map.of("iss", "my-issuer-123", "sub", "not-my-subject-456"));
+    var client =
+        getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
+            .addRequestHeader("Authorization", wrongClaimFormat);
+    expectFailWith(
+        client.jwtStaticClaimPattern(),
+        "PERMISSION_DENIED: Bearer token does not contain required claims");
 
-    var correctSub = getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
-        .addRequestHeader("Authorization", bearerTokenWith(Map.of("iss", "my-issuer-456", "sub", "my-subject-456")));
+    var correctSub =
+        getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
+            .addRequestHeader(
+                "Authorization",
+                bearerTokenWith(Map.of("iss", "my-issuer-456", "sub", "my-subject-456")));
     var response = correctSub.jwtStaticClaimPattern().invoke(request);
     assertThat(response.getData()).isEqualTo(request.getData());
   }
@@ -115,13 +139,15 @@ public class JwtEndpointTest extends TestKitSupport {
   @Test
   public void shouldCorrectlyInheritFromClass() {
     String classIssuer = bearerTokenWith(Map.of("iss", "class-level-issuer"));
-    var client = getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
-        .addRequestHeader("Authorization", classIssuer);
+    var client =
+        getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
+            .addRequestHeader("Authorization", classIssuer);
     var response = client.jwtInherited().invoke(request);
     assertThat(response.getData()).isEqualTo(request.getData());
 
-    var correctSub = getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
-        .addRequestHeader("Authorization", bearerTokenWith(Map.of("iss", "my-issuer-123")));
+    var correctSub =
+        getGrpcEndpointClient(TestJwtsGrpcServiceClient.class)
+            .addRequestHeader("Authorization", bearerTokenWith(Map.of("iss", "my-issuer-123")));
     expectFailWith(correctSub.jwtInherited(), "UNAUTHENTICATED: Bearer token from wrong issuer");
   }
 
@@ -138,7 +164,11 @@ public class JwtEndpointTest extends TestKitSupport {
     }
   }
 
-  private void expectFailWith(SingleBlockingResponseRequestBuilder<TestGrpcServiceOuterClass.In, TestGrpcServiceOuterClass.Out> method, String expected) {
+  private void expectFailWith(
+      SingleBlockingResponseRequestBuilder<
+              TestGrpcServiceOuterClass.In, TestGrpcServiceOuterClass.Out>
+          method,
+      String expected) {
     try {
       method.invoke(request);
       fail("Expected exception");
@@ -146,5 +176,4 @@ public class JwtEndpointTest extends TestKitSupport {
       assertThat(e.getMessage()).contains(expected);
     }
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/McpEndpointTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/McpEndpointTest.java
@@ -4,18 +4,17 @@
 
 package akkajavasdk;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import akka.http.javadsl.model.ContentTypes;
 import akka.http.javadsl.model.StatusCodes;
 import akka.javasdk.impl.serialization.JsonSerializer;
 import akka.javasdk.testkit.TestKitSupport;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
-import java.nio.charset.StandardCharsets;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 @ExtendWith(Junit5LogCapturing.class)
 public class McpEndpointTest extends TestKitSupport {
@@ -24,169 +23,218 @@ public class McpEndpointTest extends TestKitSupport {
 
   @Test
   public void listTools() {
-    var listingResult = httpClient.POST("/mcp")
-        .withRequestBody(ContentTypes.APPLICATION_JSON,
-            """
-            {"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}
-            """.getBytes(StandardCharsets.UTF_8)
-        ).invoke();
+    var listingResult =
+        httpClient
+            .POST("/mcp")
+            .withRequestBody(
+                ContentTypes.APPLICATION_JSON,
+                """
+                {"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}
+                """
+                    .getBytes(StandardCharsets.UTF_8))
+            .invoke();
 
     assertThat(listingResult.status()).isEqualTo(StatusCodes.OK);
-    assertThat(listingResult.body().utf8String()).isEqualTo(
-        """
-        {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"echo","description":"A method that returns what is fed to it","inputSchema":{"type":"object","properties":{"echo":{"type":"string","description":"the string to echo"}},"required":["echo"]}}]}}
-        """.trim()
-    );
+    assertThat(listingResult.body().utf8String())
+        .isEqualTo(
+            """
+{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"echo","description":"A method that returns what is fed to it","inputSchema":{"type":"object","properties":{"echo":{"type":"string","description":"the string to echo"}},"required":["echo"]}}]}}
+"""
+                .trim());
   }
 
   @Test
   public void callATool() {
-    var listingResult = httpClient.POST("/mcp")
-        .withRequestBody(ContentTypes.APPLICATION_JSON,
-            """
-            {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"echo":"hello world"}}}}}
-            """.getBytes(StandardCharsets.UTF_8)
-        ).invoke();
+    var listingResult =
+        httpClient
+            .POST("/mcp")
+            .withRequestBody(
+                ContentTypes.APPLICATION_JSON,
+                """
+{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"echo":"hello world"}}}}}
+"""
+                    .getBytes(StandardCharsets.UTF_8))
+            .invoke();
 
     assertThat(listingResult.status()).isEqualTo(StatusCodes.OK);
-    assertThat(listingResult.body().utf8String()).isEqualTo(
-        """
-        {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"hello world"}],"isError":false}}
-        """.trim()
-    );
+    assertThat(listingResult.body().utf8String())
+        .isEqualTo(
+            """
+{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"hello world"}],"isError":false}}
+"""
+                .trim());
   }
 
   @Test
   public void listResourceTemplates() {
-    var listingResult = httpClient.POST("/mcp")
-        .withRequestBody(ContentTypes.APPLICATION_JSON,
-            """
-            {
-              "jsonrpc": "2.0",
-              "id": 3,
-              "method": "resources/templates/list"
-            }
-            """.getBytes(StandardCharsets.UTF_8)
-        ).invoke();
+    var listingResult =
+        httpClient
+            .POST("/mcp")
+            .withRequestBody(
+                ContentTypes.APPLICATION_JSON,
+                """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 3,
+                  "method": "resources/templates/list"
+                }
+                """
+                    .getBytes(StandardCharsets.UTF_8))
+            .invoke();
 
     assertThat(listingResult.status()).isEqualTo(StatusCodes.OK);
-    assertThat(listingResult.body().utf8String()).isEqualTo(
-        """
-        {"jsonrpc":"2.0","id":3,"result":{"resourceTemplates":[{"uriTemplate":"file:///dynamic/{path}","name":"Dynamic resource","mimeType":"text/plain"}]}}
-        """.trim()
-    );
+    assertThat(listingResult.body().utf8String())
+        .isEqualTo(
+            """
+{"jsonrpc":"2.0","id":3,"result":{"resourceTemplates":[{"uriTemplate":"file:///dynamic/{path}","name":"Dynamic resource","mimeType":"text/plain"}]}}
+"""
+                .trim());
   }
 
   @Test
   public void fetchResourceTemplate() {
-    var listingResult = httpClient.POST("/mcp")
-        .withRequestBody(ContentTypes.APPLICATION_JSON,
-            """
-            {"jsonrpc": "2.0","id": 2,"method": "resources/read","params": {"uri": "file:///dynamic/example.txt"}}
-            """.getBytes(StandardCharsets.UTF_8)
-        ).invoke();
+    var listingResult =
+        httpClient
+            .POST("/mcp")
+            .withRequestBody(
+                ContentTypes.APPLICATION_JSON,
+                """
+{"jsonrpc": "2.0","id": 2,"method": "resources/read","params": {"uri": "file:///dynamic/example.txt"}}
+"""
+                    .getBytes(StandardCharsets.UTF_8))
+            .invoke();
 
     assertThat(listingResult.status()).isEqualTo(StatusCodes.OK);
-    assertThat(listingResult.body().utf8String()).isEqualTo("""
-       {"jsonrpc":"2.0","id":2,"result":{"contents":[{"text":"This is a dynamic resource for example.txt","uri":"file:///dynamic/example.txt","mimeType":"text/plain"}]}}
-       """.trim()
-    );
+    assertThat(listingResult.body().utf8String())
+        .isEqualTo(
+            """
+{"jsonrpc":"2.0","id":2,"result":{"contents":[{"text":"This is a dynamic resource for example.txt","uri":"file:///dynamic/example.txt","mimeType":"text/plain"}]}}
+"""
+                .trim());
   }
 
   @Test
   public void listResources() {
-    var listingResult = httpClient.POST("/mcp")
-        .withRequestBody(ContentTypes.APPLICATION_JSON,
-            """
-            {"jsonrpc":"2.0","id":1,"method":"resources/list","params":{}}
-            """.getBytes(StandardCharsets.UTF_8)
-        ).invoke();
+    var listingResult =
+        httpClient
+            .POST("/mcp")
+            .withRequestBody(
+                ContentTypes.APPLICATION_JSON,
+                """
+                {"jsonrpc":"2.0","id":1,"method":"resources/list","params":{}}
+                """
+                    .getBytes(StandardCharsets.UTF_8))
+            .invoke();
 
     assertThat(listingResult.status()).isEqualTo(StatusCodes.OK);
-    assertThat(listingResult.body().utf8String()).isEqualTo(
-        """
-        {"jsonrpc":"2.0","id":1,"result":{"resources":[{"uri":"file:///example.pdf","name":"example binary resource","description":"a pdf as sample of a binary resource","mimeType":"application/pdf"},{"uri":"file:///example.txt","name":"example text","description":"a sample text file","mimeType":"text/plain"}]}}
-        """.trim()
-    );
+    assertThat(listingResult.body().utf8String())
+        .isEqualTo(
+            """
+{"jsonrpc":"2.0","id":1,"result":{"resources":[{"uri":"file:///example.pdf","name":"example binary resource","description":"a pdf as sample of a binary resource","mimeType":"application/pdf"},{"uri":"file:///example.txt","name":"example text","description":"a sample text file","mimeType":"text/plain"}]}}
+"""
+                .trim());
   }
 
   @Test
   public void fetchTextResource() {
-    var listingResult = httpClient.POST("/mcp")
-        .withRequestBody(ContentTypes.APPLICATION_JSON,
-            """
-            {"jsonrpc": "2.0","id": 2,"method": "resources/read","params": {"uri": "file:///example.txt"}}
-            """.getBytes(StandardCharsets.UTF_8)
-        ).invoke();
+    var listingResult =
+        httpClient
+            .POST("/mcp")
+            .withRequestBody(
+                ContentTypes.APPLICATION_JSON,
+                """
+{"jsonrpc": "2.0","id": 2,"method": "resources/read","params": {"uri": "file:///example.txt"}}
+"""
+                    .getBytes(StandardCharsets.UTF_8))
+            .invoke();
 
     assertThat(listingResult.status()).isEqualTo(StatusCodes.OK);
-    assertThat(listingResult.body().utf8String()).isEqualTo("""
-       {"jsonrpc":"2.0","id":2,"result":{"contents":[{"text":"This is an example resource","uri":"file:///example.txt","mimeType":"text/plain"}]}}
-       """.trim()
-    );
+    assertThat(listingResult.body().utf8String())
+        .isEqualTo(
+            """
+{"jsonrpc":"2.0","id":2,"result":{"contents":[{"text":"This is an example resource","uri":"file:///example.txt","mimeType":"text/plain"}]}}
+"""
+                .trim());
   }
 
   @Test
   public void fetchBinaryResource() throws Exception {
-    var listingResult = httpClient.POST("/mcp")
-        .withRequestBody(ContentTypes.APPLICATION_JSON,
-            """
-            {"jsonrpc": "2.0","id": 2,"method": "resources/read","params": {"uri": "file:///example.pdf"}}
-            """.getBytes(StandardCharsets.UTF_8)
-        ).invoke();
+    var listingResult =
+        httpClient
+            .POST("/mcp")
+            .withRequestBody(
+                ContentTypes.APPLICATION_JSON,
+                """
+{"jsonrpc": "2.0","id": 2,"method": "resources/read","params": {"uri": "file:///example.pdf"}}
+"""
+                    .getBytes(StandardCharsets.UTF_8))
+            .invoke();
 
     assertThat(listingResult.status()).isEqualTo(StatusCodes.OK);
 
-    var jsonTree = JsonSerializer.internalObjectMapper().readValue(listingResult.body().utf8String(), JsonNode.class);
+    var jsonTree =
+        JsonSerializer.internalObjectMapper()
+            .readValue(listingResult.body().utf8String(), JsonNode.class);
     if (jsonTree.has("error")) {
       fail("Response message [" + listingResult.body().utf8String() + "] is an error");
     }
     assertThat(jsonTree.get("result").get("contents")).hasSize(1);
     assertThat(jsonTree.get("result").get("contents").get(0).has("blob")).isTrue();
-    assertThat(jsonTree.get("result").get("contents").get(0).get("mimeType").asText()).isEqualTo("application/pdf");
+    assertThat(jsonTree.get("result").get("contents").get(0).get("mimeType").asText())
+        .isEqualTo("application/pdf");
   }
 
   @Test
   public void listPrompts() {
-    var listingResult = httpClient.POST("/mcp")
-        .withRequestBody(ContentTypes.APPLICATION_JSON,
-            """
-            {"jsonrpc":"2.0","id":1,"method":"prompts/list","params":{}}
-            """.getBytes(StandardCharsets.UTF_8)
-        ).invoke();
+    var listingResult =
+        httpClient
+            .POST("/mcp")
+            .withRequestBody(
+                ContentTypes.APPLICATION_JSON,
+                """
+                {"jsonrpc":"2.0","id":1,"method":"prompts/list","params":{}}
+                """
+                    .getBytes(StandardCharsets.UTF_8))
+            .invoke();
 
     assertThat(listingResult.status()).isEqualTo(StatusCodes.OK);
-    assertThat(listingResult.body().utf8String()).isEqualTo(
-        """
-        {"jsonrpc":"2.0","id":1,"result":{"prompts":[{"name":"code_review","description":"Code review prompt","arguments":[{"name":"code","description":"a prompt argument","required":true}]}]}}
-        """.trim()
-    );
+    assertThat(listingResult.body().utf8String())
+        .isEqualTo(
+            """
+{"jsonrpc":"2.0","id":1,"result":{"prompts":[{"name":"code_review","description":"Code review prompt","arguments":[{"name":"code","description":"a prompt argument","required":true}]}]}}
+"""
+                .trim());
   }
 
   @Test
   public void callAPrompt() {
-    var listingResult = httpClient.POST("/mcp")
-        .withRequestBody(ContentTypes.APPLICATION_JSON,
-            """
-            {
-             "jsonrpc": "2.0",
-             "id": 2,
-             "method": "prompts/get",
-             "params": {
-               "name": "code_review",
-               "arguments": {
-                 "code": "def hello():\\n    print('world')"
-               }
-             }
-           }
-           """.getBytes(StandardCharsets.UTF_8)
-        ).invoke();
+    var listingResult =
+        httpClient
+            .POST("/mcp")
+            .withRequestBody(
+                ContentTypes.APPLICATION_JSON,
+                """
+                 {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "method": "prompts/get",
+                  "params": {
+                    "name": "code_review",
+                    "arguments": {
+                      "code": "def hello():\\n    print('world')"
+                    }
+                  }
+                }
+                """
+                    .getBytes(StandardCharsets.UTF_8))
+            .invoke();
 
     assertThat(listingResult.status()).isEqualTo(StatusCodes.OK);
-    assertThat(listingResult.body().utf8String()).isEqualTo(
-        """
-        {"jsonrpc":"2.0","id":2,"result":{"description":"","messages":[{"content":{"type":"text","text":"Please review this Python code:\\\\ndef hello():\\n    print('world')"},"role":"user"}]}}
-        """.trim()
-    );
+    assertThat(listingResult.body().utf8String())
+        .isEqualTo(
+            """
+{"jsonrpc":"2.0","id":2,"result":{"description":"","messages":[{"content":{"type":"text","text":"Please review this Python code:\\\\ndef hello():\\n    print('world')"},"role":"user"}]}}
+"""
+                .trim());
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/Ok.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/Ok.java
@@ -5,5 +5,5 @@
 package akkajavasdk;
 
 public record Ok() {
-   public static Ok instance = new Ok();
+  public static Ok instance = new Ok();
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/Result.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/Result.java
@@ -11,13 +11,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Result.Success.class, name = "S"),
-  @JsonSubTypes.Type(value = Result.Error.class, name = "E")})
+  @JsonSubTypes.Type(value = Result.Error.class, name = "E")
+})
 public sealed interface Result<E, T> {
 
-  record Success<E, T>(
-    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
-    T value
-  ) implements Result<E, T> {
+  record Success<E, T>(@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS) T value) implements Result<E, T> {
     @Override
     public E error() {
       throw new IllegalStateException("Result is not an error");
@@ -34,10 +32,7 @@ public sealed interface Result<E, T> {
     }
   }
 
-  record Error<E, T>(
-    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
-    E value
-  ) implements Result<E, T> {
+  record Error<E, T>(@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS) E value) implements Result<E, T> {
     @Override
     public E error() {
       return value;

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/SdkIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/SdkIntegrationTest.java
@@ -4,6 +4,11 @@
 
 package akkajavasdk;
 
+import static akkajavasdk.components.pubsub.PublishVEToTopic.CUSTOMERS_TOPIC;
+import static java.time.Duration.ofMillis;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import akka.javasdk.Metadata;
 import akka.javasdk.agent.PromptTemplate;
 import akka.javasdk.client.EventSourcedEntityClient;
@@ -23,6 +28,10 @@ import akkajavasdk.components.keyvalueentities.user.UserEntity;
 import akkajavasdk.components.keyvalueentities.user.UserSideEffect;
 import akkajavasdk.components.views.counter.CountersByValue;
 import akkajavasdk.components.views.customer.CustomerByCreationTime;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNull;
@@ -31,16 +40,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
-import static akkajavasdk.components.pubsub.PublishVEToTopic.CUSTOMERS_TOPIC;
-import static java.time.Duration.ofMillis;
-import static java.time.temporal.ChronoUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(Junit5LogCapturing.class)
 public class SdkIntegrationTest extends TestKitSupport {
 
@@ -48,31 +47,31 @@ public class SdkIntegrationTest extends TestKitSupport {
   protected TestKit.Settings testKitSettings() {
     // here only to show how to set different `Settings` in a test.
     return TestKit.Settings.DEFAULT
-      .withTopicOutgoingMessages(CUSTOMERS_TOPIC)
-      //one defined here and one is the Setup class
-      .withDisabledComponents(Set.of(StageCounterEntity.class));
+        .withTopicOutgoingMessages(CUSTOMERS_TOPIC)
+        // one defined here and one is the Setup class
+        .withDisabledComponents(Set.of(StageCounterEntity.class));
   }
 
   @Test
   public void shouldCreatePromptTemplate() {
-    //given
+    // given
     var testPromptClient = componentClient.forEventSourcedEntity("test-prompt");
 
-    //when
+    // when
     testPromptClient.method(PromptTemplate::init).invoke("test prompt");
     testPromptClient.method(PromptTemplate::update).invoke("test prompt2");
     var result = testPromptClient.method(PromptTemplate::get).invoke();
 
-    //then
+    // then
     assertThat(result).isEqualTo("test prompt2");
   }
 
   @Test
   public void verifyIfComponentIsActiveBasedOnConfig() {
 
-    var result = await(componentClient.forKeyValueEntity("test")
-      .method(TestCounterEntity::get)
-      .invokeAsync());
+    var result =
+        await(
+            componentClient.forKeyValueEntity("test").method(TestCounterEntity::get).invokeAsync());
 
     assertThat(result).isEqualTo(100);
   }
@@ -80,35 +79,48 @@ public class SdkIntegrationTest extends TestKitSupport {
   @Test
   public void verifyIfComponentIsDisabledBasedOnConfig() {
 
-    var exc1 = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-      await(componentClient.forKeyValueEntity("test")
-        .method(ProdCounterEntity::get)
-        .invokeAsync());
-    });
+    var exc1 =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              await(
+                  componentClient
+                      .forKeyValueEntity("test")
+                      .method(ProdCounterEntity::get)
+                      .invokeAsync());
+            });
 
     assertThat(exc1.getMessage()).contains("Unknown entity type [prod-counter]");
 
-    var exc2 = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-      await(componentClient.forKeyValueEntity("test")
-        .method(StageCounterEntity::get)
-        .invokeAsync());
-    });
+    var exc2 =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              await(
+                  componentClient
+                      .forKeyValueEntity("test")
+                      .method(StageCounterEntity::get)
+                      .invokeAsync());
+            });
 
     assertThat(exc2.getMessage()).contains("Unknown entity type [stage-counter]");
   }
 
   @Test
   public void verifyUserConfig() {
-    var result = await(componentClient.forKeyValueEntity("test")
-        .method(TestCounterEntity::getUserConfigKeys)
-        .invokeAsync(Set.of(
-            // user defined config
-            "user-app.config-value",
-            // should also be able to read sdk config
-            "akka.javasdk.dev-mode.service-name",
-            // but not other akka settings
-            "akka.actor.provider"
-            )));
+    var result =
+        await(
+            componentClient
+                .forKeyValueEntity("test")
+                .method(TestCounterEntity::getUserConfigKeys)
+                .invokeAsync(
+                    Set.of(
+                        // user defined config
+                        "user-app.config-value",
+                        // should also be able to read sdk config
+                        "akka.javasdk.dev-mode.service-name",
+                        // but not other akka settings
+                        "akka.actor.provider")));
 
     // from src/test/resources/application.conf
     assertThat(result).containsEntry("user-app.config-value", "some value");
@@ -119,86 +131,108 @@ public class SdkIntegrationTest extends TestKitSupport {
   @Test
   public void verifyEchoActionWiring() {
 
-    timerScheduler.createSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
-      .method(EchoAction::stringMessage)
-      .deferred("hello"));
+    timerScheduler.createSingleTimer(
+        "echo-action",
+        ofMillis(0),
+        componentClient.forTimedAction().method(EchoAction::stringMessage).deferred("hello"));
 
     Awaitility.await()
-      .atMost(20, TimeUnit.SECONDS)
-      .untilAsserted(() -> {
-        var value = StaticTestBuffer.getValue("echo-action");
-        assertThat(value).isEqualTo("hello");
-      });
+        .atMost(20, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var value = StaticTestBuffer.getValue("echo-action");
+              assertThat(value).isEqualTo("hello");
+            });
   }
 
   @Test
   public void verifyHierarchyTimedActionWiring() {
 
-    timerScheduler.createSingleTimer("wired", ofMillis(0), componentClient.forTimedAction()
-      .method(HierarchyTimed::stringMessage)
-      .deferred("hello"));
+    timerScheduler.createSingleTimer(
+        "wired",
+        ofMillis(0),
+        componentClient.forTimedAction().method(HierarchyTimed::stringMessage).deferred("hello"));
 
     Awaitility.await()
-      .atMost(20, TimeUnit.SECONDS)
-      .untilAsserted(() -> {
-        var value = StaticTestBuffer.getValue("hierarchy-action");
-        assertThat(value).isEqualTo("hello");
-      });
+        .atMost(20, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var value = StaticTestBuffer.getValue("hierarchy-action");
+              assertThat(value).isEqualTo("hello");
+            });
   }
 
   @Test
   public void verifyTimedActionListCommand() {
 
-    timerScheduler.createSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
-      .method(EchoAction::stringMessages)
-      .deferred(List.of("hello", "mr")));
+    timerScheduler.createSingleTimer(
+        "echo-action",
+        ofMillis(0),
+        componentClient
+            .forTimedAction()
+            .method(EchoAction::stringMessages)
+            .deferred(List.of("hello", "mr")));
 
     Awaitility.await()
-      .atMost(20, TimeUnit.SECONDS)
-      .untilAsserted(() -> {
-        var value = StaticTestBuffer.getValue("echo-action");
-        assertThat(value).isEqualTo("hello mr");
-      });
+        .atMost(20, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var value = StaticTestBuffer.getValue("echo-action");
+              assertThat(value).isEqualTo("hello mr");
+            });
 
-    timerScheduler.createSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
-      .method(EchoAction::commandMessages)
-      .deferred(List.of(new EchoAction.SomeCommand("tambourine"), new EchoAction.SomeCommand("man"))));
+    timerScheduler.createSingleTimer(
+        "echo-action",
+        ofMillis(0),
+        componentClient
+            .forTimedAction()
+            .method(EchoAction::commandMessages)
+            .deferred(
+                List.of(
+                    new EchoAction.SomeCommand("tambourine"), new EchoAction.SomeCommand("man"))));
 
     Awaitility.await()
-      .atMost(20, TimeUnit.SECONDS)
-      .untilAsserted(() -> {
-        var value = StaticTestBuffer.getValue("echo-action");
-        assertThat(value).isEqualTo("tambourine man");
-      });
+        .atMost(20, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var value = StaticTestBuffer.getValue("echo-action");
+              assertThat(value).isEqualTo("tambourine man");
+            });
   }
 
   @Test
   public void verifyTimedActionEmpty() {
-    timerScheduler.createSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
-      .method(EchoAction::emptyMessage)
-      .deferred());
+    timerScheduler.createSingleTimer(
+        "echo-action",
+        ofMillis(0),
+        componentClient.forTimedAction().method(EchoAction::emptyMessage).deferred());
 
     Awaitility.await()
-      .atMost(20, TimeUnit.SECONDS)
-      .untilAsserted(() -> {
-        var value = StaticTestBuffer.getValue("echo-action");
-        assertThat(value).isEqualTo("empty");
-      });
+        .atMost(20, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var value = StaticTestBuffer.getValue("echo-action");
+              assertThat(value).isEqualTo("empty");
+            });
   }
 
   @Test
   public void verifyTimedActionRunsOnVirtualThread() {
-    timerScheduler.createSingleTimer("echo-action", ofMillis(0), componentClient.forTimedAction()
-        .method(EchoAction::stringMessage)
-        .deferred("check-if-virtual-thread"));
+    timerScheduler.createSingleTimer(
+        "echo-action",
+        ofMillis(0),
+        componentClient
+            .forTimedAction()
+            .method(EchoAction::stringMessage)
+            .deferred("check-if-virtual-thread"));
 
     Awaitility.await()
         .atMost(20, TimeUnit.SECONDS)
-        .untilAsserted(() -> {
-          var value = StaticTestBuffer.getValue("echo-action");
-          assertThat(value).isEqualTo("is-virtual-thread:true");
-        });
-
+        .untilAsserted(
+            () -> {
+              var value = StaticTestBuffer.getValue("echo-action");
+              assertThat(value).isEqualTo("is-virtual-thread:true");
+            });
   }
 
   @Test
@@ -207,21 +241,26 @@ public class SdkIntegrationTest extends TestKitSupport {
     // WHEN the CounterEntity is requested to increase 42\
     String entityId = "hello1";
     await(
-      componentClient.forEventSourcedEntity(entityId)
-        .method(CounterEntity::increase)
-        .invokeAsync(42));
+        componentClient
+            .forEventSourcedEntity(entityId)
+            .method(CounterEntity::increase)
+            .invokeAsync(42));
 
     // THEN IncreaseAction receives the event 42 and increases the counter 1 more
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(10, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        Integer result = await(
-          componentClient.forEventSourcedEntity(entityId)
-            .method(CounterEntity::get).invokeAsync());
+        .ignoreExceptions()
+        .atMost(10, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              Integer result =
+                  await(
+                      componentClient
+                          .forEventSourcedEntity(entityId)
+                          .method(CounterEntity::get)
+                          .invokeAsync());
 
-        assertThat(result).isEqualTo(43); //42 +1
-      });
+              assertThat(result).isEqualTo(43); // 42 +1
+            });
   }
 
   @Test
@@ -234,51 +273,57 @@ public class SdkIntegrationTest extends TestKitSupport {
 
     assertThat(lastKnownValue).isEqualTo(1 * 2 + 1234);
 
-    //Once the action IncreaseActionWithIgnore processes event 1234 it adds 1 more to the counter
+    // Once the action IncreaseActionWithIgnore processes event 1234 it adds 1 more to the counter
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(10, TimeUnit.SECONDS)
-      .untilAsserted(() -> {
-        Integer result = await(
-          componentClient.forEventSourcedEntity(entityId)
-            .method(CounterEntity::get).invokeAsync());
+        .ignoreExceptions()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              Integer result =
+                  await(
+                      componentClient
+                          .forEventSourcedEntity(entityId)
+                          .method(CounterEntity::get)
+                          .invokeAsync());
 
-        assertThat(result).isEqualTo(1 * 2 + 1234 + 1);
-      });
+              assertThat(result).isEqualTo(1 * 2 + 1234 + 1);
+            });
   }
-
 
   @Test
   public void verifyFindCounterByValue() {
 
-    var emptyCounter = await(
-      componentClient.forView()
-        .method(CountersByValue::getCounterByValue)
-        .invokeAsync(CountersByValue.queryParam(101)));
+    var emptyCounter =
+        await(
+            componentClient
+                .forView()
+                .method(CountersByValue::getCounterByValue)
+                .invokeAsync(CountersByValue.queryParam(101)));
 
     assertThat(emptyCounter).isEmpty();
 
     await(
-      componentClient.forEventSourcedEntity("abc")
-        .method(CounterEntity::increase)
-        .invokeAsync(101));
-
+        componentClient
+            .forEventSourcedEntity("abc")
+            .method(CounterEntity::increase)
+            .invokeAsync(101));
 
     // the view is eventually updated
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(15, TimeUnit.of(SECONDS))
-      .untilAsserted(
-        () -> {
-          var byValue = await(
-            componentClient.forView()
-              .method(CountersByValue::getCounterByValue)
-              .invokeAsync(CountersByValue.queryParam(101)));
+        .ignoreExceptions()
+        .atMost(15, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var byValue =
+                  await(
+                      componentClient
+                          .forView()
+                          .method(CountersByValue::getCounterByValue)
+                          .invokeAsync(CountersByValue.queryParam(101)));
 
-          assertThat(byValue).hasValue(new Counter(101));
-        });
+              assertThat(byValue).hasValue(new Counter(101));
+            });
   }
-
 
   @Test
   public void verifyUserSubscriptionAction() {
@@ -288,27 +333,28 @@ public class SdkIntegrationTest extends TestKitSupport {
     createUser(user);
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(15, TimeUnit.of(SECONDS))
-      .until(() -> UserSideEffect.getUsers().get(user.id()),
-        new IsEqual(new User(user.name(), user.email())));
+        .ignoreExceptions()
+        .atMost(15, TimeUnit.of(SECONDS))
+        .until(
+            () -> UserSideEffect.getUsers().get(user.id()),
+            new IsEqual(new User(user.name(), user.email())));
 
     deleteUser(user);
 
-    var isDeleted = await(componentClient
-      .forKeyValueEntity(user.id())
-      .method(UserEntity::getDelete)
-      .invokeAsync());
+    var isDeleted =
+        await(
+            componentClient
+                .forKeyValueEntity(user.id())
+                .method(UserEntity::getDelete)
+                .invokeAsync());
 
     assertThat(isDeleted).isEqualTo(true);
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(15, TimeUnit.of(SECONDS))
-      .until(() -> UserSideEffect.getUsers().get(user.id()),
-        new IsNull<>());
+        .ignoreExceptions()
+        .atMost(15, TimeUnit.of(SECONDS))
+        .until(() -> UserSideEffect.getUsers().get(user.id()), new IsNull<>());
   }
-
 
   @Test
   public void verifyActionWithMetadata() {
@@ -317,18 +363,23 @@ public class SdkIntegrationTest extends TestKitSupport {
     String veHeaderValue = "ve-value";
     String esHeaderValue = "es-value";
 
-    timerScheduler.createSingleTimer("metadata", ofMillis(0), componentClient.forTimedAction()
-      .method(ActionWithMetadata::processWithMeta)
-      .withMetadata(Metadata.EMPTY.add(ActionWithMetadata.SOME_HEADER, metadataValue))
-      .deferred());
+    timerScheduler.createSingleTimer(
+        "metadata",
+        ofMillis(0),
+        componentClient
+            .forTimedAction()
+            .method(ActionWithMetadata::processWithMeta)
+            .withMetadata(Metadata.EMPTY.add(ActionWithMetadata.SOME_HEADER, metadataValue))
+            .deferred());
 
     Awaitility.await()
-      .atMost(20, TimeUnit.SECONDS)
-      .ignoreExceptions()
-      .untilAsserted(() -> {
-        var header = StaticTestBuffer.getValue(ActionWithMetadata.SOME_HEADER);
-        assertThat(header).isEqualTo(metadataValue);
-      });
+        .atMost(20, TimeUnit.SECONDS)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              var header = StaticTestBuffer.getValue(ActionWithMetadata.SOME_HEADER);
+              assertThat(header).isEqualTo(metadataValue);
+            });
   }
 
   @Test
@@ -339,60 +390,56 @@ public class SdkIntegrationTest extends TestKitSupport {
 
     // the view is eventually updated
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.SECONDS)
-      .until(() -> getCustomersByCreationDate(now).size(), new IsEqual(1));
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.SECONDS)
+        .until(() -> getCustomersByCreationDate(now).size(), new IsEqual(1));
 
     var later = now.plusSeconds(60 * 5);
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.SECONDS)
-      .until(() -> getCustomersByCreationDate(later).size(), new IsEqual(0));
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.SECONDS)
+        .until(() -> getCustomersByCreationDate(later).size(), new IsEqual(0));
   }
 
   private void createUser(TestUser user) {
     Ok userCreation =
-      await(
-        componentClient.forKeyValueEntity(user.id())
-          .method(UserEntity::createOrUpdateUser)
-          .invokeAsync(new UserEntity.CreatedUser(user.name(), user.email())));
+        await(
+            componentClient
+                .forKeyValueEntity(user.id())
+                .method(UserEntity::createOrUpdateUser)
+                .invokeAsync(new UserEntity.CreatedUser(user.name(), user.email())));
     assertThat(userCreation).isEqualTo(Ok.instance);
   }
-
 
   private void createCustomer(CustomerEntity.Customer customer) {
 
     Ok created =
-      await(
-        componentClient
-          .forKeyValueEntity(customer.name())
-          .method(CustomerEntity::create)
-          .invokeAsync(customer));
+        await(
+            componentClient
+                .forKeyValueEntity(customer.name())
+                .method(CustomerEntity::create)
+                .invokeAsync(customer));
 
     assertThat(created).isEqualTo(Ok.instance);
   }
 
-
   @NotNull
   private List<CustomerEntity.Customer> getCustomersByCreationDate(Instant createdOn) {
     return await(
-      componentClient.forView()
-        .method(CustomerByCreationTime::getCustomerByTime)
-        .invokeAsync(new CustomerByCreationTime.QueryParameters(createdOn)))
-      .customers();
+            componentClient
+                .forView()
+                .method(CustomerByCreationTime::getCustomerByTime)
+                .invokeAsync(new CustomerByCreationTime.QueryParameters(createdOn)))
+        .customers();
   }
-
 
   private void deleteUser(TestUser user) {
     Ok userDeleted =
-      await(
-        componentClient
-          .forKeyValueEntity(user.id())
-          .method(UserEntity::deleteUser)
-          .invokeAsync(new UserEntity.Delete()));
+        await(
+            componentClient
+                .forKeyValueEntity(user.id())
+                .method(UserEntity::deleteUser)
+                .invokeAsync(new UserEntity.Delete()));
     assertThat(userDeleted).isEqualTo(Ok.instance);
   }
-
-
 }
-

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/WorkflowTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/WorkflowTest.java
@@ -4,6 +4,10 @@
 
 package akkajavasdk;
 
+import static akkajavasdk.components.workflowentities.TransferConsumer.TRANSFER_CONSUMER_STORE;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import akka.javasdk.CommandException;
 import akka.javasdk.testkit.TestKitSupport;
 import akkajavasdk.components.MyException;
@@ -26,21 +30,16 @@ import akkajavasdk.components.workflowentities.WorkflowWithTimeout;
 import akkajavasdk.components.workflowentities.WorkflowWithTimer;
 import akkajavasdk.components.workflowentities.WorkflowWithoutInitialState;
 import akkajavasdk.components.workflowentities.hierarchy.TextWorkflow;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-
-import static akkajavasdk.components.workflowentities.TransferConsumer.TRANSFER_CONSUMER_STORE;
-import static java.time.temporal.ChronoUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(Junit5LogCapturing.class)
 public class WorkflowTest extends TestKitSupport {
@@ -56,9 +55,11 @@ public class WorkflowTest extends TestKitSupport {
     var transferId = randomTransferId();
     var transfer = new Transfer(walletId1, walletId2, -10);
 
-    Message message = componentClient.forWorkflow(transferId)
-          .method(TransferWorkflow::startTransfer)
-          .invoke(transfer);
+    Message message =
+        componentClient
+            .forWorkflow(transferId)
+            .method(TransferWorkflow::startTransfer)
+            .invoke(transfer);
 
     assertThat(message.text()).isEqualTo("Transfer amount should be greater than zero");
   }
@@ -72,48 +73,49 @@ public class WorkflowTest extends TestKitSupport {
     var transferId = randomTransferId();
     var transfer = new Transfer(walletId1, walletId2, 10);
 
-
-    Message response = componentClient.forWorkflow(transferId)
-        .method(TransferWorkflow::startTransfer)
-        .invoke(transfer);
+    Message response =
+        componentClient
+            .forWorkflow(transferId)
+            .method(TransferWorkflow::startTransfer)
+            .invoke(transfer);
 
     assertThat(response.text()).contains("transfer started");
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var balance1 = getWalletBalance(walletId1);
-        var balance2 = getWalletBalance(walletId2);
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var balance1 = getWalletBalance(walletId1);
+              var balance2 = getWalletBalance(walletId2);
 
-        assertThat(balance1).isEqualTo(90);
-        assertThat(balance2).isEqualTo(110);
-      });
-
+              assertThat(balance1).isEqualTo(90);
+              assertThat(balance2).isEqualTo(110);
+            });
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        // this is mostly to verify that the last step (Runnable + Supplier) worked as expect
-        String lastStep =
-          componentClient.forWorkflow(transferId)
-            .method(TransferWorkflow::getLastStep).invoke().text();
-        assertThat(lastStep).isEqualTo("logAndStop");
-      });
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              // this is mostly to verify that the last step (Runnable + Supplier) worked as expect
+              String lastStep =
+                  componentClient
+                      .forWorkflow(transferId)
+                      .method(TransferWorkflow::getLastStep)
+                      .invoke()
+                      .text();
+              assertThat(lastStep).isEqualTo("logAndStop");
+            });
 
-    var isDeleted = componentClient.forWorkflow(transferId)
-      .method(TransferWorkflow::hasBeenDeleted)
-      .invoke();
+    var isDeleted =
+        componentClient.forWorkflow(transferId).method(TransferWorkflow::hasBeenDeleted).invoke();
     assertThat(isDeleted).isFalse();
 
-    componentClient.forWorkflow(transferId)
-      .method(TransferWorkflow::delete)
-      .invoke();
+    componentClient.forWorkflow(transferId).method(TransferWorkflow::delete).invoke();
 
-    var isDeletedAfterDeletion = componentClient.forWorkflow(transferId)
-      .method(TransferWorkflow::hasBeenDeleted)
-      .invoke();
+    var isDeletedAfterDeletion =
+        componentClient.forWorkflow(transferId).method(TransferWorkflow::hasBeenDeleted).invoke();
     assertThat(isDeletedAfterDeletion).isTrue();
   }
 
@@ -124,13 +126,13 @@ public class WorkflowTest extends TestKitSupport {
     var transferId = randomTransferId();
     var transfer = new Transfer(walletId1, walletId2, 10);
 
-    componentClient.forWorkflow(transferId)
-      .method(TransferWorkflow::updateAndDelete)
-      .invoke(transfer);
+    componentClient
+        .forWorkflow(transferId)
+        .method(TransferWorkflow::updateAndDelete)
+        .invoke(transfer);
 
-    var isDeleted = componentClient.forWorkflow(transferId)
-      .method(TransferWorkflow::hasBeenDeleted)
-      .invoke();
+    var isDeleted =
+        componentClient.forWorkflow(transferId).method(TransferWorkflow::hasBeenDeleted).invoke();
     assertThat(isDeleted).isTrue();
   }
 
@@ -145,51 +147,51 @@ public class WorkflowTest extends TestKitSupport {
     var transfer1 = new Transfer(walletId1, walletId2, 10);
     var transfer2 = new Transfer(walletId1, walletId2, 20);
 
-    componentClient.forWorkflow(transferId1)
-      .method(TransferWorkflow::startTransfer)
-      .invoke(transfer1);
-    componentClient.forWorkflow(transferId2)
-      .method(TransferWorkflow::startTransfer)
-      .invoke(transfer2);
+    componentClient
+        .forWorkflow(transferId1)
+        .method(TransferWorkflow::startTransfer)
+        .invoke(transfer1);
+    componentClient
+        .forWorkflow(transferId2)
+        .method(TransferWorkflow::startTransfer)
+        .invoke(transfer2);
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var transferState1 = DummyTransferStore.get(TRANSFER_CONSUMER_STORE, transferId1);
-        var transferState2 = DummyTransferStore.get(TRANSFER_CONSUMER_STORE, transferId2);
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var transferState1 = DummyTransferStore.get(TRANSFER_CONSUMER_STORE, transferId1);
+              var transferState2 = DummyTransferStore.get(TRANSFER_CONSUMER_STORE, transferId2);
 
-        assertThat(transferState1.transfer()).isEqualTo(transfer1);
-        assertThat(transferState2.transfer()).isEqualTo(transfer2);
+              assertThat(transferState1.transfer()).isEqualTo(transfer1);
+              assertThat(transferState2.transfer()).isEqualTo(transfer2);
 
-        var result = componentClient.forView().method(TransferView::getAll).invoke();
-        assertThat(result.entries()).contains(
-          new TransferView.TransferEntry(transferId1, true),
-          new TransferView.TransferEntry(transferId2, true));
-      });
+              var result = componentClient.forView().method(TransferView::getAll).invoke();
+              assertThat(result.entries())
+                  .contains(
+                      new TransferView.TransferEntry(transferId1, true),
+                      new TransferView.TransferEntry(transferId2, true));
+            });
 
-    componentClient.forWorkflow(transferId1)
-      .method(TransferWorkflow::delete)
-      .invoke();
+    componentClient.forWorkflow(transferId1).method(TransferWorkflow::delete).invoke();
 
-    var state = componentClient.forWorkflow(transferId1)
-      .method(TransferWorkflow::get)
-      .invoke();
+    var state = componentClient.forWorkflow(transferId1).method(TransferWorkflow::get).invoke();
     assertThat(state).isEqualTo(TransferState.EMPTY);
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var transferState1 = DummyTransferStore.get(TRANSFER_CONSUMER_STORE, transferId1);
-        assertThat(transferState1).isNull();
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var transferState1 = DummyTransferStore.get(TRANSFER_CONSUMER_STORE, transferId1);
+              assertThat(transferState1).isNull();
 
-        var result = componentClient.forView().method(TransferView::getAll).invoke();
-        assertThat(result.entries()).containsOnly(
-          new TransferView.TransferEntry(transferId2, true));
-      });
+              var result = componentClient.forView().method(TransferView::getAll).invoke();
+              assertThat(result.entries())
+                  .containsOnly(new TransferView.TransferEntry(transferId2, true));
+            });
   }
-
 
   @Test
   public void shouldTransferMoneyWithoutStepInputs() {
@@ -201,22 +203,24 @@ public class WorkflowTest extends TestKitSupport {
     var transfer = new Transfer(walletId1, walletId2, 10);
 
     Message response =
-      componentClient.forWorkflow(transferId)
-        .method(TransferWorkflowWithoutInputs::startTransfer)
-        .invoke(transfer);
+        componentClient
+            .forWorkflow(transferId)
+            .method(TransferWorkflowWithoutInputs::startTransfer)
+            .invoke(transfer);
 
     assertThat(response.text()).contains("transfer started");
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var balance1 = getWalletBalance(walletId1);
-        var balance2 = getWalletBalance(walletId2);
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var balance1 = getWalletBalance(walletId1);
+              var balance2 = getWalletBalance(walletId2);
 
-        assertThat(balance1).isEqualTo(90);
-        assertThat(balance2).isEqualTo(110);
-      });
+              assertThat(balance1).isEqualTo(90);
+              assertThat(balance2).isEqualTo(110);
+            });
   }
 
   @Test
@@ -228,24 +232,25 @@ public class WorkflowTest extends TestKitSupport {
     var transferId = randomTransferId();
     var transfer = new Transfer(walletId1, walletId2, 10);
 
-
     Message response =
-      componentClient.forWorkflow(transferId)
-        .method(TransferWorkflowWithoutInputs::startTransferAsync)
-        .invoke(transfer);
+        componentClient
+            .forWorkflow(transferId)
+            .method(TransferWorkflowWithoutInputs::startTransferAsync)
+            .invoke(transfer);
 
     assertThat(response.text()).contains("transfer started");
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var balance1 = getWalletBalance(walletId1);
-        var balance2 = getWalletBalance(walletId2);
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var balance1 = getWalletBalance(walletId1);
+              var balance2 = getWalletBalance(walletId2);
 
-        assertThat(balance1).isEqualTo(90);
-        assertThat(balance2).isEqualTo(110);
-      });
+              assertThat(balance1).isEqualTo(90);
+              assertThat(balance2).isEqualTo(110);
+            });
   }
 
   @Test
@@ -257,24 +262,25 @@ public class WorkflowTest extends TestKitSupport {
     var transferId = randomTransferId();
     var transfer = new Transfer(walletId1, walletId2, 10);
 
-
     Message response =
-      componentClient.forWorkflow(transferId)
-        .method(TransferWorkflowWithFraudDetection::startTransfer)
-        .invoke(transfer);
+        componentClient
+            .forWorkflow(transferId)
+            .method(TransferWorkflowWithFraudDetection::startTransfer)
+            .invoke(transfer);
 
     assertThat(response.text()).contains("transfer started");
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var balance1 = getWalletBalance(walletId1);
-        var balance2 = getWalletBalance(walletId2);
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var balance1 = getWalletBalance(walletId1);
+              var balance2 = getWalletBalance(walletId2);
 
-        assertThat(balance1).isEqualTo(90);
-        assertThat(balance2).isEqualTo(110);
-      });
+              assertThat(balance1).isEqualTo(90);
+              assertThat(balance2).isEqualTo(110);
+            });
   }
 
   @Test
@@ -287,51 +293,53 @@ public class WorkflowTest extends TestKitSupport {
     var transfer = new Transfer(walletId1, walletId2, 1000);
 
     Message response =
-      componentClient.forWorkflow(transferId)
-        .method(TransferWorkflowWithFraudDetection::startTransfer)
-        .invoke(transfer);
+        componentClient
+            .forWorkflow(transferId)
+            .method(TransferWorkflowWithFraudDetection::startTransfer)
+            .invoke(transfer);
 
     assertThat(response.text()).contains("transfer started");
 
     Awaitility.await()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var transferState =
+                  componentClient
+                      .forWorkflow(transferId)
+                      .method(TransferWorkflowWithFraudDetection::getTransferState)
+                      .invoke();
 
-        var transferState =
-          componentClient.forWorkflow(transferId)
-            .method(TransferWorkflowWithFraudDetection::getTransferState)
-            .invoke();
-
-        assertThat(transferState.finished()).isFalse();
-        assertThat(transferState.accepted()).isFalse();
-        assertThat(transferState.lastStep()).isEqualTo("fraud-detection");
-      });
-
-
-    Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-
-        Message acceptedResponse =
-          componentClient.forWorkflow(transferId)
-            .method(TransferWorkflowWithFraudDetection::acceptTransfer)
-            .invoke();
-
-        assertThat(acceptedResponse.text()).isEqualTo("transfer accepted");
-      });
-
+              assertThat(transferState.finished()).isFalse();
+              assertThat(transferState.accepted()).isFalse();
+              assertThat(transferState.lastStep()).isEqualTo("fraud-detection");
+            });
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var balance1 = getWalletBalance(walletId1);
-        var balance2 = getWalletBalance(walletId2);
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              Message acceptedResponse =
+                  componentClient
+                      .forWorkflow(transferId)
+                      .method(TransferWorkflowWithFraudDetection::acceptTransfer)
+                      .invoke();
 
-        assertThat(balance1).isEqualTo(99000);
-        assertThat(balance2).isEqualTo(101000);
-      });
+              assertThat(acceptedResponse.text()).isEqualTo("transfer accepted");
+            });
+
+    Awaitility.await()
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var balance1 = getWalletBalance(walletId1);
+              var balance2 = getWalletBalance(walletId2);
+
+              assertThat(balance1).isEqualTo(99000);
+              assertThat(balance2).isEqualTo(101000);
+            });
   }
 
   @Test
@@ -343,294 +351,308 @@ public class WorkflowTest extends TestKitSupport {
     var transferId = randomTransferId();
     var transfer = new Transfer(walletId1, walletId2, 1000000);
 
-
     Message response =
-      componentClient.forWorkflow(transferId)
-        .method(TransferWorkflowWithFraudDetection::startTransfer)
-        .invoke(transfer);
+        componentClient
+            .forWorkflow(transferId)
+            .method(TransferWorkflowWithFraudDetection::startTransfer)
+            .invoke(transfer);
 
     assertThat(response.text()).contains("transfer started");
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var balance1 = getWalletBalance(walletId1);
-        var balance2 = getWalletBalance(walletId2);
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var balance1 = getWalletBalance(walletId1);
+              var balance2 = getWalletBalance(walletId2);
 
-        assertThat(balance1).isEqualTo(100);
-        assertThat(balance2).isEqualTo(100);
+              assertThat(balance1).isEqualTo(100);
+              assertThat(balance2).isEqualTo(100);
 
-        var transferState =
-          componentClient.forWorkflow(transferId)
-            .method(TransferWorkflowWithFraudDetection::getTransferState)
-            .invoke();
+              var transferState =
+                  componentClient
+                      .forWorkflow(transferId)
+                      .method(TransferWorkflowWithFraudDetection::getTransferState)
+                      .invoke();
 
-        assertThat(transferState.finished()).isTrue();
-        assertThat(transferState.accepted()).isFalse();
-        assertThat(transferState.lastStep()).isEqualTo("fraud-detection");
-      });
+              assertThat(transferState.finished()).isTrue();
+              assertThat(transferState.accepted()).isFalse();
+              assertThat(transferState.lastStep()).isEqualTo("fraud-detection");
+            });
   }
 
   @Test
   public void shouldRecoverFailingCounterWorkflowWithDefaultRecoverStrategy() {
-    //given
+    // given
     var counterId = randomId();
     var workflowId = randomId();
 
-    //when
+    // when
     Message response =
-      componentClient.forWorkflow(workflowId)
-        .method(WorkflowWithDefaultRecoverStrategy::startFailingCounter)
-        .invoke(counterId);
+        componentClient
+            .forWorkflow(workflowId)
+            .method(WorkflowWithDefaultRecoverStrategy::startFailingCounter)
+            .invoke(counterId);
 
     assertThat(response.text()).isEqualTo("workflow started");
 
-    //then
+    // then
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        Integer counterValue = getFailingCounterValue(counterId);
-        assertThat(counterValue).isEqualTo(3);
-      });
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              Integer counterValue = getFailingCounterValue(counterId);
+              assertThat(counterValue).isEqualTo(3);
+            });
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var state =
-          componentClient.forWorkflow(workflowId)
-            .method(WorkflowWithDefaultRecoverStrategy::get)
-            .invoke();
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var state =
+                  componentClient
+                      .forWorkflow(workflowId)
+                      .method(WorkflowWithDefaultRecoverStrategy::get)
+                      .invoke();
 
-        assertThat(state.finished()).isTrue();
-      });
+              assertThat(state.finished()).isTrue();
+            });
   }
 
   @Test
   public void shouldRecoverFailingCounterWorkflowWithRecoverStrategy() {
-    //given
+    // given
     var counterId = randomId();
     var workflowId = randomId();
 
-    //when
+    // when
     Message response =
-      componentClient.forWorkflow(workflowId)
-        .method(WorkflowWithRecoverStrategy::startFailingCounter)
-        .invoke(counterId);
+        componentClient
+            .forWorkflow(workflowId)
+            .method(WorkflowWithRecoverStrategy::startFailingCounter)
+            .invoke(counterId);
 
     assertThat(response.text()).isEqualTo("workflow started");
 
-    //then
+    // then
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        Integer counterValue = getFailingCounterValue(counterId);
-        assertThat(counterValue).isEqualTo(3);
-      });
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              Integer counterValue = getFailingCounterValue(counterId);
+              assertThat(counterValue).isEqualTo(3);
+            });
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var state =
-          componentClient.forWorkflow(workflowId)
-            .method(WorkflowWithRecoverStrategy::get)
-            .invoke();
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var state =
+                  componentClient
+                      .forWorkflow(workflowId)
+                      .method(WorkflowWithRecoverStrategy::get)
+                      .invoke();
 
-        assertThat(state.finished()).isTrue();
-      });
+              assertThat(state.finished()).isTrue();
+            });
   }
 
   @Test
   public void shouldRecoverFailingCounterWorkflowWithRecoverStrategyAndAsyncCall() {
-    //given
+    // given
     var counterId = randomId();
     var workflowId = randomId();
 
-    //when
+    // when
     Message response =
-      componentClient.forWorkflow(workflowId)
-        .method(WorkflowWithRecoverStrategyAndAsyncCall::startFailingCounter)
-        .invoke(counterId);
+        componentClient
+            .forWorkflow(workflowId)
+            .method(WorkflowWithRecoverStrategyAndAsyncCall::startFailingCounter)
+            .invoke(counterId);
 
     assertThat(response.text()).isEqualTo("workflow started");
 
-    //then
+    // then
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        Integer counterValue = getFailingCounterValue(counterId);
-        assertThat(counterValue).isEqualTo(3);
-      });
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              Integer counterValue = getFailingCounterValue(counterId);
+              assertThat(counterValue).isEqualTo(3);
+            });
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var state = await(
-          componentClient.forWorkflow(workflowId)
-            .method(WorkflowWithRecoverStrategyAndAsyncCall::get)
-            .invokeAsync());
-        assertThat(state.finished()).isTrue();
-      });
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var state =
+                  await(
+                      componentClient
+                          .forWorkflow(workflowId)
+                          .method(WorkflowWithRecoverStrategyAndAsyncCall::get)
+                          .invokeAsync());
+              assertThat(state.finished()).isTrue();
+            });
   }
 
   @Test
   public void shouldRecoverWorkflowTimeout() {
-    //given
+    // given
     var counterId = randomId();
     var workflowId = randomId();
 
-    //when
+    // when
     Message response =
-      componentClient.forWorkflow(workflowId)
-        .method(WorkflowWithTimeout::startFailingCounter)
-        .invoke(counterId);
+        componentClient
+            .forWorkflow(workflowId)
+            .method(WorkflowWithTimeout::startFailingCounter)
+            .invoke(counterId);
 
     assertThat(response.text()).isEqualTo("workflow started");
 
-    //then
+    // then
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(15, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        Integer counterValue = getFailingCounterValue(counterId);
-        assertThat(counterValue).isEqualTo(3);
-      });
+        .ignoreExceptions()
+        .atMost(15, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              Integer counterValue = getFailingCounterValue(counterId);
+              assertThat(counterValue).isEqualTo(3);
+            });
 
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var state =
-          componentClient.forWorkflow(workflowId)
-            .method(WorkflowWithTimeout::get)
-            .invoke();
-        assertThat(state.finished()).isTrue();
-      });
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var state =
+                  componentClient.forWorkflow(workflowId).method(WorkflowWithTimeout::get).invoke();
+              assertThat(state.finished()).isTrue();
+            });
   }
 
   @Test
   public void shouldRecoverWorkflowStepTimeout() {
-    //given
+    // given
     var counterId = randomId();
     var workflowId = randomId();
 
-    //when
+    // when
     Message response =
-      componentClient.forWorkflow(workflowId)
-        .method(WorkflowWithStepTimeout::startFailingCounter)
-        .invoke(counterId);
+        componentClient
+            .forWorkflow(workflowId)
+            .method(WorkflowWithStepTimeout::startFailingCounter)
+            .invoke(counterId);
 
     assertThat(response.text()).isEqualTo("workflow started");
 
-    //then
+    // then
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var state =
-          componentClient.forWorkflow(workflowId)
-            .method(WorkflowWithStepTimeout::get)
-            .invoke();
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var state =
+                  componentClient
+                      .forWorkflow(workflowId)
+                      .method(WorkflowWithStepTimeout::get)
+                      .invoke();
 
-        assertThat(state.value()).isEqualTo(2);
-        assertThat(state.finished()).isTrue();
-      });
+              assertThat(state.value()).isEqualTo(2);
+              assertThat(state.finished()).isTrue();
+            });
   }
 
   @Test
   public void shouldUseTimerInWorkflowDefinition() {
-    //given
+    // given
     var counterId = randomId();
     var workflowId = randomId();
 
-    //when
+    // when
     Message response =
-      componentClient.forWorkflow(workflowId)
-        .method(WorkflowWithTimer::startFailingCounter)
-        .invoke(counterId);
+        componentClient
+            .forWorkflow(workflowId)
+            .method(WorkflowWithTimer::startFailingCounter)
+            .invoke(counterId);
 
     assertThat(response.text()).isEqualTo("workflow started");
 
-    //then
+    // then
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var state =
-          componentClient.forWorkflow(workflowId)
-            .method(WorkflowWithTimer::get)
-            .invoke();
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var state =
+                  componentClient.forWorkflow(workflowId).method(WorkflowWithTimer::get).invoke();
 
-        assertThat(state.finished()).isTrue();
-        assertThat(state.value()).isEqualTo(12);
-      });
+              assertThat(state.finished()).isTrue();
+              assertThat(state.value()).isEqualTo(12);
+            });
   }
-
 
   @Test
   public void shouldNotUpdateWorkflowStateAfterEndTransition() {
-    //given
+    // given
     var workflowId = randomId();
-      componentClient.forWorkflow(workflowId)
-        .method(DummyWorkflow::startAndFinish)
-        .invoke();
+    componentClient.forWorkflow(workflowId).method(DummyWorkflow::startAndFinish).invoke();
 
-    assertThat(
-      componentClient.forWorkflow(workflowId)
-        .method(DummyWorkflow::get)
-        .invoke()).isEqualTo(10);
+    assertThat(componentClient.forWorkflow(workflowId).method(DummyWorkflow::get).invoke())
+        .isEqualTo(10);
 
-    //when
+    // when
     try {
 
-        componentClient.forWorkflow(workflowId)
-          .method(DummyWorkflow::update).invoke();
+      componentClient.forWorkflow(workflowId).method(DummyWorkflow::update).invoke();
     } catch (RuntimeException exception) {
       // ignore "500 Internal Server Error" exception from the proxy
     }
 
-    //then
-    assertThat(
-      componentClient.forWorkflow(workflowId)
-        .method(DummyWorkflow::get).invoke()).isEqualTo(10);
+    // then
+    assertThat(componentClient.forWorkflow(workflowId).method(DummyWorkflow::get).invoke())
+        .isEqualTo(10);
   }
 
   @Test
   public void shouldRunWorkflowStepWithoutInitialState() {
-    //given
+    // given
     var workflowId = randomId();
 
-    //when
-    String response = componentClient.forWorkflow(workflowId)
-      .method(WorkflowWithoutInitialState::start).invoke();
+    // when
+    String response =
+        componentClient.forWorkflow(workflowId).method(WorkflowWithoutInitialState::start).invoke();
 
     assertThat(response).contains("ok");
 
-    //then
+    // then
     Awaitility.await()
-      .ignoreExceptions()
-      .atMost(20, TimeUnit.of(SECONDS))
-      .untilAsserted(() -> {
-        var state = componentClient.forWorkflow(workflowId).method(WorkflowWithoutInitialState::get).invoke();
-        assertThat(state).contains("success");
-      });
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.of(SECONDS))
+        .untilAsserted(
+            () -> {
+              var state =
+                  componentClient
+                      .forWorkflow(workflowId)
+                      .method(WorkflowWithoutInitialState::get)
+                      .invoke();
+              assertThat(state).contains("success");
+            });
   }
 
   @Test
   public void shouldAllowHierarchyWorkflow() {
     var workflowId = randomId();
-    componentClient.forWorkflow(workflowId)
-      .method(TextWorkflow::setText).invoke("some text");
+    componentClient.forWorkflow(workflowId).method(TextWorkflow::setText).invoke("some text");
 
-
-    var result = componentClient.forWorkflow(workflowId)
-      .method(TextWorkflow::getText).invoke();
+    var result = componentClient.forWorkflow(workflowId).method(TextWorkflow::getText).invoke();
 
     assertThat(result).isEqualTo(Optional.of("some text"));
   }
@@ -638,67 +660,95 @@ public class WorkflowTest extends TestKitSupport {
   @Test
   public void shouldBeCallableWithGenericParameter() {
     var workflowId = randomId();
-    String response1 = componentClient.forWorkflow(workflowId)
-      .method(TransferWorkflow::genericStringsCall)
-      .invoke(List.of("somestring")).text();
+    String response1 =
+        componentClient
+            .forWorkflow(workflowId)
+            .method(TransferWorkflow::genericStringsCall)
+            .invoke(List.of("somestring"))
+            .text();
 
     assertThat(response1).isEqualTo("genericCall ok");
 
-    String response2 = componentClient.forWorkflow(workflowId)
-      .method(TransferWorkflow::genericCall)
-      .invoke(List.of(new TransferWorkflow.SomeClass("somestring"))).text();
+    String response2 =
+        componentClient
+            .forWorkflow(workflowId)
+            .method(TransferWorkflow::genericCall)
+            .invoke(List.of(new TransferWorkflow.SomeClass("somestring")))
+            .text();
 
     assertThat(response2).isEqualTo("genericCall ok");
   }
 
   @Test
   public void commandHandlerShouldBeRunningOnVirtualThread() {
-    var result = componentClient.forWorkflow(randomId())
-        .method(TransferWorkflow::commandHandlerIsOnVirtualThread)
-        .invoke();
+    var result =
+        componentClient
+            .forWorkflow(randomId())
+            .method(TransferWorkflow::commandHandlerIsOnVirtualThread)
+            .invoke();
     assertThat(result).isTrue();
   }
 
   @Test
   public void shouldTestExceptions() {
-    var exc1 = Assertions.assertThrows(CommandException.class, () -> {
-      componentClient.forWorkflow("1")
-        .method(TransferWorkflow::run)
-        .invoke("errorMessage");
-    });
+    var exc1 =
+        Assertions.assertThrows(
+            CommandException.class,
+            () -> {
+              componentClient.forWorkflow("1").method(TransferWorkflow::run).invoke("errorMessage");
+            });
     assertThat(exc1.getMessage()).isEqualTo("errorMessage");
 
-    var exc2 = Assertions.assertThrows(CommandException.class, () -> {
-      componentClient.forWorkflow("1")
-        .method(TransferWorkflow::run)
-        .invoke("errorCommandException");
-    });
+    var exc2 =
+        Assertions.assertThrows(
+            CommandException.class,
+            () -> {
+              componentClient
+                  .forWorkflow("1")
+                  .method(TransferWorkflow::run)
+                  .invoke("errorCommandException");
+            });
     assertThat(exc2.getMessage()).isEqualTo("errorCommandException");
 
-    var exc3 = Assertions.assertThrows(MyException.class, () -> {
-      componentClient.forWorkflow("1")
-        .method(TransferWorkflow::run)
-        .invoke("errorMyException");
-    });
+    var exc3 =
+        Assertions.assertThrows(
+            MyException.class,
+            () -> {
+              componentClient
+                  .forWorkflow("1")
+                  .method(TransferWorkflow::run)
+                  .invoke("errorMyException");
+            });
     assertThat(exc3.getMessage()).isEqualTo("errorMyException");
     assertThat(exc3.getData()).isEqualTo(new MyException.SomeData("some data"));
 
-    var exc4 = Assertions.assertThrows(MyException.class, () -> {
-      componentClient.forWorkflow("1")
-        .method(TransferWorkflow::run)
-        .invoke("throwMyException");
-    });
+    var exc4 =
+        Assertions.assertThrows(
+            MyException.class,
+            () -> {
+              componentClient
+                  .forWorkflow("1")
+                  .method(TransferWorkflow::run)
+                  .invoke("throwMyException");
+            });
     assertThat(exc4.getMessage()).isEqualTo("throwMyException");
     assertThat(exc4.getData()).isEqualTo(new MyException.SomeData("some data"));
 
-    var exc5 = Assertions.assertThrows(RuntimeException.class, () -> {
-      componentClient.forWorkflow("1")
-        .method(TransferWorkflow::run)
-        .invoke("throwRuntimeException");
-    });
-    assertThat(exc5.getMessage()).contains("Proxy error: user service returned failure - Unexpected failure: java.lang.RuntimeException: throwRuntimeException"); //it's not the original message, but the one from the runtime
+    var exc5 =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () -> {
+              componentClient
+                  .forWorkflow("1")
+                  .method(TransferWorkflow::run)
+                  .invoke("throwRuntimeException");
+            });
+    assertThat(exc5.getMessage())
+        .contains(
+            "Proxy error: user service returned failure - Unexpected failure:"
+                + " java.lang.RuntimeException:" // it's not the original message
+                + " throwRuntimeException"); // but the one from the runtime
   }
-
 
   private String randomTransferId() {
     return randomId();
@@ -711,18 +761,15 @@ public class WorkflowTest extends TestKitSupport {
   private Integer getFailingCounterValue(String counterId) {
     return componentClient
         .forEventSourcedEntity(counterId)
-        .method(FailingCounterEntity::get).invoke();
+        .method(FailingCounterEntity::get)
+        .invoke();
   }
 
   private void createWallet(String walletId, int amount) {
-      componentClient.forKeyValueEntity(walletId)
-        .method(WalletEntity::create)
-        .invoke(amount);
+    componentClient.forKeyValueEntity(walletId).method(WalletEntity::create).invoke(amount);
   }
 
   private int getWalletBalance(String walletId) {
-    return componentClient.forKeyValueEntity(walletId)
-        .method(WalletEntity::get)
-        .invoke().value;
+    return componentClient.forKeyValueEntity(walletId).method(WalletEntity::get).invoke().value;
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/Setup.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/Setup.java
@@ -7,10 +7,9 @@ package akkajavasdk.components;
 import akka.javasdk.ServiceSetup;
 import akka.javasdk.annotations.Acl;
 import akkajavasdk.components.keyvalueentities.user.ProdCounterEntity;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Set;
 
 @akka.javasdk.annotations.Setup
 @Acl(allow = @Acl.Matcher(principal = Acl.Principal.ALL))

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/actions/echo/ActionWithMetadata.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/actions/echo/ActionWithMetadata.java
@@ -4,8 +4,8 @@
 
 package akkajavasdk.components.actions.echo;
 
-import akka.javasdk.timedaction.TimedAction;
 import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.timedaction.TimedAction;
 import akkajavasdk.StaticTestBuffer;
 
 @ComponentId("with-metadata")

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/actions/echo/ActionWithPrimitives.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/actions/echo/ActionWithPrimitives.java
@@ -4,14 +4,13 @@
 
 package akkajavasdk.components.actions.echo;
 
-import akka.javasdk.timedaction.TimedAction;
 import akka.javasdk.annotations.ComponentId;
-
+import akka.javasdk.timedaction.TimedAction;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
 @ComponentId("with-primitives")
-//TODO remove or bring tests back
+// TODO remove or bring tests back
 public class ActionWithPrimitives extends TimedAction {
 
   public Effect stringMessageWithOptionalParams(long longValue) {
@@ -27,5 +26,4 @@ public class ActionWithPrimitives extends TimedAction {
     String response = ints.stream().map(Object::toString).collect(Collectors.joining(","));
     return effects().done();
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/actions/echo/EchoAction.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/actions/echo/EchoAction.java
@@ -4,11 +4,10 @@
 
 package akkajavasdk.components.actions.echo;
 
-import akka.javasdk.timedaction.TimedAction;
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.client.ComponentClient;
+import akka.javasdk.timedaction.TimedAction;
 import akkajavasdk.StaticTestBuffer;
-
 import java.util.List;
 import java.util.concurrent.Executor;
 
@@ -18,8 +17,7 @@ public class EchoAction extends TimedAction {
   private boolean constructedOnVt = Thread.currentThread().isVirtual();
 
   // executor and component client just to cover that they can be injected, not really used here
-  public EchoAction(ComponentClient componentClient, Executor virtualThreadExecutor) {
-  }
+  public EchoAction(ComponentClient componentClient, Executor virtualThreadExecutor) {}
 
   public Effect emptyMessage() {
     StaticTestBuffer.addValue("echo-action", "empty");
@@ -28,7 +26,9 @@ public class EchoAction extends TimedAction {
 
   public Effect stringMessage(String msg) {
     if (msg.equals("check-if-virtual-thread")) {
-      StaticTestBuffer.addValue("echo-action", "is-virtual-thread:" + (Thread.currentThread().isVirtual() && constructedOnVt));
+      StaticTestBuffer.addValue(
+          "echo-action",
+          "is-virtual-thread:" + (Thread.currentThread().isVirtual() && constructedOnVt));
     } else {
       StaticTestBuffer.addValue("echo-action", msg);
     }
@@ -41,9 +41,10 @@ public class EchoAction extends TimedAction {
   }
 
   public record SomeCommand(String text) {}
+
   public Effect commandMessages(List<SomeCommand> msg) {
-    StaticTestBuffer.addValue("echo-action", String.join(" ", msg.stream().map(c -> c.text).toList()));
+    StaticTestBuffer.addValue(
+        "echo-action", String.join(" ", msg.stream().map(c -> c.text).toList()));
     return effects().done();
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/actions/echo/Message.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/actions/echo/Message.java
@@ -4,5 +4,4 @@
 
 package akkajavasdk.components.actions.echo;
 
-public record Message(String text) {
-}
+public record Message(String text) {}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/actions/headers/EchoAction.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/actions/headers/EchoAction.java
@@ -4,12 +4,10 @@
 
 package akkajavasdk.components.actions.headers;
 
-import akka.javasdk.timedaction.TimedAction;
 import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.timedaction.TimedAction;
 
-/**
- * Action with the same class name in a different package.
- */
+/** Action with the same class name in a different package. */
 @SuppressWarnings("unused") // not here to be called, but to test conflicting names
 @ComponentId("echo2")
 public class EchoAction extends TimedAction {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/AgentIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/AgentIntegrationTest.java
@@ -8,8 +8,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import akka.actor.testkit.typed.javadsl.LoggingTestKit;
-import akka.javasdk.DependencyProvider;
 import akka.javasdk.CommandException;
+import akka.javasdk.DependencyProvider;
 import akka.javasdk.agent.AgentRegistry;
 import akka.javasdk.testkit.TestKit;
 import akka.javasdk.testkit.TestKitSupport;
@@ -18,11 +18,10 @@ import akka.javasdk.testkit.TestModelProvider.AiResponse;
 import akka.javasdk.testkit.TestModelProvider.ToolInvocationRequest;
 import akka.stream.javadsl.Sink;
 import akkajavasdk.Junit5LogCapturing;
+import akkajavasdk.components.MyException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
-import akkajavasdk.components.MyException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -56,9 +55,6 @@ public class AgentIntegrationTest extends TestKitSupport {
         .withDependencyProvider(depsProvider);
   }
 
-
-
-
   @AfterEach
   public void afterEach() {
     testModelProvider.reset();
@@ -71,32 +67,34 @@ public class AgentIntegrationTest extends TestKitSupport {
   @Test
   public void shouldMapStringResponse() {
     // given
-    testModelProvider
-      .whenMessage(s -> s.equals("hello"))
-      .reply("123456");
+    testModelProvider.whenMessage(s -> s.equals("hello")).reply("123456");
 
-    //when
-    SomeAgent.SomeResponse result = componentClient.forAgent().inSession(newSessionId())
-      .method(SomeAgent::mapLlmResponse)
-      .invoke("hello");
+    // when
+    SomeAgent.SomeResponse result =
+        componentClient
+            .forAgent()
+            .inSession(newSessionId())
+            .method(SomeAgent::mapLlmResponse)
+            .invoke("hello");
 
-    //then
+    // then
     assertThat(result.response()).isEqualTo("123456");
   }
 
   @Test
   public void shouldMapStructuredResponse() {
     // given
-    testModelProvider
-        .whenMessage(s -> s.equals("structured"))
-        .reply("{\"response\": \"123456\"}");
+    testModelProvider.whenMessage(s -> s.equals("structured")).reply("{\"response\": \"123456\"}");
 
-    //when
-    SomeStructureResponseAgent.SomeResponse result = componentClient.forAgent().inSession(newSessionId())
-      .method(SomeStructureResponseAgent::mapStructureResponse)
-      .invoke("structured");
+    // when
+    SomeStructureResponseAgent.SomeResponse result =
+        componentClient
+            .forAgent()
+            .inSession(newSessionId())
+            .method(SomeStructureResponseAgent::mapStructureResponse)
+            .invoke("structured");
 
-    //then
+    // then
     assertThat(result.response()).isEqualTo("123456");
   }
 
@@ -107,15 +105,17 @@ public class AgentIntegrationTest extends TestKitSupport {
         .whenMessage(s -> s.equals("structured"))
         .reply("{\"corrupted json: \"123456\"}");
 
-    //when
-    SomeStructureResponseAgent.SomeResponse result = componentClient.forAgent().inSession(newSessionId())
-      .method(SomeStructureResponseAgent::mapStructureResponse)
-      .invoke("structured");
+    // when
+    SomeStructureResponseAgent.SomeResponse result =
+        componentClient
+            .forAgent()
+            .inSession(newSessionId())
+            .method(SomeStructureResponseAgent::mapStructureResponse)
+            .invoke("structured");
 
-    //then
+    // then
     assertThat(result.response()).isEqualTo("default response");
   }
-
 
   @Test
   public void shouldCallToolFunctionsFromInstances() {
@@ -141,13 +141,15 @@ public class AgentIntegrationTest extends TestKitSupport {
         .whenToolResult(result -> result.content().startsWith("The weather is"))
         .thenReply(result -> new AiResponse(result.content()));
 
-    //when
-    var response = componentClient.forAgent().inSession(newSessionId())
-      .method(SomeAgentWithTool::query)
-      .invoke(userQuestion);
+    // when
+    var response =
+        componentClient
+            .forAgent()
+            .inSession(newSessionId())
+            .method(SomeAgentWithTool::query)
+            .invoke(userQuestion);
 
-
-    //then
+    // then
     assertThat(response.response()).isEqualTo("The weather is sunny in Leuven. (date=2025-01-01)");
   }
 
@@ -164,20 +166,22 @@ public class AgentIntegrationTest extends TestKitSupport {
             new ToolInvocationRequest(
                 "TrafficService_getTrafficNow",
                 """
-          { "location" : "Leuven" }"""));
+                { "location" : "Leuven" }"""));
 
     // receives the traffic info as the final answer
     testModelProvider
         .whenToolResult(result -> result.content().startsWith("There is traffic jam"))
         .thenReply(result -> new AiResponse(result.content()));
 
-    //when
-    var response = componentClient.forAgent().inSession(newSessionId())
-      .method(SomeAgentWithTool::query)
-      .invoke(userQuestion);
+    // when
+    var response =
+        componentClient
+            .forAgent()
+            .inSession(newSessionId())
+            .method(SomeAgentWithTool::query)
+            .invoke(userQuestion);
 
-
-    //then
+    // then
     assertThat(response.response()).isEqualTo("There is traffic jam in Leuven.");
   }
 
@@ -188,14 +192,15 @@ public class AgentIntegrationTest extends TestKitSupport {
     testModelProvider.fixedResponse("Hello");
 
     try {
-      componentClient.forAgent().inSession(newSessionId())
-        .method(SomeAgentWithBadlyConfiguredTool::query)
-        .invoke(userQuestion);
+      componentClient
+          .forAgent()
+          .inSession(newSessionId())
+          .method(SomeAgentWithBadlyConfiguredTool::query)
+          .invoke(userQuestion);
       fail("Should have thrown an exception");
     } catch (Exception e) {
       assertThat(e.getMessage()).startsWith("Component client error");
     }
-
   }
 
   @Test
@@ -208,9 +213,11 @@ public class AgentIntegrationTest extends TestKitSupport {
         .reply(new ToolInvocationRequest("TrafficService_getTrafficNow", ""));
 
     try {
-      componentClient.forAgent().inSession(newSessionId())
-        .method(SomeAgentWithTool::query)
-        .invoke(userQuestion);
+      componentClient
+          .forAgent()
+          .inSession(newSessionId())
+          .method(SomeAgentWithTool::query)
+          .invoke(userQuestion);
 
       fail("Should have thrown an exception");
     } catch (Exception e) {
@@ -224,15 +231,21 @@ public class AgentIntegrationTest extends TestKitSupport {
     // given
     testModelProvider.whenMessage(s -> s.equals("hello")).reply("Hi mate, how are you today?");
 
-    //when
-    var source = componentClient.forAgent().inSession(newSessionId())
-        .tokenStream(SomeStreamingAgent::ask)
-        .source("hello");
+    // when
+    var source =
+        componentClient
+            .forAgent()
+            .inSession(newSessionId())
+            .tokenStream(SomeStreamingAgent::ask)
+            .source("hello");
 
-    var resultTokens = source.runWith(Sink.seq(), testKit.getMaterializer())
-        .toCompletableFuture().get(5, TimeUnit.SECONDS);
+    var resultTokens =
+        source
+            .runWith(Sink.seq(), testKit.getMaterializer())
+            .toCompletableFuture()
+            .get(5, TimeUnit.SECONDS);
 
-    //then
+    // then
     assertThat(resultTokens.size()).isEqualTo(13); // by word + separators
     assertThat(resultTokens.getFirst()).isEqualTo("Hi");
     assertThat(resultTokens.getLast()).isEqualTo("?");
@@ -240,9 +253,15 @@ public class AgentIntegrationTest extends TestKitSupport {
 
   @Test
   public void shouldIncludeAgentsInRegistry() {
-    assertThat(testKit.getAgentRegistry().allAgents().stream().map(AgentRegistry.AgentInfo::id).toList())
+    assertThat(
+            testKit.getAgentRegistry().allAgents().stream()
+                .map(AgentRegistry.AgentInfo::id)
+                .toList())
         .contains("some-agent", "some-streaming-agent", "structured-response-agent");
-    assertThat(testKit.getAgentRegistry().agentsWithRole("streaming").stream().map(AgentRegistry.AgentInfo::id).toList())
+    assertThat(
+            testKit.getAgentRegistry().agentsWithRole("streaming").stream()
+                .map(AgentRegistry.AgentInfo::id)
+                .toList())
         .isEqualTo(List.of("some-streaming-agent"));
 
     var someStructuredInfo = testKit.getAgentRegistry().agentInfo("structured-response-agent");
@@ -261,9 +280,12 @@ public class AgentIntegrationTest extends TestKitSupport {
   public void shouldSupportDynamicCall() {
     testModelProvider.whenMessage(s -> s.equals("hello")).reply("123456");
 
-    var obj = componentClient.forAgent().inSession(newSessionId())
-        .dynamicCall("some-agent")
-        .invoke("hello");
+    var obj =
+        componentClient
+            .forAgent()
+            .inSession(newSessionId())
+            .dynamicCall("some-agent")
+            .invoke("hello");
     SomeAgent.SomeResponse result = (SomeAgent.SomeResponse) obj;
 
     assertThat(result.response()).isEqualTo("123456");
@@ -295,9 +317,7 @@ public class AgentIntegrationTest extends TestKitSupport {
     testModelProvider.whenMessage(s -> s.equals("hello")).reply("123456");
 
     try {
-      componentClient.forAgent().inSession(newSessionId())
-          .dynamicCall("some-agent")
-          .invoke(17);
+      componentClient.forAgent().inSession(newSessionId()).dynamicCall("some-agent").invoke(17);
 
       fail("Expected exception");
     } catch (RuntimeException e) {
@@ -307,57 +327,80 @@ public class AgentIntegrationTest extends TestKitSupport {
 
   @Test
   public void shouldBeConstructedOnVirtualThread() {
-    var result = componentClient.forAgent()
-        .inSession(newSessionId())
-        .method(SomeAgentWithTool::query)
-        .invoke("Running on virtual thread?");
+    var result =
+        componentClient
+            .forAgent()
+            .inSession(newSessionId())
+            .method(SomeAgentWithTool::query)
+            .invoke("Running on virtual thread?");
 
     assertThat(result.response()).isEqualTo("Query on vt: true, constructed on vt: true");
   }
 
   @Test
   public void shouldTestExceptions() {
-    var exc1 = Assertions.assertThrows(CommandException.class, () -> {
-      componentClient.forAgent()
-        .inSession(newSessionId())
-        .method(SomeAgentReturningErrors::run)
-        .invoke("errorMessage");
-    });
+    var exc1 =
+        Assertions.assertThrows(
+            CommandException.class,
+            () -> {
+              componentClient
+                  .forAgent()
+                  .inSession(newSessionId())
+                  .method(SomeAgentReturningErrors::run)
+                  .invoke("errorMessage");
+            });
     assertThat(exc1.getMessage()).isEqualTo("errorMessage");
 
-    var exc2 = Assertions.assertThrows(CommandException.class, () -> {
-      componentClient.forAgent()
-        .inSession(newSessionId())
-        .method(SomeAgentReturningErrors::run)
-        .invoke("errorCommandException");
-    });
+    var exc2 =
+        Assertions.assertThrows(
+            CommandException.class,
+            () -> {
+              componentClient
+                  .forAgent()
+                  .inSession(newSessionId())
+                  .method(SomeAgentReturningErrors::run)
+                  .invoke("errorCommandException");
+            });
     assertThat(exc2.getMessage()).isEqualTo("errorCommandException");
 
-    var exc3 = Assertions.assertThrows(MyException.class, () -> {
-      componentClient.forAgent()
-        .inSession(newSessionId())
-        .method(SomeAgentReturningErrors::run)
-        .invoke("errorMyException");
-    });
+    var exc3 =
+        Assertions.assertThrows(
+            MyException.class,
+            () -> {
+              componentClient
+                  .forAgent()
+                  .inSession(newSessionId())
+                  .method(SomeAgentReturningErrors::run)
+                  .invoke("errorMyException");
+            });
     assertThat(exc3.getMessage()).isEqualTo("errorMyException");
     assertThat(exc3.getData()).isEqualTo(new MyException.SomeData("some data"));
 
-    var exc4 = Assertions.assertThrows(MyException.class, () -> {
-      componentClient.forAgent()
-        .inSession(newSessionId())
-        .method(SomeAgentReturningErrors::run)
-        .invoke("throwMyException");
-    });
+    var exc4 =
+        Assertions.assertThrows(
+            MyException.class,
+            () -> {
+              componentClient
+                  .forAgent()
+                  .inSession(newSessionId())
+                  .method(SomeAgentReturningErrors::run)
+                  .invoke("throwMyException");
+            });
     assertThat(exc4.getMessage()).isEqualTo("throwMyException");
     assertThat(exc4.getData()).isEqualTo(new MyException.SomeData("some data"));
 
-    var exc5 = Assertions.assertThrows(RuntimeException.class, () -> {
-      componentClient.forAgent()
-        .inSession(newSessionId())
-        .method(SomeAgentReturningErrors::run)
-        .invoke("throwRuntimeException");
-    });
-    assertThat(exc5.getMessage()).contains("Component client error"); //it's not the original message, but the one from the runtime
+    var exc5 =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () -> {
+              componentClient
+                  .forAgent()
+                  .inSession(newSessionId())
+                  .method(SomeAgentReturningErrors::run)
+                  .invoke("throwRuntimeException");
+            });
+    assertThat(exc5.getMessage())
+        .contains("Component client error"); // it's not the original message, but the one from the
+    // runtime
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/PromptTemplateTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/PromptTemplateTest.java
@@ -4,37 +4,38 @@
 
 package akkajavasdk.components.agent;
 
+import static akka.Done.done;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import akka.Done;
 import akka.javasdk.agent.PromptTemplate;
 import akka.javasdk.testkit.EventSourcedResult;
 import akka.javasdk.testkit.EventSourcedTestKit;
-import org.junit.jupiter.api.Test;
-
 import java.util.Optional;
-
-import static akka.Done.done;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 public class PromptTemplateTest {
 
   @Test
   public void shouldAllowToInitPromptOnlyOnce() {
-    //given
+    // given
     var testKit = EventSourcedTestKit.of(PromptTemplate::new);
     String promptValue = "prompt-1";
 
-    //when
+    // when
     EventSourcedResult<Done> result = testKit.method(PromptTemplate::init).invoke(promptValue);
 
-    //then
+    // then
     assertThat(result.getReply()).isEqualTo(done());
-    assertThat(result.getAllEvents()).containsExactly(new PromptTemplate.Event.Updated(promptValue));
+    assertThat(result.getAllEvents())
+        .containsExactly(new PromptTemplate.Event.Updated(promptValue));
     assertThat(result.getUpdatedState()).isEqualTo(new PromptTemplate.Prompt(promptValue));
 
-    //when
-    EventSourcedResult<Done> secondInit = testKit.method(PromptTemplate::init).invoke("next-prompt");
+    // when
+    EventSourcedResult<Done> secondInit =
+        testKit.method(PromptTemplate::init).invoke("next-prompt");
 
-    //then
+    // then
     assertThat(secondInit.getReply()).isEqualTo(done());
     assertThat(secondInit.didPersistEvents()).isFalse();
     assertThat(secondInit.getUpdatedState()).isEqualTo(new PromptTemplate.Prompt(promptValue));
@@ -42,39 +43,42 @@ public class PromptTemplateTest {
 
   @Test
   public void shouldGetPrompt() {
-    //given
+    // given
     var testKit = EventSourcedTestKit.of(PromptTemplate::new);
     String promptValue = "prompt-1";
 
     {
-      //when
+      // when
       EventSourcedResult<String> result = testKit.method(PromptTemplate::get).invoke();
-      EventSourcedResult<Optional<String>> resultOpt = testKit.method(PromptTemplate::getOptional).invoke();
+      EventSourcedResult<Optional<String>> resultOpt =
+          testKit.method(PromptTemplate::getOptional).invoke();
 
-      //then
+      // then
       assertThat(result.isError()).isTrue();
       assertThat(resultOpt.getReply()).isEqualTo(Optional.empty());
     }
 
     {
-      //when
+      // when
       testKit.method(PromptTemplate::init).invoke(promptValue);
       EventSourcedResult<String> result = testKit.method(PromptTemplate::get).invoke();
-      EventSourcedResult<Optional<String>> resultOpt = testKit.method(PromptTemplate::getOptional).invoke();
+      EventSourcedResult<Optional<String>> resultOpt =
+          testKit.method(PromptTemplate::getOptional).invoke();
 
-      //then
+      // then
       assertThat(result.getReply()).isEqualTo(promptValue);
       assertThat(resultOpt.getReply()).isEqualTo(Optional.of(promptValue));
     }
 
     {
-      //when
+      // when
       testKit.method(PromptTemplate::init).invoke(promptValue);
       testKit.method(PromptTemplate::delete).invoke();
       EventSourcedResult<String> result = testKit.method(PromptTemplate::get).invoke();
-      EventSourcedResult<Optional<String>> resultOpt = testKit.method(PromptTemplate::getOptional).invoke();
+      EventSourcedResult<Optional<String>> resultOpt =
+          testKit.method(PromptTemplate::getOptional).invoke();
 
-      //then
+      // then
       assertThat(result.isError()).isTrue();
       assertThat(resultOpt.getReply()).isEqualTo(Optional.empty());
     }
@@ -82,25 +86,27 @@ public class PromptTemplateTest {
 
   @Test
   public void shouldEditPrompt() {
-    //given
+    // given
     var testKit = EventSourcedTestKit.of(PromptTemplate::new);
     String promptValue1 = "prompt-1";
     String promptValue2 = "prompt-2";
 
     EventSourcedResult<Done> result1 = testKit.method(PromptTemplate::init).invoke(promptValue1);
-    assertThat(result1.getAllEvents()).containsExactly(new PromptTemplate.Event.Updated(promptValue1));
+    assertThat(result1.getAllEvents())
+        .containsExactly(new PromptTemplate.Event.Updated(promptValue1));
     assertThat(result1.getUpdatedState()).isEqualTo(new PromptTemplate.Prompt(promptValue1));
 
     EventSourcedResult<Done> result2 = testKit.method(PromptTemplate::update).invoke(promptValue2);
-    assertThat(result2.getAllEvents()).containsExactly(new PromptTemplate.Event.Updated(promptValue2));
+    assertThat(result2.getAllEvents())
+        .containsExactly(new PromptTemplate.Event.Updated(promptValue2));
     assertThat(result2.getUpdatedState()).isEqualTo(new PromptTemplate.Prompt(promptValue2));
 
-    //updating with the same value
+    // updating with the same value
     EventSourcedResult<Done> result3 = testKit.method(PromptTemplate::update).invoke(promptValue2);
     assertThat(result3.didPersistEvents()).isFalse();
     assertThat(result3.getUpdatedState()).isEqualTo(new PromptTemplate.Prompt(promptValue2));
 
-    //wrong value
+    // wrong value
     EventSourcedResult<Done> result4 = testKit.method(PromptTemplate::update).invoke("");
     assertThat(result4.isError()).isTrue();
     assertThat(result4.getUpdatedState()).isEqualTo(new PromptTemplate.Prompt(promptValue2));

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SessionMemoryEntityTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SessionMemoryEntityTest.java
@@ -4,6 +4,9 @@
 
 package akkajavasdk.components.agent;
 
+import static akka.Done.done;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import akka.Done;
 import akka.javasdk.agent.SessionHistory;
 import akka.javasdk.agent.SessionMemoryEntity;
@@ -15,14 +18,10 @@ import akka.javasdk.testkit.EventSourcedResult;
 import akka.javasdk.testkit.EventSourcedTestKit;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import org.junit.jupiter.api.Test;
-
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
-
-import static akka.Done.done;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 public class SessionMemoryEntityTest {
 
@@ -43,8 +42,10 @@ public class SessionMemoryEntityTest {
     var aiMessage = new AiMessage(timestamp, aiMsg, COMPONENT_ID);
 
     // when
-    EventSourcedResult<Done> result = testKit.method(SessionMemoryEntity::addInteraction)
-      .invoke(new AddInteractionCmd(userMessage, aiMessage));
+    EventSourcedResult<Done> result =
+        testKit
+            .method(SessionMemoryEntity::addInteraction)
+            .invoke(new AddInteractionCmd(userMessage, aiMessage));
 
     // then
     assertThat(result.getReply()).isEqualTo(done());
@@ -69,12 +70,10 @@ public class SessionMemoryEntityTest {
 
     // when retrieving history
     EventSourcedResult<SessionHistory> historyResult =
-      testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
+        testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
 
     // then
-    assertThat(historyResult.getReply().messages()).containsExactly(
-      userMessage,
-      aiMessage);
+    assertThat(historyResult.getReply().messages()).containsExactly(userMessage, aiMessage);
   }
 
   @Test
@@ -93,10 +92,13 @@ public class SessionMemoryEntityTest {
     var aiMessage2 = new AiMessage(timestamp.plusMillis(1), aiMsg2, COMPONENT_ID);
 
     // when
-    testKit.method(SessionMemoryEntity::addInteraction)
-      .invoke(new AddInteractionCmd(userMessage1, aiMessage1));
-    EventSourcedResult<Done> result = testKit.method(SessionMemoryEntity::addInteraction)
-      .invoke(new AddInteractionCmd(userMessage2, aiMessage2));
+    testKit
+        .method(SessionMemoryEntity::addInteraction)
+        .invoke(new AddInteractionCmd(userMessage1, aiMessage1));
+    EventSourcedResult<Done> result =
+        testKit
+            .method(SessionMemoryEntity::addInteraction)
+            .invoke(new AddInteractionCmd(userMessage2, aiMessage2));
 
     // then
     assertThat(result.getReply()).isEqualTo(done());
@@ -104,18 +106,17 @@ public class SessionMemoryEntityTest {
     assertThat(events.size()).isEqualTo(2);
     assertThat(events.get(1)).isInstanceOf(SessionMemoryEntity.Event.AiMessageAdded.class);
     var aiEvent = (SessionMemoryEntity.Event.AiMessageAdded) events.get(1);
-    assertThat(aiEvent.historySizeInBytes()).isEqualTo(userMessage1.size() + aiMessage1.size() + userMessage2.size() + aiMessage2.size());
+    assertThat(aiEvent.historySizeInBytes())
+        .isEqualTo(
+            userMessage1.size() + aiMessage1.size() + userMessage2.size() + aiMessage2.size());
 
     // when retrieving history
     EventSourcedResult<SessionHistory> historyResult =
-      testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
+        testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
 
     // then
-    assertThat(historyResult.getReply().messages()).containsExactly(
-      userMessage1,
-      aiMessage1,
-      userMessage2,
-      aiMessage2);
+    assertThat(historyResult.getReply().messages())
+        .containsExactly(userMessage1, aiMessage1, userMessage2, aiMessage2);
   }
 
   @Test
@@ -127,7 +128,8 @@ public class SessionMemoryEntityTest {
     var userMessage1 = new UserMessage(timestamp, "Hello", COMPONENT_ID);
     var aiMessage1 = new AiMessage(timestamp, "Hi there!", COMPONENT_ID);
 
-    testKit.method(SessionMemoryEntity::addInteraction)
+    testKit
+        .method(SessionMemoryEntity::addInteraction)
         .invoke(new AddInteractionCmd(userMessage1, aiMessage1));
 
     // when
@@ -138,8 +140,8 @@ public class SessionMemoryEntityTest {
     var userMessage2 = new UserMessage(timestamp, "Hey", COMPONENT_ID);
     var aiMessage2 = new AiMessage(timestamp, "Hi!", COMPONENT_ID);
     var cmd = new SessionMemoryEntity.CompactionCmd(userMessage2, aiMessage2, sequenceNumber);
-    EventSourcedResult<Done> compactResult = testKit.method(SessionMemoryEntity::compactHistory)
-        .invoke(cmd);
+    EventSourcedResult<Done> compactResult =
+        testKit.method(SessionMemoryEntity::compactHistory).invoke(cmd);
 
     // then
     assertThat(compactResult.getReply()).isEqualTo(done());
@@ -159,9 +161,7 @@ public class SessionMemoryEntityTest {
         testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
 
     // then
-    assertThat(historyResult2.getReply().messages()).containsExactly(
-        userMessage2,
-        aiMessage2);
+    assertThat(historyResult2.getReply().messages()).containsExactly(userMessage2, aiMessage2);
   }
 
   @Test
@@ -173,7 +173,8 @@ public class SessionMemoryEntityTest {
     var userMessage1 = new UserMessage(timestamp, "Hello", COMPONENT_ID);
     var aiMessage1 = new AiMessage(timestamp, "Hi there!", COMPONENT_ID);
 
-    testKit.method(SessionMemoryEntity::addInteraction)
+    testKit
+        .method(SessionMemoryEntity::addInteraction)
         .invoke(new AddInteractionCmd(userMessage1, aiMessage1));
 
     // when
@@ -188,11 +189,12 @@ public class SessionMemoryEntityTest {
     // but before making the compaction update, there is some other update
     var userMessage3 = new UserMessage(timestamp, "I'm Alice", COMPONENT_ID);
     var aiMessage3 = new AiMessage(timestamp, "Hi Alice, I'm bot", COMPONENT_ID);
-    testKit.method(SessionMemoryEntity::addInteraction)
+    testKit
+        .method(SessionMemoryEntity::addInteraction)
         .invoke(new AddInteractionCmd(userMessage3, aiMessage3));
 
-    EventSourcedResult<Done> compactResult = testKit.method(SessionMemoryEntity::compactHistory)
-        .invoke(cmd);
+    EventSourcedResult<Done> compactResult =
+        testKit.method(SessionMemoryEntity::compactHistory).invoke(cmd);
 
     // then
     assertThat(compactResult.getReply()).isEqualTo(done());
@@ -203,18 +205,17 @@ public class SessionMemoryEntityTest {
     assertThat(((SessionMemoryEntity.Event.AiMessageAdded) events.get(2)).historySizeInBytes())
         .isEqualTo(userMessage2.size() + aiMessage2.size());
     assertThat(((SessionMemoryEntity.Event.AiMessageAdded) events.get(4)).historySizeInBytes())
-        .isEqualTo(userMessage2.size() + aiMessage2.size() + userMessage3.size() + aiMessage3.size());
+        .isEqualTo(
+            userMessage2.size() + aiMessage2.size() + userMessage3.size() + aiMessage3.size());
 
     // when retrieving history after compacting
     EventSourcedResult<SessionHistory> historyResult2 =
         testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
 
     // then
-    assertThat(historyResult2.getReply().messages().stream().map(SessionMessage::text).toList()).containsExactly(
-        userMessage2.text(),
-        aiMessage2.text(),
-        userMessage3.text(),
-        aiMessage3.text());
+    assertThat(historyResult2.getReply().messages().stream().map(SessionMessage::text).toList())
+        .containsExactly(
+            userMessage2.text(), aiMessage2.text(), userMessage3.text(), aiMessage3.text());
   }
 
   @Test
@@ -228,8 +229,9 @@ public class SessionMemoryEntityTest {
     var userMessage = new UserMessage(timestamp, userMsg, COMPONENT_ID);
     var aiMessage = new AiMessage(timestamp, aiMsg, COMPONENT_ID);
 
-    testKit.method(SessionMemoryEntity::addInteraction)
-      .invoke(new AddInteractionCmd(userMessage, aiMessage));
+    testKit
+        .method(SessionMemoryEntity::addInteraction)
+        .invoke(new AddInteractionCmd(userMessage, aiMessage));
 
     // when
     EventSourcedResult<Done> clearResult = testKit.method(SessionMemoryEntity::delete).invoke();
@@ -244,7 +246,7 @@ public class SessionMemoryEntityTest {
 
     // when retrieving history after clearing
     EventSourcedResult<SessionHistory> historyResult =
-      testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
+        testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
 
     // then
     assertThat(historyResult.getReply().messages()).isEmpty();
@@ -257,7 +259,7 @@ public class SessionMemoryEntityTest {
 
     // when
     EventSourcedResult<SessionHistory> historyResult =
-      testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
+        testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
 
     // then
     assertThat(historyResult.getReply().messages()).isEmpty();
@@ -270,10 +272,10 @@ public class SessionMemoryEntityTest {
     var timestamp = Instant.now();
 
     // Calculate the total bytes needed for each message
-    String userMsg1 = "First message";      // 13 bytes
-    String aiMsg1 = "First response";       // 14 bytes
-    String userMsg2 = "Second message";     // 14 bytes
-    String aiMsg2 = "Second response";      // 15 bytes
+    String userMsg1 = "First message"; // 13 bytes
+    String aiMsg1 = "First response"; // 14 bytes
+    String userMsg2 = "Second message"; // 14 bytes
+    String aiMsg2 = "Second response"; // 15 bytes
 
     var userMessage1 = new UserMessage(timestamp, userMsg1, COMPONENT_ID);
     var aiMessage1 = new AiMessage(timestamp, aiMsg1, COMPONENT_ID);
@@ -286,23 +288,24 @@ public class SessionMemoryEntityTest {
     testKit.method(SessionMemoryEntity::setLimitedWindow).invoke(limitedBuffer);
 
     // when
-    testKit.method(SessionMemoryEntity::addInteraction)
-      .invoke(new AddInteractionCmd(userMessage1, aiMessage1));
-    EventSourcedResult<Done> result = testKit.method(SessionMemoryEntity::addInteraction)
-      .invoke(new AddInteractionCmd(userMessage2, aiMessage2));
+    testKit
+        .method(SessionMemoryEntity::addInteraction)
+        .invoke(new AddInteractionCmd(userMessage1, aiMessage1));
+    EventSourcedResult<Done> result =
+        testKit
+            .method(SessionMemoryEntity::addInteraction)
+            .invoke(new AddInteractionCmd(userMessage2, aiMessage2));
 
     // then
     assertThat(result.getReply()).isEqualTo(done());
 
     // when retrieving history
     EventSourcedResult<SessionHistory> historyResult =
-      testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
+        testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
 
     // then - only the most recent interactions should be present
     // note that the 1st aiMsg was also removed because it was orphan
-    assertThat(historyResult.getReply().messages()).containsExactly(
-      userMessage2,
-      aiMessage2);
+    assertThat(historyResult.getReply().messages()).containsExactly(userMessage2, aiMessage2);
     assertThat(historyResult.getReply().messages().size()).isEqualTo(2);
   }
 
@@ -313,12 +316,12 @@ public class SessionMemoryEntityTest {
     var timestamp = Instant.now();
 
     // Calculate the total bytes needed for each message
-    String userMsg1 = "First message";      // 13 bytes
-    String aiMsg1 = "First response";       // 14 bytes
-    String userMsg2 = "Second message";     // 14 bytes
-    String aiMsg2 = "Second response";      // 15 bytes
-    String userMsg3 = "Third message";      // 13 bytes
-    String aiMsg3 = "Third response";       // 14 bytes
+    String userMsg1 = "First message"; // 13 bytes
+    String aiMsg1 = "First response"; // 14 bytes
+    String userMsg2 = "Second message"; // 14 bytes
+    String aiMsg2 = "Second response"; // 15 bytes
+    String userMsg3 = "Third message"; // 13 bytes
+    String aiMsg3 = "Third response"; // 14 bytes
 
     var userMessage1 = new UserMessage(timestamp, userMsg1, COMPONENT_ID);
     var aiMessage1 = new AiMessage(timestamp, aiMsg1, COMPONENT_ID);
@@ -333,43 +336,49 @@ public class SessionMemoryEntityTest {
     testKit.method(SessionMemoryEntity::setLimitedWindow).invoke(limitedBuffer);
 
     // when adding first interaction
-    testKit.method(SessionMemoryEntity::addInteraction)
-      .invoke(new AddInteractionCmd(userMessage1, aiMessage1));
+    testKit
+        .method(SessionMemoryEntity::addInteraction)
+        .invoke(new AddInteractionCmd(userMessage1, aiMessage1));
     EventSourcedResult<SessionHistory> result1 =
-      testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
+        testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
 
     // then
-    assertThat(result1.getReply().messages()).containsExactly(
-      new UserMessage(timestamp, userMsg1, COMPONENT_ID),
-      new AiMessage(timestamp, aiMsg1, COMPONENT_ID));
+    assertThat(result1.getReply().messages())
+        .containsExactly(
+            new UserMessage(timestamp, userMsg1, COMPONENT_ID),
+            new AiMessage(timestamp, aiMsg1, COMPONENT_ID));
     assertThat(result1.getReply().messages().size()).isEqualTo(2);
 
     // when adding second interaction (reaching the limit)
-    testKit.method(SessionMemoryEntity::addInteraction)
-      .invoke(new AddInteractionCmd(userMessage2, aiMessage2));
+    testKit
+        .method(SessionMemoryEntity::addInteraction)
+        .invoke(new AddInteractionCmd(userMessage2, aiMessage2));
     EventSourcedResult<SessionHistory> result2 =
-      testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
+        testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
 
     // then
-    assertThat(result2.getReply().messages()).containsExactly(
-      new UserMessage(timestamp, userMsg1, COMPONENT_ID),
-      new AiMessage(timestamp, aiMsg1, COMPONENT_ID),
-      new UserMessage(timestamp.plusMillis(1), userMsg2, COMPONENT_ID),
-      new AiMessage(timestamp.plusMillis(1), aiMsg2, COMPONENT_ID));
+    assertThat(result2.getReply().messages())
+        .containsExactly(
+            new UserMessage(timestamp, userMsg1, COMPONENT_ID),
+            new AiMessage(timestamp, aiMsg1, COMPONENT_ID),
+            new UserMessage(timestamp.plusMillis(1), userMsg2, COMPONENT_ID),
+            new AiMessage(timestamp.plusMillis(1), aiMsg2, COMPONENT_ID));
     assertThat(result2.getReply().messages().size()).isEqualTo(4);
 
     // when adding third interaction (exceeding the limit)
-    testKit.method(SessionMemoryEntity::addInteraction)
-      .invoke(new AddInteractionCmd(userMessage3, aiMessage3));
+    testKit
+        .method(SessionMemoryEntity::addInteraction)
+        .invoke(new AddInteractionCmd(userMessage3, aiMessage3));
     EventSourcedResult<SessionHistory> result3 =
-      testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
+        testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
 
     // then - first interaction should be removed
-    assertThat(result3.getReply().messages()).containsExactly(
-      new UserMessage(timestamp.plusMillis(1), userMsg2, COMPONENT_ID),
-      new AiMessage(timestamp.plusMillis(1), aiMsg2, COMPONENT_ID),
-      new UserMessage(timestamp.plusMillis(2), userMsg3, COMPONENT_ID),
-      new AiMessage(timestamp.plusMillis(2), aiMsg3, COMPONENT_ID));
+    assertThat(result3.getReply().messages())
+        .containsExactly(
+            new UserMessage(timestamp.plusMillis(1), userMsg2, COMPONENT_ID),
+            new AiMessage(timestamp.plusMillis(1), aiMsg2, COMPONENT_ID),
+            new UserMessage(timestamp.plusMillis(2), userMsg3, COMPONENT_ID),
+            new AiMessage(timestamp.plusMillis(2), aiMsg3, COMPONENT_ID));
     assertThat(result3.getReply().messages().size()).isEqualTo(4);
   }
 
@@ -380,7 +389,8 @@ public class SessionMemoryEntityTest {
     var invalidBuffer = new SessionMemoryEntity.LimitedWindow(0);
 
     // when
-    EventSourcedResult<Done> result = testKit.method(SessionMemoryEntity::setLimitedWindow).invoke(invalidBuffer);
+    EventSourcedResult<Done> result =
+        testKit.method(SessionMemoryEntity::setLimitedWindow).invoke(invalidBuffer);
 
     // then
     assertThat(result.isError()).isTrue();
@@ -402,12 +412,13 @@ public class SessionMemoryEntityTest {
     testKit.method(SessionMemoryEntity::setLimitedWindow).invoke(limitedBuffer);
 
     // Add the large interaction
-    testKit.method(SessionMemoryEntity::addInteraction)
-      .invoke(new AddInteractionCmd(userMessage, aiMessage));
+    testKit
+        .method(SessionMemoryEntity::addInteraction)
+        .invoke(new AddInteractionCmd(userMessage, aiMessage));
 
     // Retrieve history
     EventSourcedResult<SessionHistory> historyResult =
-      testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
+        testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
 
     // The history should be empty, as the first interaction cannot fit
     assertThat(historyResult.getReply().messages()).isEmpty();
@@ -416,48 +427,51 @@ public class SessionMemoryEntityTest {
   @Test
   public void shouldReturnOnlyLastNMessages() {
     // Create test kit with the configuration
-    EventSourcedTestKit<SessionMemoryEntity.State, SessionMemoryEntity.Event, SessionMemoryEntity> testKit =
-      EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
+    EventSourcedTestKit<SessionMemoryEntity.State, SessionMemoryEntity.Event, SessionMemoryEntity>
+        testKit = EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
     var timestamp = Instant.now();
 
     // Add several interactions
     String[] userMsgs = {"U1", "U2", "U3", "U4"};
     String[] aiMsgs = {"A1", "A2", "A3", "A4"};
     for (int i = 0; i < userMsgs.length; i++) {
-      testKit.method(SessionMemoryEntity::addInteraction)
-        .invoke(new AddInteractionCmd(
-          new UserMessage(timestamp, userMsgs[i], COMPONENT_ID),
-          new AiMessage(timestamp, aiMsgs[i], COMPONENT_ID)));
+      testKit
+          .method(SessionMemoryEntity::addInteraction)
+          .invoke(
+              new AddInteractionCmd(
+                  new UserMessage(timestamp, userMsgs[i], COMPONENT_ID),
+                  new AiMessage(timestamp, aiMsgs[i], COMPONENT_ID)));
     }
 
     // Request only the last 4 messages (should be: U3, A3, U4, A4)
     var lastN = 4;
-    EventSourcedResult<SessionHistory> result = testKit
-      .method(SessionMemoryEntity::getHistory)
-      .invoke(new SessionMemoryEntity.GetHistoryCmd(Optional.of(lastN)));
+    EventSourcedResult<SessionHistory> result =
+        testKit
+            .method(SessionMemoryEntity::getHistory)
+            .invoke(new SessionMemoryEntity.GetHistoryCmd(Optional.of(lastN)));
 
     // The expected last 4 messages
-    var expected = List.of(
-      new UserMessage(timestamp, "U3", COMPONENT_ID),
-      new AiMessage(timestamp, "A3", COMPONENT_ID),
-      new UserMessage(timestamp, "U4", COMPONENT_ID),
-      new AiMessage(timestamp, "A4", COMPONENT_ID)
-    );
+    var expected =
+        List.of(
+            new UserMessage(timestamp, "U3", COMPONENT_ID),
+            new AiMessage(timestamp, "A3", COMPONENT_ID),
+            new UserMessage(timestamp, "U4", COMPONENT_ID),
+            new AiMessage(timestamp, "A4", COMPONENT_ID));
 
     assertThat(result.getReply().messages()).containsExactlyElementsOf(expected);
   }
 
   @Test
   public void shouldReturnEmptyHistoryWithLastN() {
-    EventSourcedTestKit<SessionMemoryEntity.State, SessionMemoryEntity.Event, SessionMemoryEntity> testKit =
-      EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
+    EventSourcedTestKit<SessionMemoryEntity.State, SessionMemoryEntity.Event, SessionMemoryEntity>
+        testKit = EventSourcedTestKit.of((context) -> new SessionMemoryEntity(config, context));
 
     var lastN = 4;
-    EventSourcedResult<SessionHistory> result = testKit
-      .method(SessionMemoryEntity::getHistory)
-      .invoke(new SessionMemoryEntity.GetHistoryCmd(Optional.of(lastN)));
+    EventSourcedResult<SessionHistory> result =
+        testKit
+            .method(SessionMemoryEntity::getHistory)
+            .invoke(new SessionMemoryEntity.GetHistoryCmd(Optional.of(lastN)));
 
     assertThat(result.getReply().messages()).isEmpty();
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SomeAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SomeAgent.java
@@ -7,18 +7,16 @@ package akkajavasdk.components.agent;
 import akka.javasdk.agent.Agent;
 import akka.javasdk.annotations.ComponentId;
 
-/**
- * Dummy agent for testing component auto registration, e.g. PromptTemplate.
- */
+/** Dummy agent for testing component auto registration, e.g. PromptTemplate. */
 @ComponentId("some-agent")
 public class SomeAgent extends Agent {
   public record SomeResponse(String response) {}
 
   public Effect<SomeResponse> mapLlmResponse(String question) {
     return effects()
-      .systemMessage("You are a helpful...")
-      .userMessage(question)
-      .map(SomeResponse::new)
-      .thenReply();
+        .systemMessage("You are a helpful...")
+        .userMessage(question)
+        .map(SomeResponse::new)
+        .thenReply();
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SomeAgentWithBadlyConfiguredTool.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SomeAgentWithBadlyConfiguredTool.java
@@ -10,23 +10,20 @@ import akka.javasdk.annotations.ComponentId;
 @ComponentId("some-agent-with-bad-tool")
 public class SomeAgentWithBadlyConfiguredTool extends Agent {
 
-  static public class WeatherServiceWithAnnotation {
+  public static class WeatherServiceWithAnnotation {
     public String getWeather(String location, String date) {
-      return "The weather is sunny in "+location+". (date="+date+")";
+      return "The weather is sunny in " + location + ". (date=" + date + ")";
     }
   }
 
-  public record SomeResponse(String response) {
-  }
+  public record SomeResponse(String response) {}
 
   public Effect<SomeResponse> query(String question) {
     return effects()
-      .systemMessage("You are a helpful...")
-      .tools(new WeatherServiceWithAnnotation())
-      .userMessage(question)
-      .map(SomeResponse::new)
-      .thenReply();
+        .systemMessage("You are a helpful...")
+        .tools(new WeatherServiceWithAnnotation())
+        .userMessage(question)
+        .map(SomeResponse::new)
+        .thenReply();
   }
-
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SomeAgentWithTool.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SomeAgentWithTool.java
@@ -11,42 +11,45 @@ import akka.javasdk.annotations.FunctionTool;
 @ComponentId("some-agent-with-tool")
 public class SomeAgentWithTool extends Agent {
 
-  static public class WeatherService {
+  public static class WeatherService {
     @FunctionTool(description = "Returns the weather for the passed date")
     public String getWeather(String location, String date) {
-      return "The weather is sunny in "+location+". (date="+date+")";
+      return "The weather is sunny in " + location + ". (date=" + date + ")";
     }
   }
 
-  static public class TrafficService {
+  public static class TrafficService {
     @FunctionTool(description = "Returns the traffic conditions at passed location")
     public String getTrafficNow(String location) {
-      return "There is traffic jam in "+location + ".";
+      return "There is traffic jam in " + location + ".";
     }
   }
 
-  public record SomeResponse(String response) {
-  }
+  public record SomeResponse(String response) {}
 
   private boolean constructedOnVt = Thread.currentThread().isVirtual();
 
   public Effect<SomeResponse> query(String question) {
     if (question.equals("Running on virtual thread?")) {
-      return effects().reply(new SomeResponse("Query on vt: " + Thread.currentThread().isVirtual() + ", constructed on vt: " + constructedOnVt));
+      return effects()
+          .reply(
+              new SomeResponse(
+                  "Query on vt: "
+                      + Thread.currentThread().isVirtual()
+                      + ", constructed on vt: "
+                      + constructedOnVt));
     }
 
     return effects()
-      .systemMessage("You are a helpful...")
-      .tools(new WeatherService(), TrafficService.class)
-      .userMessage(question)
-      .map(SomeResponse::new)
-      .thenReply();
+        .systemMessage("You are a helpful...")
+        .tools(new WeatherService(), TrafficService.class)
+        .userMessage(question)
+        .map(SomeResponse::new)
+        .thenReply();
   }
-
 
   @FunctionTool(description = "Returns today's date")
   private String getDateOfToday() {
     return "2025-01-01";
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SomeStreamingAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SomeStreamingAgent.java
@@ -8,17 +8,12 @@ import akka.javasdk.agent.Agent;
 import akka.javasdk.annotations.AgentDescription;
 import akka.javasdk.annotations.ComponentId;
 
-/**
- * Dummy agent for testing token streaming.
- */
+/** Dummy agent for testing token streaming. */
 @ComponentId("some-streaming-agent")
 @AgentDescription(name = "Dummy Agent", description = "Not very smart agent", role = "streaming")
 public class SomeStreamingAgent extends Agent {
 
   public StreamEffect ask(String question) {
-    return streamEffects()
-      .systemMessage("You are a helpful...")
-      .userMessage(question)
-      .thenReply();
+    return streamEffects().systemMessage("You are a helpful...").userMessage(question).thenReply();
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SomeStructureResponseAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SomeStructureResponseAgent.java
@@ -17,22 +17,24 @@ public class SomeStructureResponseAgent extends Agent {
   private static final Logger log = LoggerFactory.getLogger(SomeStructureResponseAgent.class);
 
   public record SomeResponse(String response) {}
+
   public record StructuredResponse(String response) {}
 
   public Effect<SomeResponse> mapStructureResponse(String question) {
     return effects()
-      .systemMessage("You are a helpful...")
-      .userMessage(question)
-      .responseAs(StructuredResponse.class)
-      .map(r -> new SomeResponse(r.response()))
-      .onFailure(throwable -> {
-        if (throwable instanceof JsonParsingException jsonParsingException){
-          log.info("Raw json: {}", jsonParsingException.getRawJson());
-          return new SomeResponse("default response");
-        }else {
-          throw new RuntimeException(throwable);
-        }
-      })
-      .thenReply();
+        .systemMessage("You are a helpful...")
+        .userMessage(question)
+        .responseAs(StructuredResponse.class)
+        .map(r -> new SomeResponse(r.response()))
+        .onFailure(
+            throwable -> {
+              if (throwable instanceof JsonParsingException jsonParsingException) {
+                log.info("Raw json: {}", jsonParsingException.getRawJson());
+                return new SomeResponse("default response");
+              } else {
+                throw new RuntimeException(throwable);
+              }
+            })
+        .thenReply();
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/counter/CounterCommand.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/counter/CounterCommand.java
@@ -10,12 +10,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = CounterCommand.Increase.class, name = "I"),
-  @JsonSubTypes.Type(value = CounterCommand.Set.class, name = "S")})
+  @JsonSubTypes.Type(value = CounterCommand.Set.class, name = "S")
+})
 public sealed interface CounterCommand {
 
-  record Increase(int value) implements CounterCommand {
-  }
+  record Increase(int value) implements CounterCommand {}
 
-  record Set(int value) implements CounterCommand {
-  }
+  record Set(int value) implements CounterCommand {}
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/counter/CounterEvent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/counter/CounterEvent.java
@@ -9,14 +9,11 @@ import akka.javasdk.annotations.TypeName;
 public sealed interface CounterEvent {
 
   @TypeName("increased")
-  record ValueIncreased(int value) implements CounterEvent {
-  }
+  record ValueIncreased(int value) implements CounterEvent {}
 
   @TypeName("set")
-  record ValueSet(int value) implements CounterEvent {
-  }
+  record ValueSet(int value) implements CounterEvent {}
 
   @TypeName("multiplied")
-  record ValueMultiplied(int value) implements CounterEvent {
-  }
+  record ValueMultiplied(int value) implements CounterEvent {}
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/counter/IncreaseActionWithIgnore.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/counter/IncreaseActionWithIgnore.java
@@ -9,27 +9,29 @@ import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.annotations.Consume;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.consumer.Consumer;
-
 import java.util.concurrent.CompletionStage;
 
 @ComponentId("increase-action-with-ignore")
 @Consume.FromEventSourcedEntity(value = CounterEntity.class, ignoreUnknown = true)
 public class IncreaseActionWithIgnore extends Consumer {
 
-    private ComponentClient componentClient;
+  private ComponentClient componentClient;
 
-    public IncreaseActionWithIgnore(ComponentClient componentClient) {
-        this.componentClient = componentClient;
-    }
+  public IncreaseActionWithIgnore(ComponentClient componentClient) {
+    this.componentClient = componentClient;
+  }
 
-    public Effect oneShallPass(CounterEvent.ValueIncreased event) {
-        String entityId = this.messageContext().metadata().asCloudEvent().subject().get();
-        if (event.value() == 1234) {
-            CompletionStage<Done> res =
-                componentClient.forEventSourcedEntity(entityId).method(CounterEntity::increase).invokeAsync(1)
-                  .thenApply(__ -> Done.done());
-            return effects().asyncDone(res);
-        }
-        return effects().done();
+  public Effect oneShallPass(CounterEvent.ValueIncreased event) {
+    String entityId = this.messageContext().metadata().asCloudEvent().subject().get();
+    if (event.value() == 1234) {
+      CompletionStage<Done> res =
+          componentClient
+              .forEventSourcedEntity(entityId)
+              .method(CounterEntity::increase)
+              .invokeAsync(1)
+              .thenApply(__ -> Done.done());
+      return effects().asyncDone(res);
     }
+    return effects().done();
+  }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/counter/IncreaseConsumer.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/counter/IncreaseConsumer.java
@@ -9,7 +9,6 @@ import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.annotations.Consume;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.consumer.Consumer;
-
 import java.util.concurrent.CompletionStage;
 
 @ComponentId("increase-action")
@@ -33,7 +32,12 @@ public class IncreaseConsumer extends Consumer {
   public Effect printIncrease(CounterEvent.ValueIncreased event) {
     String entityId = this.messageContext().metadata().asCloudEvent().subject().get();
     if (event.value() == 42) {
-      CompletionStage<Done> res = componentClient.forEventSourcedEntity(entityId).method(CounterEntity::increase).invokeAsync(1).thenApply(__ -> Done.getInstance());
+      CompletionStage<Done> res =
+          componentClient
+              .forEventSourcedEntity(entityId)
+              .method(CounterEntity::increase)
+              .invokeAsync(1)
+              .thenApply(__ -> Done.getInstance());
       return effects().asyncDone(res);
     }
     return effects().done();

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/hierarchy/AbstractTextConsumer.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/hierarchy/AbstractTextConsumer.java
@@ -14,5 +14,4 @@ public abstract class AbstractTextConsumer extends Consumer {
   protected void onText(String text) {
     StaticTestBuffer.addValue(BUFFER_KEY, text);
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/hierarchy/AbstractTextEsEntity.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/hierarchy/AbstractTextEsEntity.java
@@ -6,8 +6,8 @@ package akkajavasdk.components.eventsourcedentities.hierarchy;
 
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
 
-public abstract class AbstractTextEsEntity<E> extends EventSourcedEntity<AbstractTextEsEntity.State, E> {
+public abstract class AbstractTextEsEntity<E>
+    extends EventSourcedEntity<AbstractTextEsEntity.State, E> {
 
   public record State(String value) {}
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/hierarchy/TextEsEntity.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/hierarchy/TextEsEntity.java
@@ -5,12 +5,12 @@
 package akkajavasdk.components.eventsourcedentities.hierarchy;
 
 import akka.javasdk.annotations.ComponentId;
-
 import java.util.Optional;
 
 @ComponentId("hierarchy-es-entity")
 public class TextEsEntity extends AbstractTextEsEntity<TextEsEntity.Event> {
   sealed interface Event {}
+
   record TextSet(String value) implements Event {}
 
   public Effect<String> setText(String text) {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/grpc/TestGrpcServiceImpl.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/grpc/TestGrpcServiceImpl.java
@@ -13,7 +13,6 @@ import io.grpc.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 @Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET), denyCode = 5)
 @GrpcEndpoint
 public class TestGrpcServiceImpl implements TestGrpcService {
@@ -24,7 +23,8 @@ public class TestGrpcServiceImpl implements TestGrpcService {
   private final GrpcRequestContext requestContext;
   private boolean constructedOnVt = Thread.currentThread().isVirtual();
 
-  public TestGrpcServiceImpl(GrpcClientProvider grpcClientProvider, GrpcRequestContext requestContext) {
+  public TestGrpcServiceImpl(
+      GrpcClientProvider grpcClientProvider, GrpcRequestContext requestContext) {
     this.grpcClientProvider = grpcClientProvider;
     this.requestContext = requestContext;
   }
@@ -32,7 +32,14 @@ public class TestGrpcServiceImpl implements TestGrpcService {
   private void logDetailsIfNotVt() {
     if (!Thread.currentThread().isVirtual()) {
       // try to gather more info
-      logger.error("Not on virtual thread, thread name [" + Thread.currentThread().getName() + "], thread state " + Thread.currentThread().getState() + " thread group [" + Thread.currentThread().getThreadGroup().getName() + "]",
+      logger.error(
+          "Not on virtual thread, thread name ["
+              + Thread.currentThread().getName()
+              + "], thread state "
+              + Thread.currentThread().getState()
+              + " thread group ["
+              + Thread.currentThread().getThreadGroup().getName()
+              + "]",
           new RuntimeException("Error to get stacktrace"));
     }
   }
@@ -49,16 +56,18 @@ public class TestGrpcServiceImpl implements TestGrpcService {
   @Override
   public TestGrpcServiceOuterClass.Out readMetadata(TestGrpcServiceOuterClass.In in) {
     logDetailsIfNotVt();
-    return TestGrpcServiceOuterClass.Out.newBuilder().setData(
-            requestContext.metadata().getText(in.getData()).orElse("")).build();
+    return TestGrpcServiceOuterClass.Out.newBuilder()
+        .setData(requestContext.metadata().getText(in.getData()).orElse(""))
+        .build();
   }
-
 
   @Override
   public TestGrpcServiceOuterClass.Out delegateToAkkaService(TestGrpcServiceOuterClass.In in) {
     logDetailsIfNotVt();
-    // alias for external defined in application.conf - but note that it is only allowed for dev/test
-    var grpcServiceClient = grpcClientProvider.grpcClientFor(TestGrpcServiceClient.class, "other-service");
+    // alias for external defined in application.conf - but note that it is only allowed for
+    // dev/test
+    var grpcServiceClient =
+        grpcClientProvider.grpcClientFor(TestGrpcServiceClient.class, "other-service");
     return grpcServiceClient.simple(in);
   }
 
@@ -66,7 +75,8 @@ public class TestGrpcServiceImpl implements TestGrpcService {
   public TestGrpcServiceOuterClass.Out delegateToExternal(TestGrpcServiceOuterClass.In in) {
     logDetailsIfNotVt();
     // alias for external defined in application.conf
-    var grpcServiceClient = grpcClientProvider.grpcClientFor(TestGrpcServiceClient.class, "some.example.com");
+    var grpcServiceClient =
+        grpcClientProvider.grpcClientFor(TestGrpcServiceClient.class, "some.example.com");
     return grpcServiceClient.simple(in);
   }
 
@@ -112,5 +122,4 @@ public class TestGrpcServiceImpl implements TestGrpcService {
   public TestGrpcServiceOuterClass.Out aclDefaultDenyCode(TestGrpcServiceOuterClass.In in) {
     return simple(in);
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/grpc/TestJwtsGrpcServiceImpl.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/grpc/TestJwtsGrpcServiceImpl.java
@@ -11,10 +11,6 @@ import akka.javasdk.grpc.GrpcClientProvider;
 import akkajavasdk.protocol.TestGrpcServiceOuterClass;
 import akkajavasdk.protocol.TestJwtsGrpcService;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-
-
 @Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET), denyCode = 5)
 @JWT(validate = JWT.JwtMethodMode.BEARER_TOKEN, bearerTokenIssuers = "class-level-issuer")
 @GrpcEndpoint
@@ -36,13 +32,17 @@ public class TestJwtsGrpcServiceImpl implements TestJwtsGrpcService {
     return simple(in);
   }
 
-  @JWT(validate = JWT.JwtMethodMode.BEARER_TOKEN, staticClaims = { @JWT.StaticClaim(claim = "sub", values = "my-subject-123")})
+  @JWT(
+      validate = JWT.JwtMethodMode.BEARER_TOKEN,
+      staticClaims = {@JWT.StaticClaim(claim = "sub", values = "my-subject-123")})
   @Override
   public TestGrpcServiceOuterClass.Out jwtStaticClaimValue(TestGrpcServiceOuterClass.In in) {
     return simple(in);
   }
 
-  @JWT(validate = JWT.JwtMethodMode.BEARER_TOKEN, staticClaims = { @JWT.StaticClaim(claim = "sub", pattern = "my-subject-\\d+")})
+  @JWT(
+      validate = JWT.JwtMethodMode.BEARER_TOKEN,
+      staticClaims = {@JWT.StaticClaim(claim = "sub", pattern = "my-subject-\\d+")})
   public TestGrpcServiceOuterClass.Out jwtStaticClaimPattern(TestGrpcServiceOuterClass.In in) {
     return simple(in);
   }
@@ -51,5 +51,4 @@ public class TestJwtsGrpcServiceImpl implements TestJwtsGrpcService {
   public TestGrpcServiceOuterClass.Out jwtInherited(TestGrpcServiceOuterClass.In in) {
     return simple(in);
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/http/ResourcesEndpoint.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/http/ResourcesEndpoint.java
@@ -28,12 +28,11 @@ public class ResourcesEndpoint {
     return HttpResponses.staticResource(request, "/static");
   }
 
-
   @Post("static-exploit-try")
   public HttpResponse oneSpecificResourceExploit(SomeRequest request) {
-    // Not possible to exploit through the wildcard path as Akka HTTP would normalize 'something/somewhere/..' into `something/'
+    // Not possible to exploit through the wildcard path as Akka HTTP would normalize
+    // 'something/somewhere/..' into `something/'
     // already when parsing the request
     return HttpResponses.staticResource(request.path);
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/http/RetryEndpoint.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/http/RetryEndpoint.java
@@ -11,7 +11,6 @@ import akka.javasdk.annotations.http.Post;
 import akka.javasdk.client.ComponentClient;
 import akka.pattern.RetrySettings;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEntity;
-
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 
@@ -29,23 +28,29 @@ public class RetryEndpoint {
 
   @Post("/retry/{counterId}")
   public CompletionStage<Integer> useRetry(String counterId) {
-    return componentClient.forEventSourcedEntity(counterId)
-      .method(CounterEntity::failedIncrease)
-      .withRetry(RetrySettings.create(3).withFixedDelay(Duration.ofMillis(100)))
-      .invokeAsync(111);
+    return componentClient
+        .forEventSourcedEntity(counterId)
+        .method(CounterEntity::failedIncrease)
+        .withRetry(RetrySettings.create(3).withFixedDelay(Duration.ofMillis(100)))
+        .invokeAsync(111);
   }
 
   @Post("/async-utils/{counterId}")
   public CompletionStage<Integer> useAsyncUtilsRetry(String counterId) {
-    return retries.retryAsync(() -> componentClient.forEventSourcedEntity(counterId)
-      .method(CounterEntity::failedIncrease)
-      .invokeAsync(111), RetrySettings.create(3));
+    return retries.retryAsync(
+        () ->
+            componentClient
+                .forEventSourcedEntity(counterId)
+                .method(CounterEntity::failedIncrease)
+                .invokeAsync(111),
+        RetrySettings.create(3));
   }
 
   @Post("/failing/{counterId}")
   public CompletionStage<Integer> failingIncrease(String counterId) {
-    return componentClient.forEventSourcedEntity(counterId)
-      .method(CounterEntity::failedIncrease)
-      .invokeAsync(111);
+    return componentClient
+        .forEventSourcedEntity(counterId)
+        .method(CounterEntity::failedIncrease)
+        .invokeAsync(111);
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/http/TestEndpoint.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/http/TestEndpoint.java
@@ -9,7 +9,6 @@ import akka.javasdk.annotations.http.Get;
 import akka.javasdk.annotations.http.HttpEndpoint;
 import akka.javasdk.annotations.http.Post;
 import akka.javasdk.http.AbstractHttpEndpoint;
-
 import java.util.List;
 
 @HttpEndpoint()

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/jwt/HelloJwtEndpoint.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/jwt/HelloJwtEndpoint.java
@@ -4,29 +4,33 @@
 
 package akkajavasdk.components.jwt;
 
-import akka.javasdk.annotations.Acl;
-import akka.javasdk.annotations.JWT;
-import akka.javasdk.annotations.http.HttpEndpoint;
-import akka.javasdk.annotations.http.Get;
-import akka.javasdk.http.AbstractHttpEndpoint;
-
-import java.util.concurrent.CompletionStage;
 import static java.util.concurrent.CompletableFuture.completedStage;
 
+import akka.javasdk.annotations.Acl;
+import akka.javasdk.annotations.JWT;
+import akka.javasdk.annotations.http.Get;
+import akka.javasdk.annotations.http.HttpEndpoint;
+import akka.javasdk.http.AbstractHttpEndpoint;
+import java.util.concurrent.CompletionStage;
+
 // Opened up for access from the public internet to make the sample service easy to try out.
-// For actual services meant for production this must be carefully considered, and often set more limited
+// For actual services meant for production this must be carefully considered, and often set more
+// limited
 @Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET))
 // tag::bearer-token[]
 @HttpEndpoint("/hello")
-@JWT(validate = JWT.JwtMethodMode.BEARER_TOKEN, bearerTokenIssuers = "my-issuer-123", staticClaims = { @JWT.StaticClaim(claim = "sub", pattern = "my-subject-123")})
+@JWT(
+    validate = JWT.JwtMethodMode.BEARER_TOKEN,
+    bearerTokenIssuers = "my-issuer-123",
+    staticClaims = {@JWT.StaticClaim(claim = "sub", pattern = "my-subject-123")})
 public class HelloJwtEndpoint extends AbstractHttpEndpoint {
-    // end::bearer-token[]
+  // end::bearer-token[]
 
-    @Get("/")
-    public CompletionStage<String> helloWorld() {
-        var claims = requestContext().getJwtClaims();
-        var issuer = claims.issuer().get();
-        var sub = claims.subject().get();
-        return completedStage("issuer: " + issuer + ", subject: " + sub);
-    }
+  @Get("/")
+  public CompletionStage<String> helloWorld() {
+    var claims = requestContext().getJwtClaims();
+    var issuer = claims.issuer().get();
+    var sub = claims.subject().get();
+    return completedStage("issuer: " + issuer + ", subject: " + sub);
+  }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/jwt/MissingJwtEndpoint.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/jwt/MissingJwtEndpoint.java
@@ -4,33 +4,35 @@
 
 package akkajavasdk.components.jwt;
 
+import static java.util.concurrent.CompletableFuture.completedStage;
+
 import akka.javasdk.annotations.Acl;
 import akka.javasdk.annotations.http.Get;
 import akka.javasdk.annotations.http.HttpEndpoint;
 import akka.javasdk.http.RequestContext;
-
 import java.util.concurrent.CompletionStage;
 
-import static java.util.concurrent.CompletableFuture.completedStage;
-
 // Opened up for access from the public internet to make the sample service easy to try out.
-// For actual services meant for production this must be carefully considered, and often set more limited
+// For actual services meant for production this must be carefully considered, and often set more
+// limited
 @Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET))
 @HttpEndpoint("/missingjwt")
 public class MissingJwtEndpoint {
 
-    // Note: leaving this with injected request context rather than extend AbstractHttpEndpoint to keep
-    // some test coverage
-    RequestContext context;
-    public MissingJwtEndpoint(RequestContext context){
-        this.context = context;
-    }
+  // Note: leaving this with injected request context rather than extend AbstractHttpEndpoint to
+  // keep
+  // some test coverage
+  RequestContext context;
 
-    @Get("/")
-    public CompletionStage<String> missingjwt() {
-        var claims = context.getJwtClaims();
-        var issuer = claims.issuer().get();
-        var sub = claims.subject().get();
-        return completedStage("issuer: " + issuer + ", subject: " + sub);
-    }
+  public MissingJwtEndpoint(RequestContext context) {
+    this.context = context;
+  }
+
+  @Get("/")
+  public CompletionStage<String> missingjwt() {
+    var claims = context.getJwtClaims();
+    var issuer = claims.issuer().get();
+    var sub = claims.subject().get();
+    return completedStage("issuer: " + issuer + ", subject: " + sub);
+  }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/customer/CustomerEntity.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/customer/CustomerEntity.java
@@ -4,10 +4,9 @@
 
 package akkajavasdk.components.keyvalueentities.customer;
 
-import akkajavasdk.Ok;
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.keyvalueentity.KeyValueEntity;
-
+import akkajavasdk.Ok;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -15,8 +14,7 @@ import java.util.Optional;
 @ComponentId("customer")
 public class CustomerEntity extends KeyValueEntity<CustomerEntity.Customer> {
 
-  public record Customer(String name, Instant createdOn) {
-  }
+  public record Customer(String name, Instant createdOn) {}
 
   public record SomeRecord(String name, int number) {}
 
@@ -30,10 +28,7 @@ public class CustomerEntity extends KeyValueEntity<CustomerEntity.Customer> {
 
   // test coverage for serialization handling a list of records
   public ReadOnlyEffect<List<SomeRecord>> returnAListOfRecords() {
-    return effects().reply(List.of(
-        new SomeRecord("text1", 1),
-        new SomeRecord("text2", 2)
-    ));
+    return effects().reply(List.of(new SomeRecord("text1", 1), new SomeRecord("text2", 2)));
   }
 
   public ReadOnlyEffect<Optional<SomeRecord>> returnOptionalRecord() {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/hierarchy/AbstractTextConsumer.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/hierarchy/AbstractTextConsumer.java
@@ -14,5 +14,4 @@ public abstract class AbstractTextConsumer extends Consumer {
   protected void onText(String text) {
     StaticTestBuffer.addValue(BUFFER_KEY, text);
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/hierarchy/AbstractTextKvEntity.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/hierarchy/AbstractTextKvEntity.java
@@ -9,5 +9,4 @@ import akka.javasdk.keyvalueentity.KeyValueEntity;
 public class AbstractTextKvEntity extends KeyValueEntity<AbstractTextKvEntity.State> {
 
   public record State(String value) {}
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/hierarchy/TextKvEntity.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/hierarchy/TextKvEntity.java
@@ -5,7 +5,6 @@
 package akkajavasdk.components.keyvalueentities.hierarchy;
 
 import akka.javasdk.annotations.ComponentId;
-
 import java.util.Optional;
 
 @ComponentId("hierarchy-kv-entity")
@@ -18,5 +17,4 @@ public class TextKvEntity extends AbstractTextKvEntity {
   public Effect<Optional<String>> getText() {
     return effects().reply(Optional.ofNullable(currentState()).map(State::value));
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/user/TestCounterEntity.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/user/TestCounterEntity.java
@@ -8,8 +8,6 @@ import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.keyvalueentity.KeyValueEntity;
 import akka.javasdk.keyvalueentity.KeyValueEntityContext;
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigRenderOptions;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -35,11 +33,12 @@ public class TestCounterEntity extends KeyValueEntity<Integer> {
 
   public Effect<Map<String, String>> getUserConfigKeys(Set<String> keys) {
     var found = new HashMap<String, String>();
-    keys.forEach(key -> {
-      if (userConfig.hasPath(key)) {
-        found.put(key, userConfig.getString(key));
-      }
-    });
+    keys.forEach(
+        key -> {
+          if (userConfig.hasPath(key)) {
+            found.put(key, userConfig.getString(key));
+          }
+        });
     return effects().reply(found);
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/user/User.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/user/User.java
@@ -6,7 +6,6 @@ package akkajavasdk.components.keyvalueentities.user;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Objects;
 
 public class User {
@@ -27,7 +26,6 @@ public class User {
     return Objects.equals(email, user.email) && Objects.equals(name, user.name);
   }
 
-
   @Override
   public int hashCode() {
     return Objects.hash(email, name);
@@ -35,9 +33,6 @@ public class User {
 
   @Override
   public String toString() {
-    return "User{" +
-        "email='" + email + '\'' +
-        ", name='" + name + '\'' +
-        '}';
+    return "User{" + "email='" + email + '\'' + ", name='" + name + '\'' + '}';
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/user/UserEntity.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/user/UserEntity.java
@@ -5,51 +5,66 @@
 package akkajavasdk.components.keyvalueentities.user;
 
 import akka.javasdk.CommandException;
-import akkajavasdk.Ok;
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.keyvalueentity.KeyValueEntity;
+import akkajavasdk.Ok;
 import akkajavasdk.components.MyException;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
 
 @ComponentId("user")
 public class UserEntity extends KeyValueEntity<User> {
 
   private Logger logger = LoggerFactory.getLogger(getClass());
 
-  public record CreatedUser(String name, String email) {};
-  public record UpdateEmail(String newEmail) {};
-  public record Delete() {};
-  public record Restart() {};
+  public record CreatedUser(String name, String email) {}
+  ;
 
+  public record UpdateEmail(String newEmail) {}
+  ;
+
+  public record Delete() {}
+  ;
+
+  public record Restart() {}
+  ;
 
   public ReadOnlyEffect<User> getUser() {
-    if (currentState() == null)
-      return effects().error("User not found");
+    if (currentState() == null) return effects().error("User not found");
 
     return effects().reply(currentState());
   }
 
   public Effect<Ok> createOrUpdateUser(CreatedUser createdUser) {
-    return effects().updateState(new User(createdUser.name, createdUser.email)).thenReply(Ok.instance);
+    return effects()
+        .updateState(new User(createdUser.name, createdUser.email))
+        .thenReply(Ok.instance);
   }
 
   public Effect<Ok> createUser(CreatedUser createdUser) {
-    return effects().updateState(new User(createdUser.name, createdUser.email)).thenReply(Ok.instance);
+    return effects()
+        .updateState(new User(createdUser.name, createdUser.email))
+        .thenReply(Ok.instance);
   }
 
   public Effect<Ok> updateEmail(UpdateEmail cmd) {
-    return effects().updateState(new User(currentState().name, cmd.newEmail)).thenReply(Ok.instance);
+    return effects()
+        .updateState(new User(currentState().name, cmd.newEmail))
+        .thenReply(Ok.instance);
   }
 
   public Effect<Boolean> nameIsLikeOneOf(List<String> names) {
-    return effects().reply(currentState() != null && names.stream().anyMatch(n -> n.equals(currentState().name)));
+    return effects()
+        .reply(
+            currentState() != null && names.stream().anyMatch(n -> n.equals(currentState().name)));
   }
 
   public Effect<Boolean> nameIsLikeOneOfUsers(List<User> users) {
-    return effects().reply(currentState() != null && users.stream().anyMatch(c -> c.name.equals(currentState().name)));
+    return effects()
+        .reply(
+            currentState() != null
+                && users.stream().anyMatch(c -> c.name.equals(currentState().name)));
   }
 
   public Effect<Ok> deleteUser(Delete cmd) {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/user/UserSideEffect.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/user/UserSideEffect.java
@@ -10,11 +10,11 @@ public class UserSideEffect {
 
   static final ConcurrentHashMap<String, User> users = new ConcurrentHashMap<>();
 
-  static void addUser(String id, User user){
+  static void addUser(String id, User user) {
     users.put(id, user);
   }
 
-  static void removeUser(String id){
+  static void removeUser(String id) {
     users.remove(id);
   }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/user/ValidateUserAction.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/user/ValidateUserAction.java
@@ -5,8 +5,8 @@
 package akkajavasdk.components.keyvalueentities.user;
 
 import akka.Done;
-import akka.javasdk.timedaction.TimedAction;
 import akka.javasdk.client.ComponentClient;
+import akka.javasdk.timedaction.TimedAction;
 
 public class ValidateUserAction extends TimedAction {
 
@@ -16,36 +16,41 @@ public class ValidateUserAction extends TimedAction {
     this.componentClient = componentClient;
   }
 
-  public record CreateUser(String user, String email, String name){}
+  public record CreateUser(String user, String email, String name) {}
+
   public TimedAction.Effect createOrUpdateUser(CreateUser createUser) {
     if (createUser.email.isEmpty() || createUser.name.isEmpty())
       return effects().error("No field can be empty");
 
     var reply =
-      componentClient
-        .forKeyValueEntity(createUser.user)
-        .method(UserEntity::createUser)
-        .invokeAsync(new UserEntity.CreatedUser(createUser.name, createUser.email));
+        componentClient
+            .forKeyValueEntity(createUser.user)
+            .method(UserEntity::createUser)
+            .invokeAsync(new UserEntity.CreatedUser(createUser.name, createUser.email));
     return effects().done();
   }
 
-  public record UpdateEmail(String user, String email){}
-  public TimedAction.Effect updateEmail(UpdateEmail updateEmail) {
-    if (updateEmail.email.isEmpty())
-      return effects().error("No field can be empty");
+  public record UpdateEmail(String user, String email) {}
 
-    return effects().asyncDone(      componentClient
-      .forKeyValueEntity(updateEmail.user)
-      .method(UserEntity::updateEmail)
-      .invokeAsync(new UserEntity.UpdateEmail(updateEmail.email))
-      .thenApply(__ -> Done.done()));
+  public TimedAction.Effect updateEmail(UpdateEmail updateEmail) {
+    if (updateEmail.email.isEmpty()) return effects().error("No field can be empty");
+
+    return effects()
+        .asyncDone(
+            componentClient
+                .forKeyValueEntity(updateEmail.user)
+                .method(UserEntity::updateEmail)
+                .invokeAsync(new UserEntity.UpdateEmail(updateEmail.email))
+                .thenApply(__ -> Done.done()));
   }
 
   public TimedAction.Effect delete(String user) {
-    return effects().asyncDone(componentClient
-      .forKeyValueEntity(user)
-      .method(UserEntity::deleteUser)
-      .invokeAsync(new UserEntity.Delete())
-      .thenApply(__ -> Done.done()));
+    return effects()
+        .asyncDone(
+            componentClient
+                .forKeyValueEntity(user)
+                .method(UserEntity::deleteUser)
+                .invokeAsync(new UserEntity.Delete())
+                .thenApply(__ -> Done.done()));
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/mcp/TestMcpEndpoint.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/mcp/TestMcpEndpoint.java
@@ -8,7 +8,6 @@ import akka.javasdk.annotations.Acl;
 import akka.javasdk.annotations.Description;
 import akka.javasdk.annotations.mcp.*;
 import akka.javasdk.mcp.AbstractMcpEndpoint;
-
 import java.io.IOException;
 
 @McpEndpoint(serverName = "test")
@@ -20,24 +19,27 @@ public class TestMcpEndpoint extends AbstractMcpEndpoint {
     return echo;
   }
 
-  @McpResource(name = "example text", uri = "file:///example.txt", description = "a sample text file")
+  @McpResource(
+      name = "example text",
+      uri = "file:///example.txt",
+      description = "a sample text file")
   public String exampleTxt() {
     return "This is an example resource";
   }
 
-  @McpResource(name = "example binary resource", uri = "file:///example.pdf", description = "a pdf as sample of a binary resource", mimeType = "application/pdf")
+  @McpResource(
+      name = "example binary resource",
+      uri = "file:///example.pdf",
+      description = "a pdf as sample of a binary resource",
+      mimeType = "application/pdf")
   public byte[] exampleBytes() throws IOException {
     return getClass().getResourceAsStream("/static-resources/sample-pdf-file.pdf").readAllBytes();
   }
 
-  @McpResource(
-      uriTemplate = "file:///dynamic/{path}",
-      name = "Dynamic resource"
-  )
+  @McpResource(uriTemplate = "file:///dynamic/{path}", name = "Dynamic resource")
   public String exampleDynamicResource(String path) {
     return "This is a dynamic resource for " + path;
   }
-
 
   @McpPrompt(name = "code_review", description = "Code review prompt")
   public String pythonCodeReview(@Description("a prompt argument") String code) {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/pubsub/CounterView.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/pubsub/CounterView.java
@@ -4,5 +4,4 @@
 
 package akkajavasdk.components.pubsub;
 
-public record CounterView(String counterId, int value) {
-}
+public record CounterView(String counterId, int value) {}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/pubsub/DummyCounterEventStore.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/pubsub/DummyCounterEventStore.java
@@ -5,7 +5,6 @@
 package akkajavasdk.components.pubsub;
 
 import akkajavasdk.components.eventsourcedentities.counter.CounterEvent;
-
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -15,7 +14,11 @@ public class DummyCounterEventStore {
   private static ConcurrentHashMap<String, List<CounterEvent>> events = new ConcurrentHashMap<>();
 
   public static void store(String entityId, CounterEvent counterEvent) {
-    events.merge(entityId, List.of(counterEvent), (exisitingList, newList) -> Stream.concat(exisitingList.stream(), newList.stream()).toList());
+    events.merge(
+        entityId,
+        List.of(counterEvent),
+        (exisitingList, newList) ->
+            Stream.concat(exisitingList.stream(), newList.stream()).toList());
   }
 
   public static List<CounterEvent> get(String entityId) {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/pubsub/DummyCustomerStore.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/pubsub/DummyCustomerStore.java
@@ -5,7 +5,6 @@
 package akkajavasdk.components.pubsub;
 
 import akkajavasdk.components.keyvalueentities.customer.CustomerEntity.Customer;
-
 import java.util.concurrent.ConcurrentHashMap;
 
 public class DummyCustomerStore {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/pubsub/PublishVEToTopic.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/pubsub/PublishVEToTopic.java
@@ -4,19 +4,19 @@
 
 package akkajavasdk.components.pubsub;
 
-import akka.javasdk.annotations.ComponentId;
-import akka.javasdk.consumer.Consumer;
-import akkajavasdk.components.keyvalueentities.customer.CustomerEntity;
-import akka.javasdk.Metadata;
-import akka.javasdk.annotations.Produce;
-import akka.javasdk.annotations.Consume;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import static akka.javasdk.impl.MetadataImpl.CeSubject;
 import static akkajavasdk.components.pubsub.PublishVEToTopic.CUSTOMERS_TOPIC;
 
-//@Profile({"docker-it-test", "eventing-testkit-destination"})
+import akka.javasdk.Metadata;
+import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Consume;
+import akka.javasdk.annotations.Produce;
+import akka.javasdk.consumer.Consumer;
+import akkajavasdk.components.keyvalueentities.customer.CustomerEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// @Profile({"docker-it-test", "eventing-testkit-destination"})
 @ComponentId("publish-ve-to-topic")
 @Consume.FromKeyValueEntity(CustomerEntity.class)
 @Produce.ToTopic(CUSTOMERS_TOPIC)

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/pubsub/SubscribeToCounterEventsTopic.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/pubsub/SubscribeToCounterEventsTopic.java
@@ -5,9 +5,9 @@
 package akkajavasdk.components.pubsub;
 
 import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Consume;
 import akka.javasdk.consumer.Consumer;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEvent;
-import akka.javasdk.annotations.Consume;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/pubsub/ViewFromCounterEventsTopic.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/pubsub/ViewFromCounterEventsTopic.java
@@ -4,6 +4,7 @@
 
 package akkajavasdk.components.pubsub;
 
+import static akka.javasdk.impl.MetadataImpl.CeSubject;
 
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.annotations.Consume;
@@ -11,13 +12,9 @@ import akka.javasdk.annotations.Query;
 import akka.javasdk.view.TableUpdater;
 import akka.javasdk.view.View;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEvent;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-
-import static akka.javasdk.impl.MetadataImpl.CeSubject;
-
 
 @ComponentId("counter_view_topic_sub")
 public class ViewFromCounterEventsTopic extends View {
@@ -27,6 +24,7 @@ public class ViewFromCounterEventsTopic extends View {
   private static Logger logger = LoggerFactory.getLogger(ViewFromCounterEventsTopic.class);
 
   public record QueryParameters(int counterValue) {}
+
   public record CounterViewList(List<CounterView> counters) {}
 
   @Query("SELECT * AS counters FROM counter_view_topic_sub WHERE value < :counterValue")
@@ -51,8 +49,8 @@ public class ViewFromCounterEventsTopic extends View {
     public Effect<CounterView> handleMultiply(CounterEvent.ValueMultiplied multiplied) {
       String entityId = updateContext().metadata().get(CeSubject()).orElseThrow();
       logger.info("Consuming: " + multiplied + " from " + entityId);
-      return effects().updateRow(new CounterView(entityId, rowState().value() * multiplied.value()));
-
+      return effects()
+          .updateRow(new CounterView(entityId, rowState().value() * multiplied.value()));
     }
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/AllTheTypesKvEntity.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/AllTheTypesKvEntity.java
@@ -6,7 +6,6 @@ package akkajavasdk.components.views;
 
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.keyvalueentity.KeyValueEntity;
-
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -16,12 +15,13 @@ import java.util.Optional;
 public class AllTheTypesKvEntity extends KeyValueEntity<AllTheTypesKvEntity.AllTheTypes> {
 
   public enum AnEnum {
-    ONE, TWO, THREE
+    ONE,
+    TWO,
+    THREE
   }
 
   // common query parameter for views in this file
-  public record ByEmail(String email) {
-  }
+  public record ByEmail(String email) {}
 
   public record Recursive(Recursive recurse, String field) {}
 
@@ -45,10 +45,7 @@ public class AllTheTypesKvEntity extends KeyValueEntity<AllTheTypesKvEntity.AllT
       List<String> repeatedString,
       ByEmail nestedMessage,
       AnEnum anEnum,
-      Recursive recursive
-  ) {}
-
-
+      Recursive recursive) {}
 
   public Effect<String> store(AllTheTypes value) {
     return effects().updateState(value).thenReply("OK");

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/AllTheTypesView.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/AllTheTypesView.java
@@ -9,7 +9,6 @@ import akka.javasdk.annotations.Consume;
 import akka.javasdk.annotations.Query;
 import akka.javasdk.view.TableUpdater;
 import akka.javasdk.view.View;
-
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -42,13 +41,13 @@ public class AllTheTypesView extends View {
       String nestedEmail
       // FIXME indexing on enums not supported yet: AllTheTypesKvEntity.AnEnum anEnum
       // Note: recursive structures cannot be indexed
-  ) {}
-
+      ) {}
 
   @Consume.FromKeyValueEntity(AllTheTypesKvEntity.class)
-  public static class Events extends TableUpdater<AllTheTypesKvEntity.AllTheTypes> { }
+  public static class Events extends TableUpdater<AllTheTypesKvEntity.AllTheTypes> {}
 
-  @Query("""
+  @Query(
+      """
       SELECT * FROM events WHERE
       intValue = :intValue AND
       longValue = :longValue AND
@@ -68,7 +67,10 @@ public class AllTheTypesView extends View {
       :stringValue = ANY(repeatedString) AND
       nestedMessage.email = :nestedEmail
       """)
-  public QueryStreamEffect<AllTheTypesKvEntity.AllTheTypes> specificRow(AllTheQueryableTypes query) { return queryStreamResult(); }
+  public QueryStreamEffect<AllTheTypesKvEntity.AllTheTypes> specificRow(
+      AllTheQueryableTypes query) {
+    return queryStreamResult();
+  }
 
   @Query("SELECT * FROM events")
   public QueryStreamEffect<AllTheTypesKvEntity.AllTheTypes> allRows() {
@@ -76,33 +78,49 @@ public class AllTheTypesView extends View {
   }
 
   public record CountResult(long count) {}
+
   @Query("SELECT COUNT(*) FROM events")
   public QueryEffect<CountResult> countRows() {
     return queryResult();
   }
 
   public record InstantRequest(Instant instant) {}
+
   @Query("SELECT * FROM events WHERE instant > :instant")
-  public QueryStreamEffect<AllTheTypesKvEntity.AllTheTypes> compareInstant(InstantRequest request) { return queryStreamResult(); }
+  public QueryStreamEffect<AllTheTypesKvEntity.AllTheTypes> compareInstant(InstantRequest request) {
+    return queryStreamResult();
+  }
 
   public record GroupResult(List<AllTheTypesKvEntity.AllTheTypes> grouped, long totalCount) {}
+
   @Query("SELECT collect(*) AS grouped, total_count() FROM events GROUP BY intValue")
-  public QueryStreamEffect<GroupResult> groupQuery() { return queryStreamResult(); }
+  public QueryStreamEffect<GroupResult> groupQuery() {
+    return queryStreamResult();
+  }
 
-  public record ProjectedGroupResult(int intValue, List<String> groupedStringValues, long totalCount) {}
-  @Query("SELECT intValue, stringValue AS groupedStringValues, total_count() FROM events GROUP BY intValue")
-  public QueryStreamEffect<ProjectedGroupResult> projectedGroupQuery() { return queryStreamResult(); }
+  public record ProjectedGroupResult(
+      int intValue, List<String> groupedStringValues, long totalCount) {}
 
+  @Query(
+      "SELECT intValue, stringValue AS groupedStringValues, total_count() FROM events GROUP BY"
+          + " intValue")
+  public QueryStreamEffect<ProjectedGroupResult> projectedGroupQuery() {
+    return queryStreamResult();
+  }
 
-  @Query("SELECT * FROM events WHERE optionalString IS NOT NULL AND nestedMessage.email IS NOT NULL")
+  @Query(
+      "SELECT * FROM events WHERE optionalString IS NOT NULL AND nestedMessage.email IS NOT NULL")
   public QueryStreamEffect<AllTheTypesKvEntity.AllTheTypes> nullableQuery() {
     return queryStreamResult();
   }
 
   public record PageRequest(String pageToken) {}
-  public record Page(List<AllTheTypesKvEntity.AllTheTypes> entries, String nextPageToken, boolean hasMore) { }
 
-  @Query("""
+  public record Page(
+      List<AllTheTypesKvEntity.AllTheTypes> entries, String nextPageToken, boolean hasMore) {}
+
+  @Query(
+      """
       SELECT * AS entries, next_page_token() AS nextPageToken, has_more() AS hasMore
       FROM events
       OFFSET page_token_offset(:pageToken)
@@ -115,5 +133,7 @@ public class AllTheTypesView extends View {
   public record BeforeRequest(Instant instant) {}
 
   @Query("SELECT * FROM events WHERE zonedDateTime < :instant")
-  public QueryStreamEffect<AllTheTypesKvEntity.AllTheTypes> beforeInstant(BeforeRequest query)  { return queryStreamResult(); }
+  public QueryStreamEffect<AllTheTypesKvEntity.AllTheTypes> beforeInstant(BeforeRequest query) {
+    return queryStreamResult();
+  }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/TransferView.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/TransferView.java
@@ -12,7 +12,6 @@ import akka.javasdk.view.TableUpdater;
 import akka.javasdk.view.View;
 import akkajavasdk.components.workflowentities.TransferState;
 import akkajavasdk.components.workflowentities.TransferWorkflow;
-
 import java.util.Collection;
 
 @ComponentId("transfer-view")

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/UserCounter.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/UserCounter.java
@@ -7,7 +7,6 @@ package akkajavasdk.components.views;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEvent;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Objects;
 
 public class UserCounter {
@@ -29,15 +28,18 @@ public class UserCounter {
     return new UserCounter(id, value * event.value());
   }
 
-
   public UserCounter onValueSet(CounterEvent.ValueSet event) {
     return new UserCounter(id, event.value());
   }
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {return true;}
-    if (o == null || getClass() != o.getClass()) {return false;}
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     UserCounter that = (UserCounter) o;
     return Objects.equals(id, that.id) && Objects.equals(value, that.value);
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/UserCounters.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/UserCounters.java
@@ -6,7 +6,6 @@ package akkajavasdk.components.views;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 public class UserCounters {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/UserCountersView.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/UserCountersView.java
@@ -4,38 +4,39 @@
 
 package akkajavasdk.components.views;
 
+import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Consume;
+import akka.javasdk.annotations.Query;
+import akka.javasdk.annotations.Table;
 import akka.javasdk.view.TableUpdater;
+import akka.javasdk.view.View;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEntity;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEvent;
 import akkajavasdk.components.keyvalueentities.user.AssignedCounter;
 import akkajavasdk.components.keyvalueentities.user.AssignedCounterEntity;
 import akkajavasdk.components.keyvalueentities.user.User;
 import akkajavasdk.components.keyvalueentities.user.UserEntity;
-import akka.javasdk.view.View;
-import akka.javasdk.annotations.Query;
-import akka.javasdk.annotations.Consume;
-import akka.javasdk.annotations.Table;
-import akka.javasdk.annotations.ComponentId;
 import akkajavasdk.components.views.user.UserWithId;
-
 import java.util.Optional;
 
 @ComponentId("user-counters")
 public class UserCountersView extends View {
 
   public record QueryParameters(String userId) {}
+
   public static QueryParameters queryParam(String userId) {
     return new QueryParameters(userId);
   }
 
-  @Query("""
-    SELECT users.*, counters.* as counters
-    FROM users
-    JOIN assigned ON assigned.assigneeId = users.id
-    JOIN counters ON assigned.counterId = counters.id
-    WHERE users.id = :userId
-    ORDER BY counters.id
-    """)
+  @Query(
+      """
+      SELECT users.*, counters.* as counters
+      FROM users
+      JOIN assigned ON assigned.assigneeId = users.id
+      JOIN counters ON assigned.counterId = counters.id
+      WHERE users.id = :userId
+      ORDER BY counters.id
+      """)
   public View.QueryEffect<UserCounters> get(QueryParameters params) {
     return queryResult();
   }
@@ -54,7 +55,6 @@ public class UserCountersView extends View {
   @Consume.FromEventSourcedEntity(CounterEntity.class)
   public static class Counters extends TableUpdater<UserCounter> {
 
-
     private UserCounter counterState() {
       return Optional.ofNullable(rowState())
           .orElseGet(() -> new UserCounter(updateContext().eventSubject().orElse(""), 0));
@@ -72,7 +72,6 @@ public class UserCountersView extends View {
       return effects().updateRow(counterState().onValueSet(event));
     }
   }
-
 
   @Table("assigned")
   @Consume.FromKeyValueEntity(AssignedCounterEntity.class)

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/counter/CountersByValue.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/counter/CountersByValue.java
@@ -8,15 +8,14 @@
 
 package akkajavasdk.components.views.counter;
 
+import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Consume;
+import akka.javasdk.annotations.Query;
 import akka.javasdk.view.TableUpdater;
+import akka.javasdk.view.View;
 import akkajavasdk.components.eventsourcedentities.counter.Counter;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEntity;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEvent;
-import akka.javasdk.annotations.ComponentId;
-import akka.javasdk.view.View;
-import akka.javasdk.annotations.Query;
-import akka.javasdk.annotations.Consume;
-
 import java.util.Optional;
 
 @ComponentId("counters_by_value")
@@ -27,11 +26,14 @@ public class CountersByValue extends View {
 
     public Effect<Counter> onEvent(CounterEvent event) {
       Counter counter = rowState();
-      var updatedCounter = switch(event) {
-        case CounterEvent.ValueIncreased valueIncreased -> counter.onValueIncreased(valueIncreased);
-        case CounterEvent.ValueMultiplied valueMultiplied -> counter.onValueMultiplied(valueMultiplied);
-        case CounterEvent.ValueSet valueSet -> counter.onValueSet(valueSet);
-      };
+      var updatedCounter =
+          switch (event) {
+            case CounterEvent.ValueIncreased valueIncreased ->
+                counter.onValueIncreased(valueIncreased);
+            case CounterEvent.ValueMultiplied valueMultiplied ->
+                counter.onValueMultiplied(valueMultiplied);
+            case CounterEvent.ValueSet valueSet -> counter.onValueSet(valueSet);
+          };
       return effects().updateRow(updatedCounter);
     }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/counter/CountersByValueSubscriptions.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/counter/CountersByValueSubscriptions.java
@@ -4,15 +4,14 @@
 
 package akkajavasdk.components.views.counter;
 
+import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Consume;
+import akka.javasdk.annotations.Query;
 import akka.javasdk.view.TableUpdater;
+import akka.javasdk.view.View;
 import akkajavasdk.components.eventsourcedentities.counter.Counter;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEntity;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEvent;
-import akka.javasdk.annotations.Query;
-import akka.javasdk.annotations.Consume;
-import akka.javasdk.annotations.ComponentId;
-import akka.javasdk.view.View;
-
 import java.util.List;
 
 // With Multiple Subscriptions
@@ -38,15 +37,14 @@ public class CountersByValueSubscriptions extends View {
     public Effect<Counter> onEvent(CounterEvent.ValueSet event) {
       return effects().updateRow(rowState().onValueSet(event));
     }
-
   }
 
   public record QueryParameters(int value) {}
+
   public record CounterList(List<Counter> counters) {}
 
   @Query("SELECT * AS counters FROM counters WHERE value = :value")
   public QueryEffect<CounterList> getCounterByValue(QueryParameters params) {
     return queryResult();
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/counter/CountersByValueWithIgnore.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/counter/CountersByValueWithIgnore.java
@@ -4,14 +4,14 @@
 
 package akkajavasdk.components.views.counter;
 
+import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Consume;
+import akka.javasdk.annotations.Query;
 import akka.javasdk.view.TableUpdater;
+import akka.javasdk.view.View;
 import akkajavasdk.components.eventsourcedentities.counter.Counter;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEntity;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEvent;
-import akka.javasdk.annotations.Query;
-import akka.javasdk.annotations.Consume;
-import akka.javasdk.annotations.ComponentId;
-import akka.javasdk.view.View;
 
 @ComponentId("counters_by_value_with_ignore")
 public class CountersByValueWithIgnore extends View {
@@ -23,7 +23,7 @@ public class CountersByValueWithIgnore extends View {
       return new Counter(0);
     }
 
-    public Effect<Counter> onValueIncreased(CounterEvent.ValueIncreased event){
+    public Effect<Counter> onValueIncreased(CounterEvent.ValueIncreased event) {
       Counter counter = rowState();
       return effects().updateRow(counter.onValueIncreased(event));
     }
@@ -39,5 +39,4 @@ public class CountersByValueWithIgnore extends View {
   public QueryEffect<Counter> getCounterByValue(QueryParameters params) {
     return queryResult();
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/customer/CustomerByCreationTime.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/customer/CustomerByCreationTime.java
@@ -4,16 +4,14 @@
 
 package akkajavasdk.components.views.customer;
 
-import akka.javasdk.view.TableUpdater;
-import akkajavasdk.components.keyvalueentities.customer.CustomerEntity;
-import akka.javasdk.annotations.Query;
-import akka.javasdk.annotations.Consume;
 import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Consume;
+import akka.javasdk.annotations.Query;
+import akka.javasdk.view.TableUpdater;
 import akka.javasdk.view.View;
-
+import akkajavasdk.components.keyvalueentities.customer.CustomerEntity;
 import java.time.Instant;
 import java.util.List;
-
 
 @ComponentId("view_customers_by_creation_time")
 public class CustomerByCreationTime extends View {
@@ -21,13 +19,12 @@ public class CustomerByCreationTime extends View {
   @Consume.FromKeyValueEntity(CustomerEntity.class)
   public static class Customers extends TableUpdater<CustomerEntity.Customer> {}
 
-  public record CustomerList(List<CustomerEntity.Customer> customers){}
+  public record CustomerList(List<CustomerEntity.Customer> customers) {}
+
   public record QueryParameters(Instant createdOn) {}
 
   @Query("SELECT * as customers FROM customers WHERE createdOn >= :createdOn")
   public QueryEffect<CustomerList> getCustomerByTime(QueryParameters params) {
     return queryResult();
   }
-
 }
-

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/hierarchy/HierarchyCountersByValue.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/hierarchy/HierarchyCountersByValue.java
@@ -15,7 +15,6 @@ import akka.javasdk.view.TableUpdater;
 import akkajavasdk.components.eventsourcedentities.counter.Counter;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEntity;
 import akkajavasdk.components.eventsourcedentities.counter.CounterEvent;
-
 import java.util.Optional;
 
 @ComponentId("counters_by_value_hierarchy")
@@ -27,11 +26,14 @@ public class HierarchyCountersByValue extends CountersByValueBaseClass {
 
     public Effect<Counter> onEvent(CounterEvent event) {
       Counter counter = rowState();
-      var updatedCounter = switch(event) {
-        case CounterEvent.ValueIncreased valueIncreased -> counter.onValueIncreased(valueIncreased);
-        case CounterEvent.ValueMultiplied valueMultiplied -> counter.onValueMultiplied(valueMultiplied);
-        case CounterEvent.ValueSet valueSet -> counter.onValueSet(valueSet);
-      };
+      var updatedCounter =
+          switch (event) {
+            case CounterEvent.ValueIncreased valueIncreased ->
+                counter.onValueIncreased(valueIncreased);
+            case CounterEvent.ValueMultiplied valueMultiplied ->
+                counter.onValueMultiplied(valueMultiplied);
+            case CounterEvent.ValueSet valueSet -> counter.onValueSet(valueSet);
+          };
       return effects().updateRow(updatedCounter);
     }
 
@@ -40,7 +42,6 @@ public class HierarchyCountersByValue extends CountersByValueBaseClass {
       return new Counter(0);
     }
   }
-
 
   @Query("SELECT * FROM counters WHERE value = :value")
   public QueryEffect<Optional<Counter>> getCounterByValue(Integer value) {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/user/UserWithId.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/user/UserWithId.java
@@ -4,5 +4,4 @@
 
 package akkajavasdk.components.views.user;
 
-public record UserWithId(String id, String email, String name) {
-}
+public record UserWithId(String id, String email, String name) {}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/user/UserWithVersion.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/user/UserWithVersion.java
@@ -20,9 +20,6 @@ public class UserWithVersion {
 
   @Override
   public String toString() {
-    return "UserWithVersion{" +
-        "email='" + email + '\'' +
-        ", version=" + version +
-        '}';
+    return "UserWithVersion{" + "email='" + email + '\'' + ", version=" + version + '}';
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/user/UserWithVersionView.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/user/UserWithVersionView.java
@@ -4,14 +4,14 @@
 
 package akkajavasdk.components.views.user;
 
-import akka.javasdk.view.TableUpdater;
+import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Consume;
 import akka.javasdk.annotations.DeleteHandler;
+import akka.javasdk.annotations.Query;
+import akka.javasdk.view.TableUpdater;
+import akka.javasdk.view.View;
 import akkajavasdk.components.keyvalueentities.user.User;
 import akkajavasdk.components.keyvalueentities.user.UserEntity;
-import akka.javasdk.annotations.Query;
-import akka.javasdk.annotations.Consume;
-import akka.javasdk.annotations.ComponentId;
-import akka.javasdk.view.View;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,5 +45,4 @@ public class UserWithVersionView extends View {
   public QueryEffect<UserWithVersion> getUser(QueryParameters params) {
     return queryResult();
   }
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/user/UsersByEmailAndName.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/user/UsersByEmailAndName.java
@@ -4,13 +4,13 @@
 
 package akkajavasdk.components.views.user;
 
+import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Consume;
+import akka.javasdk.annotations.Query;
 import akka.javasdk.view.TableUpdater;
+import akka.javasdk.view.View;
 import akkajavasdk.components.keyvalueentities.user.User;
 import akkajavasdk.components.keyvalueentities.user.UserEntity;
-import akka.javasdk.annotations.Query;
-import akka.javasdk.annotations.Consume;
-import akka.javasdk.annotations.ComponentId;
-import akka.javasdk.view.View;
 
 @ComponentId("users_by_email_and_name")
 public class UsersByEmailAndName extends View {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/user/UsersByName.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/user/UsersByName.java
@@ -4,15 +4,14 @@
 
 package akkajavasdk.components.views.user;
 
-import akka.javasdk.view.TableUpdater;
+import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Consume;
 import akka.javasdk.annotations.DeleteHandler;
+import akka.javasdk.annotations.Query;
+import akka.javasdk.view.TableUpdater;
+import akka.javasdk.view.View;
 import akkajavasdk.components.keyvalueentities.user.User;
 import akkajavasdk.components.keyvalueentities.user.UserEntity;
-import akka.javasdk.annotations.Query;
-import akka.javasdk.annotations.Consume;
-import akka.javasdk.annotations.ComponentId;
-import akka.javasdk.view.View;
-
 import java.util.List;
 
 @ComponentId("users_by_name")
@@ -27,6 +26,7 @@ public class UsersByName extends View {
   }
 
   public record QueryParameters(String name) {}
+
   public record UserList(List<User> users) {}
 
   @Query("SELECT * AS users FROM users WHERE name = :name")

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/user/UsersByPrimitives.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/user/UsersByPrimitives.java
@@ -11,7 +11,6 @@ import akka.javasdk.view.TableUpdater;
 import akka.javasdk.view.View;
 import akkajavasdk.components.keyvalueentities.user.User;
 import akkajavasdk.components.keyvalueentities.user.UserEntity;
-
 import java.util.List;
 
 @ComponentId("users_by_primitives")
@@ -21,13 +20,19 @@ public class UsersByPrimitives extends View {
   public static class Users extends TableUpdater<UserWithByPrimitivesModel> {
     public Effect<UserWithByPrimitivesModel> onChange(User user) {
       return effects()
-        .updateRow(
-          new UserWithByPrimitivesModel(updateContext().eventSubject().orElse(""), user.email, 123, 321, 12.3d, true));
+          .updateRow(
+              new UserWithByPrimitivesModel(
+                  updateContext().eventSubject().orElse(""), user.email, 123, 321, 12.3d, true));
     }
   }
 
-  public record UserWithByPrimitivesModel(String id, String email, int intValue, long longValue, double doubleValue, boolean booleanValue) {
-  }
+  public record UserWithByPrimitivesModel(
+      String id,
+      String email,
+      int intValue,
+      long longValue,
+      double doubleValue,
+      boolean booleanValue) {}
 
   public record UserByPrimitiveList(List<UserWithByPrimitivesModel> users) {}
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/user/UsersView.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/views/user/UsersView.java
@@ -4,21 +4,19 @@
 
 package akkajavasdk.components.views.user;
 
+import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Consume;
+import akka.javasdk.annotations.Query;
 import akka.javasdk.view.TableUpdater;
+import akka.javasdk.view.View;
 import akkajavasdk.components.keyvalueentities.user.User;
 import akkajavasdk.components.keyvalueentities.user.UserEntity;
-import akka.javasdk.annotations.Query;
-import akka.javasdk.annotations.Consume;
-import akka.javasdk.annotations.ComponentId;
-import akka.javasdk.view.View;
-
-import java.util.List;
 
 @ComponentId("users")
 public class UsersView extends View {
 
   @Consume.FromKeyValueEntity(UserEntity.class)
-  public static class Users extends TableUpdater<User> { }
+  public static class Users extends TableUpdater<User> {}
 
   public static QueryByEmailParam byEmailParam(String email) {
     return new QueryByEmailParam(email);
@@ -29,6 +27,7 @@ public class UsersView extends View {
   }
 
   public record QueryByEmailParam(String email) {}
+
   public record QueryByNameParam(String name) {}
 
   @Query("SELECT * FROM users WHERE email = :email")

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/CounterScheduledValue.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/CounterScheduledValue.java
@@ -4,5 +4,4 @@
 
 package akkajavasdk.components.workflowentities;
 
-public record CounterScheduledValue(int value) {
-}
+public record CounterScheduledValue(int value) {}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/FailingCounterEntity.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/FailingCounterEntity.java
@@ -4,10 +4,10 @@
 
 package akkajavasdk.components.workflowentities;
 
-import akkajavasdk.components.eventsourcedentities.counter.Counter;
-import akkajavasdk.components.eventsourcedentities.counter.CounterEvent;
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
+import akkajavasdk.components.eventsourcedentities.counter.Counter;
+import akkajavasdk.components.eventsourcedentities.counter.CounterEvent;
 
 @ComponentId("failing-counter")
 public class FailingCounterEntity extends EventSourcedEntity<Counter, CounterEvent> {
@@ -17,15 +17,11 @@ public class FailingCounterEntity extends EventSourcedEntity<Counter, CounterEve
     return new Counter(0);
   }
 
-
-
   public Effect<Integer> increase(Integer value) {
     if (value % 3 != 0) {
       return effects().error("wrong value: " + value);
     } else {
-      return effects()
-          .persist(new CounterEvent.ValueIncreased(value))
-          .thenReply(Counter::value);
+      return effects().persist(new CounterEvent.ValueIncreased(value)).thenReply(Counter::value);
     }
   }
 
@@ -36,7 +32,7 @@ public class FailingCounterEntity extends EventSourcedEntity<Counter, CounterEve
   @Override
   public Counter applyEvent(CounterEvent event) {
     return switch (event) {
-      case CounterEvent.ValueIncreased increased-> currentState().onValueIncreased(increased);
+      case CounterEvent.ValueIncreased increased -> currentState().onValueIncreased(increased);
       case CounterEvent.ValueMultiplied multiplied -> currentState().onValueMultiplied(multiplied);
       case CounterEvent.ValueSet valueSet -> currentState().onValueSet(valueSet);
     };

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/FailingCounterState.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/FailingCounterState.java
@@ -8,6 +8,7 @@ public record FailingCounterState(String counterId, int value, boolean finished)
   public FailingCounterState asFinished() {
     return new FailingCounterState(counterId, value, true);
   }
+
   public FailingCounterState asFinished(int value) {
     return new FailingCounterState(counterId, value, true);
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/FraudDetectionResult.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/FraudDetectionResult.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public sealed interface FraudDetectionResult {
 
-  final class TransferVerified implements FraudDetectionResult{
+  final class TransferVerified implements FraudDetectionResult {
     public final Transfer transfer;
 
     @JsonCreator

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/Transfer.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/Transfer.java
@@ -4,5 +4,4 @@
 
 package akkajavasdk.components.workflowentities;
 
-public record Transfer(String from, String to, int amount) {
-}
+public record Transfer(String from, String to, int amount) {}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferConsumer.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferConsumer.java
@@ -16,7 +16,8 @@ public class TransferConsumer extends Consumer {
   public static final String TRANSFER_CONSUMER_STORE = "transfer-consumer-store";
 
   public Effect onTransfer(TransferState transfer) {
-    DummyTransferStore.store(TRANSFER_CONSUMER_STORE, messageContext().eventSubject().get(), transfer);
+    DummyTransferStore.store(
+        TRANSFER_CONSUMER_STORE, messageContext().eventSubject().get(), transfer);
     return effects().done();
   }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferState.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferState.java
@@ -4,7 +4,8 @@
 
 package akkajavasdk.components.workflowentities;
 
-public record TransferState(Transfer transfer, String lastStep, boolean finished, boolean accepted) {
+public record TransferState(
+    Transfer transfer, String lastStep, boolean finished, boolean accepted) {
 
   public static final TransferState EMPTY = new TransferState(null, null, false, false);
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflow.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflow.java
@@ -4,6 +4,8 @@
 
 package akkajavasdk.components.workflowentities;
 
+import static akka.Done.done;
+
 import akka.Done;
 import akka.javasdk.CommandException;
 import akka.javasdk.annotations.ComponentId;
@@ -11,13 +13,10 @@ import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
 import akkajavasdk.components.MyException;
 import akkajavasdk.components.actions.echo.Message;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.Duration;
 import java.util.List;
-
-import static akka.Done.done;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ComponentId("transfer-workflow")
 public class TransferWorkflow extends Workflow<TransferState> {
@@ -38,44 +37,55 @@ public class TransferWorkflow extends Workflow<TransferState> {
   @Override
   public WorkflowDef<TransferState> definition() {
     var withdraw =
-      step(withdrawStepName)
-        .call(Withdraw.class, cmd ->
-          componentClient.forKeyValueEntity(cmd.from)
-            .method(WalletEntity::withdraw).invoke(cmd.amount))
-        .andThen(() -> {
-          var state = currentState().withLastStep("withdrawn").asAccepted();
+        step(withdrawStepName)
+            .call(
+                Withdraw.class,
+                cmd ->
+                    componentClient
+                        .forKeyValueEntity(cmd.from)
+                        .method(WalletEntity::withdraw)
+                        .invoke(cmd.amount))
+            .andThen(
+                () -> {
+                  var state = currentState().withLastStep("withdrawn").asAccepted();
 
-          var depositInput = new Deposit(currentState().transfer().to(), currentState().transfer().amount());
+                  var depositInput =
+                      new Deposit(
+                          currentState().transfer().to(), currentState().transfer().amount());
 
-          return effects()
-            .updateState(state)
-            .transitionTo(depositStepName, depositInput);
-        });
+                  return effects().updateState(state).transitionTo(depositStepName, depositInput);
+                });
 
     var deposit =
-      step(depositStepName)
-        .call(Deposit.class, cmd ->
-          componentClient.forKeyValueEntity(cmd.to)
-            .method(WalletEntity::deposit).invoke(cmd.amount))
-        .andThen(() -> {
-          var state = currentState().withLastStep("deposited").asFinished();
-          return effects().updateState(state).transitionTo("logAndStop");
-        });
+        step(depositStepName)
+            .call(
+                Deposit.class,
+                cmd ->
+                    componentClient
+                        .forKeyValueEntity(cmd.to)
+                        .method(WalletEntity::deposit)
+                        .invoke(cmd.amount))
+            .andThen(
+                () -> {
+                  var state = currentState().withLastStep("deposited").asFinished();
+                  return effects().updateState(state).transitionTo("logAndStop");
+                });
 
     // this last step is mainly to ensure that Runnables are properly supported
     var logAndStop =
-      step("logAndStop")
-        .call(() -> logger.info("Workflow finished"))
-        .andThen(() -> {
-          var state = currentState().withLastStep("logAndStop");
-          return effects().updateState(state).end();
-        });
+        step("logAndStop")
+            .call(() -> logger.info("Workflow finished"))
+            .andThen(
+                () -> {
+                  var state = currentState().withLastStep("logAndStop");
+                  return effects().updateState(state).end();
+                });
 
     return workflow()
-      .timeout(Duration.ofSeconds(10))
-      .addStep(withdraw)
-      .addStep(deposit)
-      .addStep(logAndStop);
+        .timeout(Duration.ofSeconds(10))
+        .addStep(withdraw)
+        .addStep(deposit)
+        .addStep(logAndStop);
   }
 
   public Effect<Message> startTransfer(Transfer transfer) {
@@ -84,9 +94,9 @@ public class TransferWorkflow extends Workflow<TransferState> {
     } else {
       if (currentState() == null) {
         return effects()
-          .updateState(new TransferState(transfer, "started"))
-          .transitionTo(withdrawStepName, new Withdraw(transfer.from(), transfer.amount()))
-          .thenReply(new Message("transfer started"));
+            .updateState(new TransferState(transfer, "started"))
+            .transitionTo(withdrawStepName, new Withdraw(transfer.from(), transfer.amount()))
+            .thenReply(new Message("transfer started"));
       } else {
         return effects().reply(new Message("transfer started already"));
       }
@@ -95,9 +105,9 @@ public class TransferWorkflow extends Workflow<TransferState> {
 
   public Effect<Done> updateAndDelete(Transfer transfer) {
     return effects()
-      .updateState(new TransferState(transfer, "startedAndDeleted"))
-      .delete()
-      .thenReply(done());
+        .updateState(new TransferState(transfer, "startedAndDeleted"))
+        .delete()
+        .thenReply(done());
   }
 
   public Effect<Boolean> commandHandlerIsOnVirtualThread() {
@@ -107,7 +117,6 @@ public class TransferWorkflow extends Workflow<TransferState> {
   public Effect<Message> genericStringsCall(List<String> primitives) {
     return effects().reply(new Message("genericCall ok"));
   }
-
 
   public Effect<Message> getLastStep() {
     return effects().reply(new Message(currentState().lastStep()));
@@ -128,8 +137,7 @@ public class TransferWorkflow extends Workflow<TransferState> {
     return effects().reply(isDeleted());
   }
 
-  public record SomeClass(String someValue) {
-  }
+  public record SomeClass(String someValue) {}
 
   public Effect<Message> genericCall(List<SomeClass> objects) {
     return effects().reply(new Message("genericCall ok"));

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflowWithoutInputs.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflowWithoutInputs.java
@@ -4,10 +4,10 @@
 
 package akkajavasdk.components.workflowentities;
 
-import akkajavasdk.components.actions.echo.Message;
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
+import akkajavasdk.components.actions.echo.Message;
 
 @ComponentId("transfer-workflow-without-inputs")
 public class TransferWorkflowWithoutInputs extends Workflow<TransferState> {
@@ -26,59 +26,74 @@ public class TransferWorkflowWithoutInputs extends Workflow<TransferState> {
   @Override
   public WorkflowDef<TransferState> definition() {
     var withdraw =
-      step(withdrawStepName)
-        .call(() -> {
-          var transfer = currentState().transfer();
-          return componentClient.forKeyValueEntity(transfer.from()).method(WalletEntity::withdraw).invoke(transfer.amount());
-        })
-        .andThen(() -> {
-          var state = currentState().withLastStep("withdrawn").asAccepted();
-          return effects()
-            .updateState(state)
-            .transitionTo(depositStepName);
-        });
+        step(withdrawStepName)
+            .call(
+                () -> {
+                  var transfer = currentState().transfer();
+                  return componentClient
+                      .forKeyValueEntity(transfer.from())
+                      .method(WalletEntity::withdraw)
+                      .invoke(transfer.amount());
+                })
+            .andThen(
+                () -> {
+                  var state = currentState().withLastStep("withdrawn").asAccepted();
+                  return effects().updateState(state).transitionTo(depositStepName);
+                });
 
     var withdrawAsync =
-      step(withdrawAsyncStepName)
-        .asyncCall(() -> {
-          var transfer = currentState().transfer();
-          return componentClient.forKeyValueEntity(transfer.from()).method(WalletEntity::withdraw).invokeAsync(transfer.amount());
-        })
-        .andThen(() -> {
-          var state = currentState().withLastStep("withdrawn").asAccepted();
-          return effects()
-            .updateState(state)
-            .transitionTo(depositAsyncStepName);
-        });
-
+        step(withdrawAsyncStepName)
+            .asyncCall(
+                () -> {
+                  var transfer = currentState().transfer();
+                  return componentClient
+                      .forKeyValueEntity(transfer.from())
+                      .method(WalletEntity::withdraw)
+                      .invokeAsync(transfer.amount());
+                })
+            .andThen(
+                () -> {
+                  var state = currentState().withLastStep("withdrawn").asAccepted();
+                  return effects().updateState(state).transitionTo(depositAsyncStepName);
+                });
 
     var deposit =
-      step(depositStepName)
-        .call(() -> {
-          var transfer = currentState().transfer();
-          return componentClient.forKeyValueEntity(transfer.to()).method(WalletEntity::deposit).invoke(transfer.amount());
-        })
-        .andThen(() -> {
-          var state = currentState().withLastStep("deposited").asFinished();
-          return effects().updateState(state).end();
-        });
+        step(depositStepName)
+            .call(
+                () -> {
+                  var transfer = currentState().transfer();
+                  return componentClient
+                      .forKeyValueEntity(transfer.to())
+                      .method(WalletEntity::deposit)
+                      .invoke(transfer.amount());
+                })
+            .andThen(
+                () -> {
+                  var state = currentState().withLastStep("deposited").asFinished();
+                  return effects().updateState(state).end();
+                });
 
     var depositAsync =
-      step(depositAsyncStepName)
-        .asyncCall(() -> {
-          var transfer = currentState().transfer();
-          return componentClient.forKeyValueEntity(transfer.to()).method(WalletEntity::deposit).invokeAsync(transfer.amount());
-        })
-        .andThen(() -> {
-          var state = currentState().withLastStep("deposited").asFinished();
-          return effects().updateState(state).end();
-        });
+        step(depositAsyncStepName)
+            .asyncCall(
+                () -> {
+                  var transfer = currentState().transfer();
+                  return componentClient
+                      .forKeyValueEntity(transfer.to())
+                      .method(WalletEntity::deposit)
+                      .invokeAsync(transfer.amount());
+                })
+            .andThen(
+                () -> {
+                  var state = currentState().withLastStep("deposited").asFinished();
+                  return effects().updateState(state).end();
+                });
 
     return workflow()
-      .addStep(withdraw)
-      .addStep(deposit)
-      .addStep(withdrawAsync)
-      .addStep(depositAsync);
+        .addStep(withdraw)
+        .addStep(deposit)
+        .addStep(withdrawAsync)
+        .addStep(depositAsync);
   }
 
   public Effect<Message> startTransfer(Transfer transfer) {
@@ -95,9 +110,9 @@ public class TransferWorkflowWithoutInputs extends Workflow<TransferState> {
     } else {
       if (currentState() == null) {
         return effects()
-          .updateState(new TransferState(transfer, "started"))
-          .transitionTo(withdrawStepName)
-          .thenReply(new Message("transfer started"));
+            .updateState(new TransferState(transfer, "started"))
+            .transitionTo(withdrawStepName)
+            .thenReply(new Message("transfer started"));
       } else {
         return effects().reply(new Message("transfer started already"));
       }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithDefaultRecoverStrategy.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithDefaultRecoverStrategy.java
@@ -4,12 +4,12 @@
 
 package akkajavasdk.components.workflowentities;
 
-import akkajavasdk.components.actions.echo.Message;
+import static java.time.Duration.ofSeconds;
+
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
-
-import static java.time.Duration.ofSeconds;
+import akkajavasdk.components.actions.echo.Message;
 
 @ComponentId("workflow-with-default-recover-strategy")
 public class WorkflowWithDefaultRecoverStrategy extends Workflow<FailingCounterState> {
@@ -27,26 +27,22 @@ public class WorkflowWithDefaultRecoverStrategy extends Workflow<FailingCounterS
   public WorkflowDef<FailingCounterState> definition() {
     var counterInc =
         step(counterStepName)
-            .call(() -> {
-              var nextValue = currentState().value() + 1;
-              return componentClient
-                  .forEventSourcedEntity(currentState().counterId())
-                  .method(FailingCounterEntity::increase)
-                  .invoke(nextValue);
-            })
-            .andThen(Integer.class, __ -> effects()
-                .updateState(currentState().asFinished())
-                .end());
+            .call(
+                () -> {
+                  var nextValue = currentState().value() + 1;
+                  return componentClient
+                      .forEventSourcedEntity(currentState().counterId())
+                      .method(FailingCounterEntity::increase)
+                      .invoke(nextValue);
+                })
+            .andThen(Integer.class, __ -> effects().updateState(currentState().asFinished()).end());
 
     var counterIncFailover =
         step(counterFailoverStepName)
             .call(() -> "nothing")
-            .andThen(String.class, __ ->
-                effects()
-                    .updateState(currentState().inc())
-                    .transitionTo(counterStepName)
-            );
-
+            .andThen(
+                String.class,
+                __ -> effects().updateState(currentState().inc()).transitionTo(counterStepName));
 
     return workflow()
         .timeout(ofSeconds(30))
@@ -63,7 +59,7 @@ public class WorkflowWithDefaultRecoverStrategy extends Workflow<FailingCounterS
         .thenReply(new Message("workflow started"));
   }
 
-  public Effect<FailingCounterState> get(){
+  public Effect<FailingCounterState> get() {
     return effects().reply(currentState());
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithRecoverStrategy.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithRecoverStrategy.java
@@ -4,12 +4,12 @@
 
 package akkajavasdk.components.workflowentities;
 
-import akkajavasdk.components.actions.echo.Message;
+import static java.time.Duration.ofSeconds;
+
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
-
-import static java.time.Duration.ofSeconds;
+import akkajavasdk.components.actions.echo.Message;
 
 @ComponentId("workflow-with-recover-strategy")
 public class WorkflowWithRecoverStrategy extends Workflow<FailingCounterState> {
@@ -23,31 +23,26 @@ public class WorkflowWithRecoverStrategy extends Workflow<FailingCounterState> {
     this.componentClient = componentClient;
   }
 
-
   @Override
   public WorkflowDef<FailingCounterState> definition() {
     var counterInc =
         step(counterStepName)
-            .call(() -> {
-              var nextValue = currentState().value() + 1;
-              return componentClient
-                  .forEventSourcedEntity(currentState().counterId())
-                  .method(FailingCounterEntity::increase)
-                  .invoke(nextValue);
-            })
-            .andThen(Integer.class, __ -> effects()
-                .updateState(currentState().asFinished())
-                .end());
+            .call(
+                () -> {
+                  var nextValue = currentState().value() + 1;
+                  return componentClient
+                      .forEventSourcedEntity(currentState().counterId())
+                      .method(FailingCounterEntity::increase)
+                      .invoke(nextValue);
+                })
+            .andThen(Integer.class, __ -> effects().updateState(currentState().asFinished()).end());
 
     var counterIncFailover =
         step(counterFailoverStepName)
             .call(() -> "nothing")
-            .andThen(String.class, __ ->
-                effects()
-                    .updateState(currentState().inc())
-                    .transitionTo(counterStepName)
-            );
-
+            .andThen(
+                String.class,
+                __ -> effects().updateState(currentState().inc()).transitionTo(counterStepName));
 
     return workflow()
         .timeout(ofSeconds(30))
@@ -63,7 +58,7 @@ public class WorkflowWithRecoverStrategy extends Workflow<FailingCounterState> {
         .thenReply(new Message("workflow started"));
   }
 
-  public Effect<FailingCounterState> get(){
+  public Effect<FailingCounterState> get() {
     if (currentState() != null) {
       return effects().reply(currentState());
     } else {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithTimeout.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithTimeout.java
@@ -4,18 +4,17 @@
 
 package akkajavasdk.components.workflowentities;
 
-import akkajavasdk.components.actions.echo.Message;
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
-
+import akkajavasdk.components.actions.echo.Message;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-
-import static java.time.Duration.ofMillis;
-import static java.time.Duration.ofSeconds;
 
 @ComponentId("workflow-with-timeout")
 public class WorkflowWithTimeout extends Workflow<FailingCounterState> {
@@ -29,40 +28,45 @@ public class WorkflowWithTimeout extends Workflow<FailingCounterState> {
     this.componentClient = componentClient;
   }
 
-
   public Executor delayedExecutor = CompletableFuture.delayedExecutor(1, TimeUnit.SECONDS);
 
   @Override
   public WorkflowDef<FailingCounterState> definition() {
     var counterInc =
-      step(counterStepName)
-        .asyncCall(() -> CompletableFuture.supplyAsync(() -> "nothing", delayedExecutor))
-        .andThen(String.class, __ -> effects().end())
-        .timeout(Duration.ofMillis(50));
+        step(counterStepName)
+            .asyncCall(() -> CompletableFuture.supplyAsync(() -> "nothing", delayedExecutor))
+            .andThen(String.class, __ -> effects().end())
+            .timeout(Duration.ofMillis(50));
 
     var counterIncFailover =
-      step(counterFailoverStepName)
-        .call(Integer.class, value -> componentClient.forEventSourcedEntity(currentState().counterId()).method(FailingCounterEntity::increase).invoke(value))
-        .andThen(Integer.class, __ ->
-          effects()
-            .updateState(currentState().asFinished())
-            .transitionTo(counterStepName)
-        );
-
+        step(counterFailoverStepName)
+            .call(
+                Integer.class,
+                value ->
+                    componentClient
+                        .forEventSourcedEntity(currentState().counterId())
+                        .method(FailingCounterEntity::increase)
+                        .invoke(value))
+            .andThen(
+                Integer.class,
+                __ ->
+                    effects()
+                        .updateState(currentState().asFinished())
+                        .transitionTo(counterStepName));
 
     return workflow()
-      .timeout(ofSeconds(1))
-      .defaultStepTimeout(ofMillis(999))
-      .failoverTo(counterFailoverStepName, 3, maxRetries(1))
-      .addStep(counterInc, maxRetries(1).failoverTo(counterStepName))
-      .addStep(counterIncFailover);
+        .timeout(ofSeconds(1))
+        .defaultStepTimeout(ofMillis(999))
+        .failoverTo(counterFailoverStepName, 3, maxRetries(1))
+        .addStep(counterInc, maxRetries(1).failoverTo(counterStepName))
+        .addStep(counterIncFailover);
   }
 
   public Effect<Message> startFailingCounter(String counterId) {
     return effects()
-      .updateState(new FailingCounterState(counterId, 0, false))
-      .transitionTo(counterStepName)
-      .thenReply(new Message("workflow started"));
+        .updateState(new FailingCounterState(counterId, 0, false))
+        .transitionTo(counterStepName)
+        .thenReply(new Message("workflow started"));
   }
 
   public Effect<FailingCounterState> get() {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithTimer.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithTimer.java
@@ -5,12 +5,11 @@
 package akkajavasdk.components.workflowentities;
 
 import akka.Done;
-import akkajavasdk.components.actions.echo.Message;
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
 import akka.javasdk.workflow.WorkflowContext;
-
+import akkajavasdk.components.actions.echo.Message;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
@@ -30,45 +29,45 @@ public class WorkflowWithTimer extends Workflow<FailingCounterState> {
   @Override
   public WorkflowDef<FailingCounterState> definition() {
     var counterInc =
-      step(counterStepName)
-        .asyncCall(() -> {
-          var pingWorkflow =
-            componentClient
-              .forWorkflow(workflowContext.workflowId())
-              .method(WorkflowWithTimer::pingWorkflow)
-              .deferred(new CounterScheduledValue(12));
+        step(counterStepName)
+            .asyncCall(
+                () -> {
+                  var pingWorkflow =
+                      componentClient
+                          .forWorkflow(workflowContext.workflowId())
+                          .method(WorkflowWithTimer::pingWorkflow)
+                          .deferred(new CounterScheduledValue(12));
 
-          timers().createSingleTimer("ping", Duration.ofSeconds(2), pingWorkflow);
+                  timers().createSingleTimer("ping", Duration.ofSeconds(2), pingWorkflow);
 
-          return CompletableFuture.completedFuture(Done.done()); // FIXME remove once we have sync/blocking workflow calls
-        })
-        .andThen(Done.class, __ -> effects().pause())
-        .timeout(Duration.ofMillis(50));
+                  return CompletableFuture.completedFuture(
+                      Done.done()); // FIXME remove once we have sync/blocking workflow calls
+                })
+            .andThen(Done.class, __ -> effects().pause())
+            .timeout(Duration.ofMillis(50));
 
-
-    return workflow()
-      .addStep(counterInc);
+    return workflow().addStep(counterInc);
   }
 
   public Effect<Message> startFailingCounter(String counterId) {
     return effects()
-      .updateState(new FailingCounterState(counterId, 0, false))
-      .transitionTo(counterStepName)
-      .thenReply(new Message("workflow started"));
+        .updateState(new FailingCounterState(counterId, 0, false))
+        .transitionTo(counterStepName)
+        .thenReply(new Message("workflow started"));
   }
 
   public Effect<Message> startFailingCounterWithReqParam(String counterId) {
     return effects()
-      .updateState(new FailingCounterState(counterId, 0, false))
-      .transitionTo(counterStepName)
-      .thenReply(new Message("workflow started"));
+        .updateState(new FailingCounterState(counterId, 0, false))
+        .transitionTo(counterStepName)
+        .thenReply(new Message("workflow started"));
   }
 
   public Effect<String> pingWorkflow(CounterScheduledValue counterScheduledValue) {
     return effects()
-      .updateState(currentState().asFinished(counterScheduledValue.value()))
-      .end()
-      .thenReply("workflow finished");
+        .updateState(currentState().asFinished(counterScheduledValue.value()))
+        .end()
+        .thenReply("workflow finished");
   }
 
   public Effect<FailingCounterState> get() {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithoutInitialState.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithoutInitialState.java
@@ -10,7 +10,6 @@ import akka.javasdk.workflow.Workflow;
 @ComponentId("workflow-without-initial-state")
 public class WorkflowWithoutInitialState extends Workflow<String> {
 
-
   @Override
   public WorkflowDef<String> definition() {
     var test =
@@ -18,8 +17,7 @@ public class WorkflowWithoutInitialState extends Workflow<String> {
             .call(() -> "ok")
             .andThen(String.class, result -> effects().updateState("success").end());
 
-    return workflow()
-        .addStep(test);
+    return workflow().addStep(test);
   }
 
   public Effect<String> start() {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/hierarchy/AbstractTextKvWorkflow.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/hierarchy/AbstractTextKvWorkflow.java
@@ -9,6 +9,4 @@ import akka.javasdk.workflow.Workflow;
 public abstract class AbstractTextKvWorkflow extends Workflow<AbstractTextKvWorkflow.State> {
 
   public record State(String value) {}
-
-
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/hierarchy/TextWorkflow.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/hierarchy/TextWorkflow.java
@@ -5,18 +5,17 @@
 package akkajavasdk.components.workflowentities.hierarchy;
 
 import akka.javasdk.annotations.ComponentId;
-
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 @ComponentId("hierarchy-workflow")
 public class TextWorkflow extends AbstractTextKvWorkflow {
   @Override
   public WorkflowDef<State> definition() {
-    return workflow().addStep(step("dummy-step")
-        .call(() -> "step completed")
-        .andThen(String.class, result -> effects().end()));
-
+    return workflow()
+        .addStep(
+            step("dummy-step")
+                .call(() -> "step completed")
+                .andThen(String.class, result -> effects().end()));
   }
 
   public Effect<String> setText(String text) {

--- a/akka-javasdk/src/main/java/akka/javasdk/CloudEvent.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/CloudEvent.java
@@ -19,8 +19,10 @@ public interface CloudEvent {
   String specversion();
 
   /**
-   * The id of this CloudEvent. According to the CloudEvents https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id[specification],
-   * the ID is not guaranteed to be the same for redelivery of the same event, hence we can't use it for deduplication.
+   * The id of this CloudEvent. According to the CloudEvents
+   * https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id[specification], the ID
+   * is not guaranteed to be the same for redelivery of the same event, hence we can't use it for
+   * deduplication.
    *
    * @return The id.
    */
@@ -130,14 +132,10 @@ public interface CloudEvent {
    */
   CloudEvent clearSubject();
 
-  /**
-   * The sequence of this CloudEvent parsed to Long value.
-   */
+  /** The sequence of this CloudEvent parsed to Long value. */
   Optional<Long> sequence();
 
-  /**
-   * The sequence of this CloudEvent.
-   */
+  /** The sequence of this CloudEvent. */
   Optional<String> sequenceString();
 
   /**
@@ -155,10 +153,7 @@ public interface CloudEvent {
    */
   CloudEvent clearSequence();
 
-
-  /**
-   * The sequence type of this CloudEvent.
-   */
+  /** The sequence type of this CloudEvent. */
   Optional<String> sequenceType();
 
   /**

--- a/akka-javasdk/src/main/java/akka/javasdk/CommandException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/CommandException.java
@@ -9,56 +9,61 @@ import akka.javasdk.keyvalueentity.KeyValueEntity;
 import akka.javasdk.workflow.Workflow;
 
 /**
- * An exception that can be thrown by user code to signal domain validation errors or business rule violations.
- * 
- * <p>This exception is designed to be used in command handlers of {@link KeyValueEntity}, {@link EventSourcedEntity}, 
- * or {@link Workflow} components when the incoming command doesn't fulfill the requirements or the current state 
- * doesn't allow the command to be handled.
- * 
+ * An exception that can be thrown by user code to signal domain validation errors or business rule
+ * violations.
+ *
+ * <p>This exception is designed to be used in command handlers of {@link KeyValueEntity}, {@link
+ * EventSourcedEntity}, or {@link Workflow} components when the incoming command doesn't fulfill the
+ * requirements or the current state doesn't allow the command to be handled.
+ *
  * <p><strong>HTTP Response Behavior:</strong>
+ *
  * <ul>
- *   <li>By default, {@code CommandException} is transformed into an HTTP 400 Bad Request response</li>
- *   <li>The exception message becomes the response body</li>
- *   <li>Can be caught and transformed into custom HTTP responses for fine-tuned error handling</li>
+ *   <li>By default, {@code CommandException} is transformed into an HTTP 400 Bad Request response
+ *   <li>The exception message becomes the response body
+ *   <li>Can be caught and transformed into custom HTTP responses for fine-tuned error handling
  * </ul>
- * 
- * <p><strong>Network Serialization:</strong>
- * Only {@code CommandException} and its subtypes are serialized and sent over the network when components
- * are called across different nodes. Other exceptions are transformed into generic HTTP 500 errors.
- * The Jackson serialization is configured to ignore fields like stack trace or cause from the 
- * {@link Throwable} class.
- * 
+ *
+ * <p><strong>Network Serialization:</strong> Only {@code CommandException} and its subtypes are
+ * serialized and sent over the network when components are called across different nodes. Other
+ * exceptions are transformed into generic HTTP 500 errors. The Jackson serialization is configured
+ * to ignore fields like stack trace or cause from the {@link Throwable} class.
+ *
  * <p><strong>Usage Examples:</strong>
- * 
+ *
  * <p>Using error effects:
+ *
  * <pre>{@code
  * // In a command handler
  * if (value > 10000) {
  *   return effects().error("Increasing counter above 10000 is blocked");
  * }
  * }</pre>
- * 
+ *
  * <p>Throwing directly:
+ *
  * <pre>{@code
  * // In a command handler
  * if (value > 10000) {
  *   throw new CommandException("Increasing counter above 10000 is blocked");
  * }
  * }</pre>
- * 
+ *
  * <p>Creating custom subtypes:
+ *
  * <pre>{@code
  * public class CounterLimitExceededException extends CommandException {
  *   public CounterLimitExceededException(String message) {
  *     super(message);
  *   }
  * }
- * 
+ *
  * // Usage
  * throw new CounterLimitExceededException("Counter limit exceeded");
  * }</pre>
- * 
+ *
  * <p><strong>Error Handling in Endpoints:</strong>
+ *
  * <pre>{@code
  * try {
  *   return componentClient
@@ -69,9 +74,9 @@ import akka.javasdk.workflow.Workflow;
  *   // Handle the command exception, e.g., return a bad request response
  * }
  * }</pre>
- * 
+ *
  * @see KeyValueEntity
- * @see EventSourcedEntity  
+ * @see EventSourcedEntity
  * @see Workflow
  */
 public class CommandException extends IllegalArgumentException {

--- a/akka-javasdk/src/main/java/akka/javasdk/DeferredCall.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/DeferredCall.java
@@ -17,9 +17,13 @@ public interface DeferredCall<I, O> {
   /** The message to pass to the call when the call is invoked. */
   I message();
 
-  /** @return The metadata to pass with the message when the call is invoked. */
+  /**
+   * @return The metadata to pass with the message when the call is invoked.
+   */
   Metadata metadata();
 
-  /** @return DeferredCall with updated metadata */
+  /**
+   * @return DeferredCall with updated metadata
+   */
   DeferredCall<I, O> withMetadata(Metadata metadata);
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/DependencyProvider.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/DependencyProvider.java
@@ -5,19 +5,21 @@
 package akka.javasdk;
 
 /**
-  * A factory method to provide additional dependencies to the component implementations.
-  * <p>
-  * Implementations of this interface must be thread-safe.
-  * <p>
-  * The {@code DependencyProvider} must be configured using the {@link ServiceSetup#createDependencyProvider} method.
-  * This ensures that the correct dependencies are available to the component implementations at runtime.
-  */
+ * A factory method to provide additional dependencies to the component implementations.
+ *
+ * <p>Implementations of this interface must be thread-safe.
+ *
+ * <p>The {@code DependencyProvider} must be configured using the {@link
+ * ServiceSetup#createDependencyProvider} method. This ensures that the correct dependencies are
+ * available to the component implementations at runtime.
+ */
 public interface DependencyProvider {
 
   /**
-   * Get a dependency for a given class. If the dependency is not found, an exception should be thrown.
-   * <p>
-   * Returned instance for a given class must be safe to use concurrently.
+   * Get a dependency for a given class. If the dependency is not found, an exception should be
+   * thrown.
+   *
+   * <p>Returned instance for a given class must be safe to use concurrently.
    *
    * @param clazz The class of the dependency to get
    * @return The dependency instance
@@ -27,17 +29,18 @@ public interface DependencyProvider {
 
   /**
    * Create a dependency provider that always returns the same instance for a given class.
+   *
    * @param single The single instance to return
    * @return The dependency provider
    */
-  static DependencyProvider single(Object single){
+  static DependencyProvider single(Object single) {
     return new DependencyProvider() {
       @Override
       public <T> T getDependency(Class<T> clazz) {
         if (clazz.isAssignableFrom(single.getClass())) {
           return (T) single;
         } else {
-          throw new RuntimeException("No such dependency found: "+ clazz);
+          throw new RuntimeException("No such dependency found: " + clazz);
         }
       }
     };

--- a/akka-javasdk/src/main/java/akka/javasdk/JsonMigration.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/JsonMigration.java
@@ -5,51 +5,48 @@
 package akka.javasdk;
 
 import com.fasterxml.jackson.databind.JsonNode;
-
 import java.util.List;
 
 /**
  * Allows to specify dedicated strategy for JSON schema evolution.
- * <p>
- * It is used when deserializing data of older version than the
- * {@link JsonMigration#currentVersion}. You implement the transformation of the
- * JSON structure in the {@link JsonMigration#transform} method. If you have changed the
- * class name you should add it to {@link JsonMigration#supportedClassNames}.
+ *
+ * <p>It is used when deserializing data of older version than the {@link
+ * JsonMigration#currentVersion}. You implement the transformation of the JSON structure in the
+ * {@link JsonMigration#transform} method. If you have changed the class name you should add it to
+ * {@link JsonMigration#supportedClassNames}.
  */
 public abstract class JsonMigration {
 
   /**
-   * Define current version, that is, the value used when serializing new data. The first version, when no
-   * migration was used, is always 0.
+   * Define current version, that is, the value used when serializing new data. The first version,
+   * when no migration was used, is always 0.
    */
   public abstract int currentVersion();
 
   /**
-   * Define the supported forward version this migration can read (must be greater or equal than {@code currentVersion}).
-   * If this value is different from {@link JsonMigration#currentVersion} a {@link JsonMigration#transform} will be used to downcast
-   * the received payload to the current schema.
+   * Define the supported forward version this migration can read (must be greater or equal than
+   * {@code currentVersion}). If this value is different from {@link JsonMigration#currentVersion} a
+   * {@link JsonMigration#transform} will be used to downcast the received payload to the current
+   * schema.
    */
   public int supportedForwardVersion() {
     return currentVersion();
   }
 
   /**
-   * Implement the transformation of the incoming JSON structure to the current
-   * JSON structure. The {@code JsonNode} is mutable so you can add and remove fields,
-   * or change values. Note that you have to cast to specific sub-classes such
-   * as {@code ObjectNode} and {@code ArrayNode} to get access to mutators.
+   * Implement the transformation of the incoming JSON structure to the current JSON structure. The
+   * {@code JsonNode} is mutable so you can add and remove fields, or change values. Note that you
+   * have to cast to specific sub-classes such as {@code ObjectNode} and {@code ArrayNode} to get
+   * access to mutators.
    *
    * @param fromVersion the version of the old data
-   * @param json        the incoming JSON data
+   * @param json the incoming JSON data
    */
   public JsonNode transform(int fromVersion, JsonNode json) {
     return json;
   }
 
-  /**
-   * Override this method if you have changed the class name. Return
-   * all old class names.
-   */
+  /** Override this method if you have changed the class name. Return all old class names. */
   public List<String> supportedClassNames() {
     return List.of();
   }

--- a/akka-javasdk/src/main/java/akka/javasdk/Metadata.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/Metadata.java
@@ -5,7 +5,6 @@
 package akka.javasdk;
 
 import akka.javasdk.impl.MetadataImpl;
-
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -218,7 +217,8 @@ public interface Metadata extends Iterable<Metadata.MetadataEntry> {
   CloudEvent asCloudEvent(String id, URI source, String type);
 
   /**
-   * Merge the given Metadata entries with this Metadata. If the same key is present in both, both values will be kept.
+   * Merge the given Metadata entries with this Metadata. If the same key is present in both, both
+   * values will be kept.
    *
    * @param other The Metadata to merge with this Metadata.
    * @return a copy of this Metadata with the other Metadata merged in.

--- a/akka-javasdk/src/main/java/akka/javasdk/OriginAwareContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/OriginAwareContext.java
@@ -7,42 +7,42 @@ package akka.javasdk;
 import akka.javasdk.annotations.Consume;
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
 import akka.javasdk.keyvalueentity.KeyValueEntity;
-
 import java.util.Optional;
 
 public interface OriginAwareContext extends Context {
-
 
   /**
    * When available, this method returns the region where a message was first created.
    *
    * <ul>
    *   <li>It returns a non-empty Optional when consuming events from an {@link EventSourcedEntity}
-   *   or a change updates from a {@link KeyValueEntity}</li>
-   *   <li>It returns an empty Optional when consuming messages from a topic (see {@link Consume.FromTopic})
-   *   or from another service (see {@link Consume.FromServiceStream})</li>
+   *       or a change updates from a {@link KeyValueEntity}
+   *   <li>It returns an empty Optional when consuming messages from a topic (see {@link
+   *       Consume.FromTopic}) or from another service (see {@link Consume.FromServiceStream})
    * </ul>
    *
-   * @return the region where a message was first created. When not applicable, it returns an empty Optional.
+   * @return the region where a message was first created. When not applicable, it returns an empty
+   *     Optional.
    */
   Optional<String> originRegion();
 
   /**
-   * Returns {@code true} if this message originated in the same region where it is currently being processed.
-   * A message is considered to have originated in a region if it was created in that region.
-   * In all other regions, the same message is treated as a replication.
+   * Returns {@code true} if this message originated in the same region where it is currently being
+   * processed. A message is considered to have originated in a region if it was created in that
+   * region. In all other regions, the same message is treated as a replication.
    *
    * <p>For messages coming from Akka entities:
    *
    * <ul>
    *   <li>If the message is an event from an {@link EventSourcedEntity} or a change update from a
-   *   {@link KeyValueEntity}, it returns {@code true} if it was originated in the region where this consumer is
-   *   running. Otherwise, it returns {@code false}.
+   *       {@link KeyValueEntity}, it returns {@code true} if it was originated in the region where
+   *       this consumer is running. Otherwise, it returns {@code false}.
    *   <li>This method will always return {@code false} when consuming messages from another service
-   *   (see {@link Consume.FromServiceStream}) or from a topic (see {@link Consume.FromTopic}).
+   *       (see {@link Consume.FromServiceStream}) or from a topic (see {@link Consume.FromTopic}).
    * </ul>
    *
-   * @return {@code true} if the message originated in the current processing region, {@code false} otherwise
+   * @return {@code true} if the message originated in the current processing region, {@code false}
+   *     otherwise
    */
   default boolean hasLocalOrigin() {
     // empty means we are consuming from a broker or service-to-service
@@ -50,5 +50,4 @@ public interface OriginAwareContext extends Context {
     // in dev-mode, both will be "" and therefore always considered as local
     return originRegion().stream().allMatch(orig -> orig.equals(selfRegion()));
   }
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/Principal.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/Principal.java
@@ -48,8 +48,10 @@ public interface Principal {
 
   /** Abstract principal representing all requests from the internet */
   Principal INTERNET = Basic.INTERNET;
+
   /** Abstract principal representing all requests from self */
   Principal SELF = Basic.SELF;
+
   /** Abstract principal representing all requests from the backoffice */
   Principal BACKOFFICE = Basic.BACKOFFICE;
 

--- a/akka-javasdk/src/main/java/akka/javasdk/Principals.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/Principals.java
@@ -24,8 +24,10 @@ public interface Principals {
    * @param name The name of the service.
    */
   boolean isLocalService(String name);
+
   /** Whether this request was from any service in the local project. */
   boolean isAnyLocalService();
+
   /** Get the service that invoked this call, if any. */
   Optional<String> getLocalService();
 

--- a/akka-javasdk/src/main/java/akka/javasdk/ServiceSetup.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/ServiceSetup.java
@@ -5,7 +5,6 @@
 package akka.javasdk;
 
 import akka.javasdk.annotations.Setup;
-
 import java.util.Set;
 
 /**
@@ -39,8 +38,8 @@ public interface ServiceSetup {
   default void onStartup() {}
 
   /**
-   * Invoked once before the service is started, to create a dependency provider. It is not possible to
-   * interact with components in this method.
+   * Invoked once before the service is started, to create a dependency provider. It is not possible
+   * to interact with components in this method.
    *
    * <p>This hook is called before {@link #onStartup()}.
    */
@@ -48,9 +47,7 @@ public interface ServiceSetup {
     return null;
   }
 
-  /**
-   * Provides a set of components that should be disabled from running.
-   */
+  /** Provides a set of components that should be disabled from running. */
   default Set<Class<?>> disabledComponents() {
     return Set.of();
   }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/Agent.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/Agent.java
@@ -12,40 +12,42 @@ import akka.javasdk.annotations.FunctionTool;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.impl.agent.AgentStreamEffectImpl;
 import akka.javasdk.impl.agent.BaseAgentEffectBuilder;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 /**
- * An AI agent component that interacts with an AI model, such as a large language model (LLM),
- * to perform specific tasks.
- * <p>
- * An Agent is typically backed by a large language model and maintains contextual history in a session memory,
- * which may be shared between multiple agents collaborating on the same goal. It can provide function tools
- * and call them as requested by the model.
- * <p>
- * <strong>Key Features:</strong>
+ * An AI agent component that interacts with an AI model, such as a large language model (LLM), to
+ * perform specific tasks.
+ *
+ * <p>An Agent is typically backed by a large language model and maintains contextual history in a
+ * session memory, which may be shared between multiple agents collaborating on the same goal. It
+ * can provide function tools and call them as requested by the model.
+ *
+ * <p><strong>Key Features:</strong>
+ *
  * <ul>
- *   <li><strong>Session-based:</strong> Participates in a session with contextual memory</li>
- *   <li><strong>Memory Management:</strong> Automatically stores user and AI messages for context</li>
- *   <li><strong>Function Tools:</strong> Can be extended with custom tools for the model to invoke</li>
- *   <li><strong>Model Integration:</strong> Supports multiple AI model providers (OpenAI, Anthropic, etc.)</li>
- *   <li><strong>Streaming Support:</strong> Can stream responses token by token for real-time UX</li>
+ *   <li><strong>Session-based:</strong> Participates in a session with contextual memory
+ *   <li><strong>Memory Management:</strong> Automatically stores user and AI messages for context
+ *   <li><strong>Function Tools:</strong> Can be extended with custom tools for the model to invoke
+ *   <li><strong>Model Integration:</strong> Supports multiple AI model providers (OpenAI,
+ *       Anthropic, etc.)
+ *   <li><strong>Streaming Support:</strong> Can stream responses token by token for real-time UX
  * </ul>
- * <p>
- * <strong>Session Memory:</strong>
- * The agent maintains contextual history in session memory, identified by a session id accessible
- * via {@link Agent#context()}. This memory is persistent and shared between agents using the same session id.
- * <p>
- * <strong>Component Identification:</strong>
- * The agent must be annotated with {@link akka.javasdk.annotations.ComponentId} to provide a unique
- * identifier for the component class. For multi-agent systems, use {@link akka.javasdk.annotations.AgentDescription}
- * to provide metadata for the {@link AgentRegistry}.
- * <p>
- * <strong>Calling Agents:</strong>
- * Agents are typically called from workflows, endpoints, or consumers using the ComponentClient:
+ *
+ * <p><strong>Session Memory:</strong> The agent maintains contextual history in session memory,
+ * identified by a session id accessible via {@link Agent#context()}. This memory is persistent and
+ * shared between agents using the same session id.
+ *
+ * <p><strong>Component Identification:</strong> The agent must be annotated with {@link
+ * akka.javasdk.annotations.ComponentId} to provide a unique identifier for the component class. For
+ * multi-agent systems, use {@link akka.javasdk.annotations.AgentDescription} to provide metadata
+ * for the {@link AgentRegistry}.
+ *
+ * <p><strong>Calling Agents:</strong> Agents are typically called from workflows, endpoints, or
+ * consumers using the ComponentClient:
+ *
  * <pre>{@code
  * String response = componentClient
  *     .forAgent()
@@ -53,8 +55,9 @@ import java.util.function.Function;
  *     .method(MyAgent::query)
  *     .invoke("What is the weather like?");
  * }</pre>
- * <p>
- * For reliable execution with error handling and retries, consider calling agents from a {@link akka.javasdk.workflow.Workflow}.
+ *
+ * <p>For reliable execution with error handling and retries, consider calling agents from a {@link
+ * akka.javasdk.workflow.Workflow}.
  */
 public abstract class Agent {
 
@@ -75,6 +78,7 @@ public abstract class Agent {
 
   /**
    * INTERNAL API
+   *
    * @hidden
    */
   @InternalApi
@@ -91,15 +95,17 @@ public abstract class Agent {
   }
 
   /**
-   * An Effect is a description of what the runtime needs to do after the command is handled.
-   * You can think of it as a set of instructions you are passing to the runtime, which will process
-   * the instructions on your behalf.
+   * An Effect is a description of what the runtime needs to do after the command is handled. You
+   * can think of it as a set of instructions you are passing to the runtime, which will process the
+   * instructions on your behalf.
+   *
+   * <p>Each component defines its own effects, which are a set of predefined operations that match
+   * the capabilities of that component.
+   *
+   * <p>An Agent Effect can:
+   *
    * <p>
-   * Each component defines its own effects, which are a set of predefined
-   * operations that match the capabilities of that component.
-   * <p>
-   * An Agent Effect can:
-   * <p>
+   *
    * <ul>
    *   <li>Make a request to the model and return the transformed response.
    * </ul>
@@ -108,35 +114,33 @@ public abstract class Agent {
    */
   public interface Effect<T> {
 
-    /**
-     * Construct the effect that is returned by the message handler.
-     */
+    /** Construct the effect that is returned by the message handler. */
     interface Builder {
 
       /**
-       * Define the AI model (LLM) to use.
-       * If undefined, the model is defined by the default configuration in
-       * {@code akka.javasdk.agent.model-provider}
+       * Define the AI model (LLM) to use. If undefined, the model is defined by the default
+       * configuration in {@code akka.javasdk.agent.model-provider}
        */
       Builder model(ModelProvider provider);
 
       /**
        * Provides system-level instructions to the AI model that defines its behavior and context.
-       * The system message acts as a foundational prompt that establishes the AI's role, constraints,
-       * and operational parameters. It is processed before user messages and helps maintain consistent
-       * behavior throughout the interaction.
+       * The system message acts as a foundational prompt that establishes the AI's role,
+       * constraints, and operational parameters. It is processed before user messages and helps
+       * maintain consistent behavior throughout the interaction.
        */
       Builder systemMessage(String message);
 
       /**
        * Adds one or more tool instances or classes that the AI model can use.
-       * <p>
-       * Each argument can be either an object instance or a {@link Class} object. If a {@link Class} is provided,
-       * it will be instantiated at runtime using the configured {@link DependencyProvider}.
-       * <p>
-       * Each instance or class must have at least one public method annotated with {@link FunctionTool}.
-       * If no such method is found, an {@link IllegalArgumentException} will be thrown.
-       * These methods will be available as tools for the AI model to invoke.
+       *
+       * <p>Each argument can be either an object instance or a {@link Class} object. If a {@link
+       * Class} is provided, it will be instantiated at runtime using the configured {@link
+       * DependencyProvider}.
+       *
+       * <p>Each instance or class must have at least one public method annotated with {@link
+       * FunctionTool}. If no such method is found, an {@link IllegalArgumentException} will be
+       * thrown. These methods will be available as tools for the AI model to invoke.
        *
        * @return this builder for method chaining
        */
@@ -144,13 +148,14 @@ public abstract class Agent {
 
       /**
        * Adds one or more tool instances or classes that the AI model can use.
-       * <p>
-       * Each element in the list can be either an object instance or a {@link Class} object. If a {@link Class} is provided,
-       * it will be instantiated at runtime using the configured {@link DependencyProvider}.
-       * <p>
-       * Each instance or class must have at least one public method annotated with {@link FunctionTool}.
-       * If no such method is found, an {@link IllegalArgumentException} will be thrown.
-       * These methods will be available as tools for the AI model to invoke.
+       *
+       * <p>Each element in the list can be either an object instance or a {@link Class} object. If
+       * a {@link Class} is provided, it will be instantiated at runtime using the configured {@link
+       * DependencyProvider}.
+       *
+       * <p>Each instance or class must have at least one public method annotated with {@link
+       * FunctionTool}. If no such method is found, an {@link IllegalArgumentException} will be
+       * thrown. These methods will be available as tools for the AI model to invoke.
        *
        * @param toolInstancesOrClasses one or more objects or classes exposing tool methods
        * @return this builder for method chaining
@@ -158,25 +163,27 @@ public abstract class Agent {
       Builder tools(List<Object> toolInstancesOrClasses);
 
       /**
-       * Create a system message from a template. Call @{@link PromptTemplate} before to initiate or update template value.
-       * <p>
-       * Provides system-level instructions to the AI model that defines its behavior and context.
-       * The system message acts as a foundational prompt that establishes the AI's role, constraints,
-       * and operational parameters. It is processed before user messages and helps maintain consistent
-       * behavior throughout the interaction.
+       * Create a system message from a template. Call @{@link PromptTemplate} before to initiate or
+       * update template value.
+       *
+       * <p>Provides system-level instructions to the AI model that defines its behavior and
+       * context. The system message acts as a foundational prompt that establishes the AI's role,
+       * constraints, and operational parameters. It is processed before user messages and helps
+       * maintain consistent behavior throughout the interaction.
        *
        * @param templateId the id of the template to use
        */
       Builder systemMessageFromTemplate(String templateId);
 
       /**
-       * Create a system message from a template. Call @{@link PromptTemplate} before to initiate or update template value.
-       * Provide arguments that will be applied to the template using Java {@link String#formatted} method.
-       * <p>
-       * Provides system-level instructions to the AI model that defines its behavior and context.
-       * The system message acts as a foundational prompt that establishes the AI's role, constraints,
-       * and operational parameters. It is processed before user messages and helps maintain consistent
-       * behavior throughout the interaction.
+       * Create a system message from a template. Call @{@link PromptTemplate} before to initiate or
+       * update template value. Provide arguments that will be applied to the template using Java
+       * {@link String#formatted} method.
+       *
+       * <p>Provides system-level instructions to the AI model that defines its behavior and
+       * context. The system message acts as a foundational prompt that establishes the AI's role,
+       * constraints, and operational parameters. It is processed before user messages and helps
+       * maintain consistent behavior throughout the interaction.
        *
        * @param templateId the id of the template to use
        * @param args the arguments to apply to the template
@@ -187,15 +194,15 @@ public abstract class Agent {
 
       /**
        * Adds tools from one or more remote MCP servers.
-       * <p>
-       * Construct instances using {@link RemoteMcpTools#fromServer(String)}
+       *
+       * <p>Construct instances using {@link RemoteMcpTools#fromServer(String)}
        */
       Builder mcpTools(RemoteMcpTools tools, RemoteMcpTools... moreTools);
 
       /**
        * Adds tools from one or more remote MCP servers.
-       * <p>
-       * Construct instances using {@link RemoteMcpTools#fromServer(String)}
+       *
+       * <p>Construct instances using {@link RemoteMcpTools#fromServer(String)}
        */
       Builder mcpTools(List<RemoteMcpTools> tools);
 
@@ -225,7 +232,8 @@ public abstract class Agent {
       <T> Agent.Effect<T> reply(T message, Metadata metadata);
 
       /**
-       * Create an error reply without calling the model. A short version of {{@code effects().error(new CommandException(message))}}.
+       * Create an error reply without calling the model. A short version of {{@code
+       * effects().error(new CommandException(message))}}.
        *
        * @param message The error message.
        * @param <T> The type of the message that must be returned by this call.
@@ -235,26 +243,28 @@ public abstract class Agent {
 
       /**
        * Create an error reply. {@link CommandException} will be serialized and sent to the client.
-       * It's possible to catch it with try-catch statement or {@link CompletionStage} API when using async {@link ComponentClient} API.
+       * It's possible to catch it with try-catch statement or {@link CompletionStage} API when
+       * using async {@link ComponentClient} API.
        *
        * @param commandException The command exception to be returned.
        * @param <T> The type of the message that must be returned by this call.
        * @return An error reply.
        */
       <T> Agent.Effect<T> error(CommandException commandException);
-
     }
 
     interface OnSuccessBuilder {
 
       /**
        * Reply with the response from the model.
+       *
        * @return A message reply.
        */
       Agent.Effect<String> thenReply();
 
       /**
        * Reply with the response from the model.
+       *
        * @param metadata The metadata for the message.
        * @return A message reply.
        */
@@ -262,28 +272,28 @@ public abstract class Agent {
 
       /**
        * Parse the response from the model into a structured response of a given responseType.
+       *
        * @param responseType The structured response type.
        */
       <T> MappingResponseBuilder<T> responseAs(Class<T> responseType);
 
-      /**
-       * Map the String response from the model into a different response type.
-       */
+      /** Map the String response from the model into a different response type. */
       <T> MappingResponseBuilder<T> map(Function<String, T> mapper);
 
       /**
-       * Handle failures that occur during model processing.
-       * This method allows recovery from various types of exceptions including:
+       * Handle failures that occur during model processing. This method allows recovery from
+       * various types of exceptions including:
+       *
        * <ul>
-       * <li>{@link ModelException} - General model processing failures</li>
-       * <li>{@link RateLimitException} - API rate limiting exceeded</li>
-       * <li>{@link ModelTimeoutException} - Model request timeout</li>
-       * <li>{@link UnsupportedFeatureException} - Unsupported model features</li>
-       * <li>{@link InternalServerException} - Internal service errors</li>
-       * <li>{@link JsonParsingException} - Response parsing failures</li>
-       * <li>{@link ToolCallLimitReachedException} - Tool call limit exceeded</li>
-       * <li>{@link ToolCallExecutionException} - Function tool execution errors</li>
-       * <li>{@link McpToolCallExecutionException} - MCP tool execution errors</li>
+       *   <li>{@link ModelException} - General model processing failures
+       *   <li>{@link RateLimitException} - API rate limiting exceeded
+       *   <li>{@link ModelTimeoutException} - Model request timeout
+       *   <li>{@link UnsupportedFeatureException} - Unsupported model features
+       *   <li>{@link InternalServerException} - Internal service errors
+       *   <li>{@link JsonParsingException} - Response parsing failures
+       *   <li>{@link ToolCallLimitReachedException} - Tool call limit exceeded
+       *   <li>{@link ToolCallExecutionException} - Function tool execution errors
+       *   <li>{@link McpToolCallExecutionException} - MCP tool execution errors
        * </ul>
        */
       FailureBuilder<String> onFailure(Function<Throwable, String> exceptionHandler);
@@ -293,35 +303,36 @@ public abstract class Agent {
 
       /**
        * Reply with the response from the model.
+       *
        * @return A message reply.
        */
       Agent.Effect<Result> thenReply();
 
       /**
        * Reply with the response from the model.
+       *
        * @param metadata The metadata for the message.
        * @return A message reply.
        */
       Agent.Effect<Result> thenReply(Metadata metadata);
 
-      /**
-       * Map the response from the model into a different response type.
-       */
+      /** Map the response from the model into a different response type. */
       <T> MappingFailureBuilder<T> map(Function<Result, T> mapper);
 
       /**
-       * Handle failures that occur during model processing.
-       * This method allows recovery from various types of exceptions including:
+       * Handle failures that occur during model processing. This method allows recovery from
+       * various types of exceptions including:
+       *
        * <ul>
-       * <li>{@link ModelException} - General model processing failures</li>
-       * <li>{@link RateLimitException} - API rate limiting exceeded</li>
-       * <li>{@link ModelTimeoutException} - Model request timeout</li>
-       * <li>{@link UnsupportedFeatureException} - Unsupported model features</li>
-       * <li>{@link InternalServerException} - Internal service errors</li>
-       * <li>{@link JsonParsingException} - Response parsing failures</li>
-       * <li>{@link ToolCallLimitReachedException} - Tool call limit exceeded</li>
-       * <li>{@link ToolCallExecutionException} - Function tool execution errors</li>
-       * <li>{@link McpToolCallExecutionException} - MCP tool execution errors</li>
+       *   <li>{@link ModelException} - General model processing failures
+       *   <li>{@link RateLimitException} - API rate limiting exceeded
+       *   <li>{@link ModelTimeoutException} - Model request timeout
+       *   <li>{@link UnsupportedFeatureException} - Unsupported model features
+       *   <li>{@link InternalServerException} - Internal service errors
+       *   <li>{@link JsonParsingException} - Response parsing failures
+       *   <li>{@link ToolCallLimitReachedException} - Tool call limit exceeded
+       *   <li>{@link ToolCallExecutionException} - Function tool execution errors
+       *   <li>{@link McpToolCallExecutionException} - MCP tool execution errors
        * </ul>
        */
       FailureBuilder<Result> onFailure(Function<Throwable, Result> exceptionHandler);
@@ -331,30 +342,33 @@ public abstract class Agent {
 
       /**
        * Reply with the response from the model.
+       *
        * @return A message reply.
        */
       Agent.Effect<Result> thenReply();
 
       /**
        * Reply with the response from the model.
+       *
        * @param metadata The metadata for the message.
        * @return A message reply.
        */
       Agent.Effect<Result> thenReply(Metadata metadata);
 
       /**
-       * Handle failures that occur during model processing.
-       * This method allows recovery from various types of exceptions including:
+       * Handle failures that occur during model processing. This method allows recovery from
+       * various types of exceptions including:
+       *
        * <ul>
-       * <li>{@link ModelException} - General model processing failures</li>
-       * <li>{@link RateLimitException} - API rate limiting exceeded</li>
-       * <li>{@link ModelTimeoutException} - Model request timeout</li>
-       * <li>{@link UnsupportedFeatureException} - Unsupported model features</li>
-       * <li>{@link InternalServerException} - Internal service errors</li>
-       * <li>{@link JsonParsingException} - Response parsing failures</li>
-       * <li>{@link ToolCallLimitReachedException} - Tool call limit exceeded</li>
-       * <li>{@link ToolCallExecutionException} - Function tool execution errors</li>
-       * <li>{@link McpToolCallExecutionException} - MCP tool execution errors</li>
+       *   <li>{@link ModelException} - General model processing failures
+       *   <li>{@link RateLimitException} - API rate limiting exceeded
+       *   <li>{@link ModelTimeoutException} - Model request timeout
+       *   <li>{@link UnsupportedFeatureException} - Unsupported model features
+       *   <li>{@link InternalServerException} - Internal service errors
+       *   <li>{@link JsonParsingException} - Response parsing failures
+       *   <li>{@link ToolCallLimitReachedException} - Tool call limit exceeded
+       *   <li>{@link ToolCallExecutionException} - Function tool execution errors
+       *   <li>{@link McpToolCallExecutionException} - MCP tool execution errors
        * </ul>
        */
       FailureBuilder<Result> onFailure(Function<Throwable, Result> exceptionHandler);
@@ -363,62 +377,62 @@ public abstract class Agent {
     interface FailureBuilder<Result> {
       /**
        * Reply with the response from the model.
+       *
        * @return A message reply.
        */
       Agent.Effect<Result> thenReply();
 
       /**
        * Reply with the response from the model.
+       *
        * @param metadata The metadata for the message.
        * @return A message reply.
        */
       Agent.Effect<Result> thenReply(Metadata metadata);
     }
-
   }
 
   public interface StreamEffect {
 
-    /**
-     * Construct the effect for token streaming that is returned by the message handler.
-     */
+    /** Construct the effect for token streaming that is returned by the message handler. */
     interface Builder {
 
       /**
-       * Define the AI model (LLM) to use.
-       * If undefined, the model is defined by the default configuration in
-       * {@code akka.javasdk.agent.model-provider}
+       * Define the AI model (LLM) to use. If undefined, the model is defined by the default
+       * configuration in {@code akka.javasdk.agent.model-provider}
        */
       Builder model(ModelProvider provider);
 
       /**
        * Provides system-level instructions to the AI model that defines its behavior and context.
-       * The system message acts as a foundational prompt that establishes the AI's role, constraints,
-       * and operational parameters. It is processed before user messages and helps maintain consistent
-       * behavior throughout the interaction.
+       * The system message acts as a foundational prompt that establishes the AI's role,
+       * constraints, and operational parameters. It is processed before user messages and helps
+       * maintain consistent behavior throughout the interaction.
        */
       Builder systemMessage(String message);
 
       /**
-       * Create a system message from a template. Call @{@link PromptTemplate} before to initiate or update template value.
-       * <p>
-       * Provides system-level instructions to the AI model that defines its behavior and context.
-       * The system message acts as a foundational prompt that establishes the AI's role, constraints,
-       * and operational parameters. It is processed before user messages and helps maintain consistent
-       * behavior throughout the interaction.
+       * Create a system message from a template. Call @{@link PromptTemplate} before to initiate or
+       * update template value.
+       *
+       * <p>Provides system-level instructions to the AI model that defines its behavior and
+       * context. The system message acts as a foundational prompt that establishes the AI's role,
+       * constraints, and operational parameters. It is processed before user messages and helps
+       * maintain consistent behavior throughout the interaction.
        *
        * @param templateId the id of the template to use
        */
       Builder systemMessageFromTemplate(String templateId);
 
       /**
-       * Create a system message from a template. Call @{@link PromptTemplate} before to initiate or update template value.
-       * Provide arguments that will be applied to the template using Java {@link String#formatted} method.
-       * <p>
-       * Provides system-level instructions to the AI model that defines its behavior and context.
-       * The system message acts as a foundational prompt that establishes the AI's role, constraints,
-       * and operational parameters. It is processed before user messages and helps maintain consistent
-       * behavior throughout the interaction.
+       * Create a system message from a template. Call @{@link PromptTemplate} before to initiate or
+       * update template value. Provide arguments that will be applied to the template using Java
+       * {@link String#formatted} method.
+       *
+       * <p>Provides system-level instructions to the AI model that defines its behavior and
+       * context. The system message acts as a foundational prompt that establishes the AI's role,
+       * constraints, and operational parameters. It is processed before user messages and helps
+       * maintain consistent behavior throughout the interaction.
        *
        * @param templateId the id of the template to use
        * @param args the arguments to apply to the template
@@ -429,13 +443,14 @@ public abstract class Agent {
 
       /**
        * Adds one or more tool instances or classes that the AI model can use.
-       * <p>
-       * Each argument can be either an object instance or a {@link Class} object. If a {@link Class} is provided,
-       * it will be instantiated at runtime using the configured {@link DependencyProvider}.
-       * <p>
-       * Each instance or class must have at least one public method annotated with {@link FunctionTool}.
-       * If no such method is found, an {@link IllegalArgumentException} will be thrown.
-       * These methods will be available as tools for the AI model to invoke.
+       *
+       * <p>Each argument can be either an object instance or a {@link Class} object. If a {@link
+       * Class} is provided, it will be instantiated at runtime using the configured {@link
+       * DependencyProvider}.
+       *
+       * <p>Each instance or class must have at least one public method annotated with {@link
+       * FunctionTool}. If no such method is found, an {@link IllegalArgumentException} will be
+       * thrown. These methods will be available as tools for the AI model to invoke.
        *
        * @return this builder for method chaining
        */
@@ -443,13 +458,14 @@ public abstract class Agent {
 
       /**
        * Adds one or more tool instances or classes that the AI model can use.
-       * <p>
-       * Each element in the list can be either an object instance or a {@link Class} object. If a {@link Class} is provided,
-       * it will be instantiated at runtime using the configured {@link DependencyProvider}.
-       * <p>
-       * Each instance or class must have at least one public method annotated with {@link FunctionTool}.
-       * If no such method is found, an {@link IllegalArgumentException} will be thrown.
-       * These methods will be available as tools for the AI model to invoke.
+       *
+       * <p>Each element in the list can be either an object instance or a {@link Class} object. If
+       * a {@link Class} is provided, it will be instantiated at runtime using the configured {@link
+       * DependencyProvider}.
+       *
+       * <p>Each instance or class must have at least one public method annotated with {@link
+       * FunctionTool}. If no such method is found, an {@link IllegalArgumentException} will be
+       * thrown. These methods will be available as tools for the AI model to invoke.
        *
        * @param toolInstancesOrClasses one or more objects or classes exposing tool methods
        * @return this builder for method chaining
@@ -458,15 +474,15 @@ public abstract class Agent {
 
       /**
        * Adds tools from one or more remote MCP servers.
-       * <p>
-       * Construct instances using {@link RemoteMcpTools#fromServer(String)}
+       *
+       * <p>Construct instances using {@link RemoteMcpTools#fromServer(String)}
        */
       Builder mcpTools(RemoteMcpTools tools, RemoteMcpTools... moreTools);
 
       /**
        * Adds tools from one or more remote MCP servers.
-       * <p>
-       * Construct instances using {@link RemoteMcpTools#fromServer(String)}
+       *
+       * <p>Construct instances using {@link RemoteMcpTools#fromServer(String)}
        */
       Builder mcpTools(List<RemoteMcpTools> tools);
 
@@ -488,7 +504,8 @@ public abstract class Agent {
       Agent.StreamEffect reply(String message, Metadata metadata);
 
       /**
-       * Create an error reply without calling the model. A short version of {{@code streamEffects().error(new CommandException(message))}}.
+       * Create an error reply without calling the model. A short version of {{@code
+       * streamEffects().error(new CommandException(message))}}.
        *
        * @param message The error message.
        * @return An error reply.
@@ -504,7 +521,6 @@ public abstract class Agent {
        */
       Agent.StreamEffect error(CommandException commandException);
 
-
       Builder memory(MemoryProvider provider);
     }
 
@@ -512,19 +528,18 @@ public abstract class Agent {
 
       /**
        * Reply with the response from the model.
+       *
        * @return A message reply.
        */
       Agent.StreamEffect thenReply();
 
       /**
        * Reply with the response from the model.
+       *
        * @param metadata The metadata for the message.
        * @return A message reply.
        */
       Agent.StreamEffect thenReply(Metadata metadata);
-
     }
-
   }
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/AgentRegistry.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/AgentRegistry.java
@@ -38,9 +38,9 @@ public interface AgentRegistry {
 
   /**
    * Information about All agents. The agent id is defined with the {@link
-   * akka.javasdk.annotations.ComponentId} annotation on the agent class.
-   * Additional information is defined with the {@link akka.javasdk.annotations.AgentDescription}
-   * annotation on the agent class.
+   * akka.javasdk.annotations.ComponentId} annotation on the agent class. Additional information is
+   * defined with the {@link akka.javasdk.annotations.AgentDescription} annotation on the agent
+   * class.
    */
   Set<AgentInfo> allAgents();
 
@@ -55,10 +55,9 @@ public interface AgentRegistry {
 
   /**
    * Information about a given agent. The agent id is defined with the {@link
-   * akka.javasdk.annotations.ComponentId} annotation on the agent class.
-   * Additional information is defined with the {@link akka.javasdk.annotations.AgentDescription}
-   * annotation on the agent class.
+   * akka.javasdk.annotations.ComponentId} annotation on the agent class. Additional information is
+   * defined with the {@link akka.javasdk.annotations.AgentDescription} annotation on the agent
+   * class.
    */
   AgentInfo agentInfo(String agentId);
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/InternalServerException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/InternalServerException.java
@@ -5,10 +5,10 @@
 package akka.javasdk.agent;
 
 /**
- * Exception thrown when there is an internal failure within the agent system.
- * This indicates an unexpected error that occurred during agent processing.
+ * Exception thrown when there is an internal failure within the agent system. This indicates an
+ * unexpected error that occurred during agent processing.
  */
-final public class InternalServerException extends RuntimeException {
+public final class InternalServerException extends RuntimeException {
 
   public InternalServerException(String message) {
     super(message);

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/JsonParsingException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/JsonParsingException.java
@@ -5,14 +5,14 @@
 package akka.javasdk.agent;
 
 /**
- * Exception thrown when there is an error parsing JSON responses from the model.
- * This exception can be used to handle JSON parsing errors gracefully.
+ * Exception thrown when there is an error parsing JSON responses from the model. This exception can
+ * be used to handle JSON parsing errors gracefully.
  *
- * It includes the raw JSON string that caused the error.
+ * <p>It includes the raw JSON string that caused the error.
  */
 public class JsonParsingException extends RuntimeException {
 
-  final private String rawJson;
+  private final String rawJson;
 
   public JsonParsingException(String message, Throwable cause, String rawJson) {
     super(message, cause);

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/McpToolCallExecutionException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/McpToolCallExecutionException.java
@@ -6,26 +6,25 @@ package akka.javasdk.agent;
 
 /**
  * Exception thrown when an MCP (Model Context Protocol) tool call fails during execution.
- * <p>
- * This exception is thrown by agents when they attempt to call MCP tools from remote servers
- * and the tool execution fails. It provides detailed information about which tool and endpoint
- * failed to help with debugging and error handling.
- * <p>
- * <strong>Context Information:</strong>
- * The exception includes the tool name and endpoint URL to help identify the source of the failure.
- * This is particularly useful when agents are using multiple MCP servers or when debugging
- * tool integration issues.
- * <p>
- * <strong>Error Handling:</strong>
- * Agents can catch this exception in their {@code onFailure} handlers to provide fallback
- * behavior or alternative responses when MCP tools are unavailable.
+ *
+ * <p>This exception is thrown by agents when they attempt to call MCP tools from remote servers and
+ * the tool execution fails. It provides detailed information about which tool and endpoint failed
+ * to help with debugging and error handling.
+ *
+ * <p><strong>Context Information:</strong> The exception includes the tool name and endpoint URL to
+ * help identify the source of the failure. This is particularly useful when agents are using
+ * multiple MCP servers or when debugging tool integration issues.
+ *
+ * <p><strong>Error Handling:</strong> Agents can catch this exception in their {@code onFailure}
+ * handlers to provide fallback behavior or alternative responses when MCP tools are unavailable.
  */
-final public class McpToolCallExecutionException extends RuntimeException {
+public final class McpToolCallExecutionException extends RuntimeException {
 
   private final String toolName;
   private final String endpoint;
 
-  public McpToolCallExecutionException(String message, String toolName, String endpoint, Throwable cause) {
+  public McpToolCallExecutionException(
+      String message, String toolName, String endpoint, Throwable cause) {
     super(message, cause);
     this.toolName = toolName;
     this.endpoint = endpoint;
@@ -33,6 +32,7 @@ final public class McpToolCallExecutionException extends RuntimeException {
 
   /**
    * Returns the name of the MCP tool that failed to execute.
+   *
    * @return the tool name
    */
   public String getToolName() {
@@ -41,6 +41,7 @@ final public class McpToolCallExecutionException extends RuntimeException {
 
   /**
    * Returns the MCP endpoint where the failure occurred.
+   *
    * @return the endpoint
    */
   public String getEndpoint() {

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/MemoryProvider.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/MemoryProvider.java
@@ -8,18 +8,20 @@ import java.util.Optional;
 
 /**
  * Interface for configuring memory management in agent systems.
- * <p>
- * MemoryProvider defines how session history is stored and retrieved during agent interactions.
+ *
+ * <p>MemoryProvider defines how session history is stored and retrieved during agent interactions.
  * It offers several implementation strategies:
+ *
  * <ul>
- *   <li>Limited window memory management via {@link LimitedWindowMemoryProvider}</li>
- *   <li>Custom memory implementation via {@link CustomMemoryProvider}</li>
+ *   <li>Limited window memory management via {@link LimitedWindowMemoryProvider}
+ *   <li>Custom memory implementation via {@link CustomMemoryProvider}
  * </ul>
  */
 public sealed interface MemoryProvider {
 
   /**
    * Creates a configuration-based memory provider based on configuration defaults.
+   *
    * @return A configuration-based model provider
    */
   static MemoryProvider fromConfig() {
@@ -29,26 +31,23 @@ public sealed interface MemoryProvider {
   /**
    * Creates a memory provider based on configuration settings.
    *
-   * @param configPath Path to the configuration. If empty, uses the default path "akka.javasdk.agent.memory"
+   * @param configPath Path to the configuration. If empty, uses the default path
+   *     "akka.javasdk.agent.memory"
    * @return A configuration-based model provider
    */
   static MemoryProvider fromConfig(String configPath) {
     return new MemoryProvider.FromConfig(configPath);
   }
 
-  /**
-   * Configuration-based memory provider that reads settings from the specified path.
-   */
+  /** Configuration-based memory provider that reads settings from the specified path. */
   record FromConfig(String configPath) implements MemoryProvider {}
 
-
-  /**
-   * Disabled memory provider, which does not store or retrieve contextual history.
-   */
+  /** Disabled memory provider, which does not store or retrieve contextual history. */
   record Disabled() implements MemoryProvider {}
 
   /**
    * Disabled memory provider, which does not store or retrieve contextual history.
+   *
    * @return A memory provider without memory.
    */
   static Disabled none() {
@@ -57,11 +56,12 @@ public sealed interface MemoryProvider {
 
   /**
    * Creates a limited window memory provider with default settings.
-   * <p>
-   * The default settings are:
+   *
+   * <p>The default settings are:
+   *
    * <ul>
-   *   <li>Include all session history in each interaction with the model</li>
-   *   <li>Record all interactions into memory</li>
+   *   <li>Include all session history in each interaction with the model
+   *   <li>Record all interactions into memory
    * </ul>
    *
    * @return A new limited window memory provider with default settings
@@ -72,23 +72,22 @@ public sealed interface MemoryProvider {
 
   /**
    * Memory provider that limits session history based on size or message count.
-   * <p>
-   * This provider allows fine-grained control over memory usage by limiting:
+   *
+   * <p>This provider allows fine-grained control over memory usage by limiting:
+   *
    * <ul>
-   *   <li>Use only last N messages from the history</li>
-   *   <li>Whether reading from memory is enabled</li>
-   *   <li>Whether writing to memory is enabled</li>
+   *   <li>Use only last N messages from the history
+   *   <li>Whether reading from memory is enabled
+   *   <li>Whether writing to memory is enabled
    * </ul>
    */
-  record LimitedWindowMemoryProvider(
-      Optional<Integer> readLastN,
-      boolean read,
-      boolean write) implements MemoryProvider {
+  record LimitedWindowMemoryProvider(Optional<Integer> readLastN, boolean read, boolean write)
+      implements MemoryProvider {
 
     /**
      * Creates a read-only version of this memory provider.
-     * <p>
-     * The returned provider will allow reading from memory but disable writing.
+     *
+     * <p>The returned provider will allow reading from memory but disable writing.
      *
      * @return A new memory provider with writing disabled
      */
@@ -98,8 +97,8 @@ public sealed interface MemoryProvider {
 
     /**
      * Creates a write-only version of this memory provider.
-     * <p>
-     * The returned provider will allow writing to memory but disable reading.
+     *
+     * <p>The returned provider will allow writing to memory but disable reading.
      *
      * @return A new memory provider with reading disabled
      */
@@ -109,10 +108,11 @@ public sealed interface MemoryProvider {
 
     /**
      * Creates a new memory provider with an updated history limit.
-     * <p>
-     * The history limit controls the maximum number of messages to retain in memory.
      *
-     * @param onlyLastN parameter controls the maximum number of most recent messages to read from memory.
+     * <p>The history limit controls the maximum number of messages to retain in memory.
+     *
+     * @param onlyLastN parameter controls the maximum number of most recent messages to read from
+     *     memory.
      * @return A new memory provider with the specified history limit
      */
     public MemoryProvider readLast(int onlyLastN) {
@@ -122,8 +122,8 @@ public sealed interface MemoryProvider {
 
   /**
    * Creates a custom memory provider using the specified SessionMemory implementation.
-   * <p>
-   * This allows for complete customization of memory management behavior.
+   *
+   * <p>This allows for complete customization of memory management behavior.
    *
    * @param sessionMemory The custom SessionMemory implementation
    * @return A new custom memory provider
@@ -134,9 +134,9 @@ public sealed interface MemoryProvider {
 
   /**
    * Memory provider that uses a custom SessionMemory implementation.
-   * <p>
-   * This provider allows for complete customization of memory management behavior
-   * by delegating to the provided SessionMemory implementation.
+   *
+   * <p>This provider allows for complete customization of memory management behavior by delegating
+   * to the provided SessionMemory implementation.
    */
   record CustomMemoryProvider(SessionMemory sessionMemory) implements MemoryProvider {
 
@@ -149,5 +149,4 @@ public sealed interface MemoryProvider {
       return sessionMemory;
     }
   }
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/ModelException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/ModelException.java
@@ -5,13 +5,12 @@
 package akka.javasdk.agent;
 
 /**
- * Exception thrown when there is a failure with the AI model.
- * This can include model errors, invalid requests, or other model-related issues.
+ * Exception thrown when there is a failure with the AI model. This can include model errors,
+ * invalid requests, or other model-related issues.
  */
-final public class ModelException extends RuntimeException {
+public final class ModelException extends RuntimeException {
 
   public ModelException(String message) {
     super(message);
   }
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/ModelProvider.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/ModelProvider.java
@@ -4,26 +4,25 @@
 
 package akka.javasdk.agent;
 
-import akka.runtime.sdk.spi.SpiAgent;
 import com.typesafe.config.Config;
 
 /**
  * Configuration interface for AI model providers used by agents.
- * <p>
- * ModelProvider defines which AI model and settings to use for agent interactions.
- * Akka supports multiple model providers including hosted services (OpenAI, Anthropic, Google AI Gemini, 
+ *
+ * <p>ModelProvider defines which AI model and settings to use for agent interactions. Akka supports
+ * multiple model providers including hosted services (OpenAI, Anthropic, Google AI Gemini,
  * HuggingFace) and locally running models (Ollama, LocalAI).
- * <p>
- * Different agents can use different models by specifying the ModelProvider in the agent effect.
+ *
+ * <p>Different agents can use different models by specifying the ModelProvider in the agent effect.
  * If no model is specified, the default model from configuration is used.
  */
 public sealed interface ModelProvider {
-  
+
   /**
    * Creates a model provider from the default configuration path.
-   * <p>
-   * Reads configuration from {@code akka.javasdk.agent.model-provider}.
-   * 
+   *
+   * <p>Reads configuration from {@code akka.javasdk.agent.model-provider}.
+   *
    * @return a configuration-based model provider
    */
   static ModelProvider fromConfig() {
@@ -32,10 +31,10 @@ public sealed interface ModelProvider {
 
   /**
    * Creates a model provider from the specified configuration path.
-   * <p>
-   * Allows using different model configurations for different agents by
-   * defining multiple model configurations and referencing them by path.
-   * 
+   *
+   * <p>Allows using different model configurations for different agents by defining multiple model
+   * configurations and referencing them by path.
+   *
    * @param configPath the configuration path to read model settings from
    * @return a configuration-based model provider
    */
@@ -45,24 +44,12 @@ public sealed interface ModelProvider {
 
   record FromConfig(String configPath) implements ModelProvider {}
 
-  /**
-   * Settings for the Anthropic Large Language Model provider.
-   */
+  /** Settings for the Anthropic Large Language Model provider. */
   static Anthropic anthropic() {
-    return new Anthropic(
-        "",
-        "",
-        "",
-        Double.NaN,
-        Double.NaN,
-        -1,
-        -1);
+    return new Anthropic("", "", "", Double.NaN, Double.NaN, -1, -1);
   }
 
-  
-  /**
-   * Settings for the Anthropic Large Language Model provider.
-   */
+  /** Settings for the Anthropic Large Language Model provider. */
   record Anthropic(
       /** API key for authentication with Anthropic's API */
       String apiKey,
@@ -73,24 +60,23 @@ public sealed interface ModelProvider {
       /** Controls randomness in the model's output (0.0-1.0, higher = more random) */
       double temperature,
       /**
-       * Nucleus sampling parameter (0.0 to 1.0). Controls text generation by
-       * only considering the most likely tokens whose cumulative probability
-       * exceeds the threshold value. It helps balance between diversity and
-       * quality of outputs—lower values (like 0.3) produce more focused,
-       * predictable text while higher values (like 0.9) allow more creativity
-       * and variation.
+       * Nucleus sampling parameter (0.0 to 1.0). Controls text generation by only considering the
+       * most likely tokens whose cumulative probability exceeds the threshold value. It helps
+       * balance between diversity and quality of outputs—lower values (like 0.3) produce more
+       * focused, predictable text while higher values (like 0.9) allow more creativity and
+       * variation.
        */
       double topP,
       /**
-       * Top-k sampling limits text generation to only the k most probable
-       * tokens at each step, discarding all other possibilities regardless
-       * of their probability. It provides a simpler way to control randomness,
-       * smaller k values (like 10) produce more focused outputs while larger
-       * values (like 50) allow for more diversity.
+       * Top-k sampling limits text generation to only the k most probable tokens at each step,
+       * discarding all other possibilities regardless of their probability. It provides a simpler
+       * way to control randomness, smaller k values (like 10) produce more focused outputs while
+       * larger values (like 50) allow for more diversity.
        */
       int topK,
       /** Maximum number of tokens to generate in the response */
-      int maxTokens) implements ModelProvider {
+      int maxTokens)
+      implements ModelProvider {
 
     public static Anthropic fromConfig(Config config) {
       return new Anthropic(
@@ -102,23 +88,23 @@ public sealed interface ModelProvider {
           config.getInt("top-k"),
           config.getInt("max-tokens"));
     }
-    
+
     public Anthropic withApiKey(String apiKey) {
       return new Anthropic(apiKey, modelName, baseUrl, temperature, topP, topK, maxTokens);
     }
-    
+
     public Anthropic withModelName(String modelName) {
       return new Anthropic(apiKey, modelName, baseUrl, temperature, topP, topK, maxTokens);
     }
-    
+
     public Anthropic withBaseUrl(String baseUrl) {
       return new Anthropic(apiKey, modelName, baseUrl, temperature, topP, topK, maxTokens);
     }
-    
+
     public Anthropic withTemperature(double temperature) {
       return new Anthropic(apiKey, modelName, baseUrl, temperature, topP, topK, maxTokens);
     }
-    
+
     public Anthropic withTopP(double topP) {
       return new Anthropic(apiKey, modelName, baseUrl, temperature, topP, topK, maxTokens);
     }
@@ -132,17 +118,15 @@ public sealed interface ModelProvider {
     }
   }
 
-  /**
-   * Settings for the Google AI Gemini Large Language Model provider.
-   */
+  /** Settings for the Google AI Gemini Large Language Model provider. */
   static GoogleAIGemini googleAiGemini() {
     return new GoogleAIGemini("", "", Double.NaN, Double.NaN, -1);
   }
 
-  /**
-   * Settings for the Google AI Gemini Large Language Model provider.
-   */
-  record GoogleAIGemini(String apiKey, String modelName, Double temperature, Double topP, int maxOutputTokens) implements ModelProvider {
+  /** Settings for the Google AI Gemini Large Language Model provider. */
+  record GoogleAIGemini(
+      String apiKey, String modelName, Double temperature, Double topP, int maxOutputTokens)
+      implements ModelProvider {
 
     public static GoogleAIGemini fromConfig(Config config) {
       return new GoogleAIGemini(
@@ -150,8 +134,7 @@ public sealed interface ModelProvider {
           config.getString("model-name"),
           config.getDouble("temperature"),
           config.getDouble("top-p"),
-          config.getInt("max-output-tokens")
-      );
+          config.getInt("max-output-tokens"));
     }
 
     public GoogleAIGemini withApiKey(String apiKey) {
@@ -162,70 +145,61 @@ public sealed interface ModelProvider {
       return new GoogleAIGemini(apiKey, modelName, temperature, topP, maxOutputTokens);
     }
 
-     public GoogleAIGemini withTemperature(double temperature) {
+    public GoogleAIGemini withTemperature(double temperature) {
       return new GoogleAIGemini(apiKey, modelName, temperature, topP, maxOutputTokens);
-     }
+    }
 
-     public GoogleAIGemini withTopP(double topP) {
+    public GoogleAIGemini withTopP(double topP) {
       return new GoogleAIGemini(apiKey, modelName, temperature, topP, maxOutputTokens);
-     }
+    }
 
-     public GoogleAIGemini withMaxOutputTokens(int maxOutputTokens) {
+    public GoogleAIGemini withMaxOutputTokens(int maxOutputTokens) {
       return new GoogleAIGemini(apiKey, modelName, temperature, topP, maxOutputTokens);
-     }
+    }
   }
 
-  /**
-   * Settings for the Local AI Large Language Model provider.
-   */
+  /** Settings for the Local AI Large Language Model provider. */
   static LocalAI localAI() {
     return new LocalAI("", "", Double.NaN, Double.NaN, -1);
   }
 
-  /**
-   * Settings for the Local AI Large Language Model provider.
-   */
-  record LocalAI(String baseUrl, String modelName, Double temperature, Double topP, int maxTokens) implements ModelProvider {
+  /** Settings for the Local AI Large Language Model provider. */
+  record LocalAI(String baseUrl, String modelName, Double temperature, Double topP, int maxTokens)
+      implements ModelProvider {
     public static LocalAI fromConfig(Config config) {
       return new LocalAI(
           config.getString("base-url"),
           config.getString("model-name"),
           config.getDouble("temperature"),
           config.getDouble("top-p"),
-          config.getInt("max-tokens")
-      );
+          config.getInt("max-tokens"));
     }
 
-      public LocalAI withModelName(String modelName) {
-        return new LocalAI(baseUrl, modelName, temperature, topP, maxTokens);
-      }
+    public LocalAI withModelName(String modelName) {
+      return new LocalAI(baseUrl, modelName, temperature, topP, maxTokens);
+    }
 
-      public LocalAI withTemperature(double temperature) {
-        return new LocalAI(baseUrl, modelName, temperature, topP, maxTokens);
-      }
+    public LocalAI withTemperature(double temperature) {
+      return new LocalAI(baseUrl, modelName, temperature, topP, maxTokens);
+    }
 
-      public LocalAI withTopP(double topP) {
-        return new LocalAI(baseUrl, modelName, temperature, topP, maxTokens);
-      }
+    public LocalAI withTopP(double topP) {
+      return new LocalAI(baseUrl, modelName, temperature, topP, maxTokens);
+    }
 
-      public LocalAI withMaxTokens(int maxTokens) {
-        return new LocalAI(baseUrl, modelName, temperature, topP, maxTokens);
-      }
-
+    public LocalAI withMaxTokens(int maxTokens) {
+      return new LocalAI(baseUrl, modelName, temperature, topP, maxTokens);
+    }
   }
 
-
-  /**
-   * Settings for the Ollama Large Language Model provider.
-   */
+  /** Settings for the Ollama Large Language Model provider. */
   static Ollama ollama() {
     return new Ollama("", "", Double.NaN, Double.NaN);
   }
 
-  /**
-   * Settings for the Ollama Large Language Model provider.
-   */
-  record Ollama(String baseUrl, String modelName, Double temperature, Double topP) implements ModelProvider {
+  /** Settings for the Ollama Large Language Model provider. */
+  record Ollama(String baseUrl, String modelName, Double temperature, Double topP)
+      implements ModelProvider {
 
     public static Ollama fromConfig(Config config) {
       return new Ollama(
@@ -250,25 +224,14 @@ public sealed interface ModelProvider {
     public Ollama withTopP(double topP) {
       return new Ollama(baseUrl, modelName, temperature, topP);
     }
-
   }
 
-  /**
-   * Settings for the OpenAI Large Language Model provider.
-   */
+  /** Settings for the OpenAI Large Language Model provider. */
   static OpenAi openAi() {
-    return new OpenAi(
-        "",
-        "",
-        "",
-        Double.NaN,
-        Double.NaN,
-        -1);
+    return new OpenAi("", "", "", Double.NaN, Double.NaN, -1);
   }
 
-  /**
-   * Settings for the OpenAI Large Language Model provider.
-   */
+  /** Settings for the OpenAI Large Language Model provider. */
   record OpenAi(
       /** API key for authentication with OpenAI's API */
       String apiKey,
@@ -279,16 +242,16 @@ public sealed interface ModelProvider {
       /** Controls randomness in the model's output (0.0-1.0, higher = more random) */
       double temperature,
       /**
-       * Nucleus sampling parameter (0.0 to 1.0). Controls text generation by
-       * only considering the most likely tokens whose cumulative probability
-       * exceeds the threshold value. It helps balance between diversity and
-       * quality of outputs—lower values (like 0.3) produce more focused,
-       * predictable text while higher values (like 0.9) allow more creativity
-       * and variation.
+       * Nucleus sampling parameter (0.0 to 1.0). Controls text generation by only considering the
+       * most likely tokens whose cumulative probability exceeds the threshold value. It helps
+       * balance between diversity and quality of outputs—lower values (like 0.3) produce more
+       * focused, predictable text while higher values (like 0.9) allow more creativity and
+       * variation.
        */
       double topP,
       /** Maximum number of tokens to generate in the response */
-      int maxTokens) implements ModelProvider {
+      int maxTokens)
+      implements ModelProvider {
 
     public static OpenAi fromConfig(Config config) {
       return new OpenAi(
@@ -299,38 +262,36 @@ public sealed interface ModelProvider {
           config.getDouble("top-p"),
           config.getInt("max-tokens"));
     }
-    
+
     public OpenAi withApiKey(String apiKey) {
       return new OpenAi(apiKey, modelName, baseUrl, temperature, topP, maxTokens);
     }
-    
+
     public OpenAi withModelName(String modelName) {
       return new OpenAi(apiKey, modelName, baseUrl, temperature, topP, maxTokens);
     }
-    
+
     public OpenAi withBaseUrl(String baseUrl) {
       return new OpenAi(apiKey, modelName, baseUrl, temperature, topP, maxTokens);
     }
-    
+
     public OpenAi withTemperature(double temperature) {
       return new OpenAi(apiKey, modelName, baseUrl, temperature, topP, maxTokens);
     }
-    
+
     public OpenAi withTopP(double topP) {
       return new OpenAi(apiKey, modelName, baseUrl, temperature, topP, maxTokens);
     }
-    
+
     public OpenAi withMaxTokens(int maxTokens) {
       return new OpenAi(apiKey, modelName, baseUrl, temperature, topP, maxTokens);
     }
   }
 
-  /**
-   * Settings for the HuggingFace Large Language Model provider.
-   */
+  /** Settings for the HuggingFace Large Language Model provider. */
   static HuggingFace huggingFace() {
     // Implementation omitted for shortness
-    return new HuggingFace("","", "", Double.NaN, Double.NaN, -1);
+    return new HuggingFace("", "", "", Double.NaN, Double.NaN, -1);
   }
 
   record HuggingFace(
@@ -339,7 +300,8 @@ public sealed interface ModelProvider {
       String baseUrl,
       double temperature,
       double topP,
-      int maxNewTokens) implements ModelProvider {
+      int maxNewTokens)
+      implements ModelProvider {
 
     public static HuggingFace fromConfig(Config config) {
       return new HuggingFace(
@@ -352,30 +314,35 @@ public sealed interface ModelProvider {
     }
 
     public HuggingFace withAccessToken(String accessToken) {
-      return new HuggingFace(accessToken, this.modelId, this.baseUrl, this.temperature, this.topP, this.maxNewTokens);
+      return new HuggingFace(
+          accessToken, this.modelId, this.baseUrl, this.temperature, this.topP, this.maxNewTokens);
     }
 
     public HuggingFace withModelId(String modelId) {
-      return new HuggingFace(this.accessToken, modelId, this.baseUrl, this.temperature, this.topP, this.maxNewTokens);
+      return new HuggingFace(
+          this.accessToken, modelId, this.baseUrl, this.temperature, this.topP, this.maxNewTokens);
     }
 
     public HuggingFace withBaseUrl(String baseUrl) {
-      return new HuggingFace(this.accessToken, this.modelId, baseUrl, this.temperature, this.topP, this.maxNewTokens);
+      return new HuggingFace(
+          this.accessToken, this.modelId, baseUrl, this.temperature, this.topP, this.maxNewTokens);
     }
 
     public HuggingFace withTemperature(Double temperature) {
-      return new HuggingFace(this.accessToken, this.modelId, this.baseUrl, temperature, this.topP, this.maxNewTokens);
+      return new HuggingFace(
+          this.accessToken, this.modelId, this.baseUrl, temperature, this.topP, this.maxNewTokens);
     }
 
     public HuggingFace withTopP(Double topP) {
-      return new HuggingFace(this.accessToken, this.modelId, this.baseUrl, this.temperature, topP, this.maxNewTokens);
+      return new HuggingFace(
+          this.accessToken, this.modelId, this.baseUrl, this.temperature, topP, this.maxNewTokens);
     }
 
     public HuggingFace withMaxNewTokens(Integer maxNewTokens) {
-      return new HuggingFace(this.accessToken, this.modelId, this.baseUrl, this.temperature, this.topP, maxNewTokens);
+      return new HuggingFace(
+          this.accessToken, this.modelId, this.baseUrl, this.temperature, this.topP, maxNewTokens);
     }
   }
-
 
   static Custom custom(Custom provider) {
     return provider;
@@ -393,5 +360,3 @@ public sealed interface ModelProvider {
     Object createStreamingChatModel();
   }
 }
-
-

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/ModelTimeoutException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/ModelTimeoutException.java
@@ -5,10 +5,10 @@
 package akka.javasdk.agent;
 
 /**
- * Exception thrown when a request to an AI model or external service times out.
- * This indicates that the operation took longer than the configured timeout period.
+ * Exception thrown when a request to an AI model or external service times out. This indicates that
+ * the operation took longer than the configured timeout period.
  */
-final public class ModelTimeoutException extends RuntimeException {
+public final class ModelTimeoutException extends RuntimeException {
 
   public ModelTimeoutException(String message) {
     super(message);

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/RateLimitException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/RateLimitException.java
@@ -5,13 +5,12 @@
 package akka.javasdk.agent;
 
 /**
- * Exception thrown when rate limits are exceeded when calling an AI model or external service.
- * This indicates that too many requests have been made within a time window.
+ * Exception thrown when rate limits are exceeded when calling an AI model or external service. This
+ * indicates that too many requests have been made within a time window.
  */
-final public class RateLimitException extends RuntimeException {
+public final class RateLimitException extends RuntimeException {
 
   public RateLimitException(String message) {
     super(message);
   }
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/RemoteMcpTools.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/RemoteMcpTools.java
@@ -90,7 +90,9 @@ public interface RemoteMcpTools {
    */
   @DoNotInherit
   interface ToolInterceptorContext {
-    /** @return The tool name that the call is for */
+    /**
+     * @return The tool name that the call is for
+     */
     String toolName();
   }
 
@@ -120,6 +122,7 @@ public interface RemoteMcpTools {
     default String interceptResponse(
         ToolInterceptorContext context, String requestPayloadJson, String responsePayload) {
       return responsePayload;
-    };
+    }
+    ;
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMemory.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMemory.java
@@ -12,40 +12,39 @@ import java.util.List;
 
 /**
  * Interface for managing contextual session history between users and AI models.
- * <p>
- * SessionMemory provides functionality to store, retrieve, and manage messages exchanged during
+ *
+ * <p>SessionMemory provides functionality to store, retrieve, and manage messages exchanged during
  * interactions in an agent system. It enables agents to maintain context across multiple
  * interactions within the same session.
- * <p>
- * <strong>Default Implementation:</strong>
- * The default implementation is backed by {@link SessionMemoryEntity}, a built-in Event Sourced Entity
- * that automatically stores contextual history. This provides durability and allows for session
- * memory to be shared between multiple agents using the same session id.
- * <p>
- * <strong>Custom Implementation:</strong>
- * You can provide a custom implementation using {@link MemoryProvider#custom(SessionMemory)} to
- * store session memory in external databases or services.
- * <p>
- * <strong>Memory Management:</strong>
- * Session memory can be configured to limit the amount of history retained, either by message count
- * or total size, to control token usage and performance.
+ *
+ * <p><strong>Default Implementation:</strong> The default implementation is backed by {@link
+ * SessionMemoryEntity}, a built-in Event Sourced Entity that automatically stores contextual
+ * history. This provides durability and allows for session memory to be shared between multiple
+ * agents using the same session id.
+ *
+ * <p><strong>Custom Implementation:</strong> You can provide a custom implementation using {@link
+ * MemoryProvider#custom(SessionMemory)} to store session memory in external databases or services.
+ *
+ * <p><strong>Memory Management:</strong> Session memory can be configured to limit the amount of
+ * history retained, either by message count or total size, to control token usage and performance.
  */
 public interface SessionMemory {
 
   /**
-   * Adds an interaction between a user and an AI model to the session history for the
-   * specified session.
+   * Adds an interaction between a user and an AI model to the session history for the specified
+   * session.
    *
    * @param sessionId The unique identifier for the contextual session
    * @param userMessage The content of the user message
-   * @param messages All other messages generated during this interaction, typically AiMessage but also Tool Call
-   *                 responses.
+   * @param messages All other messages generated during this interaction, typically AiMessage but
+   *     also Tool Call responses.
    */
-  void addInteraction(String sessionId, SessionMessage.UserMessage userMessage,
-                       List<SessionMessage> messages);
+  void addInteraction(
+      String sessionId, SessionMessage.UserMessage userMessage, List<SessionMessage> messages);
+
   /**
-   * Retrieves the complete session history for the specified session. For very long sessions,
-   * this might return a compacted version of the history.
+   * Retrieves the complete session history for the specified session. For very long sessions, this
+   * might return a compacted version of the history.
    *
    * @param sessionId The unique identifier for the contextual session
    * @return The complete session history containing all messages

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMemoryEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMemoryEntity.java
@@ -4,6 +4,8 @@
 
 package akka.javasdk.agent;
 
+import static akka.Done.done;
+
 import akka.Done;
 import akka.javasdk.agent.SessionMemoryEntity.Event;
 import akka.javasdk.agent.SessionMemoryEntity.State;
@@ -16,43 +18,43 @@ import akka.javasdk.client.ComponentClient;
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
 import akka.javasdk.eventsourcedentity.EventSourcedEntityContext;
 import com.typesafe.config.Config;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-
-import static akka.Done.done;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Built-in Event Sourced Entity that provides persistent session memory for agent interactions with the AI model.
- * <p>
- * SessionMemoryEntity maintains a limited history of contextual messages in FIFO (First In, First Out) style,
- * automatically managing memory size to prevent unbounded growth. It serves as the default implementation
- * of session memory for agents.
- * <p>
- * <strong>Automatic Registration:</strong>
- * This entity is automatically registered by the Akka runtime when Agent components are detected.
- * Each session is identified by the entity id, which corresponds to the agent's session id.
- * <p>
- * <strong>Memory Management:</strong>
+ * Built-in Event Sourced Entity that provides persistent session memory for agent interactions with
+ * the AI model.
+ *
+ * <p>SessionMemoryEntity maintains a limited history of contextual messages in FIFO (First In,
+ * First Out) style, automatically managing memory size to prevent unbounded growth. It serves as
+ * the default implementation of session memory for agents.
+ *
+ * <p><strong>Automatic Registration:</strong> This entity is automatically registered by the Akka
+ * runtime when Agent components are detected. Each session is identified by the entity id, which
+ * corresponds to the agent's session id.
+ *
+ * <p><strong>Memory Management:</strong>
+ *
  * <ul>
- *   <li>Configurable maximum memory size via {@code akka.javasdk.agent.memory.limited-window.max-size}</li>
- *   <li>Automatic removal of oldest messages when size limit is exceeded</li>
- *   <li>Orphan message cleanup (removes AI/tool messages when their triggering user message is removed)</li>
+ *   <li>Configurable maximum memory size via {@code
+ *       akka.javasdk.agent.memory.limited-window.max-size}
+ *   <li>Automatic removal of oldest messages when size limit is exceeded
+ *   <li>Orphan message cleanup (removes AI/tool messages when their triggering user message is
+ *       removed)
  * </ul>
- * <p>
- * <strong>Direct Access:</strong>
- * You can interact directly with session memory using {@link ComponentClient}.
- * <p>
- * <strong>Event Subscription:</strong>
- * You can subscribe to session memory events using a {@link akka.javasdk.consumer.Consumer} to
- * monitor session activity, implement custom analytics, or trigger compaction when memory usage
- * exceeds thresholds.
+ *
+ * <p><strong>Direct Access:</strong> You can interact directly with session memory using {@link
+ * ComponentClient}.
+ *
+ * <p><strong>Event Subscription:</strong> You can subscribe to session memory events using a {@link
+ * akka.javasdk.consumer.Consumer} to monitor session activity, implement custom analytics, or
+ * trigger compaction when memory usage exceeds thresholds.
  */
 @ComponentId("akka-session-memory")
 public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> {
@@ -67,14 +69,20 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
     this.sessionId = context.entityId();
   }
 
-  public record State(String sessionId, long maxSizeInBytes, long currentSizeInBytes, List<SessionMessage> messages) {
+  public record State(
+      String sessionId,
+      long maxSizeInBytes,
+      long currentSizeInBytes,
+      List<SessionMessage> messages) {
 
     private static final Logger logger = LoggerFactory.getLogger(State.class);
 
     public State {
-      if (maxSizeInBytes <= 0) throw new IllegalArgumentException("Maximum size must be greater than 0");
+      if (maxSizeInBytes <= 0)
+        throw new IllegalArgumentException("Maximum size must be greater than 0");
       messages = messages != null ? messages : new LinkedList<>();
-      currentSizeInBytes = enforceMaxCapacity(sessionId, messages, currentSizeInBytes, maxSizeInBytes);
+      currentSizeInBytes =
+          enforceMaxCapacity(sessionId, messages, currentSizeInBytes, maxSizeInBytes);
     }
 
     public boolean isEmpty() {
@@ -86,7 +94,8 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
     }
 
     public State addMessage(SessionMessage message) {
-      // avoid copies of the list for efficiency, need to be careful not to return the list ref to outside
+      // avoid copies of the list for efficiency, need to be careful not to return the list ref to
+      // outside
       messages.add(message);
 
       var updatedSize = currentSizeInBytes + message.size();
@@ -97,24 +106,31 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
       return new State(sessionId, maxSizeInBytes, 0, new LinkedList<>());
     }
 
-    private static long enforceMaxCapacity(String sessionId, List<SessionMessage> messages, long currentSize, long maxSize) {
+    private static long enforceMaxCapacity(
+        String sessionId, List<SessionMessage> messages, long currentSize, long maxSize) {
       var freedSpace = 0;
       while ((currentSize - freedSpace) > maxSize) {
         freedSpace += messages.removeFirst().size();
-        logger.debug("Removed oldest message for sessionId [{}]. Remaining size [{}], maxSizeInBytes [{}]",
-            sessionId, currentSize, maxSize);
+        logger.debug(
+            "Removed oldest message for sessionId [{}]. Remaining size [{}], maxSizeInBytes [{}]",
+            sessionId,
+            currentSize,
+            maxSize);
       }
 
-      // remove all messages that are not UserMessage since those were driven by the deleted UserMessage
+      // remove all messages that are not UserMessage since those were driven by the deleted
+      // UserMessage
       while (!messages.isEmpty() && !(messages.getFirst() instanceof UserMessage)) {
         freedSpace += messages.removeFirst().size();
-        logger.debug("Removed orphan message for sessionId [{}]. Remaining size [{}], maxSizeInBytes [{}]",
-            sessionId, currentSize, maxSize);
+        logger.debug(
+            "Removed orphan message for sessionId [{}]. Remaining size [{}], maxSizeInBytes [{}]",
+            sessionId,
+            currentSize,
+            maxSize);
       }
 
       return currentSize - freedSpace;
     }
-
   }
 
   @Override
@@ -123,63 +139,59 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
     return new State(sessionId, maxSizeInBytes, 0, new LinkedList<>());
   }
 
-  /**
-   * Sealed interface representing events that can occur in the SessionMemory entity.
-   */
+  /** Sealed interface representing events that can occur in the SessionMemory entity. */
   public sealed interface Event {
 
     @TypeName("akka-memory-limited-window-set")
-    record LimitedWindowSet(Instant timestamp, int maxSizeInBytes) implements Event {
-    }
+    record LimitedWindowSet(Instant timestamp, int maxSizeInBytes) implements Event {}
 
     @TypeName("akka-memory-user-message-added")
-    record UserMessageAdded(Instant timestamp, String componentId, String message, int sizeInBytes) implements Event {
-    }
+    record UserMessageAdded(Instant timestamp, String componentId, String message, int sizeInBytes)
+        implements Event {}
 
     @TypeName("akka-memory-ai-message-added")
-    record AiMessageAdded(Instant timestamp,
-                          String componentId,
-                          String message,
-                          int sizeInBytes,
-                          long historySizeInBytes,
-                          List<SessionMessage.ToolCallRequest> toolCallRequests) implements Event {
+    record AiMessageAdded(
+        Instant timestamp,
+        String componentId,
+        String message,
+        int sizeInBytes,
+        long historySizeInBytes,
+        List<SessionMessage.ToolCallRequest> toolCallRequests)
+        implements Event {
 
       AiMessageAdded withHistorySizeInBytes(long newSize) {
-        return new AiMessageAdded(timestamp, componentId, message, sizeInBytes, newSize, toolCallRequests);
+        return new AiMessageAdded(
+            timestamp, componentId, message, sizeInBytes, newSize, toolCallRequests);
       }
-
     }
 
     @TypeName("akka-memory-tool-response-message-added")
-    record ToolResponseMessageAdded(Instant timestamp,
-                                    String componentId,
-                                    String id,
-                                    String name,
-                                    String content,
-                                    int sizeInBytes) implements Event {
-
-    }
+    record ToolResponseMessageAdded(
+        Instant timestamp,
+        String componentId,
+        String id,
+        String name,
+        String content,
+        int sizeInBytes)
+        implements Event {}
 
     @TypeName("akka-memory-cleared")
-    record HistoryCleared() implements Event {
-    }
+    record HistoryCleared() implements Event {}
 
     @TypeName("akka-memory-deleted")
-    record Deleted(Instant timestamp) implements Event {
-    }
+    record Deleted(Instant timestamp) implements Event {}
   }
 
   // Request commands
-  public record LimitedWindow(int maxSizeInBytes) {
-  }
+  public record LimitedWindow(int maxSizeInBytes) {}
 
   public Effect<Done> setLimitedWindow(LimitedWindow limitedWindow) {
     if (limitedWindow.maxSizeInBytes <= 0) {
       return effects().error("Maximum size must be greater than 0");
     } else {
       return effects()
-        .persist(new Event.LimitedWindowSet(Instant.now(), limitedWindow.maxSizeInBytes))
-        .thenReply(__ -> done());
+          .persist(new Event.LimitedWindowSet(Instant.now(), limitedWindow.maxSizeInBytes))
+          .thenReply(__ -> done());
     }
   }
 
@@ -192,45 +204,48 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
   public Effect<Done> addInteraction(AddInteractionCmd cmd) {
 
     if (cmd.messages.stream()
-      .filter(msg -> msg instanceof AiMessage)
-      .map(msg -> ((AiMessage) msg).componentId())
-      .anyMatch(aiComponentId -> !cmd.userMessage.componentId().equals(aiComponentId))) {
+        .filter(msg -> msg instanceof AiMessage)
+        .map(msg -> ((AiMessage) msg).componentId())
+        .anyMatch(aiComponentId -> !cmd.userMessage.componentId().equals(aiComponentId))) {
       return effects().error("componentId in userMessage must be the same as in all aiMessages");
     }
 
     var modelAndToolEvents =
-      cmd.messages.stream()
-        .map(msg -> {
+        cmd.messages.stream()
+            .map(
+                msg -> {
+                  return (Event)
+                      switch (msg) {
+                        case AiMessage aiMessage ->
+                            new Event.AiMessageAdded(
+                                aiMessage.timestamp(),
+                                aiMessage.componentId(),
+                                aiMessage.text(),
+                                aiMessage.size(),
+                                0L, // filled in later
+                                aiMessage.toolCallRequests());
 
-            return (Event) switch (msg) {
-              case AiMessage aiMessage ->
-                  new Event.AiMessageAdded(
-                      aiMessage.timestamp(),
-                      aiMessage.componentId(),
-                      aiMessage.text(),
-                      aiMessage.size(),
-                0L, // filled in later
-                      aiMessage.toolCallRequests());
+                        case SessionMessage.ToolCallResponse toolCallResponse ->
+                            new Event.ToolResponseMessageAdded(
+                                toolCallResponse.timestamp(),
+                                toolCallResponse.componentId(),
+                                toolCallResponse.id(),
+                                toolCallResponse.name(),
+                                toolCallResponse.text(),
+                                toolCallResponse.size());
 
-              case SessionMessage.ToolCallResponse toolCallResponse ->
-                  new Event.ToolResponseMessageAdded(
-                      toolCallResponse.timestamp(),
-                      toolCallResponse.componentId(),
-                      toolCallResponse.id(),
-                      toolCallResponse.name(),
-                      toolCallResponse.text(),
-                      toolCallResponse.size());
+                        default ->
+                            throw new IllegalArgumentException("Unsupported message: " + msg);
+                      };
+                })
+            .toList();
 
-              default -> throw new IllegalArgumentException("Unsupported message: " + msg);
-            };
-          }
-        ).toList();
-
-    var userMessageEvent = new Event.UserMessageAdded(
-      cmd.userMessage.timestamp(),
-      cmd.userMessage.componentId(),
-      cmd.userMessage.text(),
-        cmd.userMessage.size());
+    var userMessageEvent =
+        new Event.UserMessageAdded(
+            cmd.userMessage.timestamp(),
+            cmd.userMessage.componentId(),
+            cmd.userMessage.text(),
+            cmd.userMessage.size());
 
     List<Event> allEvents = new ArrayList<>();
     allEvents.add(userMessageEvent);
@@ -238,33 +253,28 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
 
     var allEventsWithSize = updateHistorySize(allEvents);
 
-    return effects()
-        .persistAll(allEventsWithSize)
-        .thenReply(__ -> done());
+    return effects().persistAll(allEventsWithSize).thenReply(__ -> done());
   }
 
-  public record GetHistoryCmd(Optional<Integer> lastNMessages) {
-  }
+  public record GetHistoryCmd(Optional<Integer> lastNMessages) {}
 
   public ReadOnlyEffect<SessionHistory> getHistory(GetHistoryCmd cmd) {
     List<SessionMessage> messages = currentState().messages();
     if (cmd.lastNMessages != null
-      && cmd.lastNMessages.isPresent()
-      && messages.size() > cmd.lastNMessages.get()) {
-      var lastN = messages
-        .subList(messages.size() - cmd.lastNMessages.get(), messages.size());
+        && cmd.lastNMessages.isPresent()
+        && messages.size() > cmd.lastNMessages.get()) {
+      var lastN = messages.subList(messages.size() - cmd.lastNMessages.get(), messages.size());
       // make sure this returns a copy of the list and not the list itself
-      return effects().reply(
-        new SessionHistory(new LinkedList<>(lastN), commandContext().sequenceNumber()));
+      return effects()
+          .reply(new SessionHistory(new LinkedList<>(lastN), commandContext().sequenceNumber()));
     } else {
       // make sure this returns a copy of the list and not the list itself
-      return effects().reply(
-        new SessionHistory(new LinkedList<>(messages), commandContext().sequenceNumber()));
+      return effects()
+          .reply(new SessionHistory(new LinkedList<>(messages), commandContext().sequenceNumber()));
     }
   }
 
-  public record CompactionCmd(UserMessage userMessage, AiMessage aiMessage, long sequenceNumber) {
-  }
+  public record CompactionCmd(UserMessage userMessage, AiMessage aiMessage, long sequenceNumber) {}
 
   public Effect<Done> compactHistory(CompactionCmd cmd) {
 
@@ -274,58 +284,73 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
 
     var events = new ArrayList<Event>();
     events.add(new Event.HistoryCleared());
-    events.add(new Event.UserMessageAdded(cmd.userMessage.timestamp(), componentId, cmd.userMessage.text(), cmd.userMessage.size()));
-    events.add(new Event.AiMessageAdded(
-      cmd.aiMessage.timestamp(),
-      componentId,
-      cmd.aiMessage.text(),
-        cmd.aiMessage.size(),
-        0L, // filled in later
-      Collections.emptyList()));
+    events.add(
+        new Event.UserMessageAdded(
+            cmd.userMessage.timestamp(),
+            componentId,
+            cmd.userMessage.text(),
+            cmd.userMessage.size()));
+    events.add(
+        new Event.AiMessageAdded(
+            cmd.aiMessage.timestamp(),
+            componentId,
+            cmd.aiMessage.text(),
+            cmd.aiMessage.size(),
+            0L, // filled in later
+            Collections.emptyList()));
 
-    if (commandContext().sequenceNumber() > cmd.sequenceNumber && !currentState().messages.isEmpty()) {
+    if (commandContext().sequenceNumber() > cmd.sequenceNumber
+        && !currentState().messages.isEmpty()) {
       int diff = (int) (commandContext().sequenceNumber() - cmd.sequenceNumber);
-      currentState().messages.subList(currentState().messages.size() - diff, currentState().messages.size())
-          .forEach(msg -> {
-        switch (msg) {
-          case UserMessage userMessage -> {
-            events.add(new Event.UserMessageAdded(userMessage.timestamp(), userMessage.componentId(), userMessage.text(), userMessage.size()));
-          }
+      currentState()
+          .messages
+          .subList(currentState().messages.size() - diff, currentState().messages.size())
+          .forEach(
+              msg -> {
+                switch (msg) {
+                  case UserMessage userMessage -> {
+                    events.add(
+                        new Event.UserMessageAdded(
+                            userMessage.timestamp(),
+                            userMessage.componentId(),
+                            userMessage.text(),
+                            userMessage.size()));
+                  }
 
-          case ToolCallResponse toolCallResponse -> {
-            events.add(new Event.ToolResponseMessageAdded(
-              toolCallResponse.timestamp(),
-              toolCallResponse.componentId(),
-              toolCallResponse.id(),
-              toolCallResponse.name(),
-              toolCallResponse.text(),
-                toolCallResponse.size()));
-          }
+                  case ToolCallResponse toolCallResponse -> {
+                    events.add(
+                        new Event.ToolResponseMessageAdded(
+                            toolCallResponse.timestamp(),
+                            toolCallResponse.componentId(),
+                            toolCallResponse.id(),
+                            toolCallResponse.name(),
+                            toolCallResponse.text(),
+                            toolCallResponse.size()));
+                  }
 
-          case AiMessage aiMessage -> {
-            events.add(new Event.AiMessageAdded(
-              aiMessage.timestamp(),
-              aiMessage.componentId(),
-              aiMessage.text(),
-                aiMessage.size(),
-                0L, // filled in later
-              aiMessage.toolCallRequests()));
-          }
-        }
-      });
+                  case AiMessage aiMessage -> {
+                    events.add(
+                        new Event.AiMessageAdded(
+                            aiMessage.timestamp(),
+                            aiMessage.componentId(),
+                            aiMessage.text(),
+                            aiMessage.size(),
+                            0L, // filled in later
+                            aiMessage.toolCallRequests()));
+                  }
+                }
+              });
     }
 
     var eventsWithSize = updateHistorySize(events);
 
-    return effects()
-        .persistAll(eventsWithSize)
-        .thenReply(__ -> Done.done());
+    return effects().persistAll(eventsWithSize).thenReply(__ -> Done.done());
   }
 
   private List<Event> updateHistorySize(List<Event> events) {
     var result = new ArrayList<Event>();
     var size = currentState().currentSizeInBytes;
-    for (Event event: events) {
+    for (Event event : events) {
       switch (event) {
         case Event.HistoryCleared evt -> {
           size = 0L;
@@ -356,9 +381,9 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
       return effects().reply(done());
     } else {
       return effects()
-        .persist(new Event.Deleted(Instant.now()))
-        .deleteEntity()
-        .thenReply(__ -> done());
+          .persist(new Event.Deleted(Instant.now()))
+          .deleteEntity()
+          .thenReply(__ -> done());
     }
   }
 
@@ -370,32 +395,28 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
 
       case Event.UserMessageAdded userMsg ->
           currentState()
-            .addMessage(new UserMessage(userMsg.timestamp(), userMsg.message(), userMsg.componentId));
+              .addMessage(
+                  new UserMessage(userMsg.timestamp(), userMsg.message(), userMsg.componentId));
 
       case Event.AiMessageAdded aiMsg ->
           currentState()
-            .addMessage(
-              new AiMessage(
-                aiMsg.timestamp,
-                aiMsg.message,
-                aiMsg.componentId,
-                aiMsg.toolCallRequests));
+              .addMessage(
+                  new AiMessage(
+                      aiMsg.timestamp, aiMsg.message, aiMsg.componentId, aiMsg.toolCallRequests));
 
       case Event.ToolResponseMessageAdded toolMsg ->
           currentState()
-            .addMessage(
-              new ToolCallResponse(
-                toolMsg.timestamp(),
-                toolMsg.componentId,
-                toolMsg.id(),
-                toolMsg.name,
-                toolMsg.content()));
+              .addMessage(
+                  new ToolCallResponse(
+                      toolMsg.timestamp(),
+                      toolMsg.componentId,
+                      toolMsg.id(),
+                      toolMsg.name,
+                      toolMsg.content()));
 
-      case Event.HistoryCleared __ ->
-        currentState().clear();
+      case Event.HistoryCleared __ -> currentState().clear();
 
-      case Event.Deleted __ ->
-          currentState().clear();
+      case Event.Deleted __ -> currentState().clear();
     };
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMessage.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMessage.java
@@ -9,19 +9,16 @@ import akka.javasdk.agent.SessionMessage.ToolCallResponse;
 import akka.javasdk.agent.SessionMessage.UserMessage;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
 import java.time.Instant;
 import java.util.List;
 
-
-/**
- * Interface for message representation used inside SessionMemoryEntity state.
- */
+/** Interface for message representation used inside SessionMemoryEntity state. */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "@type")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = UserMessage.class, name = "UM"),
   @JsonSubTypes.Type(value = AiMessage.class, name = "AIM"),
-  @JsonSubTypes.Type(value = ToolCallResponse.class, name = "TCR")})
+  @JsonSubTypes.Type(value = ToolCallResponse.class, name = "TCR")
+})
 public sealed interface SessionMessage {
   static int sizeInBytes(String text) {
     return text.length(); // simple implementation, but not correct for all encodings
@@ -39,13 +36,11 @@ public sealed interface SessionMessage {
     }
   }
 
-  record ToolCallRequest(String id, String name, String arguments)  {
-  }
+  record ToolCallRequest(String id, String name, String arguments) {}
 
-  record AiMessage(Instant timestamp,
-                   String text,
-                   String componentId,
-                   List<ToolCallRequest> toolCallRequests) implements SessionMessage {
+  record AiMessage(
+      Instant timestamp, String text, String componentId, List<ToolCallRequest> toolCallRequests)
+      implements SessionMessage {
 
     public AiMessage(Instant timestamp, String text, String componentId) {
       this(timestamp, text, componentId, List.of());
@@ -56,20 +51,25 @@ public sealed interface SessionMessage {
       var textLength = text == null ? 0 : SessionMessage.sizeInBytes(text);
       // calculating the length of tool call requests arguments
       // NOTE: not accounting for the real payload, only the arguments
-      int argsLength = toolCallRequests == null ? 0 : toolCallRequests.stream()
-          .mapToInt(req -> req.arguments() == null ? 0 : SessionMessage.sizeInBytes(req.arguments()))
-          .sum();
+      int argsLength =
+          toolCallRequests == null
+              ? 0
+              : toolCallRequests.stream()
+                  .mapToInt(
+                      req ->
+                          req.arguments() == null ? 0 : SessionMessage.sizeInBytes(req.arguments()))
+                  .sum();
 
       return textLength + argsLength;
     }
   }
 
-  record ToolCallResponse(Instant timestamp, String componentId, String id, String name, String text) implements SessionMessage {
+  record ToolCallResponse(
+      Instant timestamp, String componentId, String id, String name, String text)
+      implements SessionMessage {
     @Override
     public int size() {
       return SessionMessage.sizeInBytes(text);
     }
   }
-
 }
-

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/ToolCallExecutionException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/ToolCallExecutionException.java
@@ -5,13 +5,12 @@
 package akka.javasdk.agent;
 
 /**
- * Exception thrown when there is a failure executing a tool call.
- * This includes the name of the tool that failed to execute.
+ * Exception thrown when there is a failure executing a tool call. This includes the name of the
+ * tool that failed to execute.
  */
-final public class ToolCallExecutionException extends RuntimeException {
+public final class ToolCallExecutionException extends RuntimeException {
 
   private final String toolName;
-
 
   public ToolCallExecutionException(String message, String toolName, Throwable cause) {
     super(message, cause);
@@ -20,6 +19,7 @@ final public class ToolCallExecutionException extends RuntimeException {
 
   /**
    * Returns the name of the tool that failed to execute.
+   *
    * @return the tool name
    */
   public String getToolName() {

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/ToolCallLimitReachedException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/ToolCallLimitReachedException.java
@@ -5,12 +5,13 @@
 package akka.javasdk.agent;
 
 /**
- * Thrown when the maximum number of tool call steps has been reached.
- * Indicates that too many tool calls were made within a single request/response cycle.
- * <p>
- * You can configure this limit in the `application.conf` file using the setting {@code akka.javasdk.agent.max-tool-call-steps}.
+ * Thrown when the maximum number of tool call steps has been reached. Indicates that too many tool
+ * calls were made within a single request/response cycle.
+ *
+ * <p>You can configure this limit in the `application.conf` file using the setting {@code
+ * akka.javasdk.agent.max-tool-call-steps}.
  */
-final public class ToolCallLimitReachedException extends RuntimeException {
+public final class ToolCallLimitReachedException extends RuntimeException {
 
   public ToolCallLimitReachedException(String message) {
     super(message);

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/UnsupportedFeatureException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/UnsupportedFeatureException.java
@@ -5,10 +5,10 @@
 package akka.javasdk.agent;
 
 /**
- * Exception thrown when an unsupported feature is requested from an AI model or service.
- * This indicates that the feature is not available or not supported by the current configuration.
+ * Exception thrown when an unsupported feature is requested from an AI model or service. This
+ * indicates that the feature is not available or not supported by the current configuration.
  */
-final public class UnsupportedFeatureException extends RuntimeException {
+public final class UnsupportedFeatureException extends RuntimeException {
 
   public UnsupportedFeatureException(String message) {
     super(message);

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/Acl.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/Acl.java
@@ -6,55 +6,51 @@ package akka.javasdk.annotations;
 
 import java.lang.annotation.*;
 
-
-/**
- * Defines ACL configuration for a resource.
- */
+/** Defines ACL configuration for a resource. */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Acl {
 
   /**
-   * Principals that are allowed to access this resource.
-   * An incoming request must have at least one principal associated with it in this list to be allowed.
+   * Principals that are allowed to access this resource. An incoming request must have at least one
+   * principal associated with it in this list to be allowed.
    */
   Matcher[] allow() default {};
 
-
   /**
-   * After matching an allow rule, an incoming request that has at least one principal
-   * that matches a deny rule will be denied.
+   * After matching an allow rule, an incoming request that has at least one principal that matches
+   * a deny rule will be denied.
    */
   Matcher[] deny() default {};
 
-
   /**
    * The status code to respond with when access is denied.
-   * <p>
-   * By default, this will be '403 Forbidden' for HTTP endpoints and 'PERMISSION DENIED (7)' for gRPC endpoints.
-   * If set at class-level, it will automatically be inherited by all methods in the class that are not
-   * annotated with their own @Acl definition.
    *
-   * For HTTP, common used values are between 400 and 599,
-   * see exhaustive list at https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes
+   * <p>By default, this will be '403 Forbidden' for HTTP endpoints and 'PERMISSION DENIED (7)' for
+   * gRPC endpoints. If set at class-level, it will automatically be inherited by all methods in the
+   * class that are not annotated with their own @Acl definition.
    *
-   * For gRPC, the status codes values can be consulted at https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+   * <p>For HTTP, common used values are between 400 and 599, see exhaustive list at
+   * https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes
    *
+   * <p>For gRPC, the status codes values can be consulted at
+   * https://grpc.github.io/grpc/core/md_doc_statuscodes.html
    */
   int denyCode() default -1;
 
   /**
    * A principal matcher that can be used in an ACL.
-   * <p>
-   * A principal is a very broad concept. It can correlate to a person, a system, or a more abstract concept, such as
-   * the internet.
-   * <p>
-   * A single request may have multiple principals associated with it, for example, it may have come from a particular
-   * source system, and it may have certain credentials associated with it. When a matcher is applied to the request,
-   * the request is considered to match if at least one of the principals attached to the request matches.
-   * <p>
-   * Each Matcher can be configured either with a 'service' or a 'principal', but not both.
+   *
+   * <p>A principal is a very broad concept. It can correlate to a person, a system, or a more
+   * abstract concept, such as the internet.
+   *
+   * <p>A single request may have multiple principals associated with it, for example, it may have
+   * come from a particular source system, and it may have certain credentials associated with it.
+   * When a matcher is applied to the request, the request is considered to match if at least one of
+   * the principals attached to the request matches.
+   *
+   * <p>Each Matcher can be configured either with a 'service' or a 'principal', but not both.
    */
   @Target({ElementType.TYPE, ElementType.METHOD})
   @Retention(RetentionPolicy.RUNTIME)
@@ -63,10 +59,10 @@ public @interface Acl {
 
     /**
      * Match a service principal.
-     * <p>
-     * This matches a service in the same project.
-     * <p>
-     * Supports glob matching, that is, * means all services in this project.
+     *
+     * <p>This matches a service in the same project.
+     *
+     * <p>Supports glob matching, that is, * means all services in this project.
      */
     String service() default "";
 
@@ -74,10 +70,9 @@ public @interface Acl {
     Principal principal() default Principal.UNSPECIFIED;
   }
 
-
   /**
-   * This enum contains principal matchers that don't have any configuration, such as a name, associated with them,
-   * for ease of reference in annotations.
+   * This enum contains principal matchers that don't have any configuration, such as a name,
+   * associated with them, for ease of reference in annotations.
    */
   enum Principal {
     UNSPECIFIED,

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/AgentDescription.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/AgentDescription.java
@@ -12,24 +12,26 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to provide metadata and description for an Agent component.
- * <p>
- * This annotation is essential for multi-agent systems where agents need to be discovered
- * and selected dynamically. The information provided here is used by the {@link akka.javasdk.agent.AgentRegistry}
- * for agent selection and planning.
- * <p>
- * <strong>Agent Selection:</strong>
- * Planning agents can use this metadata to automatically select appropriate agents for specific tasks.
- * The description should clearly explain the agent's capabilities and domain of expertise.
- * <p>
- * <strong>Role-based Organization:</strong>
- * The role field allows grouping agents by function (e.g., "worker", "planner", "coordinator")
- * for easier discovery and organization in complex multi-agent systems.
+ *
+ * <p>This annotation is essential for multi-agent systems where agents need to be discovered and
+ * selected dynamically. The information provided here is used by the {@link
+ * akka.javasdk.agent.AgentRegistry} for agent selection and planning.
+ *
+ * <p><strong>Agent Selection:</strong> Planning agents can use this metadata to automatically
+ * select appropriate agents for specific tasks. The description should clearly explain the agent's
+ * capabilities and domain of expertise.
+ *
+ * <p><strong>Role-based Organization:</strong> The role field allows grouping agents by function
+ * (e.g., "worker", "planner", "coordinator") for easier discovery and organization in complex
+ * multi-agent systems.
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface AgentDescription {
   String name();
+
   String description();
+
   String role() default "";
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/ComponentId.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/ComponentId.java
@@ -8,12 +8,13 @@ import java.lang.annotation.*;
 
 /**
  * Assign a type identifier to a component (required for all component types aside from Endpoints).
- * <p>
- * The identifier should be unique among the different components.
- * <p>
- * In the case of Entities, Workflows and Views, the ComponentId should be stable as a different identifier means a
- * different representation in storage. Changing this identifier will create a new class of component and all previous
- * instances using the old identifier won't be accessible anymore.
+ *
+ * <p>The identifier should be unique among the different components.
+ *
+ * <p>In the case of Entities, Workflows and Views, the ComponentId should be stable as a different
+ * identifier means a different representation in storage. Changing this identifier will create a
+ * new class of component and all previous instances using the old identifier won't be accessible
+ * anymore.
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/Consume.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/Consume.java
@@ -7,61 +7,58 @@ package akka.javasdk.annotations;
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
 import akka.javasdk.keyvalueentity.KeyValueEntity;
 import akka.javasdk.workflow.Workflow;
-
 import java.lang.annotation.*;
 
 /**
- * Annotation for providing ways to consume a stream of messages from Entities, other services,
- * or message broker topics.
- * <p>
- * Use on {@link akka.javasdk.consumer.Consumer} or {@link akka.javasdk.view.TableUpdater}.
+ * Annotation for providing ways to consume a stream of messages from Entities, other services, or
+ * message broker topics.
+ *
+ * <p>Use on {@link akka.javasdk.consumer.Consumer} or {@link akka.javasdk.view.TableUpdater}.
  */
 public @interface Consume {
 
   /**
    * Annotation for consuming state updates from a {@link KeyValueEntity}.
-   * <p>
-   * The underlying method must be declared to receive one parameter for
-   * the received state changes.
+   *
+   * <p>The underlying method must be declared to receive one parameter for the received state
+   * changes.
    */
   @Target(ElementType.TYPE)
   @Retention(RetentionPolicy.RUNTIME)
   @Documented
   @interface FromKeyValueEntity {
     /**
-     * Assign the class type of the entity one intends to consume from, which must extend
-     *  {@link KeyValueEntity}.
+     * Assign the class type of the entity one intends to consume from, which must extend {@link
+     * KeyValueEntity}.
      */
     Class<? extends KeyValueEntity<?>> value();
   }
 
   /**
    * Annotation for consuming events from an {@link EventSourcedEntity}.
-   * <p>
-   * The underlying method must be declared to receive one parameter for
-   * the received events. Use one method with the common event type as parameter,
-   * or several methods with different parameter types corresponding to different
-   * event types.
    *
+   * <p>The underlying method must be declared to receive one parameter for the received events. Use
+   * one method with the common event type as parameter, or several methods with different parameter
+   * types corresponding to different event types.
    */
   @Target(ElementType.TYPE)
   @Retention(RetentionPolicy.RUNTIME)
   @Documented
   @interface FromEventSourcedEntity {
     /**
-     * Assign the class type of the entity one intends to consume from, which must extend
-     * {@link EventSourcedEntity EventSourcedEntity}.
+     * Assign the class type of the entity one intends to consume from, which must extend {@link
+     * EventSourcedEntity EventSourcedEntity}.
      */
     Class<? extends EventSourcedEntity<?, ?>> value();
 
     /**
      * This option is only available for classes. Using it in a method has no effect.
      *
-     * <p>
-     * When there is no method in the class whose input type matches the event type:
+     * <p>When there is no method in the class whose input type matches the event type:
+     *
      * <ul>
-     *   <li>if ignoreUnknown is true the event is discarded</li>
-     *   <li>if false, an Exception is raised</li>
+     *   <li>if ignoreUnknown is true the event is discarded
+     *   <li>if false, an Exception is raised
      * </ul>
      */
     boolean ignoreUnknown() default false;
@@ -69,101 +66,94 @@ public @interface Consume {
 
   /**
    * Annotation for consuming state updates from a {@link akka.javasdk.workflow.Workflow}.
-   * <p>
-   * The underlying method must be declared to receive one parameter for
-   * the received workflow state changes.
+   *
+   * <p>The underlying method must be declared to receive one parameter for the received workflow
+   * state changes.
    */
   @Target(ElementType.TYPE)
   @Retention(RetentionPolicy.RUNTIME)
   @Documented
   @interface FromWorkflow {
     /**
-     * Assign the class type of the workflow one intends to consume from, which must extend
-     *  {@link akka.javasdk.workflow.Workflow}.
+     * Assign the class type of the workflow one intends to consume from, which must extend {@link
+     * akka.javasdk.workflow.Workflow}.
      */
     Class<? extends Workflow<?>> value();
   }
 
   /**
    * Annotation for consuming messages from a topic (i.e PubSub or Kafka topic).
-   * <p>
-   * The underlying method must be declared to receive one parameter for
-   * the received messages. Use one method with the common message type as parameter,
-   * or several methods with different parameter types corresponding to different
-   * messages types.
+   *
+   * <p>The underlying method must be declared to receive one parameter for the received messages.
+   * Use one method with the common message type as parameter, or several methods with different
+   * parameter types corresponding to different messages types.
    */
   @Target(ElementType.TYPE)
   @Retention(RetentionPolicy.RUNTIME)
   @Documented
   @interface FromTopic {
-    /**
-     * Assign the name of the topic to consume the stream from.
-     */
+    /** Assign the name of the topic to consume the stream from. */
     String value();
 
-    /**
-     * Assign the consumer group name to be used on the broker.
-     */
+    /** Assign the consumer group name to be used on the broker. */
     String consumerGroup() default "";
 
     /**
      * This option is only available for classes. Using it in a method has no effect.
      *
-     * <p>
-     * When there is no method in the class whose input type matches the event type:
+     * <p>When there is no method in the class whose input type matches the event type:
+     *
      * <ul>
-     *   <li>if ignoreUnknown is true the event is discarded</li>
-     *   <li>if false, an Exception is raised</li>
+     *   <li>if ignoreUnknown is true the event is discarded
+     *   <li>if false, an Exception is raised
      * </ul>
-     **/
+     */
     boolean ignoreUnknown() default false;
   }
 
-
   /**
    * Annotation for consuming messages from another service.
-   * <p>
-   * The underlying method must be declared to receive one parameter for
-   * the received messages. Use one method with the common event type as parameter,
-   * or several methods with different parameter types corresponding to different
-   * message types.
+   *
+   * <p>The underlying method must be declared to receive one parameter for the received messages.
+   * Use one method with the common event type as parameter, or several methods with different
+   * parameter types corresponding to different message types.
    */
   @Target(ElementType.TYPE)
   @Retention(RetentionPolicy.RUNTIME)
   @Documented
   @interface FromServiceStream {
 
-    /**
-     * The unique identifier of the stream in the producing service
-     */
+    /** The unique identifier of the stream in the producing service */
     String id();
 
     /**
-     * The deployed name of the service to consume from, can be the deployed name of another
-     * service in the same project or a fully qualified public hostname of a service in a
-     * different project.
-     * <p>
-     * Note: The service name is used as unique identifier for tracking progress when consuming it.
-     * Changing this name will lead to starting over from the beginning of the event stream.
-     * <p>
-     * Can be a template referencing an environment variable "${MY_ENV_NAME}" set for the service at deployment.
+     * The deployed name of the service to consume from, can be the deployed name of another service
+     * in the same project or a fully qualified public hostname of a service in a different project.
+     *
+     * <p>Note: The service name is used as unique identifier for tracking progress when consuming
+     * it. Changing this name will lead to starting over from the beginning of the event stream.
+     *
+     * <p>Can be a template referencing an environment variable "${MY_ENV_NAME}" set for the service
+     * at deployment.
      */
     String service();
 
     /**
-     * In case you need to consume the same stream multiple times, each subscription should have a unique consumer group.
-     * <p>
-     * Changing the consumer group will lead to starting over from the beginning of the stream.
+     * In case you need to consume the same stream multiple times, each subscription should have a
+     * unique consumer group.
+     *
+     * <p>Changing the consumer group will lead to starting over from the beginning of the stream.
      */
     String consumerGroup() default "";
 
     /**
      * When there is no method in the class whose input type matches the event type:
+     *
      * <ul>
-     *   <li>if ignoreUnknown is true the event is discarded</li>
-     *   <li>if false, an Exception is raised</li>
+     *   <li>if ignoreUnknown is true the event is discarded
+     *   <li>if false, an Exception is raised
      * </ul>
-     **/
+     */
     boolean ignoreUnknown() default false;
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/DeleteHandler.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/DeleteHandler.java
@@ -13,5 +13,4 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface DeleteHandler {
-}
+public @interface DeleteHandler {}

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/Description.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/Description.java
@@ -5,12 +5,13 @@
 package akka.javasdk.annotations;
 
 import java.lang.annotation.*;
+
 /**
- * Used to define a human language description for fields and method parameters,
- * such as MCP tool parameters or tool methods.
- * <p>
- * This annotation can be used to provide additional context.
- * Fields and method parameters of type {@code Optional} are considered as non-required.
+ * Used to define a human language description for fields and method parameters, such as MCP tool
+ * parameters or tool methods.
+ *
+ * <p>This annotation can be used to provide additional context. Fields and method parameters of
+ * type {@code Optional} are considered as non-required.
  */
 // FIXME share field/parameter description metadata with other parts of the SDK API for agents
 @Target({ElementType.FIELD, ElementType.PARAMETER})

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/FunctionTool.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/FunctionTool.java
@@ -12,30 +12,31 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to expose methods as function tools that can be invoked by AI agents.
- * <p>
- * Methods annotated with {@code @FunctionTool} become available as tools that the AI model can choose
- * to invoke based on the task requirements. The LLM determines which tools to call and with which
- * parameters based on the tool descriptions and the user's request.
- * <p>
- * <strong>Tool Discovery:</strong>
- * Function tools can be defined in two ways:
+ *
+ * <p>Methods annotated with {@code @FunctionTool} become available as tools that the AI model can
+ * choose to invoke based on the task requirements. The LLM determines which tools to call and with
+ * which parameters based on the tool descriptions and the user's request.
+ *
+ * <p><strong>Tool Discovery:</strong> Function tools can be defined in two ways:
+ *
  * <ul>
- *   <li><strong>Agent-defined:</strong> Methods within the agent class itself (can be private)</li>
- *   <li><strong>External tools:</strong> Methods in separate classes registered via {@code effects().tools()}</li>
+ *   <li><strong>Agent-defined:</strong> Methods within the agent class itself (can be private)
+ *   <li><strong>External tools:</strong> Methods in separate classes registered via {@code
+ *       effects().tools()}
  * </ul>
- * <p>
- * <strong>Best Practices:</strong>
+ *
+ * <p><strong>Best Practices:</strong>
+ *
  * <ul>
- *   <li>Provide clear, descriptive tool descriptions</li>
- *   <li>Use {@link Description} annotations on parameters to help the LLM understand usage</li>
- *   <li>Use {@code Optional} parameters for non-required arguments</li>
- *   <li>Keep tool functions focused on a single, well-defined task</li>
+ *   <li>Provide clear, descriptive tool descriptions
+ *   <li>Use {@link Description} annotations on parameters to help the LLM understand usage
+ *   <li>Use {@code Optional} parameters for non-required arguments
+ *   <li>Keep tool functions focused on a single, well-defined task
  * </ul>
- * <p>
- * <strong>Tool Execution:</strong>
- * The agent automatically handles the tool execution loop: the LLM requests tool calls,
- * the agent executes them, incorporates results into the session context, and continues
- * until the LLM no longer needs to invoke tools.
+ *
+ * <p><strong>Tool Execution:</strong> The agent automatically handles the tool execution loop: the
+ * LLM requests tool calls, the agent executes them, incorporates results into the session context,
+ * and continues until the LLM no longer needs to invoke tools.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -43,5 +44,6 @@ import java.lang.annotation.Target;
 public @interface FunctionTool {
 
   String name() default "";
+
   String description();
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/GrpcEndpoint.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/GrpcEndpoint.java
@@ -7,21 +7,21 @@ package akka.javasdk.annotations;
 import java.lang.annotation.*;
 
 /**
- * Mark a class to be made available as a gRPC endpoint. The annotated class should extend a gRPC service interface
- * generated using Akka gRPC, be public and have a public constructor.
- * <p>
- * Annotated classes can accept the following types to the constructor:
+ * Mark a class to be made available as a gRPC endpoint. The annotated class should extend a gRPC
+ * service interface generated using Akka gRPC, be public and have a public constructor.
+ *
+ * <p>Annotated classes can accept the following types to the constructor:
+ *
  * <ul>
- *   <li>{@link akka.javasdk.client.ComponentClient}</li>
- *   <li>{@link akka.javasdk.http.HttpClientProvider}</li>
- *   <li>{@link akka.javasdk.timer.TimerScheduler}</li>
- *   <li>{@link akka.stream.Materializer}</li>
- *   <li>{@link com.typesafe.config.Config}</li>
- *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider} from the service setup</li>
+ *   <li>{@link akka.javasdk.client.ComponentClient}
+ *   <li>{@link akka.javasdk.http.HttpClientProvider}
+ *   <li>{@link akka.javasdk.timer.TimerScheduler}
+ *   <li>{@link akka.stream.Materializer}
+ *   <li>{@link com.typesafe.config.Config}
+ *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider} from the service setup
  * </ul>
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface GrpcEndpoint {
-}
+public @interface GrpcEndpoint {}

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/JWT.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/JWT.java
@@ -12,78 +12,73 @@ import java.lang.annotation.*;
 public @interface JWT {
 
   enum JwtMethodMode {
-    /**
-     * No validation.
-     */
+    /** No validation. */
     UNSPECIFIED,
 
-    /**
-     * Validates that the bearer token is present on the request, in the 'Authorization' header.
-     */
+    /** Validates that the bearer token is present on the request, in the 'Authorization' header. */
     BEARER_TOKEN,
-
   }
 
   JwtMethodMode[] validate() default JwtMethodMode.UNSPECIFIED;
 
-  //TODO: add link below to docs "configuration for JWT secrets" when available
+  // TODO: add link below to docs "configuration for JWT secrets" when available
   /**
    * If set, then the token extracted from the bearer token must have one of these issuers.
    *
-   * <p>This can be used in combination with the issuer field of configuration for JWT secrets.
-   * If there is at least one secret that has this issuer set, then only the secrets with that
-   * issuer set will be used for validation. This ensures that the token comes from a
-   * particular issuer.
+   * <p>This can be used in combination with the issuer field of configuration for JWT secrets. If
+   * there is at least one secret that has this issuer set, then only the secrets with that issuer
+   * set will be used for validation. This ensures that the token comes from a particular issuer.
    */
   String[] bearerTokenIssuers() default {};
-
 
   /**
    * A static claim is a claim that is required to be present on the token, and have a particular
    * value. This can be used to ensure that the token has a particular role, for example.
-   * <p>
-   * If the claim is not present, or does not have the expected value, then the request will be
+   *
+   * <p>If the claim is not present, or does not have the expected value, then the request will be
    * rejected with a 403 Forbidden response.
-   * <p>
-   * If the claim is present, but does not have the expected value, then the request will be
+   *
+   * <p>If the claim is present, but does not have the expected value, then the request will be
    * rejected with a 403 Forbidden response.
-   * <p>
-   * If the claim is present, and has the expected value, then the request will be allowed to
+   *
+   * <p>If the claim is present, and has the expected value, then the request will be allowed to
    * proceed.
    *
-   * Each static claim can be configured either with a 'value' or a 'pattern' that will
-   * be matched against the value of the claim, but not both.
+   * <p>Each static claim can be configured either with a 'value' or a 'pattern' that will be
+   * matched against the value of the claim, but not both.
    */
   @interface StaticClaim {
-    /**
-     * The claim name needs to be a hardcoded literal (e.g. "role")
-     */
+    /** The claim name needs to be a hardcoded literal (e.g. "role") */
     String claim();
 
     /**
-     * The value can be set as: a hardcoded literal (e.g. "admin"), an ENV variable (e.g "${ENV_VAR}")
-     * or a combination of both (e.g. "${ENV_VAR}-admin").
-     * When declaring multiple values, ALL of those will be required when validating the claim.
+     * The value can be set as: a hardcoded literal (e.g. "admin"), an ENV variable (e.g
+     * "${ENV_VAR}") or a combination of both (e.g. "${ENV_VAR}-admin"). When declaring multiple
+     * values, ALL of those will be required when validating the claim.
      */
     String[] values() default {};
 
     /**
-     *  This receives a regex expression (Java flavor) used to match on the incoming claim value.
-     *  Cannot be used in conjunction with {@code value} field above. It's one or the other.
-     *  <p>NOTE: when signing, a static claim defined with a pattern will not be included in the token.
+     * This receives a regex expression (Java flavor) used to match on the incoming claim value.
+     * Cannot be used in conjunction with {@code value} field above. It's one or the other.
      *
-     *  <p>Usage examples:
-     *  <ul>
-     *  <li>claim value is not empty: "\\S+"</li>
-     *  <li>claim value has one of 2 possible values: "^(admin|manager)$"</li>
-     *  </ul>
+     * <p>NOTE: when signing, a static claim defined with a pattern will not be included in the
+     * token.
+     *
+     * <p>Usage examples:
+     *
+     * <ul>
+     *   <li>claim value is not empty: "\\S+"
+     *   <li>claim value has one of 2 possible values: "^(admin|manager)$"
+     * </ul>
      */
     String pattern() default "";
   }
 
   /**
    * If set, the static claims provided and their values will be required when calling the service.
-   * When multiple claims are provided, all of them will be required to successfully call the service.
+   * When multiple claims are provided, all of them will be required to successfully call the
+   * service.
    */
   StaticClaim[] staticClaims() default {};
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/Migration.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/Migration.java
@@ -5,15 +5,12 @@
 package akka.javasdk.annotations;
 
 import akka.javasdk.JsonMigration;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Annotation to assign a @{@link JsonMigration} implementation for a given class.
- */
+/** Annotation to assign a @{@link JsonMigration} implementation for a given class. */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Migration {

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/Produce.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/Produce.java
@@ -8,8 +8,8 @@ import java.lang.annotation.*;
 
 /**
  * Annotation for ways of producing outgoing information.
- * <p>
- * Use on methods in a {@link akka.javasdk.consumer.Consumer}.
+ *
+ * <p>Use on methods in a {@link akka.javasdk.consumer.Consumer}.
  */
 public @interface Produce {
 
@@ -25,17 +25,15 @@ public @interface Produce {
     String value();
   }
 
-
   /**
-   * Annotation to configure the component to produce an event stream that can be consumed by other services.
+   * Annotation to configure the component to produce an event stream that can be consumed by other
+   * services.
    */
   @Target(ElementType.TYPE)
   @Retention(RetentionPolicy.RUNTIME)
   @Documented
   @interface ServiceStream {
-    /**
-     * Identifier for the event stream. Must be unique inside the same service.
-     */
+    /** Identifier for the event stream. Must be unique inside the same service. */
     String id();
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/Query.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/Query.java
@@ -10,8 +10,9 @@ import java.lang.annotation.*;
  * Annotation used in the scope of a view for providing the query that will be used to explore data
  * from that view.
  *
- * <p><b>Note: </b>the actual method implementation is never actually executed, but the return type must be either
- * {@link akka.javasdk.view.View.QueryEffect} or {@link akka.javasdk.view.View.QueryStreamEffect}
+ * <p><b>Note: </b>the actual method implementation is never actually executed, but the return type
+ * must be either {@link akka.javasdk.view.View.QueryEffect} or {@link
+ * akka.javasdk.view.View.QueryStreamEffect}
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -24,10 +25,9 @@ public @interface Query {
   String value();
 
   /**
-   * For a query that returns a {@link akka.javasdk.view.View.QueryStreamEffect}, instead of completing the
-   * stream once the end of the result is reached, keep tailing the query and emit updates to the stream as the
-   * view is updated.
+   * For a query that returns a {@link akka.javasdk.view.View.QueryStreamEffect}, instead of
+   * completing the stream once the end of the result is reached, keep tailing the query and emit
+   * updates to the stream as the view is updated.
    */
   boolean streamUpdates() default false;
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/Setup.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/Setup.java
@@ -4,21 +4,18 @@
 
 package akka.javasdk.annotations;
 
-
 import akka.javasdk.ServiceSetup;
-
 import java.lang.annotation.*;
 
 /**
- * Mark a class as a central configuration point for an entire service.
- * Note that a service will also work without any such config point.
- * <p>
- * The class must implement {@link ServiceSetup} with a predefined lifecycle hooks.
- * <p>
- * May only be used on one class per service.
+ * Mark a class as a central configuration point for an entire service. Note that a service will
+ * also work without any such config point.
+ *
+ * <p>The class must implement {@link ServiceSetup} with a predefined lifecycle hooks.
+ *
+ * <p>May only be used on one class per service.
  */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface Setup {
-}
+public @interface Setup {}

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/TypeName.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/TypeName.java
@@ -11,22 +11,23 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to assign a logical type name to events.
- * <p>
- * The type name is used for several things, such as to identify each event in order to
- * deliver them to the right event consumers.
- * If a logical type name isn't specified, the fully qualified class name is used.
- * <p>
- * Once an event is persisted, you won't be able to rename your class if no logical type name
- * has been specified, as previously persisted events would have a different identifier.
- * <p>
- * Therefore, we recommend all event classes use a logical type name.
+ *
+ * <p>The type name is used for several things, such as to identify each event in order to deliver
+ * them to the right event consumers. If a logical type name isn't specified, the fully qualified
+ * class name is used.
+ *
+ * <p>Once an event is persisted, you won't be able to rename your class if no logical type name has
+ * been specified, as previously persisted events would have a different identifier.
+ *
+ * <p>Therefore, we recommend all event classes use a logical type name.
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TypeName {
 
-  /** Logical type name for the annotated type.
-   * If missing (or defined as Empty String), the fully qualified class name will be used.
+  /**
+   * Logical type name for the annotated type. If missing (or defined as Empty String), the fully
+   * qualified class name will be used.
    */
   String value() default "";
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/http/Delete.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/http/Delete.java
@@ -10,28 +10,27 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
 /**
  * Annotation to mark a method as handling HTTP DELETE requests.
- * <p>
- * DELETE requests are used to remove resources from the server. They should be idempotent,
+ *
+ * <p>DELETE requests are used to remove resources from the server. They should be idempotent,
  * meaning multiple identical requests should have the same effect (the resource remains deleted).
- * <p>
- * <strong>Path Configuration:</strong>
- * The annotation value specifies the path pattern for this endpoint, which is combined with
- * the {@link HttpEndpoint} class-level path prefix to form the complete URL.
- * <p>
- * <strong>Path Parameters:</strong>
- * Use {@code {paramName}} in the path to identify the specific resource to delete.
- * DELETE requests typically don't include request bodies.
- * <p>
- * <strong>Response Types:</strong>
- * DELETE methods typically return:
+ *
+ * <p><strong>Path Configuration:</strong> The annotation value specifies the path pattern for this
+ * endpoint, which is combined with the {@link HttpEndpoint} class-level path prefix to form the
+ * complete URL.
+ *
+ * <p><strong>Path Parameters:</strong> Use {@code {paramName}} in the path to identify the specific
+ * resource to delete. DELETE requests typically don't include request bodies.
+ *
+ * <p><strong>Response Types:</strong> DELETE methods typically return:
+ *
  * <ul>
- *   <li>204 No Content for successful deletion with no response body</li>
- *   <li>200 OK with confirmation message or deleted resource representation</li>
- *   <li>404 Not Found if the resource doesn't exist</li>
+ *   <li>204 No Content for successful deletion with no response body
+ *   <li>200 OK with confirmation message or deleted resource representation
+ *   <li>404 Not Found if the resource doesn't exist
  * </ul>
+ *
  * Use {@link akka.javasdk.http.HttpResponses#noContent()} for standard deletion responses.
  */
 @Target(ElementType.METHOD)

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/http/Get.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/http/Get.java
@@ -12,30 +12,28 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to mark a method as handling HTTP GET requests.
- * <p>
- * GET requests are used to retrieve data from the server and should be idempotent and safe
- * (no side effects). They typically don't include request bodies and use path parameters
- * and query parameters for input.
- * <p>
- * <strong>Path Configuration:</strong>
- * The annotation value specifies the path pattern for this endpoint, which is combined with
- * the {@link HttpEndpoint} class-level path prefix to form the complete URL.
- * <p>
- * <strong>Path Parameters:</strong>
- * Use {@code {paramName}} in the path to extract URL segments as method parameters.
- * Parameters can be strings, numbers, or other primitive types.
- * <p>
- * <strong>Query Parameters:</strong>
- * Access query parameters via {@code RequestContext.queryParams()} when extending
- * {@link akka.javasdk.http.AbstractHttpEndpoint} or injecting {@link akka.javasdk.http.RequestContext}.
- * <p>
- * <strong>Response Types:</strong>
- * GET methods can return strings, objects (serialized to JSON), {@code HttpResponse} for full control,
- * or {@code CompletionStage<T>} for asynchronous responses.
+ *
+ * <p>GET requests are used to retrieve data from the server and should be idempotent and safe (no
+ * side effects). They typically don't include request bodies and use path parameters and query
+ * parameters for input.
+ *
+ * <p><strong>Path Configuration:</strong> The annotation value specifies the path pattern for this
+ * endpoint, which is combined with the {@link HttpEndpoint} class-level path prefix to form the
+ * complete URL.
+ *
+ * <p><strong>Path Parameters:</strong> Use {@code {paramName}} in the path to extract URL segments
+ * as method parameters. Parameters can be strings, numbers, or other primitive types.
+ *
+ * <p><strong>Query Parameters:</strong> Access query parameters via {@code
+ * RequestContext.queryParams()} when extending {@link akka.javasdk.http.AbstractHttpEndpoint} or
+ * injecting {@link akka.javasdk.http.RequestContext}.
+ *
+ * <p><strong>Response Types:</strong> GET methods can return strings, objects (serialized to JSON),
+ * {@code HttpResponse} for full control, or {@code CompletionStage<T>} for asynchronous responses.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Get {
-    String value() default "";
+  String value() default "";
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/http/HttpEndpoint.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/http/HttpEndpoint.java
@@ -12,58 +12,62 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to mark a class as an HTTP endpoint that exposes RESTful APIs.
- * <p>
- * HTTP endpoints handle incoming HTTP requests and can return responses in various formats including
- * JSON, plain text, or custom content types. They provide the external API for your service.
- * <p>
- * <strong>Basic Structure:</strong>
- * The annotated class should be public with a public constructor. Methods annotated with HTTP verb
- * annotations ({@link Get}, {@link Post}, {@link Put}, {@link Patch}, {@link Delete}) handle requests.
- * <p>
- * <strong>Path Configuration:</strong>
- * The annotation value specifies a common path prefix for all methods in the class. Individual method
- * paths are combined with this prefix to form the complete endpoint URL.
- * <p>
- * <strong>Method Features:</strong>
+ *
+ * <p>HTTP endpoints handle incoming HTTP requests and can return responses in various formats
+ * including JSON, plain text, or custom content types. They provide the external API for your
+ * service.
+ *
+ * <p><strong>Basic Structure:</strong> The annotated class should be public with a public
+ * constructor. Methods annotated with HTTP verb annotations ({@link Get}, {@link Post}, {@link
+ * Put}, {@link Patch}, {@link Delete}) handle requests.
+ *
+ * <p><strong>Path Configuration:</strong> The annotation value specifies a common path prefix for
+ * all methods in the class. Individual method paths are combined with this prefix to form the
+ * complete endpoint URL.
+ *
+ * <p><strong>Method Features:</strong>
+ *
  * <ul>
- *   <li><strong>Path Parameters:</strong> Use {@code {paramName}} in paths to extract URL segments</li>
- *   <li><strong>Request Bodies:</strong> Accept JSON by adding parameters Jackson can deserialize</li>
- *   <li><strong>Query Parameters:</strong> Access via {@code RequestContext.queryParams()}</li>
- *   <li><strong>Headers:</strong> Access via {@code RequestContext.requestHeader()}</li>
+ *   <li><strong>Path Parameters:</strong> Use {@code {paramName}} in paths to extract URL segments
+ *   <li><strong>Request Bodies:</strong> Accept JSON by adding parameters Jackson can deserialize
+ *   <li><strong>Query Parameters:</strong> Access via {@code RequestContext.queryParams()}
+ *   <li><strong>Headers:</strong> Access via {@code RequestContext.requestHeader()}
  * </ul>
- * <p>
- * <strong>Response Types:</strong>
+ *
+ * <p><strong>Response Types:</strong>
+ *
  * <ul>
- *   <li>String - text/plain responses</li>
- *   <li>Objects - JSON responses (serialized with Jackson)</li>
- *   <li>{@link akka.http.javadsl.model.HttpResponse} - full control over response</li>
- *   <li>{@code CompletionStage<T>} - asynchronous responses</li>
+ *   <li>String - text/plain responses
+ *   <li>Objects - JSON responses (serialized with Jackson)
+ *   <li>{@link akka.http.javadsl.model.HttpResponse} - full control over response
+ *   <li>{@code CompletionStage<T>} - asynchronous responses
  * </ul>
- * <p>
- * <strong>Constructor Injection:</strong>
- * Annotated classes can accept the following types in their constructor:
+ *
+ * <p><strong>Constructor Injection:</strong> Annotated classes can accept the following types in
+ * their constructor:
+ *
  * <ul>
- *   <li>{@link akka.javasdk.client.ComponentClient} - for calling other components</li>
- *   <li>{@link akka.javasdk.http.HttpClientProvider} - for HTTP service calls</li>
- *   <li>{@link akka.javasdk.http.RequestContext} - for request context access</li>
- *   <li>{@link akka.javasdk.timer.TimerScheduler}</li>
- *   <li>{@link akka.stream.Materializer}</li>
- *   <li>{@link com.typesafe.config.Config}</li>
- *   <li>{@link io.opentelemetry.api.trace.Span}</li>
- *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider}</li>
+ *   <li>{@link akka.javasdk.client.ComponentClient} - for calling other components
+ *   <li>{@link akka.javasdk.http.HttpClientProvider} - for HTTP service calls
+ *   <li>{@link akka.javasdk.http.RequestContext} - for request context access
+ *   <li>{@link akka.javasdk.timer.TimerScheduler}
+ *   <li>{@link akka.stream.Materializer}
+ *   <li>{@link com.typesafe.config.Config}
+ *   <li>{@link io.opentelemetry.api.trace.Span}
+ *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider}
  * </ul>
- * <p>
- * <strong>Request Context Access:</strong>
- * If the annotated class extends {@link akka.javasdk.http.AbstractHttpEndpoint}, the request context
- * is available via {@code requestContext()} without constructor injection.
- * <p>
- * <strong>Security:</strong>
- * Always annotate endpoints with appropriate {@link akka.javasdk.annotations.Acl} annotations to control access.
- * Without ACL annotations, no clients are allowed to access the endpoint.
+ *
+ * <p><strong>Request Context Access:</strong> If the annotated class extends {@link
+ * akka.javasdk.http.AbstractHttpEndpoint}, the request context is available via {@code
+ * requestContext()} without constructor injection.
+ *
+ * <p><strong>Security:</strong> Always annotate endpoints with appropriate {@link
+ * akka.javasdk.annotations.Acl} annotations to control access. Without ACL annotations, no clients
+ * are allowed to access the endpoint.
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface HttpEndpoint {
-    String value() default "";
+  String value() default "";
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/http/Patch.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/http/Patch.java
@@ -4,7 +4,6 @@
 
 package akka.javasdk.annotations.http;
 
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -13,27 +12,25 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to mark a method as handling HTTP PATCH requests.
- * <p>
- * PATCH requests are used to apply partial updates to existing resources. Unlike PUT requests
- * that replace the entire resource, PATCH only modifies the specified fields while leaving
- * other fields unchanged.
- * <p>
- * <strong>Path Configuration:</strong>
- * The annotation value specifies the path pattern for this endpoint, which is combined with
- * the {@link HttpEndpoint} class-level path prefix to form the complete URL.
- * <p>
- * <strong>Request Bodies:</strong>
- * PATCH methods typically include request bodies with the partial data to be updated.
- * The request body parameter must come last in the parameter list when combined with
- * path parameters.
- * <p>
- * <strong>Path Parameters:</strong>
- * Use {@code {paramName}} in the path to identify the specific resource to update.
- * These can be combined with request body parameters.
- * <p>
- * <strong>Response Types:</strong>
- * PATCH methods typically return the updated resource, a success confirmation, or 
- * 200 OK responses. Use {@link akka.javasdk.http.HttpResponses#ok()} for standard update responses.
+ *
+ * <p>PATCH requests are used to apply partial updates to existing resources. Unlike PUT requests
+ * that replace the entire resource, PATCH only modifies the specified fields while leaving other
+ * fields unchanged.
+ *
+ * <p><strong>Path Configuration:</strong> The annotation value specifies the path pattern for this
+ * endpoint, which is combined with the {@link HttpEndpoint} class-level path prefix to form the
+ * complete URL.
+ *
+ * <p><strong>Request Bodies:</strong> PATCH methods typically include request bodies with the
+ * partial data to be updated. The request body parameter must come last in the parameter list when
+ * combined with path parameters.
+ *
+ * <p><strong>Path Parameters:</strong> Use {@code {paramName}} in the path to identify the specific
+ * resource to update. These can be combined with request body parameters.
+ *
+ * <p><strong>Response Types:</strong> PATCH methods typically return the updated resource, a
+ * success confirmation, or 200 OK responses. Use {@link akka.javasdk.http.HttpResponses#ok()} for
+ * standard update responses.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/http/Post.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/http/Post.java
@@ -10,30 +10,26 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
 /**
  * Annotation to mark a method as handling HTTP POST requests.
- * <p>
- * POST requests are used to create new resources or submit data to the server. They typically
+ *
+ * <p>POST requests are used to create new resources or submit data to the server. They typically
  * include request bodies with the data to be processed and can have side effects.
- * <p>
- * <strong>Path Configuration:</strong>
- * The annotation value specifies the path pattern for this endpoint, which is combined with
- * the {@link HttpEndpoint} class-level path prefix to form the complete URL.
- * <p>
- * <strong>Request Bodies:</strong>
- * POST methods commonly accept request bodies by adding a parameter that Jackson can deserialize
- * from JSON. The request body parameter must come last in the parameter list when combined
- * with path parameters.
- * <p>
- * <strong>Path Parameters:</strong>
- * Use {@code {paramName}} in the path to extract URL segments as method parameters.
- * These can be combined with request body parameters.
- * <p>
- * <strong>Response Types:</strong>
- * POST methods typically return created resources (often with 201 Created status),
- * confirmation messages, or error responses. Use {@link akka.javasdk.http.HttpResponses#created()}
- * for resource creation scenarios.
+ *
+ * <p><strong>Path Configuration:</strong> The annotation value specifies the path pattern for this
+ * endpoint, which is combined with the {@link HttpEndpoint} class-level path prefix to form the
+ * complete URL.
+ *
+ * <p><strong>Request Bodies:</strong> POST methods commonly accept request bodies by adding a
+ * parameter that Jackson can deserialize from JSON. The request body parameter must come last in
+ * the parameter list when combined with path parameters.
+ *
+ * <p><strong>Path Parameters:</strong> Use {@code {paramName}} in the path to extract URL segments
+ * as method parameters. These can be combined with request body parameters.
+ *
+ * <p><strong>Response Types:</strong> POST methods typically return created resources (often with
+ * 201 Created status), confirmation messages, or error responses. Use {@link
+ * akka.javasdk.http.HttpResponses#created()} for resource creation scenarios.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/http/Put.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/http/Put.java
@@ -10,29 +10,25 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
 /**
  * Annotation to mark a method as handling HTTP PUT requests.
- * <p>
- * PUT requests are used to create or completely replace a resource at a specific location.
- * They should be idempotent, meaning multiple identical requests should have the same effect.
- * <p>
- * <strong>Path Configuration:</strong>
- * The annotation value specifies the path pattern for this endpoint, which is combined with
- * the {@link HttpEndpoint} class-level path prefix to form the complete URL.
- * <p>
- * <strong>Request Bodies:</strong>
- * PUT methods typically include request bodies with the complete resource representation
- * that should replace the existing resource. The request body parameter must come last
- * in the parameter list when combined with path parameters.
- * <p>
- * <strong>Path Parameters:</strong>
- * Use {@code {paramName}} in the path to identify the specific resource to create or update.
- * These can be combined with request body parameters.
- * <p>
- * <strong>Response Types:</strong>
- * PUT methods typically return the updated resource, a success confirmation, or appropriate
- * status codes (200 OK for updates, 201 Created for new resources).
+ *
+ * <p>PUT requests are used to create or completely replace a resource at a specific location. They
+ * should be idempotent, meaning multiple identical requests should have the same effect.
+ *
+ * <p><strong>Path Configuration:</strong> The annotation value specifies the path pattern for this
+ * endpoint, which is combined with the {@link HttpEndpoint} class-level path prefix to form the
+ * complete URL.
+ *
+ * <p><strong>Request Bodies:</strong> PUT methods typically include request bodies with the
+ * complete resource representation that should replace the existing resource. The request body
+ * parameter must come last in the parameter list when combined with path parameters.
+ *
+ * <p><strong>Path Parameters:</strong> Use {@code {paramName}} in the path to identify the specific
+ * resource to create or update. These can be combined with request body parameters.
+ *
+ * <p><strong>Response Types:</strong> PUT methods typically return the updated resource, a success
+ * confirmation, or appropriate status codes (200 OK for updates, 201 Created for new resources).
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpEndpoint.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpEndpoint.java
@@ -8,42 +8,43 @@ import java.lang.annotation.*;
 
 /**
  * Annotation to mark a class as an MCP (Model Context Protocol) server endpoint.
- * <p>
- * MCP endpoints expose services to MCP clients such as LLM chat agent desktop applications and agents
- * running on other services. They provide tools, resources, and prompts that AI models can use to
- * extend their capabilities.
- * <p>
- * <strong>Endpoint Capabilities:</strong>
+ *
+ * <p>MCP endpoints expose services to MCP clients such as LLM chat agent desktop applications and
+ * agents running on other services. They provide tools, resources, and prompts that AI models can
+ * use to extend their capabilities.
+ *
+ * <p><strong>Endpoint Capabilities:</strong>
+ *
  * <ul>
- *   <li><strong>Tools:</strong> Methods annotated with {@link McpTool} that clients can call</li>
- *   <li><strong>Resources:</strong> Methods annotated with {@link McpResource} that provide data</li>
- *   <li><strong>Prompts:</strong> Methods annotated with {@link McpPrompt} that generate prompts</li>
+ *   <li><strong>Tools:</strong> Methods annotated with {@link McpTool} that clients can call
+ *   <li><strong>Resources:</strong> Methods annotated with {@link McpResource} that provide data
+ *   <li><strong>Prompts:</strong> Methods annotated with {@link McpPrompt} that generate prompts
  * </ul>
- * <p>
- * <strong>Requirements:</strong>
- * The annotated class must be public and have a public constructor. It should also be annotated
- * with appropriate {@link akka.javasdk.annotations.Acl} annotations to control access.
- * <p>
- * <strong>Constructor Injection:</strong>
- * Annotated classes can accept the following types in their constructor:
+ *
+ * <p><strong>Requirements:</strong> The annotated class must be public and have a public
+ * constructor. It should also be annotated with appropriate {@link akka.javasdk.annotations.Acl}
+ * annotations to control access.
+ *
+ * <p><strong>Constructor Injection:</strong> Annotated classes can accept the following types in
+ * their constructor:
+ *
  * <ul>
- *   <li>{@link akka.javasdk.client.ComponentClient} - for calling other components</li>
- *   <li>{@link akka.javasdk.http.HttpClientProvider} - for HTTP service calls</li>
- *   <li>{@link akka.javasdk.mcp.McpRequestContext} - for request context access</li>
- *   <li>{@link akka.javasdk.timer.TimerScheduler}</li>
- *   <li>{@link akka.stream.Materializer}</li>
- *   <li>{@link com.typesafe.config.Config}</li>
- *   <li>{@link io.opentelemetry.api.trace.Span}</li>
- *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider}</li>
+ *   <li>{@link akka.javasdk.client.ComponentClient} - for calling other components
+ *   <li>{@link akka.javasdk.http.HttpClientProvider} - for HTTP service calls
+ *   <li>{@link akka.javasdk.mcp.McpRequestContext} - for request context access
+ *   <li>{@link akka.javasdk.timer.TimerScheduler}
+ *   <li>{@link akka.stream.Materializer}
+ *   <li>{@link com.typesafe.config.Config}
+ *   <li>{@link io.opentelemetry.api.trace.Span}
+ *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider}
  * </ul>
- * <p>
- * <strong>Request Context Access:</strong>
- * If the annotated class extends {@link akka.javasdk.mcp.AbstractMcpEndpoint}, the request context
- * is available via {@code requestContext()} without constructor injection.
- * <p>
- * <strong>Transport:</strong>
- * MCP endpoints use a stateless streamable HTTP transport as defined by the MCP specification.
- * The endpoint is served at the specified path (default: {@code /mcp}).
+ *
+ * <p><strong>Request Context Access:</strong> If the annotated class extends {@link
+ * akka.javasdk.mcp.AbstractMcpEndpoint}, the request context is available via {@code
+ * requestContext()} without constructor injection.
+ *
+ * <p><strong>Transport:</strong> MCP endpoints use a stateless streamable HTTP transport as defined
+ * by the MCP specification. The endpoint is served at the specified path (default: {@code /mcp}).
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -53,14 +54,17 @@ public @interface McpEndpoint {
    * @return The path to publish the MCP endpoint at, defaults to "/mcp"
    */
   String path() default "/mcp";
+
   /**
    * @return A server name to return to clients in the initialization response
    */
   String serverName();
+
   /**
    * @return A server version to return to clients in the initialization response
    */
   String serverVersion() default "";
+
   /**
    * @return Optional instructions to return to the client in the initialization response
    */

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpPrompt.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpPrompt.java
@@ -8,33 +8,34 @@ import java.lang.annotation.*;
 
 /**
  * Annotation to expose a method as an MCP prompt that clients can fetch and use.
- * <p>
- * MCP prompts provide template prompts that can be customized with input parameters. They help
+ *
+ * <p>MCP prompts provide template prompts that can be customized with input parameters. They help
  * standardize common prompting patterns and make them reusable across different AI interactions.
- * <p>
- * <strong>Method Requirements:</strong>
+ *
+ * <p><strong>Method Requirements:</strong>
+ *
  * <ul>
- *   <li>Must be public</li>
- *   <li>Must return a {@code String}</li>
- *   <li>Can have zero or more parameters</li>
- *   <li>Must be in a class annotated with {@link McpEndpoint}</li>
+ *   <li>Must be public
+ *   <li>Must return a {@code String}
+ *   <li>Can have zero or more parameters
+ *   <li>Must be in a class annotated with {@link McpEndpoint}
  * </ul>
- * <p>
- * <strong>Parameter Types:</strong>
- * All parameters must be either {@code String} for required parameters or {@code Optional<String>}
- * for optional parameters. Use {@link akka.javasdk.annotations.Description} annotations to describe
- * the purpose of each parameter.
- * <p>
- * <strong>Prompt Roles:</strong>
- * Prompts can be designated as "user" prompts (default) or "assistant" prompts using the {@link #role()}
- * attribute. This helps clients understand how to use the prompt in their conversation flow.
- * <p>
- * <strong>Use Cases:</strong>
+ *
+ * <p><strong>Parameter Types:</strong> All parameters must be either {@code String} for required
+ * parameters or {@code Optional<String>} for optional parameters. Use {@link
+ * akka.javasdk.annotations.Description} annotations to describe the purpose of each parameter.
+ *
+ * <p><strong>Prompt Roles:</strong> Prompts can be designated as "user" prompts (default) or
+ * "assistant" prompts using the {@link #role()} attribute. This helps clients understand how to use
+ * the prompt in their conversation flow.
+ *
+ * <p><strong>Use Cases:</strong>
+ *
  * <ul>
- *   <li>Code review templates</li>
- *   <li>Analysis frameworks</li>
- *   <li>Structured questioning patterns</li>
- *   <li>Domain-specific prompt templates</li>
+ *   <li>Code review templates
+ *   <li>Analysis frameworks
+ *   <li>Structured questioning patterns
+ *   <li>Domain-specific prompt templates
  * </ul>
  */
 @Target(ElementType.METHOD)
@@ -42,7 +43,8 @@ import java.lang.annotation.*;
 @Documented
 public @interface McpPrompt {
   /**
-   * @return The name of the prompt or prompt template. If it is undefined, the annotated method name is used.
+   * @return The name of the prompt or prompt template. If it is undefined, the annotated method
+   *     name is used.
    */
   String name() default "";
 

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpResource.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpResource.java
@@ -4,78 +4,83 @@
 
 package akka.javasdk.annotations.mcp;
 
-
 import java.lang.annotation.*;
 
 /**
  * Annotation to expose a method as an MCP resource that clients can fetch.
- * <p>
- * MCP resources provide static or dynamic content that AI models can access to gather information.
- * Resources can be static files, configuration data, or dynamically generated content based on parameters.
- * <p>
- * <strong>Resource Types:</strong>
+ *
+ * <p>MCP resources provide static or dynamic content that AI models can access to gather
+ * information. Resources can be static files, configuration data, or dynamically generated content
+ * based on parameters.
+ *
+ * <p><strong>Resource Types:</strong>
+ *
  * <ul>
- *   <li><strong>Static Resources:</strong> Use {@link #uri()} for fixed content with no parameters</li>
- *   <li><strong>Dynamic Resources:</strong> Use {@link #uriTemplate()} for parameterized content</li>
+ *   <li><strong>Static Resources:</strong> Use {@link #uri()} for fixed content with no parameters
+ *   <li><strong>Dynamic Resources:</strong> Use {@link #uriTemplate()} for parameterized content
  * </ul>
- * <p>
- * <strong>Method Requirements:</strong>
+ *
+ * <p><strong>Method Requirements:</strong>
+ *
  * <ul>
- *   <li>Must be public</li>
- *   <li>For static resources ({@code uri}): no parameters allowed</li>
- *   <li>For dynamic resources ({@code uriTemplate}): parameters must match template placeholders</li>
- *   <li>Must be in a class annotated with {@link McpEndpoint}</li>
+ *   <li>Must be public
+ *   <li>For static resources ({@code uri}): no parameters allowed
+ *   <li>For dynamic resources ({@code uriTemplate}): parameters must match template placeholders
+ *   <li>Must be in a class annotated with {@link McpEndpoint}
  * </ul>
- * <p>
- * <strong>Return Types:</strong>
+ *
+ * <p><strong>Return Types:</strong>
+ *
  * <ul>
- *   <li>{@code String}: Returns as UTF-8 encoded text resource</li>
- *   <li>{@code byte[]}: Returns as base64 encoded binary resource</li>
- *   <li>Other types: Encoded to JSON with {@code application/json} MIME type</li>
+ *   <li>{@code String}: Returns as UTF-8 encoded text resource
+ *   <li>{@code byte[]}: Returns as base64 encoded binary resource
+ *   <li>Other types: Encoded to JSON with {@code application/json} MIME type
  * </ul>
- * <p>
- * <strong>URI Templates:</strong>
- * Templates can contain named placeholders for entire path segments only. Each placeholder must match
- * a method parameter name. For example: {@code "file:///images/{category}/{file}"} matches
- * {@code file:///images/bicycles/tall_bike.jpg} and passes {@code "bicycles"} as {@code category}
- * and {@code "tall_bike.jpg"} as {@code file}.
- * <p>
- * <strong>Security:</strong>
- * Always validate input parameters to prevent path traversal attacks or unauthorized access.
+ *
+ * <p><strong>URI Templates:</strong> Templates can contain named placeholders for entire path
+ * segments only. Each placeholder must match a method parameter name. For example: {@code
+ * "file:///images/{category}/{file}"} matches {@code file:///images/bicycles/tall_bike.jpg} and
+ * passes {@code "bicycles"} as {@code category} and {@code "tall_bike.jpg"} as {@code file}.
+ *
+ * <p><strong>Security:</strong> Always validate input parameters to prevent path traversal attacks
+ * or unauthorized access.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface McpResource {
   /**
-   * @return A unique URI identifying the resource. If this is defined {@code uriTemplate} must be empty.
+   * @return A unique URI identifying the resource. If this is defined {@code uriTemplate} must be
+   *     empty.
    */
   String uri() default "";
 
   /**
-   * @return A resource template path that can be used to create a URI that will identify a resource.
-   *         If defined, {@code uri} must be empty, the URI template string can contain named variable placeholders
-   *         for entire segments only. Each variable name must match a method parameter name. The method parameters must be of
-   *         type {@code String}. For example: {@code "file:///images/{category}/{file}"} will match a resource request for
-   *         {@code file:///images/bicycles/tall_bike.jpg} and pass {@code bicycles} as the {@code category} parameter
-   *         and {@code tall_bike.jpg} as the {@code file} parameter.
+   * @return A resource template path that can be used to create a URI that will identify a
+   *     resource. If defined, {@code uri} must be empty, the URI template string can contain named
+   *     variable placeholders for entire segments only. Each variable name must match a method
+   *     parameter name. The method parameters must be of type {@code String}. For example: {@code
+   *     "file:///images/{category}/{file}"} will match a resource request for {@code
+   *     file:///images/bicycles/tall_bike.jpg} and pass {@code bicycles} as the {@code category}
+   *     parameter and {@code tall_bike.jpg} as the {@code file} parameter.
    */
   String uriTemplate() default "";
 
   /**
-   * @return A human-readable name for this resource. Clients can use this to populate UI elements, for example.
+   * @return A human-readable name for this resource. Clients can use this to populate UI elements,
+   *     for example.
    */
   String name();
 
   /**
-   * @return A description of what this resource represents. Clients can use this to improve the LLM's
-   *         understanding of available resources. It can be thought of as a "hint" to the model.
+   * @return A description of what this resource represents. Clients can use this to improve the
+   *     LLM's understanding of available resources. It can be thought of as a "hint" to the model.
    */
-  String description() default  "";
+  String description() default "";
 
   /**
-   * @return The MIME type of this resource. If not defined, String output will be presented as {@code text/plain} and
-   *         byte arrays as {@code appli}
+   * @return The MIME type of this resource. If not defined, String output will be presented as
+   *     {@code text/plain} and byte arrays as {@code appli}
    */
   String mimeType() default "";
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpTool.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/mcp/McpTool.java
@@ -8,34 +8,37 @@ import java.lang.annotation.*;
 
 /**
  * Annotation to expose a method as an MCP tool that can be called by MCP clients.
- * <p>
- * MCP tools are functions that AI models can invoke to perform specific tasks or retrieve information.
- * The LLM determines which tools to call based on the tool descriptions and the user's request.
- * <p>
- * <strong>Method Requirements:</strong>
+ *
+ * <p>MCP tools are functions that AI models can invoke to perform specific tasks or retrieve
+ * information. The LLM determines which tools to call based on the tool descriptions and the user's
+ * request.
+ *
+ * <p><strong>Method Requirements:</strong>
+ *
  * <ul>
- *   <li>Must be public</li>
- *   <li>Must return a {@code String}</li>
- *   <li>Can accept 0 or more parameters</li>
- *   <li>Must be in a class annotated with {@link McpEndpoint}</li>
+ *   <li>Must be public
+ *   <li>Must return a {@code String}
+ *   <li>Can accept 0 or more parameters
+ *   <li>Must be in a class annotated with {@link McpEndpoint}
  * </ul>
- * <p>
- * <strong>Parameter Types:</strong>
- * Only simple parameter types are supported. Fields must be primitive types, boxed Java primitives,
- * or strings. All parameters are required by default; use {@code Optional<T>} for optional parameters.
- * <p>
- * <strong>Schema Generation:</strong>
- * The input schema is automatically generated from method parameters unless a manual schema is provided
- * via {@link #inputSchema()}. Use {@link akka.javasdk.annotations.Description} annotations on parameters
- * to help the LLM understand their purpose.
- * <p>
- * <strong>Best Practices:</strong>
+ *
+ * <p><strong>Parameter Types:</strong> Only simple parameter types are supported. Fields must be
+ * primitive types, boxed Java primitives, or strings. All parameters are required by default; use
+ * {@code Optional<T>} for optional parameters.
+ *
+ * <p><strong>Schema Generation:</strong> The input schema is automatically generated from method
+ * parameters unless a manual schema is provided via {@link #inputSchema()}. Use {@link
+ * akka.javasdk.annotations.Description} annotations on parameters to help the LLM understand their
+ * purpose.
+ *
+ * <p><strong>Best Practices:</strong>
+ *
  * <ul>
- *   <li>Provide clear, descriptive tool descriptions</li>
- *   <li>Use {@link akka.javasdk.annotations.Description} on all parameters</li>
- *   <li>Keep tools focused on single, well-defined tasks</li>
- *   <li>Validate input parameters for security</li>
- *   <li>Use {@link ToolAnnotation} to describe tool behavior characteristics</li>
+ *   <li>Provide clear, descriptive tool descriptions
+ *   <li>Use {@link akka.javasdk.annotations.Description} on all parameters
+ *   <li>Keep tools focused on single, well-defined tasks
+ *   <li>Validate input parameters for security
+ *   <li>Use {@link ToolAnnotation} to describe tool behavior characteristics
  * </ul>
  */
 @Target(ElementType.METHOD)
@@ -44,25 +47,25 @@ import java.lang.annotation.*;
 public @interface McpTool {
 
   /**
-   * @return The name of the tool. Must be unique in the same MCP endpoint if specified, if not specified, the method
-   *         name is used.
+   * @return The name of the tool. Must be unique in the same MCP endpoint if specified, if not
+   *     specified, the method name is used.
    */
   String name() default "";
 
   /**
-   * @return A clear description of what the tools, used by the client LLM to determine what the tool can be used for
+   * @return A clear description of what the tools, used by the client LLM to determine what the
+   *     tool can be used for
    */
   String description();
 
   /**
    * Normally, the schema is inferred from the input parameters of the tool method.
-   * @return A manually specified schema instead of the automatic must match the input parameters and how they are
-   *         parsed by Jackson.
+   *
+   * @return A manually specified schema instead of the automatic must match the input parameters
+   *     and how they are parsed by Jackson.
    */
   String inputSchema() default "";
 
-  /**
-   * Optional annotations describing what the tool does to the client.
-   */
+  /** Optional annotations describing what the tool does to the client. */
   ToolAnnotation[] annotations() default {};
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/client/AgentClientInSession.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/AgentClientInSession.java
@@ -9,25 +9,20 @@ import akka.japi.function.Function;
 import akka.japi.function.Function2;
 import akka.javasdk.agent.Agent;
 
-/**
- * Not for user extension or instantiation, returned by the SDK component client
- */
+/** Not for user extension or instantiation, returned by the SDK component client */
 @DoNotInherit
 public interface AgentClientInSession {
 
   /**
-   * Pass in an Agent command handler method reference, e.g. {@code SummarizerAgent::summarizeSession}
+   * Pass in an Agent command handler method reference, e.g. {@code
+   * SummarizerAgent::summarizeSession}
    */
   <T, R> ComponentMethodRef<R> method(Function<T, Agent.Effect<R>> methodRef);
 
-  /**
-   * Pass in an Agent command handler method reference, e.g. {@code PlannerAgent::plan}
-   */
+  /** Pass in an Agent command handler method reference, e.g. {@code PlannerAgent::plan} */
   <T, A1, R> ComponentMethodRef1<A1, R> method(Function2<T, A1, Agent.Effect<R>> methodRef);
 
-  /**
-   * Pass in an Agent command handler method reference, e.g. {@code ExpertAgent::ask}
-   */
+  /** Pass in an Agent command handler method reference, e.g. {@code ExpertAgent::ask} */
   <T> ComponentStreamMethodRef<String> tokenStream(Function<T, Agent.StreamEffect> methodRef);
 
   /**
@@ -35,13 +30,12 @@ public interface AgentClientInSession {
    *
    * @param <A1> the type of parameter expected by the call
    */
-  <T, A1> ComponentStreamMethodRef1<A1, String> tokenStream(Function2<T, A1, Agent.StreamEffect> methodRef);
-
+  <T, A1> ComponentStreamMethodRef1<A1, String> tokenStream(
+      Function2<T, A1, Agent.StreamEffect> methodRef);
 
   /**
-   * Agents can be called based on the id without knowing the exact agent class
-   * or lambda of the agent method by using the {{@code dynamicCall}} of the component
-   * client.
+   * Agents can be called based on the id without knowing the exact agent class or lambda of the
+   * agent method by using the {{@code dynamicCall}} of the component client.
    *
    * <pre>{@code
    * var response =

--- a/akka-javasdk/src/main/java/akka/javasdk/client/EventSourcedEntityClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/EventSourcedEntityClient.java
@@ -9,21 +9,20 @@ import akka.japi.function.Function;
 import akka.japi.function.Function2;
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
 
-/**
- * Not for user extension
- */
+/** Not for user extension */
 @DoNotInherit
 public interface EventSourcedEntityClient {
 
   /**
-   * Pass in an Event Sourced Entity command handler method reference, e.g. {@code UserEntity::create}
+   * Pass in an Event Sourced Entity command handler method reference, e.g. {@code
+   * UserEntity::create}
    */
   <T, R> ComponentMethodRef<R> method(Function<T, EventSourcedEntity.Effect<R>> methodRef);
 
   /**
-   * Pass in an Event Sourced Entity command handler method reference, e.g. {@code UserEntity::update}
+   * Pass in an Event Sourced Entity command handler method reference, e.g. {@code
+   * UserEntity::update}
    */
-  <T, A1, R> ComponentMethodRef1<A1, R> method(Function2<T, A1, EventSourcedEntity.Effect<R>> methodRef);
-
-
+  <T, A1, R> ComponentMethodRef1<A1, R> method(
+      Function2<T, A1, EventSourcedEntity.Effect<R>> methodRef);
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/client/KeyValueEntityClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/KeyValueEntityClient.java
@@ -9,9 +9,7 @@ import akka.japi.function.Function;
 import akka.japi.function.Function2;
 import akka.javasdk.keyvalueentity.KeyValueEntity;
 
-/**
- * Not for user extension
- */
+/** Not for user extension */
 @DoNotInherit
 public interface KeyValueEntityClient {
 
@@ -23,7 +21,6 @@ public interface KeyValueEntityClient {
   /**
    * Pass in a Key Value Entity command handler method reference, e.g. {@code UserEntity::update}
    */
-  <T, A1, R> ComponentMethodRef1<A1, R> method(Function2<T, A1, KeyValueEntity.Effect<R>> methodRef);
-
-
+  <T, A1, R> ComponentMethodRef1<A1, R> method(
+      Function2<T, A1, KeyValueEntity.Effect<R>> methodRef);
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/client/NoEntryFoundException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/NoEntryFoundException.java
@@ -6,10 +6,10 @@ package akka.javasdk.client;
 
 /** Thrown for a query where the query result would be a single entry but none was found. */
 public final class NoEntryFoundException extends RuntimeException {
-    // FIXME this matches what we have now but is still not great DX, Option or always a collection
-    // would be better?
+  // FIXME this matches what we have now but is still not great DX, Option or always a collection
+  // would be better?
 
-    public NoEntryFoundException(String message) {
-        super(message);
-    }
+  public NoEntryFoundException(String message) {
+    super(message);
+  }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/client/TimedActionClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/TimedActionClient.java
@@ -9,14 +9,10 @@ import akka.japi.function.Function2;
 import akka.javasdk.timedaction.TimedAction;
 
 public interface TimedActionClient {
-  /**
-   * Pass in an Action method reference, e.g. {@code MyAction::create}
-   */
+  /** Pass in an Action method reference, e.g. {@code MyAction::create} */
   <T, R> ComponentDeferredMethodRef<R> method(Function<T, TimedAction.Effect> methodRef);
 
-  /**
-   * Pass in an Action method reference, e.g. {@code MyAction::create}
-   */
-  <T, A1, R> ComponentDeferredMethodRef1<A1, R> method(Function2<T, A1, TimedAction.Effect> methodRef);
-
+  /** Pass in an Action method reference, e.g. {@code MyAction::create} */
+  <T, A1, R> ComponentDeferredMethodRef1<A1, R> method(
+      Function2<T, A1, TimedAction.Effect> methodRef);
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/client/ViewClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/ViewClient.java
@@ -14,21 +14,20 @@ import akka.javasdk.view.View;
 public interface ViewClient {
 
   /**
-   * Pass in a View query method reference, e.g. {@code UserByCity::find} If no result is
-   * found, the result of the request will be a {@link NoEntryFoundException}
+   * Pass in a View query method reference, e.g. {@code UserByCity::find} If no result is found, the
+   * result of the request will be a {@link NoEntryFoundException}
    */
   <T, R> ComponentInvokeOnlyMethodRef<R> method(Function<T, View.QueryEffect<R>> methodRef);
 
   /**
    * Pass in a View query method reference, e.g. {@code UserByCity::find}
    *
-   * If no result is found, the result of the request will be a {@link NoEntryFoundException}
+   * <p>If no result is found, the result of the request will be a {@link NoEntryFoundException}
    */
-  <T, A1, R> ComponentInvokeOnlyMethodRef1<A1, R> method(Function2<T, A1, View.QueryEffect<R>> methodRef);
+  <T, A1, R> ComponentInvokeOnlyMethodRef1<A1, R> method(
+      Function2<T, A1, View.QueryEffect<R>> methodRef);
 
-  /**
-   * Pass in a View query method reference, e.g. {@code UserByCity::findAllInCity}
-   */
+  /** Pass in a View query method reference, e.g. {@code UserByCity::findAllInCity} */
   <T, R> ComponentStreamMethodRef<R> stream(Function<T, View.QueryStreamEffect<R>> methodRef);
 
   /**
@@ -36,5 +35,6 @@ public interface ViewClient {
    *
    * @param <A1> the type of parameter expected by the call
    */
-  <T, A1, R> ComponentStreamMethodRef1<A1, R> stream(Function2<T, A1, View.QueryStreamEffect<R>> methodRef);
+  <T, A1, R> ComponentStreamMethodRef1<A1, R> stream(
+      Function2<T, A1, View.QueryStreamEffect<R>> methodRef);
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/client/WorkflowClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/WorkflowClient.java
@@ -9,20 +9,19 @@ import akka.japi.function.Function;
 import akka.japi.function.Function2;
 import akka.javasdk.workflow.Workflow;
 
-/**
- * Not for user extension
- */
+/** Not for user extension */
 @DoNotInherit
 public interface WorkflowClient {
 
   /**
-   * Pass in a Workflow method reference annotated as a REST endpoint, e.g. {@code MyWorkflow::start}
+   * Pass in a Workflow method reference annotated as a REST endpoint, e.g. {@code
+   * MyWorkflow::start}
    */
   <T, R> ComponentMethodRef<R> method(Function<T, Workflow.Effect<R>> methodRef);
 
   /**
-   * Pass in a Workflow method reference annotated as a REST endpoint, e.g. {@code MyWorkflow::start}
+   * Pass in a Workflow method reference annotated as a REST endpoint, e.g. {@code
+   * MyWorkflow::start}
    */
   <T, A1, R> ComponentMethodRef1<A1, R> method(Function2<T, A1, Workflow.Effect<R>> methodRef);
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/consumer/Consumer.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/consumer/Consumer.java
@@ -10,34 +10,34 @@ import akka.javasdk.Metadata;
 import akka.javasdk.impl.consumer.ConsumerEffectImpl;
 import akka.javasdk.impl.consumer.MessageContextImpl;
 import akka.javasdk.timer.TimerScheduler;
-
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
- *
  * Consumers are stateless components that can be used to implement different uses cases, such as:
  *
  * <p>
+ *
  * <ul>
- *   <li>subscribe to events from an Event Sourced Entity.</li>
- *   <li>subscribe to state changes from a Key Value Entity.</li>
+ *   <li>subscribe to events from an Event Sourced Entity.
+ *   <li>subscribe to state changes from a Key Value Entity.
  * </ul>
  *
  * A Consumer method should return an {@link Effect} that describes what to do next.
- * <p>
- * Concrete classes can accept the following types to the constructor:
+ *
+ * <p>Concrete classes can accept the following types to the constructor:
+ *
  * <ul>
- *   <li>{@link akka.javasdk.client.ComponentClient}</li>
- *   <li>{@link akka.javasdk.http.HttpClientProvider}</li>
- *   <li>{@link akka.javasdk.timer.TimerScheduler}</li>
- *   <li>{@link akka.stream.Materializer}</li>
- *   <li>{@link com.typesafe.config.Config}</li>
- *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider} from the service setup</li>
+ *   <li>{@link akka.javasdk.client.ComponentClient}
+ *   <li>{@link akka.javasdk.http.HttpClientProvider}
+ *   <li>{@link akka.javasdk.timer.TimerScheduler}
+ *   <li>{@link akka.stream.Materializer}
+ *   <li>{@link com.typesafe.config.Config}
+ *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider} from the service setup
  * </ul>
- * <p>
- * Concrete class must be annotated with {@link akka.javasdk.annotations.ComponentId} and
- * one of the {@link akka.javasdk.annotations.Consume} annotations.
+ *
+ * <p>Concrete class must be annotated with {@link akka.javasdk.annotations.ComponentId} and one of
+ * the {@link akka.javasdk.annotations.Consume} annotations.
  */
 public abstract class Consumer {
 
@@ -58,6 +58,7 @@ public abstract class Consumer {
 
   /**
    * INTERNAL API
+   *
    * @hidden
    */
   @InternalApi
@@ -69,62 +70,55 @@ public abstract class Consumer {
     return ConsumerEffectImpl.builder();
   }
 
-  /**
-   * Returns a {@link TimerScheduler} that can be used to schedule further in time.
-   */
+  /** Returns a {@link TimerScheduler} that can be used to schedule further in time. */
   public final TimerScheduler timers() {
     MessageContextImpl impl =
-      (MessageContextImpl)
-        messageContext("Timers can only be scheduled or cancelled when handling a message.");
+        (MessageContextImpl)
+            messageContext("Timers can only be scheduled or cancelled when handling a message.");
     return impl.timers();
   }
 
   /**
-   * An Effect is a description of what the runtime needs to do after the command is handled.
-   * You can think of it as a set of instructions you are passing to the runtime, which will process
-   * the instructions on your behalf.
+   * An Effect is a description of what the runtime needs to do after the command is handled. You
+   * can think of it as a set of instructions you are passing to the runtime, which will process the
+   * instructions on your behalf.
+   *
+   * <p>Each component defines its own effects, which are a set of predefined operations that match
+   * the capabilities of that component.
+   *
+   * <p>A Consumer Effect can either:
+   *
    * <p>
-   * Each component defines its own effects, which are a set of predefined
-   * operations that match the capabilities of that component.
-   * <p>
-   * A Consumer Effect can either:
-   * <p>
+   *
    * <ul>
    *   <li>return a message to be published to a Topic (in case the method is a publisher)
    *   <li>return Done to indicate that the message was processed successfully
    *   <li>ignore the call
    * </ul>
-   *
    */
   public interface Effect {
 
-    /**
-     * Construct the effect that is returned by the message handler.
-     */
+    /** Construct the effect that is returned by the message handler. */
     interface Builder {
 
-      /**
-       * Mark message as processed.
-       */
+      /** Mark message as processed. */
       Effect done();
 
-      /**
-       * Mark message as processed from an async operation result
-       */
+      /** Mark message as processed from an async operation result */
       Effect asyncDone(CompletionStage<Done> message);
 
       /**
        * Produce a message.
        *
        * @param message The payload of the message.
-       * @param <S>     The type of the message.
+       * @param <S> The type of the message.
        */
       <S> Effect produce(S message);
 
       /**
        * Produce a message with custom Metadata.
        *
-       * @param message  The payload of the message.
+       * @param message The payload of the message.
        * @param metadata The metadata for the message.
        */
       <S> Effect produce(S message, Metadata metadata);
@@ -151,9 +145,7 @@ public abstract class Consumer {
        */
       Effect asyncEffect(CompletionStage<Effect> futureEffect);
 
-      /**
-       * Ignore the current message and proceed with processing the next message
-       */
+      /** Ignore the current message and proceed with processing the next message */
       Effect ignore();
     }
   }

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/EventSourcedEntity.java
@@ -8,60 +8,69 @@ import akka.annotation.InternalApi;
 import akka.javasdk.CommandException;
 import akka.javasdk.Metadata;
 import akka.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 /**
- * Event Sourced Entities are stateful components that persist changes as events in a journal rather than
- * storing the current state directly. The current entity state is derived by replaying all persisted events.
- * This approach provides a complete audit trail and enables reliable state replication.
- * 
- * <p>Event Sourced Entities provide strong consistency guarantees through entity sharding, where each
- * entity instance is identified by a unique id and distributed across the service cluster. Only one
- * instance of each entity exists in the cluster at any time, ensuring sequential message processing
- * without concurrency concerns.
- * 
- * <p>The entity state is kept in memory while active and can serve read requests or command validation
- * without additional reads from the journal. Inactive entities are passivated and recover their state
- * by replaying events from the journal when accessed again.
- * 
+ * Event Sourced Entities are stateful components that persist changes as events in a journal rather
+ * than storing the current state directly. The current entity state is derived by replaying all
+ * persisted events. This approach provides a complete audit trail and enables reliable state
+ * replication.
+ *
+ * <p>Event Sourced Entities provide strong consistency guarantees through entity sharding, where
+ * each entity instance is identified by a unique id and distributed across the service cluster.
+ * Only one instance of each entity exists in the cluster at any time, ensuring sequential message
+ * processing without concurrency concerns.
+ *
+ * <p>The entity state is kept in memory while active and can serve read requests or command
+ * validation without additional reads from the journal. Inactive entities are passivated and
+ * recover their state by replaying events from the journal when accessed again.
+ *
  * <h2>Implementation Steps</h2>
+ *
  * <ol>
- *   <li>Model the entity's state and its domain events</li>
- *   <li>Implement behavior in command and event handlers</li>
+ *   <li>Model the entity's state and its domain events
+ *   <li>Implement behavior in command and event handlers
  * </ol>
- * 
+ *
  * <h2>Event Sourcing Model</h2>
+ *
  * <p>Unlike traditional CRUD systems, Event Sourced Entities never update state directly. Instead:
+ *
  * <ul>
- *   <li>Commands validate business rules and persist events representing state changes</li>
- *   <li>Events are applied to update the entity state through the {@link #applyEvent(E)} method</li>
- *   <li>The current state is always derived from the complete sequence of events (and snapshot, if exists)</li>
+ *   <li>Commands validate business rules and persist events representing state changes
+ *   <li>Events are applied to update the entity state through the {@link #applyEvent(E)} method
+ *   <li>The current state is always derived from the complete sequence of events (and snapshot, if
+ *       exists)
  * </ul>
- * 
+ *
  * <h2>Command Handlers</h2>
- * Command handlers are methods that return an {@link Effect} and define how the entity responds to commands.
- * The Effect API allows you to:
+ *
+ * Command handlers are methods that return an {@link Effect} and define how the entity responds to
+ * commands. The Effect API allows you to:
+ *
  * <ul>
- *   <li>Persist events and send a reply to the caller</li>
- *   <li>Reply directly without persisting events</li>
- *   <li>Return an error message</li>
- *   <li>Delete the entity</li>
+ *   <li>Persist events and send a reply to the caller
+ *   <li>Reply directly without persisting events
+ *   <li>Return an error message
+ *   <li>Delete the entity
  * </ul>
- * 
+ *
  * <h2>Event Handlers</h2>
- * <p>Events must inherit from a common sealed interface, and the {@link #applyEvent(E)} method should
- * be implemented using a switch statement for compile-time completeness checking.
- * 
+ *
+ * <p>Events must inherit from a common sealed interface, and the {@link #applyEvent(E)} method
+ * should be implemented using a switch statement for compile-time completeness checking.
+ *
  * <h2>Snapshots</h2>
+ *
  * <p>Akka automatically creates snapshots as an optimization to avoid replaying all events during
  * entity recovery. Snapshots are created after a configurable number of events and are handled
  * transparently without requiring specific code.
  *
  * <h2>Example Implementation</h2>
+ *
  * <pre>{@code
  * @ComponentId("shopping-cart")
  * public class ShoppingCartEntity extends EventSourcedEntity<ShoppingCart, ShoppingCartEvent> {
@@ -96,48 +105,55 @@ import java.util.function.Function;
  *   }
  * }
  * }</pre>
- * 
+ *
  * <p>Concrete classes can accept the following types in the constructor:
+ *
  * <ul>
- *   <li>{@link EventSourcedEntityContext} - provides entity context information</li>
- *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider} from the service setup</li>
+ *   <li>{@link EventSourcedEntityContext} - provides entity context information
+ *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider} from the service setup
  * </ul>
- * 
+ *
  * <p>Concrete classes must be annotated with {@link akka.javasdk.annotations.ComponentId} with a
  * stable, unique identifier that cannot be changed after production deployment.
  *
  * <h2>Multi-region Replication</h2>
- * Event Sourced Entities support multi-region replication for resilience and performance. Write requests
- * are handled by the primary region, while read requests can be served from any region. Use
- * {@link ReadOnlyEffect} for read-only operations that can be served from replicas.
+ *
+ * Event Sourced Entities support multi-region replication for resilience and performance. Write
+ * requests are handled by the primary region, while read requests can be served from any region.
+ * Use {@link ReadOnlyEffect} for read-only operations that can be served from replicas.
  *
  * <h2>Immutable state record</h2>
+ *
  * <p>It is recommended to use immutable state objects, such as Java records, for the entity state.
  * Immutable state ensures thread safety and prevents accidental modifications that could lead to
  * inconsistent state or concurrency issues.
  *
  * <p>While mutable state classes are supported, they require careful handling:
+ *
  * <ul>
- *   <li>Mutable state should not be shared outside the entity</li>
- *   <li>Mutable state should not be passed to other threads, such as in {@code CompletionStage} operations</li>
- *   <li>Any modifications to mutable state must be done within the entity's event handler</li>
+ *   <li>Mutable state should not be shared outside the entity
+ *   <li>Mutable state should not be passed to other threads, such as in {@code CompletionStage}
+ *       operations
+ *   <li>Any modifications to mutable state must be done within the entity's event handler
  * </ul>
  *
- * <p><strong>Collections in State:</strong> Collections (such as {@code List}, {@code Set}, {@code Map}) are
- * typically mutable even when contained within immutable objects. When updating state that contains collections,
- * you should create copies of the collections rather than modifying them in place. This ensures that the
- * previous state remains unchanged and prevents unintended side effects.
+ * <p><strong>Collections in State:</strong> Collections (such as {@code List}, {@code Set}, {@code
+ * Map}) are typically mutable even when contained within immutable objects. When updating state
+ * that contains collections, you should create copies of the collections rather than modifying them
+ * in place. This ensures that the previous state remains unchanged and prevents unintended side
+ * effects.
  *
- * <p><strong>Performance Considerations:</strong> Defensive copying of collections can introduce performance
- * overhead, especially for large collections or frequent updates. In performance-critical scenarios, this
- * recommendation can be carefully tuned by using mutable state with strict adherence to the safety guidelines
- * mentioned above.
+ * <p><strong>Performance Considerations:</strong> Defensive copying of collections can introduce
+ * performance overhead, especially for large collections or frequent updates. In
+ * performance-critical scenarios, this recommendation can be carefully tuned by using mutable state
+ * with strict adherence to the safety guidelines mentioned above.
  *
- * <p>Using immutable records with defensive copying of collections eliminates concurrency concerns and is the
- * preferred approach for state modeling in most cases.
+ * <p>Using immutable records with defensive copying of collections eliminates concurrency concerns
+ * and is the preferred approach for state modeling in most cases.
  *
  * @param <S> The type of the state for this entity
- * @param <E> The parent type of the event hierarchy for this entity, required to be a sealed interface
+ * @param <E> The parent type of the event hierarchy for this entity, required to be a sealed
+ *     interface
  */
 public abstract class EventSourcedEntity<S, E> {
 
@@ -148,11 +164,12 @@ public abstract class EventSourcedEntity<S, E> {
   private boolean handlingCommands = false;
 
   /**
-   * Returns the initial empty state object for this entity. This state is used when the entity
-   * is first created and before any events have been persisted and applied.
+   * Returns the initial empty state object for this entity. This state is used when the entity is
+   * first created and before any events have been persisted and applied.
    *
-   * <p>Also known as "zero state" or "neutral state". This method is called when the entity
-   * is instantiated for the first time or when recovering from the journal without any persisted events.
+   * <p>Also known as "zero state" or "neutral state". This method is called when the entity is
+   * instantiated for the first time or when recovering from the journal without any persisted
+   * events.
    *
    * <p>The default implementation returns {@code null}. Override this method to provide a more
    * meaningful initial state for your entity.
@@ -165,10 +182,11 @@ public abstract class EventSourcedEntity<S, E> {
 
   /**
    * Provides access to additional context and metadata for the current command being processed.
-   * This includes information such as the command name, entity id, sequence number, and tracing context.
+   * This includes information such as the command name, entity id, sequence number, and tracing
+   * context.
    *
-   * <p>This method can only be called from within a command handler method. Attempting to access
-   * it from the constructor or inside the {@link #applyEvent(E)} method will result in an exception.
+   * <p>This method can only be called from within a command handler method. Attempting to access it
+   * from the constructor or inside the {@link #applyEvent(E)} method will result in an exception.
    *
    * @return the command context for the current command
    * @throws IllegalStateException if accessed outside a command handler method
@@ -181,6 +199,7 @@ public abstract class EventSourcedEntity<S, E> {
 
   /**
    * INTERNAL API
+   *
    * @hidden
    */
   @InternalApi
@@ -189,11 +208,12 @@ public abstract class EventSourcedEntity<S, E> {
   }
 
   /**
-   * Provides access to additional context and metadata when handling an event in the {@link #applyEvent(E)} method.
-   * This includes information such as the sequence number of the event being processed.
+   * Provides access to additional context and metadata when handling an event in the {@link
+   * #applyEvent(E)} method. This includes information such as the sequence number of the event
+   * being processed.
    *
-   * <p>This method can only be called from within the {@link #applyEvent(E)} method. Attempting to access
-   * it from the constructor or command handler will result in an exception.
+   * <p>This method can only be called from within the {@link #applyEvent(E)} method. Attempting to
+   * access it from the constructor or command handler will result in an exception.
    *
    * @return the event context for the current event being processed
    * @throws IllegalStateException if accessed outside the {@link #applyEvent(E)} method
@@ -205,6 +225,7 @@ public abstract class EventSourcedEntity<S, E> {
 
   /**
    * INTERNAL API
+   *
    * @hidden
    */
   @InternalApi
@@ -214,9 +235,10 @@ public abstract class EventSourcedEntity<S, E> {
 
   /**
    * INTERNAL API
+   *
    * @hidden
    * @return true if this was the first (outer) call to set the state, the caller is then
-   *         responsible for finally calling _internalClearCurrentState
+   *     responsible for finally calling _internalClearCurrentState
    */
   @InternalApi
   public boolean _internalSetCurrentState(S state, boolean deleted) {
@@ -229,6 +251,7 @@ public abstract class EventSourcedEntity<S, E> {
 
   /**
    * INTERNAL API
+   *
    * @hidden
    */
   @InternalApi
@@ -238,24 +261,27 @@ public abstract class EventSourcedEntity<S, E> {
   }
 
   /**
-   * This is the main event handler method. Whenever an event is persisted, this handler will be called.
-   * It should return the new state of the entity.
-   * <p>
-   * Note that this method is called in two situations:
+   * This is the main event handler method. Whenever an event is persisted, this handler will be
+   * called. It should return the new state of the entity.
+   *
+   * <p>Note that this method is called in two situations:
+   *
    * <ul>
-   *     <li>when one or more events are persisted by the command handler, this method is called to produce
-   *     the new state of the entity.
-   *     <li>when instantiating an entity from the event journal, this method is called to restore the state of the entity.
+   *   <li>when one or more events are persisted by the command handler, this method is called to
+   *       produce the new state of the entity.
+   *   <li>when instantiating an entity from the event journal, this method is called to restore the
+   *       state of the entity.
    * </ul>
    *
-   * It's important to keep the event handler side effect free. This means that it should only apply the event
-   * on the current state and return the updated state. This is because the event handler is called during recovery.
-   * <p>
-   * Events are required to inherit from a common sealed interface, and it's recommend to implement this method using a switch statement.
-   * As such, the compiler can check if all existing events are being handled.
+   * It's important to keep the event handler side effect free. This means that it should only apply
+   * the event on the current state and return the updated state. This is because the event handler
+   * is called during recovery.
    *
-   *<pre>
-   * {@code
+   * <p>Events are required to inherit from a common sealed interface, and it's recommend to
+   * implement this method using a switch statement. As such, the compiler can check if all existing
+   * events are being handled.
+   *
+   * <pre>{@code
    * // example of sealed event interface with concrete events implementing it
    * public sealed interface Event {
    *   @TypeName("created")
@@ -271,9 +297,7 @@ public abstract class EventSourcedEntity<S, E> {
    *      case EmailUpdated emailUpdated -> this.copy(email = emailUpdated.newEmail);
    *    }
    * }
-   * }
-   *</pre>
-   *
+   * }</pre>
    */
   public abstract S applyEvent(E event);
 
@@ -282,14 +306,15 @@ public abstract class EventSourcedEntity<S, E> {
    * the latest state after applying all events in the journal.
    *
    * <p><strong>Important:</strong> Modifying the returned state object directly will not persist
-   * the changes. State can only be updated by persisting events through command handlers, which
-   * are then applied via the {@link #applyEvent(E)} method.
+   * the changes. State can only be updated by persisting events through command handlers, which are
+   * then applied via the {@link #applyEvent(E)} method.
    *
    * <p>This method can only be called from within a command handler or event handler method.
-   * Attempting to access it from the constructor or outside of command/event processing will
-   * result in an exception.
+   * Attempting to access it from the constructor or outside of command/event processing will result
+   * in an exception.
    *
-   * @return the current state of the entity, which may be {@code null} if no initial state is defined
+   * @return the current state of the entity, which may be {@code null} if no initial state is
+   *     defined
    * @throws IllegalStateException if accessed outside a handler method
    */
   protected final S currentState() {
@@ -302,12 +327,12 @@ public abstract class EventSourcedEntity<S, E> {
 
   /**
    * Returns whether this entity has been marked for deletion. When an entity is deleted using
-   * {@code effects().persist(finalEvent).deleteEntity()}, it will still exist for some time
-   * before being completely removed.
+   * {@code effects().persist(finalEvent).deleteEntity()}, it will still exist for some time before
+   * being completely removed.
    *
    * <p>After deletion, the entity can still handle read requests but no further events can be
-   * persisted. The entity and its events will be completely cleaned up after a default period
-   * of one week to allow downstream consumers time to process all events.
+   * persisted. The entity and its events will be completely cleaned up after a default period of
+   * one week to allow downstream consumers time to process all events.
    *
    * @return {@code true} if the entity has been deleted, {@code false} otherwise
    */
@@ -323,13 +348,14 @@ public abstract class EventSourcedEntity<S, E> {
    * An Effect describes the actions that the Akka runtime should perform after a command handler
    * completes. Effects are declarative instructions that tell the runtime how to persist events,
    * send replies, or handle errors.
-   * 
+   *
    * <p>Event Sourced Entity effects can:
+   *
    * <ul>
-   *   <li>Persist events and send a reply to the caller</li>
-   *   <li>Reply directly to the caller without persisting events</li>
-   *   <li>Return an error message to reject the command</li>
-   *   <li>Delete the entity after persisting a final event</li>
+   *   <li>Persist events and send a reply to the caller
+   *   <li>Reply directly to the caller without persisting events
+   *   <li>Return an error message to reject the command
+   *   <li>Delete the entity after persisting a final event
    * </ul>
    *
    * @param <T> The type of the message that must be returned by this call
@@ -345,22 +371,22 @@ public abstract class EventSourcedEntity<S, E> {
     interface Builder<S, E> {
 
       /**
-       * Persist a single event.
-       * After this event is persisted, the event handler {@link #applyEvent(E event)} is called in order to update the entity state.
+       * Persist a single event. After this event is persisted, the event handler {@link
+       * #applyEvent(E event)} is called in order to update the entity state.
        */
       OnSuccessBuilder<S> persist(E event);
 
       /**
-       * Persist the passed events.
-       * After these events are persisted, the event handler {@link #applyEvent} is called in order to update the entity state.
-       * Note, the event handler is called only once after all events are persisted.
+       * Persist the passed events. After these events are persisted, the event handler {@link
+       * #applyEvent} is called in order to update the entity state. Note, the event handler is
+       * called only once after all events are persisted.
        */
       OnSuccessBuilder<S> persist(E event1, E event2, E... events);
 
       /**
-       * Persist the passed List of events.
-       * After these events are persisted, the event handler {@link #applyEvent} is called in order to update the entity state.
-       * Note, the event handler is called only once after all events are persisted.
+       * Persist the passed List of events. After these events are persisted, the event handler
+       * {@link #applyEvent} is called in order to update the entity state. Note, the event handler
+       * is called only once after all events are persisted.
        */
       OnSuccessBuilder<S> persistAll(List<? extends E> events);
 
@@ -384,7 +410,8 @@ public abstract class EventSourcedEntity<S, E> {
       <T> ReadOnlyEffect<T> reply(T message, Metadata metadata);
 
       /**
-       * Create an error reply. A short version of {{@code effects().error(new CommandException(message))}}.
+       * Create an error reply. A short version of {{@code effects().error(new
+       * CommandException(message))}}.
        *
        * @param message The error message.
        * @return An error reply.
@@ -394,7 +421,8 @@ public abstract class EventSourcedEntity<S, E> {
 
       /**
        * Create an error reply. {@link CommandException} will be serialized and sent to the client.
-       * It's possible to catch it with try-catch statement or {@link CompletionStage} API when using async {@link akka.javasdk.client.ComponentClient} API.
+       * It's possible to catch it with try-catch statement or {@link CompletionStage} API when
+       * using async {@link akka.javasdk.client.ComponentClient} API.
        *
        * @param commandException The command exception to be returned.
        * @param <T> The type of the message that must be returned by this call.
@@ -406,9 +434,8 @@ public abstract class EventSourcedEntity<S, E> {
     interface OnSuccessBuilder<S> {
 
       /**
-       * Delete the entity. No addition events are allowed.
-       * To observe the deletion in consumers and views, persist a final event representing the deletion before
-       * triggering delete.
+       * Delete the entity. No addition events are allowed. To observe the deletion in consumers and
+       * views, persist a final event representing the deletion before triggering delete.
        */
       OnSuccessBuilder<S> deleteEntity();
 
@@ -430,14 +457,9 @@ public abstract class EventSourcedEntity<S, E> {
        * @param <T> The type of the message that must be returned by this call.
        */
       <T> Effect<T> thenReply(Function<S, T> replyMessage, Metadata metadata);
-
     }
-
   }
 
-  /**
-   * An effect that is known to be read only and does not update the state of the entity.
-   */
-  public interface ReadOnlyEffect<T> extends Effect<T> {
-  }
+  /** An effect that is known to be read only and does not update the state of the entity. */
+  public interface ReadOnlyEffect<T> extends Effect<T> {}
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/grpc/AbstractGrpcEndpoint.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/grpc/AbstractGrpcEndpoint.java
@@ -7,11 +7,12 @@ package akka.javasdk.grpc;
 import akka.annotation.InternalApi;
 
 /**
- * Optional base class for gRPC endpoints giving access to a request context without additional constructor parameters
+ * Optional base class for gRPC endpoints giving access to a request context without additional
+ * constructor parameters
  */
-abstract public class AbstractGrpcEndpoint {
+public abstract class AbstractGrpcEndpoint {
 
-  volatile private GrpcRequestContext context;
+  private volatile GrpcRequestContext context;
 
   /**
    * INTERNAL API
@@ -19,18 +20,17 @@ abstract public class AbstractGrpcEndpoint {
    * @hidden
    */
   @InternalApi
-  final public void _internalSetRequestContext(GrpcRequestContext context) {
+  public final void _internalSetRequestContext(GrpcRequestContext context) {
     this.context = context;
   }
 
-  /**
-   * Always available from request handling methods, not available from the constructor.
-   */
+  /** Always available from request handling methods, not available from the constructor. */
   protected final GrpcRequestContext requestContext() {
     if (context == null) {
-      throw new IllegalStateException("The request context can only be accessed from the request handling methods of the endpoint.");
+      throw new IllegalStateException(
+          "The request context can only be accessed from the request handling methods of the"
+              + " endpoint.");
     }
     return context;
   }
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/grpc/GrpcRequestContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/grpc/GrpcRequestContext.java
@@ -24,10 +24,14 @@ public interface GrpcRequestContext extends Context {
    */
   Principals getPrincipals();
 
-  /** @return The JWT claims, if any, associated with this request. */
+  /**
+   * @return The JWT claims, if any, associated with this request.
+   */
   JwtClaims getJwtClaims();
 
-  /** @return The metadata associated with the request being processed */
+  /**
+   * @return The metadata associated with the request being processed
+   */
   Metadata metadata();
 
   /** Access to tracing for custom app specific tracing. */

--- a/akka-javasdk/src/main/java/akka/javasdk/http/AbstractHttpEndpoint.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/http/AbstractHttpEndpoint.java
@@ -8,32 +8,34 @@ import akka.annotation.InternalApi;
 
 /**
  * Optional base class for HTTP endpoints providing convenient access to request context.
- * <p>
- * HTTP endpoints expose services to the outside world through RESTful APIs. They handle incoming HTTP requests
- * and can return responses in various formats including JSON, plain text, or custom content types.
- * <p>
- * <strong>Basic Usage:</strong>
+ *
+ * <p>HTTP endpoints expose services to the outside world through RESTful APIs. They handle incoming
+ * HTTP requests and can return responses in various formats including JSON, plain text, or custom
+ * content types.
+ *
+ * <p><strong>Basic Usage:</strong>
+ *
  * <pre>{@code
  * @HttpEndpoint("/api")
  * @Acl(allow = @Acl.Matcher(principal = Acl.Principal.ALL))
  * public class MyEndpoint extends AbstractHttpEndpoint {
- * 
+ *
  *   @Get("/hello/{name}")
  *   public String hello(String name) {
  *     return "Hello " + name;
  *   }
- * 
+ *
  *   @Post("/users")
  *   public HttpResponse createUser(CreateUserRequest request) {
  *     // Access request context for headers, query params, etc.
  *     String userAgent = requestContext().requestHeader("User-Agent")
  *         .map(HttpHeader::value)
  *         .orElse("Unknown");
- *     
+ *
  *     // Process request and return response
  *     return HttpResponses.created(new User(request.name()));
  *   }
- * 
+ *
  *   @Get("/search")
  *   public List<Result> search() {
  *     // Access query parameters
@@ -43,40 +45,38 @@ import akka.annotation.InternalApi;
  *   }
  * }
  * }</pre>
- * <p>
- * <strong>HTTP Methods:</strong>
- * Annotate methods with {@link akka.javasdk.annotations.http.Get}, {@link akka.javasdk.annotations.http.Post},
- * {@link akka.javasdk.annotations.http.Put}, {@link akka.javasdk.annotations.http.Patch}, or
- * {@link akka.javasdk.annotations.http.Delete} to handle different HTTP verbs.
- * <p>
- * <strong>Path Parameters:</strong>
- * Use {@code {paramName}} in paths to extract URL segments as method parameters. Parameters can be
- * strings, numbers, or other primitive types.
- * <p>
- * <strong>Request Bodies:</strong>
- * Accept JSON request bodies by adding parameters that Jackson can deserialize. The request body
- * parameter must come last in the parameter list when combined with path parameters.
- * <p>
- * <strong>Response Types:</strong>
- * Return strings for text responses, objects for JSON responses, {@link akka.http.javadsl.model.HttpResponse}
- * for full control, or {@code CompletionStage<T>} for asynchronous responses.
- * <p>
- * <strong>Request Context:</strong>
- * Extending this class provides access to {@link RequestContext} via {@link #requestContext()} without
- * requiring constructor injection. The context provides access to headers, query parameters, JWT claims,
- * and tracing information.
- * <p>
- * <strong>Alternative Approach:</strong>
- * Instead of extending this class, you can inject {@link RequestContext} directly into your endpoint
- * constructor or use dependency injection for other services like {@link akka.javasdk.client.ComponentClient}.
- * <p>
- * <strong>Security:</strong>
- * Always annotate endpoints with appropriate {@link akka.javasdk.annotations.Acl} annotations to control access.
- * Without ACL annotations, no clients are allowed to access the endpoint.
+ *
+ * <p><strong>HTTP Methods:</strong> Annotate methods with {@link
+ * akka.javasdk.annotations.http.Get}, {@link akka.javasdk.annotations.http.Post}, {@link
+ * akka.javasdk.annotations.http.Put}, {@link akka.javasdk.annotations.http.Patch}, or {@link
+ * akka.javasdk.annotations.http.Delete} to handle different HTTP verbs.
+ *
+ * <p><strong>Path Parameters:</strong> Use {@code {paramName}} in paths to extract URL segments as
+ * method parameters. Parameters can be strings, numbers, or other primitive types.
+ *
+ * <p><strong>Request Bodies:</strong> Accept JSON request bodies by adding parameters that Jackson
+ * can deserialize. The request body parameter must come last in the parameter list when combined
+ * with path parameters.
+ *
+ * <p><strong>Response Types:</strong> Return strings for text responses, objects for JSON
+ * responses, {@link akka.http.javadsl.model.HttpResponse} for full control, or {@code
+ * CompletionStage<T>} for asynchronous responses.
+ *
+ * <p><strong>Request Context:</strong> Extending this class provides access to {@link
+ * RequestContext} via {@link #requestContext()} without requiring constructor injection. The
+ * context provides access to headers, query parameters, JWT claims, and tracing information.
+ *
+ * <p><strong>Alternative Approach:</strong> Instead of extending this class, you can inject {@link
+ * RequestContext} directly into your endpoint constructor or use dependency injection for other
+ * services like {@link akka.javasdk.client.ComponentClient}.
+ *
+ * <p><strong>Security:</strong> Always annotate endpoints with appropriate {@link
+ * akka.javasdk.annotations.Acl} annotations to control access. Without ACL annotations, no clients
+ * are allowed to access the endpoint.
  */
-abstract public class AbstractHttpEndpoint {
+public abstract class AbstractHttpEndpoint {
 
-  volatile private RequestContext context;
+  private volatile RequestContext context;
 
   /**
    * INTERNAL API
@@ -84,18 +84,17 @@ abstract public class AbstractHttpEndpoint {
    * @hidden
    */
   @InternalApi
-  final public void _internalSetRequestContext(RequestContext context) {
+  public final void _internalSetRequestContext(RequestContext context) {
     this.context = context;
   }
 
-  /**
-   * Always available from request handling methods, not available from the constructor.
-   */
+  /** Always available from request handling methods, not available from the constructor. */
   protected final RequestContext requestContext() {
     if (context == null) {
-      throw new IllegalStateException("The request context can only be accessed from the request handling methods of the endpoint.");
+      throw new IllegalStateException(
+          "The request context can only be accessed from the request handling methods of the"
+              + " endpoint.");
     }
     return context;
   }
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/http/HttpException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/http/HttpException.java
@@ -4,39 +4,39 @@
 
 package akka.javasdk.http;
 
-import akka.http.scaladsl.model.StatusCodes;
 import akka.http.scaladsl.model.StatusCode;
+import akka.http.scaladsl.model.StatusCodes;
 import akka.javasdk.impl.http.HttpExceptionImpl;
 
 /**
  * Factory class for creating HTTP exceptions that result in specific HTTP error responses.
- * <p>
- * HttpException provides static factory methods for creating exceptions that, when thrown from
- * HTTP endpoint methods, are automatically converted to appropriate HTTP error responses with
- * the corresponding status codes.
- * <p>
- * <strong>Common Error Responses:</strong>
+ *
+ * <p>HttpException provides static factory methods for creating exceptions that, when thrown from
+ * HTTP endpoint methods, are automatically converted to appropriate HTTP error responses with the
+ * corresponding status codes.
+ *
+ * <p><strong>Common Error Responses:</strong>
+ *
  * <ul>
- *   <li>{@link #badRequest()} - 400 Bad Request for invalid client input</li>
- *   <li>{@link #unauthorized()} - 401 Unauthorized for authentication failures</li>
- *   <li>{@link #forbidden()} - 403 Forbidden for authorization failures</li>
- *   <li>{@link #notFound()} - 404 Not Found for missing resources</li>
- *   <li>{@link #notImplemented()} - 501 Not Implemented for unsupported operations</li>
+ *   <li>{@link #badRequest()} - 400 Bad Request for invalid client input
+ *   <li>{@link #unauthorized()} - 401 Unauthorized for authentication failures
+ *   <li>{@link #forbidden()} - 403 Forbidden for authorization failures
+ *   <li>{@link #notFound()} - 404 Not Found for missing resources
+ *   <li>{@link #notImplemented()} - 501 Not Implemented for unsupported operations
  * </ul>
- * <p>
- * <strong>Custom Status Codes:</strong>
- * Use {@link #error(akka.http.javadsl.model.StatusCode)} for arbitrary HTTP status codes
- * not covered by the predefined factory methods.
- * <p>
- * <strong>Error Messages:</strong>
- * Most factory methods have overloads that accept a response text parameter to provide
- * additional error details to the client.
- * <p>
- * <strong>Alternative Error Handling:</strong>
+ *
+ * <p><strong>Custom Status Codes:</strong> Use {@link #error(akka.http.javadsl.model.StatusCode)}
+ * for arbitrary HTTP status codes not covered by the predefined factory methods.
+ *
+ * <p><strong>Error Messages:</strong> Most factory methods have overloads that accept a response
+ * text parameter to provide additional error details to the client.
+ *
+ * <p><strong>Alternative Error Handling:</strong>
+ *
  * <ul>
- *   <li>{@code IllegalArgumentException} is automatically converted to 400 Bad Request</li>
- *   <li>Other exceptions become 500 Internal Server Error</li>
- *   <li>Return {@link HttpResponses} error methods for more control</li>
+ *   <li>{@code IllegalArgumentException} is automatically converted to 400 Bad Request
+ *   <li>Other exceptions become 500 Internal Server Error
+ *   <li>Return {@link HttpResponses} error methods for more control
  * </ul>
  */
 public final class HttpException {
@@ -78,21 +78,20 @@ public final class HttpException {
 
   /**
    * @return An exception with an arbitrary HTTP status code.
-   *
-   * Note: a large list of predefined status codes can be found in {@link akka.http.javadsl.model.StatusCodes}
+   *     <p>Note: a large list of predefined status codes can be found in {@link
+   *     akka.http.javadsl.model.StatusCodes}
    */
   public static RuntimeException error(akka.http.javadsl.model.StatusCode statusCode) {
     return new HttpExceptionImpl((StatusCode) statusCode);
   }
 
-
   /**
    * @return An exception with an arbitrary HTTP status code.
-   *
-   * Note: a large list of predefined status codes can be found in {@link akka.http.javadsl.model.StatusCodes}
+   *     <p>Note: a large list of predefined status codes can be found in {@link
+   *     akka.http.javadsl.model.StatusCodes}
    */
-  public static RuntimeException error(akka.http.javadsl.model.StatusCode statusCode, String responseText) {
+  public static RuntimeException error(
+      akka.http.javadsl.model.StatusCode statusCode, String responseText) {
     return new HttpExceptionImpl((StatusCode) statusCode, responseText);
   }
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/http/HttpResponses.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/http/HttpResponses.java
@@ -4,7 +4,6 @@
 
 package akka.javasdk.http;
 
-
 import akka.http.javadsl.model.*;
 import akka.http.javadsl.model.headers.CacheControl;
 import akka.http.javadsl.model.headers.CacheDirectives;
@@ -14,42 +13,44 @@ import akka.javasdk.JsonSupport;
 import akka.javasdk.impl.http.HttpClassPathResource;
 import akka.stream.javadsl.Source;
 import com.google.common.net.HttpHeaders;
-
 import java.time.Duration;
 import java.util.Arrays;
 
-
 /**
  * Factory class for creating common HTTP responses in endpoint methods.
- * <p>
- * HttpResponses provides convenient factory methods for creating {@link akka.http.javadsl.model.HttpResponse}
- * objects for the most common HTTP status codes and response types. This eliminates the need to work
- * directly with the lower-level Akka HTTP APIs in most cases.
- * <p>
- * <strong>Response Types:</strong>
+ *
+ * <p>HttpResponses provides convenient factory methods for creating {@link
+ * akka.http.javadsl.model.HttpResponse} objects for the most common HTTP status codes and response
+ * types. This eliminates the need to work directly with the lower-level Akka HTTP APIs in most
+ * cases.
+ *
+ * <p><strong>Response Types:</strong>
+ *
  * <ul>
- *   <li><strong>Success responses:</strong> {@link #ok()}, {@link #created()}, {@link #accepted()}, {@link #noContent()}</li>
- *   <li><strong>Error responses:</strong> {@link #badRequest()}, {@link #notFound()}, {@link #internalServerError()}</li>
- *   <li><strong>Static content:</strong> {@link #staticResource(String)} for serving files</li>
- *   <li><strong>Streaming:</strong> {@link #serverSentEvents(Source)} for SSE responses</li>
+ *   <li><strong>Success responses:</strong> {@link #ok()}, {@link #created()}, {@link #accepted()},
+ *       {@link #noContent()}
+ *   <li><strong>Error responses:</strong> {@link #badRequest()}, {@link #notFound()}, {@link
+ *       #internalServerError()}
+ *   <li><strong>Static content:</strong> {@link #staticResource(String)} for serving files
+ *   <li><strong>Streaming:</strong> {@link #serverSentEvents(Source)} for SSE responses
  * </ul>
- * <p>
- * <strong>Content Types:</strong>
- * Methods automatically set appropriate content types:
+ *
+ * <p><strong>Content Types:</strong> Methods automatically set appropriate content types:
+ *
  * <ul>
- *   <li>String parameters result in {@code text/plain} responses</li>
- *   <li>Object parameters are serialized to JSON with {@code application/json}</li>
- *   <li>Static resources use MIME type detection based on file extension</li>
+ *   <li>String parameters result in {@code text/plain} responses
+ *   <li>Object parameters are serialized to JSON with {@code application/json}
+ *   <li>Static resources use MIME type detection based on file extension
  * </ul>
- * <p>
- * <strong>Response Customization:</strong>
- * All returned {@code HttpResponse} objects can be further customized with additional headers,
- * different status codes, or other modifications using the Akka HTTP API.
- * <p>
- * <strong>Static Resources:</strong>
- * Use {@link #staticResource(String)} to serve files from the {@code src/main/resources/static-resources}
- * directory. This is convenient for documentation or small web UIs but not recommended for production
- * where UI and service lifecycles should be decoupled.
+ *
+ * <p><strong>Response Customization:</strong> All returned {@code HttpResponse} objects can be
+ * further customized with additional headers, different status codes, or other modifications using
+ * the Akka HTTP API.
+ *
+ * <p><strong>Static Resources:</strong> Use {@link #staticResource(String)} to serve files from the
+ * {@code src/main/resources/static-resources} directory. This is convenient for documentation or
+ * small web UIs but not recommended for production where UI and service lifecycles should be
+ * decoupled.
  */
 public class HttpResponses {
 
@@ -59,32 +60,28 @@ public class HttpResponses {
   /**
    * Creates an HTTP response with specified status code, content type and body.
    *
-   * @param statusCode  HTTP status code
+   * @param statusCode HTTP status code
    * @param contentType HTTP content type
-   * @param body        HTTP body
+   * @param body HTTP body
    */
   public static HttpResponse of(StatusCode statusCode, ContentType contentType, byte[] body) {
     return HttpResponse.create().withStatus(statusCode).withEntity(contentType, body);
   }
 
-  /**
-   * Creates a 200 OK response.
-   */
+  /** Creates a 200 OK response. */
   public static HttpResponse ok() {
     return HttpResponse.create().withStatus(StatusCodes.OK);
   }
 
-  /**
-   * Creates a 200 OK response with a text/plain body.
-   */
+  /** Creates a 200 OK response with a text/plain body. */
   public static HttpResponse ok(String text) {
     if (text == null) throw new IllegalArgumentException("text must not be null");
     return HttpResponse.create().withEntity(ContentTypes.TEXT_PLAIN_UTF8, text);
   }
 
   /**
-   * Creates a 200 OK response with an application/json body.
-   * The passed Object is serialized to json using the application's default Jackson serializer.
+   * Creates a 200 OK response with an application/json body. The passed Object is serialized to
+   * json using the application's default Jackson serializer.
    */
   public static HttpResponse ok(Object object) {
     if (object == null) throw new IllegalArgumentException("object must not be null");
@@ -92,187 +89,169 @@ public class HttpResponses {
     return HttpResponse.create().withEntity(ContentTypes.APPLICATION_JSON, body);
   }
 
-  /**
-   * Creates a 201 CREATED response.
-   */
+  /** Creates a 201 CREATED response. */
   public static HttpResponse created() {
     return HttpResponse.create().withStatus(StatusCodes.CREATED);
   }
 
-  /**
-   * Creates a 201 CREATED response with a text/plain body.
-   */
+  /** Creates a 201 CREATED response with a text/plain body. */
   public static HttpResponse created(String text) {
     return ok(text).withStatus(StatusCodes.CREATED);
   }
 
-  /**
-   * Creates a 201 CREATED response with a text/plain body and a location header.
-   */
+  /** Creates a 201 CREATED response with a text/plain body and a location header. */
   public static HttpResponse created(String text, String location) {
     return ok(text)
-      .withStatus(StatusCodes.CREATED)
-      .addHeader(HttpHeader.parse(HttpHeaders.LOCATION, location));
+        .withStatus(StatusCodes.CREATED)
+        .addHeader(HttpHeader.parse(HttpHeaders.LOCATION, location));
   }
 
   /**
-   * Creates a 201 CREATED response with an application/json body
-   * The passed Object is serialized to json using the application's default Jackson serializer.
+   * Creates a 201 CREATED response with an application/json body The passed Object is serialized to
+   * json using the application's default Jackson serializer.
    */
   public static HttpResponse created(Object object) {
     return ok(object).withStatus(StatusCodes.CREATED);
   }
 
   /**
-   * Creates a 201 CREATED response with an application/json body and a location header.
-   * The passed Object is serialized to json using the application's default Jackson serializer.
+   * Creates a 201 CREATED response with an application/json body and a location header. The passed
+   * Object is serialized to json using the application's default Jackson serializer.
    */
   public static HttpResponse created(Object object, String location) {
-    return ok(object).withStatus(StatusCodes.CREATED)
-      .addHeader(HttpHeader.parse(HttpHeaders.LOCATION, location));
+    return ok(object)
+        .withStatus(StatusCodes.CREATED)
+        .addHeader(HttpHeader.parse(HttpHeaders.LOCATION, location));
   }
 
-  /**
-   * Creates a 202 ACCEPTED response.
-   */
+  /** Creates a 202 ACCEPTED response. */
   public static HttpResponse accepted() {
     return HttpResponse.create().withStatus(StatusCodes.ACCEPTED);
   }
 
-  /**
-   * Creates a 202 ACCEPTED response with a text/plain body.
-   */
+  /** Creates a 202 ACCEPTED response with a text/plain body. */
   public static HttpResponse accepted(String text) {
     return ok(text).withStatus(StatusCodes.ACCEPTED);
   }
 
   /**
-   * Creates a 202 ACCEPTED response with an application/json body.
-   * The passed Object is serialized to json using the application's default Jackson serializer.
+   * Creates a 202 ACCEPTED response with an application/json body. The passed Object is serialized
+   * to json using the application's default Jackson serializer.
    */
   public static HttpResponse accepted(Object object) {
     return ok(object).withStatus(StatusCodes.ACCEPTED);
   }
 
-  /**
-   * Creates a 204 NO CONTENT response.
-   */
+  /** Creates a 204 NO CONTENT response. */
   public static HttpResponse noContent() {
     return HttpResponse.create().withStatus(StatusCodes.NO_CONTENT);
   }
 
-  /**
-   * Creates a 400 BAD REQUEST response.
-   */
+  /** Creates a 400 BAD REQUEST response. */
   public static HttpResponse badRequest() {
     return HttpResponse.create().withStatus(StatusCodes.BAD_REQUEST);
   }
 
-  /**
-   * Creates a 400 BAD REQUEST response with a text/plain body.
-   */
+  /** Creates a 400 BAD REQUEST response with a text/plain body. */
   public static HttpResponse badRequest(String text) {
     return ok(text).withStatus(StatusCodes.BAD_REQUEST);
   }
 
-  /**
-   * Creates a 404 NOT FOUND response.
-   */
+  /** Creates a 404 NOT FOUND response. */
   public static HttpResponse notFound() {
     return HttpResponse.create().withStatus(StatusCodes.NOT_FOUND);
   }
 
-  /**
-   * Creates a 404 NOT FOUND response with a text/plain body.
-   */
+  /** Creates a 404 NOT FOUND response with a text/plain body. */
   public static HttpResponse notFound(String text) {
     return ok(text).withStatus(StatusCodes.NOT_FOUND);
   }
 
-  /**
-   * Creates a 500 INTERNAL SERVER ERROR response.
-   */
+  /** Creates a 500 INTERNAL SERVER ERROR response. */
   public static HttpResponse internalServerError() {
     return HttpResponse.create().withStatus(StatusCodes.INTERNAL_SERVER_ERROR);
   }
 
-  /**
-   * Creates a 500 INTERNAL SERVER ERROR response with a text/plain body.
-   */
+  /** Creates a 500 INTERNAL SERVER ERROR response with a text/plain body. */
   public static HttpResponse internalServerError(String text) {
     return ok(text).withStatus(StatusCodes.INTERNAL_SERVER_ERROR);
   }
 
-  /**
-   * Creates a 501 NOT IMPLEMENTED response.
-   */
+  /** Creates a 501 NOT IMPLEMENTED response. */
   public static HttpResponse notImplemented() {
     return HttpResponse.create().withStatus(StatusCodes.NOT_IMPLEMENTED);
   }
 
-  /**
-   * Creates a 501 NOT IMPLEMENTED response with a text/plain body.
-   */
+  /** Creates a 501 NOT IMPLEMENTED response with a text/plain body. */
   public static HttpResponse notImplemented(String text) {
     return ok(text).withStatus(StatusCodes.NOT_IMPLEMENTED);
   }
 
   /**
-   * Load a resource from the class-path directory <code>static-resources</code> and return it as an HTTP response.
+   * Load a resource from the class-path directory <code>static-resources</code> and return it as an
+   * HTTP response.
    *
-   * @param resourcePath A relative path to the resource folder <code>static-resources</code> on the class path. Must not
-   *                     start with <code>/</code>
-   * @return A 404 not found response if there is no such resource. 403 forbidden if the path contains <code>..</code> or references a folder.
+   * @param resourcePath A relative path to the resource folder <code>static-resources</code> on the
+   *     class path. Must not start with <code>/</code>
+   * @return A 404 not found response if there is no such resource. 403 forbidden if the path
+   *     contains <code>..</code> or references a folder.
    */
   public static HttpResponse staticResource(String resourcePath) {
     return HttpClassPathResource.fromStaticPath(resourcePath);
   }
 
-
   /**
-   * Load a resource from the class-path directory <code>static-resources</code> and return it as an HTTP response.
+   * Load a resource from the class-path directory <code>static-resources</code> and return it as an
+   * HTTP response.
    *
    * @param request A request to use the path from
-   * @param prefixToStrip Strip this prefix from the request path, to create the actual path relative to <code>static-resources</code>
-   *                      to load the resource from. Must not be empty.
-   * @return A 404 not found response if there is no such resource. 403 forbidden if the path contains <code>..</code> or references a folder.
-   * @throws RuntimeException if the request path does not start with <code>prefixToStrip</code> or if <code>prefixToStrip</code> is empty
+   * @param prefixToStrip Strip this prefix from the request path, to create the actual path
+   *     relative to <code>static-resources</code> to load the resource from. Must not be empty.
+   * @return A 404 not found response if there is no such resource. 403 forbidden if the path
+   *     contains <code>..</code> or references a folder.
+   * @throws RuntimeException if the request path does not start with <code>prefixToStrip</code> or
+   *     if <code>prefixToStrip</code> is empty
    */
   public static HttpResponse staticResource(HttpRequest request, String prefixToStrip) {
     if (prefixToStrip.isEmpty()) throw new RuntimeException("prefixToStrip must not be empty");
     var actualPrefixToStrip = prefixToStrip.startsWith("/") ? prefixToStrip : "/" + prefixToStrip;
-    actualPrefixToStrip = actualPrefixToStrip.endsWith("/") ? actualPrefixToStrip : actualPrefixToStrip + "/";
+    actualPrefixToStrip =
+        actualPrefixToStrip.endsWith("/") ? actualPrefixToStrip : actualPrefixToStrip + "/";
     var fullPath = request.getUri().getPathString();
     if (!fullPath.startsWith(actualPrefixToStrip)) {
-      throw new RuntimeException("Request path [" + fullPath + "] does not start with the expected prefix [" + prefixToStrip + "]");
+      throw new RuntimeException(
+          "Request path ["
+              + fullPath
+              + "] does not start with the expected prefix ["
+              + prefixToStrip
+              + "]");
     }
     var strippedPath = fullPath.substring(actualPrefixToStrip.length());
     return staticResource(strippedPath);
   }
 
-
-  private final static ContentType TEXT_EVENT_STREAM = ContentTypes.parse("text/event-stream");
+  private static final ContentType TEXT_EVENT_STREAM = ContentTypes.parse("text/event-stream");
 
   /**
-   * @return A HttpResponse with a server sent events (SSE) stream response. The HTTP response will contain each element
-   *         in the source, rendered to JSON using jackson. An SSE keepalive element is emitted every 10 seconds if the stream
-   *         is idle.
+   * @return A HttpResponse with a server sent events (SSE) stream response. The HTTP response will
+   *     contain each element in the source, rendered to JSON using jackson. An SSE keepalive
+   *     element is emitted every 10 seconds if the stream is idle.
    */
   public static <T> HttpResponse serverSentEvents(Source<T, ?> source) {
-    var sseSource = source
-        .map(elem -> ServerSentEvent.create(JsonSupport.getObjectMapper().writeValueAsString(elem)))
-        .keepAlive(Duration.ofSeconds(10), ServerSentEvent::heartbeat)
-        // Note: using Akka HTTP internal method
-        .map(e -> ((akka.http.scaladsl.model.sse.ServerSentEvent) e).encode());
+    var sseSource =
+        source
+            .map(
+                elem ->
+                    ServerSentEvent.create(JsonSupport.getObjectMapper().writeValueAsString(elem)))
+            .keepAlive(Duration.ofSeconds(10), ServerSentEvent::heartbeat)
+            // Note: using Akka HTTP internal method
+            .map(e -> ((akka.http.scaladsl.model.sse.ServerSentEvent) e).encode());
 
     return HttpResponse.create()
         .withStatus(StatusCodes.OK)
-        .withHeaders(Arrays.asList(
-            CacheControl.create(CacheDirectives.NO_CACHE),
-            Connection.create("keep-alive")
-        ))
+        .withHeaders(
+            Arrays.asList(
+                CacheControl.create(CacheDirectives.NO_CACHE), Connection.create("keep-alive")))
         .withEntity(HttpEntities.create(TEXT_EVENT_STREAM, sseSource));
   }
-
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/http/RequestContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/http/RequestContext.java
@@ -53,7 +53,9 @@ public interface RequestContext extends Context {
    */
   Principals getPrincipals();
 
-  /** @return The JWT claims, if any, associated with this request. */
+  /**
+   * @return The JWT claims, if any, associated with this request.
+   */
   JwtClaims getJwtClaims();
 
   /**
@@ -62,12 +64,16 @@ public interface RequestContext extends Context {
    */
   Optional<HttpHeader> requestHeader(String headerName);
 
-  /** @return A list with all the headers of the current request */
+  /**
+   * @return A list with all the headers of the current request
+   */
   List<HttpHeader> allRequestHeaders();
 
   /** Access to tracing for custom app specific tracing. */
   Tracing tracing();
 
-  /** @return The query parameters of the current request. */
+  /**
+   * @return The query parameters of the current request.
+   */
   QueryParams queryParams();
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/http/StrictResponse.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/http/StrictResponse.java
@@ -4,17 +4,19 @@
 
 package akka.javasdk.http;
 
-
 import akka.http.javadsl.model.HttpResponse;
 import akka.http.javadsl.model.StatusCode;
 
 /**
  * A strict response that contains both the HTTP response and the body.
- * <p>
- * The body is derived from the HttpResponse. Meaning that the HttpResponse body content have
- * already been fully received and cannot be consumed once more. To access its content use the body field.
- * <p>
- * The HttpResponse can be used to access other response fields, like content-type, headers and http status code.
+ *
+ * <p>The body is derived from the HttpResponse. Meaning that the HttpResponse body content have
+ * already been fully received and cannot be consumed once more. To access its content use the body
+ * field.
+ *
+ * <p>The HttpResponse can be used to access other response fields, like content-type, headers and
+ * http status code.
+ *
  * <p>
  *
  * @param <T> The type of the body in the response.

--- a/akka-javasdk/src/main/java/akka/javasdk/impl/agent/PromptTemplateClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/impl/agent/PromptTemplateClient.java
@@ -8,9 +8,7 @@ import akka.annotation.InternalApi;
 import akka.javasdk.agent.PromptTemplate;
 import akka.javasdk.client.ComponentClient;
 
-/**
- * INTERNAL API
- */
+/** INTERNAL API */
 @InternalApi
 public final class PromptTemplateClient {
 
@@ -21,8 +19,6 @@ public final class PromptTemplateClient {
   }
 
   public String getPromptTemplate(String templateId) {
-    return componentClient.forEventSourcedEntity(templateId)
-        .method(PromptTemplate::get)
-        .invoke();
+    return componentClient.forEventSourcedEntity(templateId).method(PromptTemplate::get).invoke();
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/impl/agent/SessionMemoryClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/impl/agent/SessionMemoryClient.java
@@ -6,29 +6,21 @@ package akka.javasdk.impl.agent;
 
 import akka.annotation.InternalApi;
 import akka.javasdk.agent.SessionHistory;
+import akka.javasdk.agent.SessionMemory;
 import akka.javasdk.agent.SessionMemoryEntity;
 import akka.javasdk.agent.SessionMessage;
-import akka.javasdk.agent.SessionMemory;
 import akka.javasdk.client.ComponentClient;
 import com.typesafe.config.Config;
+import java.util.List;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.Optional;
-
-/**
- * INTERNAL USE
- * Not for user extension or instantiation
- */
+/** INTERNAL USE Not for user extension or instantiation */
 @InternalApi
 public final class SessionMemoryClient implements SessionMemory {
 
-  public record MemorySettings(
-      boolean read,
-      boolean write,
-      Optional<Integer> historyLimit
-  ) {
+  public record MemorySettings(boolean read, boolean write, Optional<Integer> historyLimit) {
     static MemorySettings disabled() {
       return new MemorySettings(false, false, Optional.empty());
     }
@@ -44,7 +36,8 @@ public final class SessionMemoryClient implements SessionMemory {
 
   public SessionMemoryClient(ComponentClient componentClient, Config memoryConfig) {
     this.componentClient = componentClient;
-    this.memorySettings = memoryConfig.getBoolean("enabled") ? MemorySettings.enabled() : MemorySettings.disabled();
+    this.memorySettings =
+        memoryConfig.getBoolean("enabled") ? MemorySettings.enabled() : MemorySettings.disabled();
   }
 
   public SessionMemoryClient(ComponentClient componentClient, MemorySettings memorySettings) {
@@ -53,27 +46,34 @@ public final class SessionMemoryClient implements SessionMemory {
   }
 
   @Override
-  public void addInteraction(String sessionId, SessionMessage.UserMessage userMessage, List<SessionMessage> messages) {
+  public void addInteraction(
+      String sessionId, SessionMessage.UserMessage userMessage, List<SessionMessage> messages) {
     if (memorySettings.write()) {
       logger.debug("Adding interaction to sessionId [{}]", sessionId);
-      componentClient.forEventSourcedEntity(sessionId)
-        .method(SessionMemoryEntity::addInteraction)
-        .invoke(new SessionMemoryEntity.AddInteractionCmd(userMessage, messages));
+      componentClient
+          .forEventSourcedEntity(sessionId)
+          .method(SessionMemoryEntity::addInteraction)
+          .invoke(new SessionMemoryEntity.AddInteractionCmd(userMessage, messages));
     } else {
-      logger.debug("Memory writing is disabled, interaction not added to sessionId [{}]", sessionId);
+      logger.debug(
+          "Memory writing is disabled, interaction not added to sessionId [{}]", sessionId);
     }
   }
 
   @Override
   public SessionHistory getHistory(String sessionId) {
     if (memorySettings.read()) {
-      var history = componentClient.forEventSourcedEntity(sessionId)
-          .method(SessionMemoryEntity::getHistory)
-          .invoke(new SessionMemoryEntity.GetHistoryCmd(memorySettings.historyLimit));
-      logger.debug("History retrieved for sessionId [{}], size [{}]", sessionId, history.messages().size());
+      var history =
+          componentClient
+              .forEventSourcedEntity(sessionId)
+              .method(SessionMemoryEntity::getHistory)
+              .invoke(new SessionMemoryEntity.GetHistoryCmd(memorySettings.historyLimit));
+      logger.debug(
+          "History retrieved for sessionId [{}], size [{}]", sessionId, history.messages().size());
       return history;
     } else {
-      logger.debug("Memory reading is disabled, history not retrieved for sessionId [{}]", sessionId);
+      logger.debug(
+          "Memory reading is disabled, history not retrieved for sessionId [{}]", sessionId);
       return SessionHistory.EMPTY;
     }
   }

--- a/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/KeyValueEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/KeyValueEntity.java
@@ -5,108 +5,118 @@
 package akka.javasdk.keyvalueentity;
 
 import akka.annotation.InternalApi;
-import akka.javasdk.Metadata;
 import akka.javasdk.CommandException;
+import akka.javasdk.Metadata;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.impl.keyvalueentity.KeyValueEntityEffectImpl;
-
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
  * Key Value Entities are stateful components that persist their complete state on every change.
- * Unlike Event Sourced Entities, only the latest state is stored without access to historical changes.
- * 
+ * Unlike Event Sourced Entities, only the latest state is stored without access to historical
+ * changes.
+ *
  * <p>Key Value Entities provide strong consistency guarantees through entity sharding, where each
  * entity instance is identified by a unique id and distributed across the service cluster. Only one
  * instance of each entity exists in the cluster at any time, ensuring sequential message processing
  * without concurrency concerns.
- * 
- * <p>The entity state is kept in memory while active and can serve read requests or command validation
- * without additional reads from durable storage. Inactive entities are passivated and recover their
- * state from durable storage when accessed again.
- * 
+ *
+ * <p>The entity state is kept in memory while active and can serve read requests or command
+ * validation without additional reads from durable storage. Inactive entities are passivated and
+ * recover their state from durable storage when accessed again.
+ *
  * <h2>Implementation Steps</h2>
+ *
  * <ol>
- *   <li>Define the entity's state</li>
- *   <li>Implement behavior in command handlers</li>
+ *   <li>Define the entity's state
+ *   <li>Implement behavior in command handlers
  * </ol>
- * 
+ *
  * <h2>Command Handlers</h2>
- * Command handlers are methods that return an {@link Effect} and define how the entity responds to commands.
- * The Effect API allows you to:
+ *
+ * Command handlers are methods that return an {@link Effect} and define how the entity responds to
+ * commands. The Effect API allows you to:
+ *
  * <ul>
- *   <li>Update the entity state and send a reply to the caller</li>
- *   <li>Reply directly without state changes</li>
- *   <li>Return an error message</li>
- *   <li>Delete the entity</li>
+ *   <li>Update the entity state and send a reply to the caller
+ *   <li>Reply directly without state changes
+ *   <li>Return an error message
+ *   <li>Delete the entity
  * </ul>
  *
  * <h2>Example Implementation</h2>
+ *
  * <pre>{@code
  * @ComponentId("counter")
  * public class CounterEntity extends KeyValueEntity<Counter> {
- *   
+ *
  *   public CounterEntity(KeyValueEntityContext context) {
  *     // Constructor can accept KeyValueEntityContext and custom dependency types
  *   }
- *   
+ *
  *   @Override
  *   public Counter emptyState() {
  *     return new Counter(0);
  *   }
- *   
+ *
  *   public Effect<Counter> set(int value) {
  *     Counter newCounter = new Counter(value);
  *     return effects()
  *         .updateState(newCounter)
  *         .thenReply(newCounter);
  *   }
- *   
+ *
  *   public ReadOnlyEffect<Counter> get() {
  *     return effects().reply(currentState());
  *   }
  * }
  * }</pre>
- * 
+ *
  * <p>Concrete classes can accept the following types in the constructor:
+ *
  * <ul>
- *   <li>{@link KeyValueEntityContext} - provides entity context information</li>
- *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider} from the service setup</li>
+ *   <li>{@link KeyValueEntityContext} - provides entity context information
+ *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider} from the service setup
  * </ul>
- * 
+ *
  * <p>Concrete classes must be annotated with {@link akka.javasdk.annotations.ComponentId} with a
  * stable, unique identifier that cannot be changed after production deployment.
  *
  * <h2>Multi-region Replication</h2>
- * Key Value Entities support multi-region replication for resilience and performance. Write requests
- * are handled by the primary region, while read requests can be served from any region. Use
- * {@link ReadOnlyEffect} for read-only operations that can be served from replicas.
+ *
+ * Key Value Entities support multi-region replication for resilience and performance. Write
+ * requests are handled by the primary region, while read requests can be served from any region.
+ * Use {@link ReadOnlyEffect} for read-only operations that can be served from replicas.
  *
  * <h2>Immutable state record</h2>
+ *
  * <p>It is recommended to use immutable state objects, such as Java records, for the entity state.
  * Immutable state ensures thread safety and prevents accidental modifications that could lead to
  * inconsistent state or concurrency issues.
  *
  * <p>While mutable state classes are supported, they require careful handling:
+ *
  * <ul>
- *   <li>Mutable state should not be shared outside the entity</li>
- *   <li>Mutable state should not be passed to other threads, such as in {@code CompletionStage} operations</li>
- *   <li>Any modifications to mutable state must be done within the entity's command handlers</li>
+ *   <li>Mutable state should not be shared outside the entity
+ *   <li>Mutable state should not be passed to other threads, such as in {@code CompletionStage}
+ *       operations
+ *   <li>Any modifications to mutable state must be done within the entity's command handlers
  * </ul>
  *
- * <p><strong>Collections in State:</strong> Collections (such as {@code List}, {@code Set}, {@code Map}) are
- * typically mutable even when contained within immutable objects. When updating state that contains collections,
- * you should create copies of the collections rather than modifying them in place. This ensures that the
- * previous state remains unchanged and prevents unintended side effects.
+ * <p><strong>Collections in State:</strong> Collections (such as {@code List}, {@code Set}, {@code
+ * Map}) are typically mutable even when contained within immutable objects. When updating state
+ * that contains collections, you should create copies of the collections rather than modifying them
+ * in place. This ensures that the previous state remains unchanged and prevents unintended side
+ * effects.
  *
- * <p><strong>Performance Considerations:</strong> Defensive copying of collections can introduce performance
- * overhead, especially for large collections or frequent updates. In performance-critical scenarios, this
- * recommendation can be carefully tuned by using mutable state with strict adherence to the safety guidelines
- * mentioned above.
+ * <p><strong>Performance Considerations:</strong> Defensive copying of collections can introduce
+ * performance overhead, especially for large collections or frequent updates. In
+ * performance-critical scenarios, this recommendation can be carefully tuned by using mutable state
+ * with strict adherence to the safety guidelines mentioned above.
  *
- * <p>Using immutable records with defensive copying of collections eliminates concurrency concerns and is the
- * preferred approach for state modeling in most cases.
+ * <p>Using immutable records with defensive copying of collections eliminates concurrency concerns
+ * and is the preferred approach for state modeling in most cases.
  *
  * @param <S> The type of the state for this entity
  */
@@ -121,11 +131,11 @@ public abstract class KeyValueEntity<S> {
   private boolean handlingCommands = false;
 
   /**
-   * Returns the initial empty state object for this entity. This state is used when the entity
-   * is first created and before any commands have been processed.
+   * Returns the initial empty state object for this entity. This state is used when the entity is
+   * first created and before any commands have been processed.
    *
-   * <p>Also known as "zero state" or "neutral state". This method is called when the entity
-   * is instantiated for the first time or when recovering from storage without any persisted state.
+   * <p>Also known as "zero state" or "neutral state". This method is called when the entity is
+   * instantiated for the first time or when recovering from storage without any persisted state.
    *
    * <p>The default implementation returns {@code null}. Override this method to provide a more
    * meaningful initial state for your entity.
@@ -140,8 +150,8 @@ public abstract class KeyValueEntity<S> {
    * Provides access to additional context and metadata for the current command being processed.
    * This includes information such as the command name, entity id, and tracing context.
    *
-   * <p>This method can only be called from within a command handler method. Attempting to access
-   * it from the constructor or outside of command processing will result in an exception.
+   * <p>This method can only be called from within a command handler method. Attempting to access it
+   * from the constructor or outside of command processing will result in an exception.
    *
    * @return the command context for the current command
    * @throws IllegalStateException if accessed outside a command handler method
@@ -154,6 +164,7 @@ public abstract class KeyValueEntity<S> {
 
   /**
    * INTERNAL API
+   *
    * @hidden
    */
   @InternalApi
@@ -163,6 +174,7 @@ public abstract class KeyValueEntity<S> {
 
   /**
    * INTERNAL API
+   *
    * @hidden
    */
   @InternalApi
@@ -174,6 +186,7 @@ public abstract class KeyValueEntity<S> {
 
   /**
    * INTERNAL API
+   *
    * @hidden
    */
   @InternalApi
@@ -190,11 +203,11 @@ public abstract class KeyValueEntity<S> {
    * the changes. To save state changes, you must use {@code effects().updateState(newState)} in
    * your command handler's return value.
    *
-   * <p>This method can only be called from within a command handler method. Attempting to access
-   * it from the constructor or outside of command processing will result in an exception.
+   * <p>This method can only be called from within a command handler method. Attempting to access it
+   * from the constructor or outside of command processing will result in an exception.
    *
-   * @return the current state of the entity, which may initially be {@code null} if
-   *   {@link #emptyState} has not been defined
+   * @return the current state of the entity, which may initially be {@code null} if {@link
+   *     #emptyState} has not been defined
    * @throws IllegalStateException if accessed outside a command handler method
    */
   protected final S currentState() {
@@ -207,12 +220,12 @@ public abstract class KeyValueEntity<S> {
 
   /**
    * Returns whether this entity has been marked for deletion. When an entity is deleted using
-   * {@code effects().deleteEntity()}, it will still exist with an empty state for some time
-   * before being completely removed.
+   * {@code effects().deleteEntity()}, it will still exist with an empty state for some time before
+   * being completely removed.
    *
-   * <p>After deletion, the entity can still handle read requests but will have an empty state.
-   * No further state changes are allowed after deletion. The entity will be completely cleaned
-   * up after a default period of one week.
+   * <p>After deletion, the entity can still handle read requests but will have an empty state. No
+   * further state changes are allowed after deletion. The entity will be completely cleaned up
+   * after a default period of one week.
    *
    * @return {@code true} if the entity has been deleted, {@code false} otherwise
    */
@@ -226,15 +239,16 @@ public abstract class KeyValueEntity<S> {
 
   /**
    * An Effect describes the actions that the Akka runtime should perform after a command handler
-   * completes. Effects are declarative instructions that tell the runtime how to update state,
-   * send replies, or handle errors.
-   * 
+   * completes. Effects are declarative instructions that tell the runtime how to update state, send
+   * replies, or handle errors.
+   *
    * <p>Key Value Entity effects can:
+   *
    * <ul>
-   *   <li>Update the entity state and send a reply to the caller</li>
-   *   <li>Reply directly to the caller without state changes</li>
-   *   <li>Return an error message to reject the command</li>
-   *   <li>Delete the entity from storage</li>
+   *   <li>Update the entity state and send a reply to the caller
+   *   <li>Reply directly to the caller without state changes
+   *   <li>Return an error message to reject the command
+   *   <li>Delete the entity from storage
    * </ul>
    *
    * @param <T> The type of the message that must be returned by this call
@@ -242,17 +256,16 @@ public abstract class KeyValueEntity<S> {
   public interface Effect<T> {
 
     /**
-     * Builder for constructing effects that describe the actions to be performed after
-     * command processing. Use this to create effects that update state, reply to callers,
-     * or handle errors.
+     * Builder for constructing effects that describe the actions to be performed after command
+     * processing. Use this to create effects that update state, reply to callers, or handle errors.
      *
      * @param <S> The type of the state for this entity
      */
     interface Builder<S> {
 
       /**
-       * Updates the entity state with the provided new state. This is the only way to persist
-       * state changes in a Key Value Entity. The new state will replace the current state entirely.
+       * Updates the entity state with the provided new state. This is the only way to persist state
+       * changes in a Key Value Entity. The new state will replace the current state entirely.
        *
        * @param newState the new state to persist, replacing the current state
        * @return a builder for chaining additional effects like replies
@@ -269,8 +282,8 @@ public abstract class KeyValueEntity<S> {
       OnSuccessBuilder<S> deleteEntity();
 
       /**
-       * Creates a reply message to send back to the caller without updating the entity state.
-       * Use this for read-only operations or when the command doesn't require state changes.
+       * Creates a reply message to send back to the caller without updating the entity state. Use
+       * this for read-only operations or when the command doesn't require state changes.
        *
        * @param message the payload of the reply message
        * @param <T> the type of the reply message
@@ -290,8 +303,8 @@ public abstract class KeyValueEntity<S> {
       <T> ReadOnlyEffect<T> reply(T message, Metadata metadata);
 
       /**
-       * Creates an error reply to reject the command and inform the caller of the failure.
-       * The entity state will not be modified when returning an error.
+       * Creates an error reply to reject the command and inform the caller of the failure. The
+       * entity state will not be modified when returning an error.
        *
        * @param message the error message.
        * @param <T> the type of the expected reply message
@@ -301,20 +314,20 @@ public abstract class KeyValueEntity<S> {
 
       /**
        * Create an error reply. {@link CommandException} will be serialized and sent to the client.
-       * It's possible to catch it with try-catch statement or {@link CompletionStage} API when using async {@link ComponentClient} API.
+       * It's possible to catch it with try-catch statement or {@link CompletionStage} API when
+       * using async {@link ComponentClient} API.
        *
        * @param commandException The command exception to be returned.
        * @param <T> The type of the message that must be returned by this call.
        * @return An error reply.
        */
       <T> ReadOnlyEffect<T> error(CommandException commandException);
-
     }
 
     /**
-     * Builder for chaining a reply after a successful state operation like {@code updateState}
-     * or {@code deleteEntity}. This allows you to both modify the entity and send a response
-     * to the caller in a single effect.
+     * Builder for chaining a reply after a successful state operation like {@code updateState} or
+     * {@code deleteEntity}. This allows you to both modify the entity and send a response to the
+     * caller in a single effect.
      *
      * @param <S> The type of the state for this entity
      */
@@ -322,8 +335,8 @@ public abstract class KeyValueEntity<S> {
 
       /**
        * Sends a reply message to the caller after the state operation (update or delete) completes
-       * successfully. This is typically used to confirm the operation and return the new state
-       * or operation result.
+       * successfully. This is typically used to confirm the operation and return the new state or
+       * operation result.
        *
        * @param message the payload of the reply message
        * @param <T> the type of the reply message
@@ -341,20 +354,17 @@ public abstract class KeyValueEntity<S> {
        * @return an effect that will perform the state operation and then send the reply
        */
       <T> Effect<T> thenReply(T message, Metadata metadata);
-
     }
-
   }
 
   /**
-   * A read-only effect that does not modify the entity state. These effects are used for
-   * operations that only read data or send replies without persisting any changes.
-   * 
-   * <p>Read-only effects are important for multi-region replication as they can be served
-   * from any region, not just the primary region where writes are handled.
+   * A read-only effect that does not modify the entity state. These effects are used for operations
+   * that only read data or send replies without persisting any changes.
+   *
+   * <p>Read-only effects are important for multi-region replication as they can be served from any
+   * region, not just the primary region where writes are handled.
    *
    * @param <T> The type of the message that will be returned by this effect
    */
-  public interface ReadOnlyEffect<T> extends Effect<T> {
-  }
+  public interface ReadOnlyEffect<T> extends Effect<T> {}
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/mcp/AbstractMcpEndpoint.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/mcp/AbstractMcpEndpoint.java
@@ -7,48 +7,52 @@ package akka.javasdk.mcp;
 import akka.annotation.InternalApi;
 
 /**
- * Optional base class for MCP (Model Context Protocol) endpoints providing convenient access to request context.
- * <p>
- * MCP endpoints expose services to MCP clients such as LLM chat agent desktop applications and agents running
- * on other services. They can provide tools, resources, and prompts that AI models can use to extend their capabilities.
- * <p>
- * <strong>MCP Capabilities:</strong>
+ * Optional base class for MCP (Model Context Protocol) endpoints providing convenient access to
+ * request context.
+ *
+ * <p>MCP endpoints expose services to MCP clients such as LLM chat agent desktop applications and
+ * agents running on other services. They can provide tools, resources, and prompts that AI models
+ * can use to extend their capabilities.
+ *
+ * <p><strong>MCP Capabilities:</strong>
+ *
  * <ul>
- *   <li><strong>Tools:</strong> Functions/logic that MCP clients can call on behalf of the LLM</li>
- *   <li><strong>Resources:</strong> Static resources or dynamic resource templates that clients can fetch</li>
- *   <li><strong>Prompts:</strong> Template prompts created from input parameters</li>
+ *   <li><strong>Tools:</strong> Functions/logic that MCP clients can call on behalf of the LLM
+ *   <li><strong>Resources:</strong> Static resources or dynamic resource templates that clients can
+ *       fetch
+ *   <li><strong>Prompts:</strong> Template prompts created from input parameters
  * </ul>
- * <p>
- * <strong>Basic Usage:</strong>
+ *
+ * <p><strong>Basic Usage:</strong>
+ *
  * <pre>{@code
  * @Acl(allow = @Acl.Matcher(principal = Acl.Principal.ALL))
  * @McpEndpoint(
  *     serverName = "my-service-mcp",
  *     serverVersion = "1.0.0")
  * public class MyMcpEndpoint extends AbstractMcpEndpoint {
- * 
+ *
  *   @McpTool(description = "Adds two numbers")
  *   public String add(@Description("First number") int a, @Description("Second number") int b) {
  *     return String.valueOf(a + b);
  *   }
  * }
  * }</pre>
- * <p>
- * <strong>Request Context:</strong>
- * Extending this class provides access to {@link McpRequestContext} via {@link #requestContext()} without
- * requiring constructor injection. The context provides access to request headers, JWT claims, principals,
- * and tracing information.
- * <p>
- * <strong>Alternative Approach:</strong>
- * Instead of extending this class, you can inject {@link McpRequestContext} directly into your endpoint
- * constructor or use dependency injection for other services like {@link akka.javasdk.client.ComponentClient}.
- * <p>
- * MCP endpoints are made available using a stateless streamable HTTP transport as defined by the
+ *
+ * <p><strong>Request Context:</strong> Extending this class provides access to {@link
+ * McpRequestContext} via {@link #requestContext()} without requiring constructor injection. The
+ * context provides access to request headers, JWT claims, principals, and tracing information.
+ *
+ * <p><strong>Alternative Approach:</strong> Instead of extending this class, you can inject {@link
+ * McpRequestContext} directly into your endpoint constructor or use dependency injection for other
+ * services like {@link akka.javasdk.client.ComponentClient}.
+ *
+ * <p>MCP endpoints are made available using a stateless streamable HTTP transport as defined by the
  * MCP specification. By default, endpoints are served at the {@code /mcp} path.
  */
-abstract public class AbstractMcpEndpoint {
+public abstract class AbstractMcpEndpoint {
 
-  volatile private McpRequestContext context;
+  private volatile McpRequestContext context;
 
   /**
    * INTERNAL API
@@ -56,18 +60,17 @@ abstract public class AbstractMcpEndpoint {
    * @hidden
    */
   @InternalApi
-  final public void _internalSetRequestContext(McpRequestContext context) {
+  public final void _internalSetRequestContext(McpRequestContext context) {
     this.context = context;
   }
 
-  /**
-   * Always available from request handling methods, not available from the constructor.
-   */
+  /** Always available from request handling methods, not available from the constructor. */
   protected final McpRequestContext requestContext() {
     if (context == null) {
-      throw new IllegalStateException("The request context can only be accessed from the request handling methods of the endpoint.");
+      throw new IllegalStateException(
+          "The request context can only be accessed from the request handling methods of the"
+              + " endpoint.");
     }
     return context;
   }
-
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/mcp/McpRequestContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/mcp/McpRequestContext.java
@@ -44,7 +44,9 @@ public interface McpRequestContext {
    */
   Principals getPrincipals();
 
-  /** @return The JWT claims, if any, associated with this request. */
+  /**
+   * @return The JWT claims, if any, associated with this request.
+   */
   JwtClaims getJwtClaims();
 
   /** Access to tracing for custom app specific tracing. */
@@ -56,6 +58,8 @@ public interface McpRequestContext {
    */
   Optional<HttpHeader> requestHeader(String headerName);
 
-  /** @return A list with all the headers of the current request */
+  /**
+   * @return A list with all the headers of the current request
+   */
   List<HttpHeader> allRequestHeaders();
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/timedaction/TimedAction.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/timedaction/TimedAction.java
@@ -9,26 +9,28 @@ import akka.annotation.InternalApi;
 import akka.javasdk.impl.timedaction.TimedActionEffectImpl;
 import akka.javasdk.impl.timedaction.TimedActionImpl.CommandContextImpl;
 import akka.javasdk.timer.TimerScheduler;
-
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
- * TimedAction is stateless component that can be used together with a {@link TimerScheduler} to schedule an action.
- * <p>
- * A TimedAction method should return an {@link Effect} that describes the result of the action invocation.
- * <p>
- * Concrete classes can accept the following types to the constructor:
+ * TimedAction is stateless component that can be used together with a {@link TimerScheduler} to
+ * schedule an action.
+ *
+ * <p>A TimedAction method should return an {@link Effect} that describes the result of the action
+ * invocation.
+ *
+ * <p>Concrete classes can accept the following types to the constructor:
+ *
  * <ul>
- *   <li>{@link akka.javasdk.client.ComponentClient}</li>
- *   <li>{@link akka.javasdk.http.HttpClientProvider}</li>
- *   <li>{@link akka.javasdk.timer.TimerScheduler}</li>
- *   <li>{@link akka.stream.Materializer}</li>
- *   <li>{@link com.typesafe.config.Config}</li>
- *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider} from the service setup</li>
+ *   <li>{@link akka.javasdk.client.ComponentClient}
+ *   <li>{@link akka.javasdk.http.HttpClientProvider}
+ *   <li>{@link akka.javasdk.timer.TimerScheduler}
+ *   <li>{@link akka.stream.Materializer}
+ *   <li>{@link com.typesafe.config.Config}
+ *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider} from the service setup
  * </ul>
- * <p>
- * Concrete class must be annotated with {@link akka.javasdk.annotations.ComponentId}.
+ *
+ * <p>Concrete class must be annotated with {@link akka.javasdk.annotations.ComponentId}.
  */
 public abstract class TimedAction {
 
@@ -49,6 +51,7 @@ public abstract class TimedAction {
 
   /**
    * INTERNAL API
+   *
    * @hidden
    */
   @InternalApi
@@ -60,26 +63,26 @@ public abstract class TimedAction {
     return TimedActionEffectImpl.builder();
   }
 
-  /**
-   * Returns a {@link TimerScheduler} that can be used to schedule further in time.
-   */
+  /** Returns a {@link TimerScheduler} that can be used to schedule further in time. */
   public final TimerScheduler timers() {
     CommandContextImpl impl =
-      (CommandContextImpl)
-        commandContext("Timers can only be scheduled or cancelled when handling a command.");
+        (CommandContextImpl)
+            commandContext("Timers can only be scheduled or cancelled when handling a command.");
     return impl.timers();
   }
 
   /**
-   * An Effect is a description of what the runtime needs to do after the command is handled.
-   * You can think of it as a set of instructions you are passing to the runtime, which will process
-   * the instructions on your behalf.
+   * An Effect is a description of what the runtime needs to do after the command is handled. You
+   * can think of it as a set of instructions you are passing to the runtime, which will process the
+   * instructions on your behalf.
+   *
+   * <p>Each component defines its own effects, which are a set of predefined operations that match
+   * the capabilities of that component.
+   *
+   * <p>An TimedAction Effect can either:
+   *
    * <p>
-   * Each component defines its own effects, which are a set of predefined
-   * operations that match the capabilities of that component.
-   * <p>
-   * An TimedAction Effect can either:
-   * <p>
+   *
    * <ul>
    *   <li>return Done to confirm that the command was processed successfully
    *   <li>return an error message
@@ -93,16 +96,11 @@ public abstract class TimedAction {
      */
     interface Builder {
 
-      /**
-       * Command was processed successfully.
-       */
+      /** Command was processed successfully. */
       Effect done();
 
-      /**
-       * Command was processed successfully from an async operation result
-       */
+      /** Command was processed successfully from an async operation result */
       Effect asyncDone(CompletionStage<Done> message);
-
 
       /**
        * Create an error reply.

--- a/akka-javasdk/src/main/java/akka/javasdk/timer/TimerScheduler.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/timer/TimerScheduler.java
@@ -128,7 +128,9 @@ public interface TimerScheduler {
   <I, O> CompletionStage<Done> startSingleTimer(
       String name, Duration delay, int maxRetries, DeferredCall<I, O> deferredCall);
 
-  /** @deprecated User {@link TimerScheduler#deleteAsync(String)} instead. */
+  /**
+   * @deprecated User {@link TimerScheduler#deleteAsync(String)} instead.
+   */
   @Deprecated(since = "3.3.0", forRemoval = true)
   CompletionStage<Done> cancel(String name);
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/view/TableUpdater.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/view/TableUpdater.java
@@ -7,20 +7,21 @@ package akka.javasdk.view;
 import akka.annotation.InternalApi;
 import akka.javasdk.annotations.Table;
 import akka.javasdk.impl.view.ViewEffectImpl;
-
 import java.util.Optional;
 
 /**
- * Responsible for consuming events from a source and emit updates to one view table. Event subject (entity id
- * for entities, cloud event subject for events from a topic) maps one to one with a row in the table.
- * <p>
- * Concrete subclasses should be public static inner classes of the view they update a table for. A public no-parameter
- * constructor must exist and is used to create instances used.
- * <p>
- * For a single table view the table name can be inferred from queries, but for a multi table view each class must
- * be annotated with {@link Table} identifying which table they update.
- * <p>
- * Concrete class must be annotated with one of the {@link akka.javasdk.annotations.Consume} annotations.
+ * Responsible for consuming events from a source and emit updates to one view table. Event subject
+ * (entity id for entities, cloud event subject for events from a topic) maps one to one with a row
+ * in the table.
+ *
+ * <p>Concrete subclasses should be public static inner classes of the view they update a table for.
+ * A public no-parameter constructor must exist and is used to create instances used.
+ *
+ * <p>For a single table view the table name can be inferred from queries, but for a multi table
+ * view each class must be annotated with {@link Table} identifying which table they update.
+ *
+ * <p>Concrete class must be annotated with one of the {@link akka.javasdk.annotations.Consume}
+ * annotations.
  *
  * @param <S> The type of each row in the table updated by this updater.
  */
@@ -29,7 +30,6 @@ public abstract class TableUpdater<S> {
   private Optional<UpdateContext> updateContext = Optional.empty();
 
   private Optional<S> viewState = Optional.empty();
-
 
   private boolean handlingUpdates = false;
 
@@ -46,6 +46,7 @@ public abstract class TableUpdater<S> {
 
   /**
    * INTERNAL API
+   *
    * @hidden
    */
   @InternalApi
@@ -53,9 +54,9 @@ public abstract class TableUpdater<S> {
     updateContext = context;
   }
 
-
   /**
    * INTERNAL API
+   *
    * @hidden
    */
   @InternalApi
@@ -67,8 +68,8 @@ public abstract class TableUpdater<S> {
   /**
    * Returns the current state of the row for the subject that is being updated.
    *
-   * <p>Note that modifying the row object directly will not update it in storage. To save the row, one
-   * must call {{@code effects().updateRow()}}.
+   * <p>Note that modifying the row object directly will not update it in storage. To save the row,
+   * one must call {{@code effects().updateRow()}}.
    *
    * <p>This method can only be called when handling an update. Calling it outside a method (eg: in
    * the constructor) will raise a IllegalStateException exception.
@@ -79,8 +80,7 @@ public abstract class TableUpdater<S> {
     // user may call this method inside a command handler and get a null because it's legal
     // to have emptyState set to null.
     if (handlingUpdates) return viewState.orElse(null);
-    else
-      throw new IllegalStateException("Current state is only available when handling updates.");
+    else throw new IllegalStateException("Current state is only available when handling updates.");
   }
 
   protected final Effect.Builder<S> effects() {
@@ -88,11 +88,11 @@ public abstract class TableUpdater<S> {
   }
 
   /**
-   * The default implementation of this method returns {@code null}. It can be overridden to
-   * return a more sensible initial state.
+   * The default implementation of this method returns {@code null}. It can be overridden to return
+   * a more sensible initial state.
    *
    * @return an empty row object or {@code null} to hand to the process method when an event for a
-   * previously unknown subject id is seen.
+   *     previously unknown subject id is seen.
    */
   public S emptyRow() {
     return null;
@@ -102,19 +102,21 @@ public abstract class TableUpdater<S> {
    * An UpdateEffect is a description of what the runtime needs to do after the command is handled.
    * You can think of it as a set of instructions you are passing to the runtime, which will process
    * the instructions on your behalf.
+   *
+   * <p>Each component defines its own effects, which are a set of predefined operations that match
+   * the capabilities of that component.
+   *
+   * <p>A View UpdateEffect can either:
+   *
    * <p>
-   * Each component defines its own effects, which are a set of predefined
-   * operations that match the capabilities of that component.
-   * <p>
-   * A View UpdateEffect can either:
-   * <p>
+   *
    * <ul>
    *   <li>update the view row
    *   <li>delete the view row
    *   <li>ignore the event or state change notification (and not update the view state)
    * </ul>
-   * <p>
-   * Construct the effect that is returned by the command handler. The effect describes next
+   *
+   * <p>Construct the effect that is returned by the command handler. The effect describes next
    * processing actions, such as emitting events and sending a reply.
    *
    * @param <S> The type of the row for this table.
@@ -127,9 +129,7 @@ public abstract class TableUpdater<S> {
 
       Effect<S> deleteRow();
 
-      /**
-       * Ignore this event (and continue to process the next).
-       */
+      /** Ignore this event (and continue to process the next). */
       Effect<S> ignore();
     }
   }

--- a/akka-javasdk/src/main/java/akka/javasdk/view/View.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/view/View.java
@@ -42,7 +42,9 @@ public abstract class View {
     return null;
   }
 
-  /** @return query effect for a query result that can be streamed */
+  /**
+   * @return query effect for a query result that can be streamed
+   */
   protected final <T> QueryStreamEffect<T> queryStreamResult() {
     return null;
   }

--- a/akka-javasdk/src/main/java/akka/javasdk/workflow/StepBuilder.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/workflow/StepBuilder.java
@@ -10,11 +10,9 @@ import java.util.function.Supplier;
 
 public class StepBuilder {
 
-  final private String name;
+  private final String name;
 
-  /**
-   * Not for direct user construction, instances are created through the workflow DSL
-   */
+  /** Not for direct user construction, instances are created through the workflow DSL */
   public StepBuilder(String name) {
     this.name = name;
   }
@@ -24,33 +22,38 @@ public class StepBuilder {
   }
 
   /**
-   * Build a step action with a  call.
-   * <p>
-   * The value returned by the call {@link Function} is made available to this workflow via the {@code andThen} method.
-   * In the {@code andThen} method, we can use the result to update the workflow state and transition to the next step.
-   * <p>
-   * On failure, the step will be retried according to the default retry strategy or the one defined in the step configuration.
+   * Build a step action with a call.
+   *
+   * <p>The value returned by the call {@link Function} is made available to this workflow via the
+   * {@code andThen} method. In the {@code andThen} method, we can use the result to update the
+   * workflow state and transition to the next step.
+   *
+   * <p>On failure, the step will be retried according to the default retry strategy or the one
+   * defined in the step configuration.
    *
    * @param callInputClass Input class for call factory.
-   * @param callFactory    Factory method for creating a call.
-   * @param <Input>        Input for the call factory, provided by transition method.
-   * @param <Output>       Output of the call.
+   * @param callFactory Factory method for creating a call.
+   * @param <Input> Input for the call factory, provided by transition method.
+   * @param <Output> Output of the call.
    * @return Step builder.
    */
-  public <Input, Output> CallStepBuilder<Input, Output> call(Class<Input> callInputClass, Function<Input, Output> callFactory) {
+  public <Input, Output> CallStepBuilder<Input, Output> call(
+      Class<Input> callInputClass, Function<Input, Output> callFactory) {
     return new CallStepBuilder<>(name, callInputClass, callFactory);
   }
 
   /**
    * Build a step action with a call.
-   * <p>
-   * The value returned by the {@link Supplier} is made available to this workflow via the {@code andThen} method.
-   * In the {@code andThen} method, we can use the result to update the workflow state and transition to the next step.
-   * <p>
-   * On failure, the step will be retried according to the default retry strategy or the one defined in the step configuration.
+   *
+   * <p>The value returned by the {@link Supplier} is made available to this workflow via the {@code
+   * andThen} method. In the {@code andThen} method, we can use the result to update the workflow
+   * state and transition to the next step.
+   *
+   * <p>On failure, the step will be retried according to the default retry strategy or the one
+   * defined in the step configuration.
    *
    * @param callSupplier Factory method for creating a call.
-   * @param <Output>     Output of the call.
+   * @param <Output> Output of the call.
    * @return Step builder.
    */
   public <Output> CallStepBuilder<Void, Output> call(Supplier<Output> callSupplier) {
@@ -59,62 +62,70 @@ public class StepBuilder {
 
   /**
    * Build a step action with a call.
-   * <p>
-   * The {@link Runnable} passed to this method is executed and if successful, the {@code andThen} method is called.
-   * In the {@code andThen} method, we can update the workflow state and transition to the next step.
-   * <p>
-   * On failure, the step will be retried according to the default retry strategy or the one defined in the step configuration.
+   *
+   * <p>The {@link Runnable} passed to this method is executed and if successful, the {@code
+   * andThen} method is called. In the {@code andThen} method, we can update the workflow state and
+   * transition to the next step.
+   *
+   * <p>On failure, the step will be retried according to the default retry strategy or the one
+   * defined in the step configuration.
    *
    * @return Step builder.
    */
   public RunnableStepBuilder call(Runnable runnable) {
-    return new RunnableStepBuilder(name,runnable);
+    return new RunnableStepBuilder(name, runnable);
   }
 
   /**
    * Build a step action with an async call.
-   * <p>
-   * The {@link Function} passed to this method should return a {@link CompletionStage}.
-   * On successful completion, its result is made available to this workflow via the {@code andThen} method.
-   * In the {@code andThen} method, we can use the result to update the workflow state and transition to the next step.
-   * <p>
-   * On failure, the step will be retried according to the default retry strategy or the one defined in the step configuration.
+   *
+   * <p>The {@link Function} passed to this method should return a {@link CompletionStage}. On
+   * successful completion, its result is made available to this workflow via the {@code andThen}
+   * method. In the {@code andThen} method, we can use the result to update the workflow state and
+   * transition to the next step.
+   *
+   * <p>On failure, the step will be retried according to the default retry strategy or the one
+   * defined in the step configuration.
    *
    * @param callInputClass Input class for call factory.
-   * @param callFactory    Factory method for creating async call.
-   * @param <Input>        Input for the async call factory, provided by transition method.
-   * @param <Output>       Output of the async call.
+   * @param callFactory Factory method for creating async call.
+   * @param <Input> Input for the async call factory, provided by transition method.
+   * @param <Output> Output of the async call.
    * @return Step builder.
    */
-  public <Input, Output> AsyncCallStepBuilder<Input, Output> asyncCall(Class<Input> callInputClass, Function<Input, CompletionStage<Output>> callFactory) {
+  public <Input, Output> AsyncCallStepBuilder<Input, Output> asyncCall(
+      Class<Input> callInputClass, Function<Input, CompletionStage<Output>> callFactory) {
     return new AsyncCallStepBuilder<>(name, callInputClass, callFactory);
   }
 
-
   /**
    * Build a step action with an async call.
-   * <p>
-   * The {@link Supplier} function passed to this method should return a {@link CompletionStage}.
-   * On successful completion, its result is made available to this workflow via the {@code andThen} method.
-   * In the {@code andThen} method, we can use the result to update the workflow state and transition to the next step.
-   * <p>
-   * On failure, the step will be retried according to the default retry strategy or the one defined in the step configuration.
+   *
+   * <p>The {@link Supplier} function passed to this method should return a {@link CompletionStage}.
+   * On successful completion, its result is made available to this workflow via the {@code andThen}
+   * method. In the {@code andThen} method, we can use the result to update the workflow state and
+   * transition to the next step.
+   *
+   * <p>On failure, the step will be retried according to the default retry strategy or the one
+   * defined in the step configuration.
    *
    * @param callSupplier Factory method for creating async call.
-   * @param <Output>     Output of the async call.
+   * @param <Output> Output of the async call.
    * @return Step builder.
    */
-  public <Output> AsyncCallStepBuilder<Void, Output> asyncCall(Supplier<CompletionStage<Output>> callSupplier) {
+  public <Output> AsyncCallStepBuilder<Void, Output> asyncCall(
+      Supplier<CompletionStage<Output>> callSupplier) {
     return new AsyncCallStepBuilder<>(name, Void.class, (Void v) -> callSupplier.get());
   }
 
   public static class CallStepBuilder<CallInput, CallOutput> {
-    final private String name;
+    private final String name;
 
-    final private Class<CallInput> callInputClass;
-    final private Function<CallInput, CallOutput> callFunc;
+    private final Class<CallInput> callInputClass;
+    private final Function<CallInput, CallOutput> callFunc;
 
-    CallStepBuilder(String name, Class<CallInput> callInputClass, Function<CallInput, CallOutput> callFunc) {
+    CallStepBuilder(
+        String name, Class<CallInput> callInputClass, Function<CallInput, CallOutput> callFunc) {
       this.name = name;
       this.callInputClass = callInputClass;
       this.callFunc = callFunc;
@@ -122,46 +133,54 @@ public class StepBuilder {
 
     /**
      * Transition to the next step based on the result of the step call.
-     * <p>
-     * The {@link Function} passed to this method should receive the return type of the step call and return
-     * an {@link Workflow.Effect.TransitionalEffect} describing the next step to transition to.
-     * <p>
-     * When defining the Effect, you can update the workflow state and indicate the next step to transition to.
-     * This can be another step, or a pause or end of the workflow.
-     * <p>
-     * When transition to another step, you can also pass an input parameter to the next step.
+     *
+     * <p>The {@link Function} passed to this method should receive the return type of the step call
+     * and return an {@link Workflow.Effect.TransitionalEffect} describing the next step to
+     * transition to.
+     *
+     * <p>When defining the Effect, you can update the workflow state and indicate the next step to
+     * transition to. This can be another step, or a pause or end of the workflow.
+     *
+     * <p>When transition to another step, you can also pass an input parameter to the next step.
      *
      * @param transitionInputClass Input class for transition.
-     * @param transitionFunc       Function that transform the action result to a {@link Workflow.Effect.TransitionalEffect}
+     * @param transitionFunc Function that transform the action result to a {@link
+     *     Workflow.Effect.TransitionalEffect}
      * @return CallStep
      */
-    public Workflow.CallStep<CallInput, CallOutput, ?> andThen(Class<CallOutput> transitionInputClass, Function<CallOutput, Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
-      return new Workflow.CallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
+    public Workflow.CallStep<CallInput, CallOutput, ?> andThen(
+        Class<CallOutput> transitionInputClass,
+        Function<CallOutput, Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
+      return new Workflow.CallStep<>(
+          name, callInputClass, callFunc, transitionInputClass, transitionFunc);
     }
 
     /**
      * Transition to the next step after the step call completes.
-     * <p>
-     * The {@link Supplier} passed to this method should return an {@link Workflow.Effect.TransitionalEffect}
-     * describing the next step to transition to. Note that the output of the call is not passed to this function.
-     * <p>
-     * When defining the Effect, you can update the workflow state and indicate the next step to transition to.
-     * This can be another step, or a pause or end of the workflow.
-     * <p>
-     * When transition to another step, you can also pass an input parameter to the next step.
      *
-     * @param transitionFunc       Supplier of {@link Workflow.Effect.TransitionalEffect}
+     * <p>The {@link Supplier} passed to this method should return an {@link
+     * Workflow.Effect.TransitionalEffect} describing the next step to transition to. Note that the
+     * output of the call is not passed to this function.
+     *
+     * <p>When defining the Effect, you can update the workflow state and indicate the next step to
+     * transition to. This can be another step, or a pause or end of the workflow.
+     *
+     * <p>When transition to another step, you can also pass an input parameter to the next step.
+     *
+     * @param transitionFunc Supplier of {@link Workflow.Effect.TransitionalEffect}
      * @return CallStep
      */
-    public Workflow.CallStep<CallInput, CallOutput, ?> andThen(Supplier<Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
-      return new Workflow.CallStep<>(name, callInputClass, callFunc, null, __ -> transitionFunc.get());
+    public Workflow.CallStep<CallInput, CallOutput, ?> andThen(
+        Supplier<Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
+      return new Workflow.CallStep<>(
+          name, callInputClass, callFunc, null, __ -> transitionFunc.get());
     }
   }
 
   public static class RunnableStepBuilder {
-    final private String name;
+    private final String name;
 
-    final private Runnable runnable;
+    private final Runnable runnable;
 
     RunnableStepBuilder(String name, Runnable runnable) {
       this.name = name;
@@ -170,34 +189,39 @@ public class StepBuilder {
 
     /**
      * Transition to the next step after the step call completes.
-     * <p>
-     * The {@link Supplier} passed to this method should return
-     * an {@link Workflow.Effect.TransitionalEffect} describing the next step to transition to.
-     * <p>
-     * When defining the Effect, you can update the workflow state and indicate the next step to transition to.
-     * This can be another step, or a pause or end of the workflow.
-     * <p>
-     * When transition to another step, you can also pass an input parameter to the next step.
      *
-     * @param transitionFunc       Supplier of {@link Workflow.Effect.TransitionalEffect}
+     * <p>The {@link Supplier} passed to this method should return an {@link
+     * Workflow.Effect.TransitionalEffect} describing the next step to transition to.
+     *
+     * <p>When defining the Effect, you can update the workflow state and indicate the next step to
+     * transition to. This can be another step, or a pause or end of the workflow.
+     *
+     * <p>When transition to another step, you can also pass an input parameter to the next step.
+     *
+     * @param transitionFunc Supplier of {@link Workflow.Effect.TransitionalEffect}
      * @return RunnableStep
      */
-    public Workflow.RunnableStep andThen(Supplier<Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
+    public Workflow.RunnableStep andThen(
+        Supplier<Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
       return new Workflow.RunnableStep(name, runnable, transitionFunc);
     }
   }
 
   public static class AsyncCallStepBuilder<CallInput, CallOutput> {
 
-    final private String name;
+    private final String name;
 
-    final private Class<CallInput> callInputClass;
-    final private Function<CallInput, CompletionStage<CallOutput>> callFunc;
+    private final Class<CallInput> callInputClass;
+    private final Function<CallInput, CompletionStage<CallOutput>> callFunc;
 
     /**
-     * Not for direct user construction, created through {{akka.javasdk.workflow.StepBuilder#asyncCall(java.lang.Class, java.util.function.Function)}}
+     * Not for direct user construction, created through
+     * {{akka.javasdk.workflow.StepBuilder#asyncCall(java.lang.Class, java.util.function.Function)}}
      */
-    public AsyncCallStepBuilder(String name, Class<CallInput> callInputClass, Function<CallInput, CompletionStage<CallOutput>> callFunc) {
+    public AsyncCallStepBuilder(
+        String name,
+        Class<CallInput> callInputClass,
+        Function<CallInput, CompletionStage<CallOutput>> callFunc) {
       this.name = name;
       this.callInputClass = callInputClass;
       this.callFunc = callFunc;
@@ -205,39 +229,47 @@ public class StepBuilder {
 
     /**
      * Transition to the next step based on the result of the step call.
-     * <p>
-     * The {@link Function} passed to this method should receive the return type of the step call and return
-     * an {@link Workflow.Effect.TransitionalEffect} describing the next step to transition to.
-     * <p>
-     * When defining the Effect, you can update the workflow state and indicate the next step to transition to.
-     * This can be another step, or a pause or end of the workflow.
-     * <p>
-     * When transition to another step, you can also pass an input parameter to the next step.
+     *
+     * <p>The {@link Function} passed to this method should receive the return type of the step call
+     * and return an {@link Workflow.Effect.TransitionalEffect} describing the next step to
+     * transition to.
+     *
+     * <p>When defining the Effect, you can update the workflow state and indicate the next step to
+     * transition to. This can be another step, or a pause or end of the workflow.
+     *
+     * <p>When transition to another step, you can also pass an input parameter to the next step.
      *
      * @param transitionInputClass Input class for transition.
-     * @param transitionFunc       Function that transform the action result to a {@link Workflow.Effect.TransitionalEffect}
+     * @param transitionFunc Function that transform the action result to a {@link
+     *     Workflow.Effect.TransitionalEffect}
      * @return AsyncCallStep
      */
-    public Workflow.AsyncCallStep<CallInput, CallOutput, ?> andThen(Class<CallOutput> transitionInputClass, Function<CallOutput, Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
-      return new Workflow.AsyncCallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
+    public Workflow.AsyncCallStep<CallInput, CallOutput, ?> andThen(
+        Class<CallOutput> transitionInputClass,
+        Function<CallOutput, Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
+      return new Workflow.AsyncCallStep<>(
+          name, callInputClass, callFunc, transitionInputClass, transitionFunc);
     }
 
     /**
      * Transition to the next step after the step call completes.
-     * <p>
-     * The {@link Supplier} passed to this method should return an {@link Workflow.Effect.TransitionalEffect}
-     * describing the next step to transition to. Note that the output of the call is not passed to this function.
-     * <p>
-     * When defining the Effect, you can update the workflow state and indicate the next step to transition to.
-     * This can be another step, or a pause or end of the workflow.
-     * <p>
-     * When transition to another step, you can also pass an input parameter to the next step.
      *
-     * @param transitionFunc       Supplier of {@link Workflow.Effect.TransitionalEffect}
+     * <p>The {@link Supplier} passed to this method should return an {@link
+     * Workflow.Effect.TransitionalEffect} describing the next step to transition to. Note that the
+     * output of the call is not passed to this function.
+     *
+     * <p>When defining the Effect, you can update the workflow state and indicate the next step to
+     * transition to. This can be another step, or a pause or end of the workflow.
+     *
+     * <p>When transition to another step, you can also pass an input parameter to the next step.
+     *
+     * @param transitionFunc Supplier of {@link Workflow.Effect.TransitionalEffect}
      * @return AsyncCallStep
      */
-    public Workflow.AsyncCallStep<CallInput, CallOutput, ?> andThen(Supplier<Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
-      return new Workflow.AsyncCallStep<>(name, callInputClass, callFunc, null, __ -> transitionFunc.get());
+    public Workflow.AsyncCallStep<CallInput, CallOutput, ?> andThen(
+        Supplier<Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
+      return new Workflow.AsyncCallStep<>(
+          name, callInputClass, callFunc, null, __ -> transitionFunc.get());
     }
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
@@ -11,7 +11,6 @@ import akka.javasdk.client.ComponentClient;
 import akka.javasdk.impl.workflow.WorkflowEffectImpl;
 import akka.javasdk.timer.TimerScheduler;
 import akka.javasdk.workflow.Workflow.RecoverStrategy.MaxRetries;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -34,22 +33,22 @@ import java.util.function.Supplier;
  * <p>The runtime keeps track of the state of the workflow and the current step. If the workflow is
  * stopped for any reason, it can be resumed from the last known state and step.
  *
- * <p>Workflow methods that handle incoming commands should return an {@link
- * Workflow.Effect} describing the next processing actions.
+ * <p>Workflow methods that handle incoming commands should return an {@link Workflow.Effect}
+ * describing the next processing actions.
  *
- * <p>
- * Concrete classes can accept the following types to the constructor:
+ * <p>Concrete classes can accept the following types to the constructor:
+ *
  * <ul>
- *   <li>{@link ComponentClient}</li>
- *   <li>{@link akka.javasdk.http.HttpClientProvider}</li>
- *   <li>{@link akka.javasdk.timer.TimerScheduler}</li>
- *   <li>{@link akka.stream.Materializer}</li>
- *   <li>{@link com.typesafe.config.Config}</li>
- *   <li>{@link akka.javasdk.workflow.WorkflowContext}</li>
- *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider} from the service setup</li>
+ *   <li>{@link ComponentClient}
+ *   <li>{@link akka.javasdk.http.HttpClientProvider}
+ *   <li>{@link akka.javasdk.timer.TimerScheduler}
+ *   <li>{@link akka.stream.Materializer}
+ *   <li>{@link com.typesafe.config.Config}
+ *   <li>{@link akka.javasdk.workflow.WorkflowContext}
+ *   <li>Custom types provided by a {@link akka.javasdk.DependencyProvider} from the service setup
  * </ul>
- * <p>
- * Concrete class must be annotated with {@link akka.javasdk.annotations.ComponentId}.
+ *
+ * <p>Concrete class must be annotated with {@link akka.javasdk.annotations.ComponentId}.
  *
  * @param <S> The type of the state for this workflow.
  */
@@ -74,8 +73,8 @@ public abstract class Workflow<S> {
   }
 
   /**
-   * Returns the initial empty state object. This object will be passed into the
-   * command and step handlers, until a new state replaces it.
+   * Returns the initial empty state object. This object will be passed into the command and step
+   * handlers, until a new state replaces it.
    *
    * <p>Also known as "zero state" or "neutral state".
    *
@@ -94,15 +93,18 @@ public abstract class Workflow<S> {
    * @throws IllegalStateException if accessed outside a handler method
    */
   protected final CommandContext commandContext() {
-    return commandContext.orElseThrow(() -> new IllegalStateException("CommandContext is only available when handling a command."));
+    return commandContext.orElseThrow(
+        () ->
+            new IllegalStateException("CommandContext is only available when handling a command."));
   }
 
-
-  /**
-   * Returns a {@link TimerScheduler} that can be used to schedule further in time.
-   */
+  /** Returns a {@link TimerScheduler} that can be used to schedule further in time. */
   public final TimerScheduler timers() {
-    return timerScheduler.orElseThrow(() -> new IllegalStateException("Timers can only be scheduled or cancelled when handling a command or running a step action."));
+    return timerScheduler.orElseThrow(
+        () ->
+            new IllegalStateException(
+                "Timers can only be scheduled or cancelled when handling a command or running a"
+                    + " step action."));
   }
 
   /**
@@ -121,12 +123,13 @@ public abstract class Workflow<S> {
     // to have emptyState set to null.
     if (stateHasBeenSet) return currentState.orElse(null);
     else
-      throw new IllegalStateException("Current state is only available when handling a command. Make sure that that you are calling the `currentState` method only in the command handler or step `call`, `andThen` lambda functions.");
+      throw new IllegalStateException(
+          "Current state is only available when handling a command. Make sure that that you are"
+              + " calling the `currentState` method only in the command handler or step `call`,"
+              + " `andThen` lambda functions.");
   }
 
-  /**
-   * Returns true if the entity has been deleted.
-   */
+  /** Returns true if the entity has been deleted. */
   protected boolean isDeleted() {
     return deleted;
   }
@@ -137,7 +140,8 @@ public abstract class Workflow<S> {
    * @hidden
    */
   @InternalApi
-  public void _internalSetup(S state, CommandContext context, TimerScheduler timerScheduler, boolean deleted) {
+  public void _internalSetup(
+      S state, CommandContext context, TimerScheduler timerScheduler, boolean deleted) {
     this.stateHasBeenSet = true;
     this.currentState = Optional.ofNullable(state);
     this.commandContext = Optional.of(context);
@@ -156,7 +160,6 @@ public abstract class Workflow<S> {
     this.currentState = Optional.ofNullable(state);
   }
 
-
   /**
    * @return A workflow definition in a form of steps and transitions between them.
    */
@@ -167,15 +170,17 @@ public abstract class Workflow<S> {
   }
 
   /**
-   * An Effect is a description of what the runtime needs to do after the command is handled.
-   * You can think of it as a set of instructions you are passing to the runtime, which will process
-   * the instructions on your behalf.
+   * An Effect is a description of what the runtime needs to do after the command is handled. You
+   * can think of it as a set of instructions you are passing to the runtime, which will process the
+   * instructions on your behalf.
+   *
+   * <p>Each component defines its own effects, which are a set of predefined operations that match
+   * the capabilities of that component.
+   *
+   * <p>A Workflow Effect can either:
+   *
    * <p>
-   * Each component defines its own effects, which are a set of predefined
-   * operations that match the capabilities of that component.
-   * <p>
-   * A Workflow Effect can either:
-   * <p>
+   *
    * <ul>
    *   <li>update the state of the workflow
    *   <li>define the next step to be executed (transition)
@@ -184,17 +189,20 @@ public abstract class Workflow<S> {
    *   <li>fail the step or reject a command by returning an error
    *   <li>reply to incoming commands
    * </ul>
+   *
    * <p>
+   *
    * <p>
-   *  @param <T> The type of the message that must be returned by this call.
+   *
+   * @param <T> The type of the message that must be returned by this call.
    */
   public interface Effect<T> {
 
     /**
      * Construct the effect that is returned by the command handler or a step transition.
-     * <p>
-     * The effect describes next processing actions, such as updating state, transition to another step
-     * and sending a reply.
+     *
+     * <p>The effect describes next processing actions, such as updating state, transition to
+     * another step and sending a reply.
      *
      * @param <S> The type of the state for this workflow.
      */
@@ -202,43 +210,42 @@ public abstract class Workflow<S> {
 
       PersistenceEffectBuilder<S> updateState(S newState);
 
-      /**
-       * Pause the workflow execution and wait for an external input, e.g. via command handler.
-       */
+      /** Pause the workflow execution and wait for an external input, e.g. via command handler. */
       TransitionalEffect<Void> pause();
 
       /**
        * Defines the next step to which the workflow should transition to.
-       * <p>
-       * The step definition identified by {@code stepName} must have an input parameter of type I.
-       * In other words, the next step call (or asyncCall) must have been defined with a {@link Function} that
-       * accepts an input parameter of type I.
+       *
+       * <p>The step definition identified by {@code stepName} must have an input parameter of type
+       * I. In other words, the next step call (or asyncCall) must have been defined with a {@link
+       * Function} that accepts an input parameter of type I.
        *
        * @param stepName The step name that should be executed next.
-       * @param input    The input param for the next step.
+       * @param input The input param for the next step.
        */
       <I> TransitionalEffect<Void> transitionTo(String stepName, I input);
 
       /**
        * Defines the next step to which the workflow should transition to.
-       * <p>
-       * The step definition identified by {@code stepName} must not have an input parameter.
-       * In other words, the next step call (or asyncCall) must have been defined with a {@link Supplier} function.
+       *
+       * <p>The step definition identified by {@code stepName} must not have an input parameter. In
+       * other words, the next step call (or asyncCall) must have been defined with a {@link
+       * Supplier} function.
        *
        * @param stepName The step name that should be executed next.
        */
       TransitionalEffect<Void> transitionTo(String stepName);
 
       /**
-       * Finish the workflow execution.
-       * After transition to {@code end}, no more transitions are allowed.
+       * Finish the workflow execution. After transition to {@code end}, no more transitions are
+       * allowed.
        */
       TransitionalEffect<Void> end();
 
       /**
-       * Finish and delete the workflow execution.
-       * After transition to {@code delete}, no more transitions are allowed.
-       * The actual workflow state deletion is done with a configurable delay to allow downstream consumers to observe that fact.
+       * Finish and delete the workflow execution. After transition to {@code delete}, no more
+       * transitions are allowed. The actual workflow state deletion is done with a configurable
+       * delay to allow downstream consumers to observe that fact.
        */
       TransitionalEffect<Void> delete();
 
@@ -246,18 +253,17 @@ public abstract class Workflow<S> {
        * Create a message reply.
        *
        * @param replyMessage The payload of the reply.
-       * @param <R>          The type of the message that must be returned by this call.
+       * @param <R> The type of the message that must be returned by this call.
        * @return A message reply.
        */
       <R> ReadOnlyEffect<R> reply(R replyMessage);
 
-
       /**
        * Reply after for example {@code updateState}.
        *
-       * @param message  The payload of the reply.
+       * @param message The payload of the reply.
        * @param metadata The metadata for the message.
-       * @param <R>      The type of the message that must be returned by this call.
+       * @param <R> The type of the message that must be returned by this call.
        * @return A message reply.
        */
       <R> ReadOnlyEffect<R> reply(R message, Metadata metadata);
@@ -266,26 +272,26 @@ public abstract class Workflow<S> {
        * Create an error reply.
        *
        * @param message The error message.
-       * @param <R>     The type of the message that must be returned by this call.
+       * @param <R> The type of the message that must be returned by this call.
        * @return An error reply.
        */
       <R> ReadOnlyEffect<R> error(String message);
 
       /**
        * Create an error reply. {@link CommandException} will be serialized and sent to the client.
-       * It's possible to catch it with try-catch statement or {@link CompletionStage} API when using async {@link ComponentClient} API.
+       * It's possible to catch it with try-catch statement or {@link CompletionStage} API when
+       * using async {@link ComponentClient} API.
        *
        * @param commandException The command exception to be returned.
        * @param <T> The type of the message that must be returned by this call.
        * @return An error reply.
        */
       <T> ReadOnlyEffect<T> error(CommandException commandException);
-
     }
 
     /**
-     * A workflow effect type that contains information about the transition to the next step.
-     * This could be also a special transition to pause or end the workflow.
+     * A workflow effect type that contains information about the transition to the next step. This
+     * could be also a special transition to pause or end the workflow.
      */
     interface TransitionalEffect<T> extends Effect<T> {
 
@@ -293,7 +299,7 @@ public abstract class Workflow<S> {
        * Reply after for example {@code updateState}.
        *
        * @param message The payload of the reply.
-       * @param <R>     The type of the message that must be returned by this call.
+       * @param <R> The type of the message that must be returned by this call.
        * @return A message reply.
        */
       <R> Effect<R> thenReply(R message);
@@ -301,9 +307,9 @@ public abstract class Workflow<S> {
       /**
        * Reply after for example {@code updateState}.
        *
-       * @param message  The payload of the reply.
+       * @param message The payload of the reply.
        * @param metadata The metadata for the message.
-       * @param <R>      The type of the message that must be returned by this call.
+       * @param <R> The type of the message that must be returned by this call.
        * @return A message reply.
        */
       <R> Effect<R> thenReply(R message, Metadata metadata);
@@ -311,61 +317,55 @@ public abstract class Workflow<S> {
 
     interface PersistenceEffectBuilder<T> {
 
-      /**
-       * Pause the workflow execution and wait for an external input, e.g. via command handler.
-       */
+      /** Pause the workflow execution and wait for an external input, e.g. via command handler. */
       TransitionalEffect<Void> pause();
 
       /**
        * Defines the next step to which the workflow should transition to.
-       * <p>
-       * The step definition identified by {@code stepName} must have an input parameter of type I.
-       * In other words, the next step call (or asyncCall) must have been defined with a {@link Function} that
-       * accepts an input parameter of type I.
+       *
+       * <p>The step definition identified by {@code stepName} must have an input parameter of type
+       * I. In other words, the next step call (or asyncCall) must have been defined with a {@link
+       * Function} that accepts an input parameter of type I.
        *
        * @param stepName The step name that should be executed next.
-       * @param input    The input param for the next step.
+       * @param input The input param for the next step.
        */
       <I> TransitionalEffect<Void> transitionTo(String stepName, I input);
 
       /**
        * Defines the next step to which the workflow should transition to.
-       * <p>
-       * The step definition identified by {@code stepName} must not have an input parameter.
-       * In other words, the next step call (or asyncCall) must have been defined with a {@link Supplier}.
+       *
+       * <p>The step definition identified by {@code stepName} must not have an input parameter. In
+       * other words, the next step call (or asyncCall) must have been defined with a {@link
+       * Supplier}.
        *
        * @param stepName The step name that should be executed next.
        */
       TransitionalEffect<Void> transitionTo(String stepName);
 
       /**
-       * Finish the workflow execution.
-       * After transition to {@code end}, no more transitions are allowed.
+       * Finish the workflow execution. After transition to {@code end}, no more transitions are
+       * allowed.
        */
       TransitionalEffect<Void> end();
 
       /**
-       * Finish and delete the workflow execution.
-       * After transition to {@code delete}, no more transitions are allowed.
-       * The actual workflow state deletion is done with a configurable delay to allow downstream consumers to observe that fact.
+       * Finish and delete the workflow execution. After transition to {@code delete}, no more
+       * transitions are allowed. The actual workflow state deletion is done with a configurable
+       * delay to allow downstream consumers to observe that fact.
        */
       TransitionalEffect<Void> delete();
     }
-
-
   }
 
-  /**
-   * An effect that is known to be read only and does not update the state of the entity.
-   */
-  public interface ReadOnlyEffect<T> extends Effect<T> {
-  }
+  /** An effect that is known to be read only and does not update the state of the entity. */
+  public interface ReadOnlyEffect<T> extends Effect<T> {}
 
   public static class WorkflowDef<S> {
 
-    final private List<Step> steps = new ArrayList<>();
-    final private List<StepConfig> stepConfigs = new ArrayList<>();
-    final private Set<String> uniqueNames = new HashSet<>();
+    private final List<Step> steps = new ArrayList<>();
+    private final List<StepConfig> stepConfigs = new ArrayList<>();
+    private final Set<String> uniqueNames = new HashSet<>();
     private Optional<Duration> workflowTimeout = Optional.empty();
     private Optional<String> failoverStepName = Optional.empty();
     private Optional<Object> failoverStepInput = Optional.empty();
@@ -373,9 +373,7 @@ public abstract class Workflow<S> {
     private Optional<Duration> stepTimeout = Optional.empty();
     private Optional<RecoverStrategy<?>> stepRecoverStrategy = Optional.empty();
 
-
-    private WorkflowDef() {
-    }
+    private WorkflowDef() {}
 
     public Optional<Step> findByName(String name) {
       return steps.stream().filter(s -> s.name().equals(name)).findFirst();
@@ -395,9 +393,10 @@ public abstract class Workflow<S> {
     }
 
     /**
-     * Add step to workflow definition with a dedicated {@link RecoverStrategy}. Step name must be unique.
+     * Add step to workflow definition with a dedicated {@link RecoverStrategy}. Step name must be
+     * unique.
      *
-     * @param step            A workflow step
+     * @param step A workflow step
      * @param recoverStrategy A Step recovery strategy
      */
     public WorkflowDef<S> addStep(Step step, RecoverStrategy<?> recoverStrategy) {
@@ -408,15 +407,16 @@ public abstract class Workflow<S> {
 
     private void addStepWithValidation(Step step) {
       if (uniqueNames.contains(step.name()))
-        throw new IllegalArgumentException("Name '" + step.name() + "' is already in use by another step in this workflow");
+        throw new IllegalArgumentException(
+            "Name '" + step.name() + "' is already in use by another step in this workflow");
 
       this.steps.add(step);
       this.uniqueNames.add(step.name());
     }
 
-
     /**
-     * Define a timeout for the duration of the entire workflow. When the timeout expires, the workflow is finished and no transitions are allowed.
+     * Define a timeout for the duration of the entire workflow. When the timeout expires, the
+     * workflow is finished and no transitions are allowed.
      *
      * @param timeout Timeout duration
      */
@@ -426,9 +426,10 @@ public abstract class Workflow<S> {
     }
 
     /**
-     * Define a failover step name after workflow timeout. Note that recover strategy for this step can set only the number of max retries.
+     * Define a failover step name after workflow timeout. Note that recover strategy for this step
+     * can set only the number of max retries.
      *
-     * @param stepName   A failover step name
+     * @param stepName A failover step name
      * @param maxRetries A recovery strategy for failover step.
      */
     public WorkflowDef<S> failoverTo(String stepName, MaxRetries maxRetries) {
@@ -438,10 +439,11 @@ public abstract class Workflow<S> {
     }
 
     /**
-     * Define a failover step name after workflow timeout. Note that recover strategy for this step can set only the number of max retries.
+     * Define a failover step name after workflow timeout. Note that recover strategy for this step
+     * can set only the number of max retries.
      *
-     * @param stepName   A failover step name
-     * @param stepInput  A failover step input
+     * @param stepName A failover step name
+     * @param stepInput A failover step input
      * @param maxRetries A recovery strategy for failover step.
      */
     public <I> WorkflowDef<S> failoverTo(String stepName, I stepInput, MaxRetries maxRetries) {
@@ -452,17 +454,15 @@ public abstract class Workflow<S> {
     }
 
     /**
-     * Define a default step timeout. If not set, a default value of 5 seconds is used.
-     * Can be overridden with step configuration.
+     * Define a default step timeout. If not set, a default value of 5 seconds is used. Can be
+     * overridden with step configuration.
      */
     public WorkflowDef<S> defaultStepTimeout(Duration timeout) {
       this.stepTimeout = Optional.of(timeout);
       return this;
     }
 
-    /**
-     * Define a default step recovery strategy. Can be overridden with step configuration.
-     */
+    /** Define a default step recovery strategy. Can be overridden with step configuration. */
     public WorkflowDef<S> defaultStepRecoverStrategy(RecoverStrategy recoverStrategy) {
       this.stepRecoverStrategy = Optional.of(recoverStrategy);
       return this;
@@ -475,7 +475,6 @@ public abstract class Workflow<S> {
     public Optional<Duration> getStepTimeout() {
       return stepTimeout;
     }
-
 
     public Optional<RecoverStrategy<?>> getStepRecoverStrategy() {
       return stepRecoverStrategy;
@@ -502,37 +501,32 @@ public abstract class Workflow<S> {
     }
   }
 
-
   public WorkflowDef<S> workflow() {
     return new WorkflowDef<>();
   }
-
 
   public interface Step {
     String name();
 
     Optional<Duration> timeout();
-
-
   }
 
   public static final class CallStep<CallInput, CallOutput, FailoverInput> implements Step {
 
-    final private String _name;
-    final public Function<CallInput, CallOutput> callFunc;
-    final public Function<CallOutput, Effect.TransitionalEffect<Void>> transitionFunc;
-    final public Class<CallInput> callInputClass;
-    final public Class<CallOutput> transitionInputClass;
+    private final String _name;
+    public final Function<CallInput, CallOutput> callFunc;
+    public final Function<CallOutput, Effect.TransitionalEffect<Void>> transitionFunc;
+    public final Class<CallInput> callInputClass;
+    public final Class<CallOutput> transitionInputClass;
     private Optional<Duration> _timeout = Optional.empty();
 
-    /**
-     * Not for direct user construction, instances are created through the workflow DSL
-     */
-    public CallStep(String name,
-                    Class<CallInput> callInputClass,
-                    Function<CallInput, CallOutput> callFunc,
-                    Class<CallOutput> transitionInputClass,
-                    Function<CallOutput, Effect.TransitionalEffect<Void>> transitionFunc) {
+    /** Not for direct user construction, instances are created through the workflow DSL */
+    public CallStep(
+        String name,
+        Class<CallInput> callInputClass,
+        Function<CallInput, CallOutput> callFunc,
+        Class<CallOutput> transitionInputClass,
+        Function<CallOutput, Effect.TransitionalEffect<Void>> transitionFunc) {
       _name = name;
       this.callInputClass = callInputClass;
       this.callFunc = callFunc;
@@ -550,9 +544,7 @@ public abstract class Workflow<S> {
       return this._timeout;
     }
 
-    /**
-     * Define a step timeout.
-     */
+    /** Define a step timeout. */
     public CallStep<CallInput, CallOutput, FailoverInput> timeout(Duration timeout) {
       this._timeout = Optional.of(timeout);
       return this;
@@ -561,17 +553,14 @@ public abstract class Workflow<S> {
 
   public static final class RunnableStep implements Step {
 
-    final private String _name;
-    final public Runnable runnable;
-    final public Supplier<Effect.TransitionalEffect<Void>> transitionFunc;
+    private final String _name;
+    public final Runnable runnable;
+    public final Supplier<Effect.TransitionalEffect<Void>> transitionFunc;
     private Optional<Duration> _timeout = Optional.empty();
 
-    /**
-     * Not for direct user construction, instances are created through the workflow DSL
-     */
-    public RunnableStep(String name,
-                        Runnable runnable,
-                        Supplier<Effect.TransitionalEffect<Void>> transitionFunc) {
+    /** Not for direct user construction, instances are created through the workflow DSL */
+    public RunnableStep(
+        String name, Runnable runnable, Supplier<Effect.TransitionalEffect<Void>> transitionFunc) {
       _name = name;
       this.runnable = runnable;
       this.transitionFunc = transitionFunc;
@@ -587,9 +576,7 @@ public abstract class Workflow<S> {
       return this._timeout;
     }
 
-    /**
-     * Define a step timeout.
-     */
+    /** Define a step timeout. */
     public RunnableStep timeout(Duration timeout) {
       this._timeout = Optional.of(timeout);
       return this;
@@ -598,21 +585,20 @@ public abstract class Workflow<S> {
 
   public static class AsyncCallStep<CallInput, CallOutput, FailoverInput> implements Step {
 
-    final private String _name;
-    final public Function<CallInput, CompletionStage<CallOutput>> callFunc;
-    final public Function<CallOutput, Effect.TransitionalEffect<Void>> transitionFunc;
-    final public Class<CallInput> callInputClass;
-    final public Class<CallOutput> transitionInputClass;
+    private final String _name;
+    public final Function<CallInput, CompletionStage<CallOutput>> callFunc;
+    public final Function<CallOutput, Effect.TransitionalEffect<Void>> transitionFunc;
+    public final Class<CallInput> callInputClass;
+    public final Class<CallOutput> transitionInputClass;
     private Optional<Duration> _timeout = Optional.empty();
 
-    /**
-     * Not for direct user construction, instances are created through the workflow DSL
-     */
-    public AsyncCallStep(String name,
-                         Class<CallInput> callInputClass,
-                         Function<CallInput, CompletionStage<CallOutput>> callFunc,
-                         Class<CallOutput> transitionInputClass,
-                         Function<CallOutput, Effect.TransitionalEffect<Void>> transitionFunc) {
+    /** Not for direct user construction, instances are created through the workflow DSL */
+    public AsyncCallStep(
+        String name,
+        Class<CallInput> callInputClass,
+        Function<CallInput, CompletionStage<CallOutput>> callFunc,
+        Class<CallOutput> transitionInputClass,
+        Function<CallOutput, Effect.TransitionalEffect<Void>> transitionFunc) {
       _name = name;
       this.callInputClass = callInputClass;
       this.callFunc = callFunc;
@@ -630,9 +616,7 @@ public abstract class Workflow<S> {
       return this._timeout;
     }
 
-    /**
-     * Define a step timeout.
-     */
+    /** Define a step timeout. */
     public AsyncCallStep<CallInput, CallOutput, FailoverInput> timeout(Duration timeout) {
       this._timeout = Optional.of(timeout);
       return this;
@@ -644,7 +628,8 @@ public abstract class Workflow<S> {
     public final Optional<Duration> timeout;
     public final Optional<RecoverStrategy<?>> recoverStrategy;
 
-    public StepConfig(String stepName, Optional<Duration> timeout, Optional<RecoverStrategy<?>> recoverStrategy) {
+    public StepConfig(
+        String stepName, Optional<Duration> timeout, Optional<RecoverStrategy<?>> recoverStrategy) {
       this.stepName = stepName;
       this.timeout = timeout;
       this.recoverStrategy = recoverStrategy;
@@ -673,9 +658,7 @@ public abstract class Workflow<S> {
       this.failoverStepInput = failoverStepInput;
     }
 
-    /**
-     * Retry strategy without failover configuration
-     */
+    /** Retry strategy without failover configuration */
     public static class MaxRetries {
       public final int maxRetries;
 
@@ -683,16 +666,12 @@ public abstract class Workflow<S> {
         this.maxRetries = maxRetries;
       }
 
-      /**
-       * Once max retries is exceeded, transition to a given step name.
-       */
+      /** Once max retries is exceeded, transition to a given step name. */
       public RecoverStrategy<?> failoverTo(String stepName) {
         return new RecoverStrategy<>(maxRetries, stepName, Optional.<Void>empty());
       }
 
-      /**
-       * Once max retries is exceeded, transition to a given step name with the input parameter.
-       */
+      /** Once max retries is exceeded, transition to a given step name with the input parameter. */
       public <T> RecoverStrategy<T> failoverTo(String stepName, T input) {
         return new RecoverStrategy<>(maxRetries, stepName, Optional.of(input));
       }
@@ -703,25 +682,24 @@ public abstract class Workflow<S> {
     }
 
     /**
-     * Set the number of retires for a failed step, {@code maxRetries} equals 0 means that the step won't retry in case of failure.
+     * Set the number of retires for a failed step, {@code maxRetries} equals 0 means that the step
+     * won't retry in case of failure.
      */
     public static MaxRetries maxRetries(int maxRetries) {
       return new MaxRetries(maxRetries);
     }
 
-    /**
-     * In case of a step failure don't retry but transition to a given step name.
-     */
+    /** In case of a step failure don't retry but transition to a given step name. */
     public static RecoverStrategy<?> failoverTo(String stepName) {
       return new RecoverStrategy<>(0, stepName, Optional.<Void>empty());
     }
 
     /**
-     * In case of a step failure don't retry but transition to a given step name with the input parameter.
+     * In case of a step failure don't retry but transition to a given step name with the input
+     * parameter.
      */
     public static <T> RecoverStrategy<T> failoverTo(String stepName, T input) {
       return new RecoverStrategy<>(0, stepName, Optional.of(input));
     }
   }
-
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/DummyClass.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/DummyClass.java
@@ -4,9 +4,8 @@
 
 package akka.javasdk;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import akka.javasdk.annotations.Migration;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -28,7 +27,9 @@ public class DummyClass {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     DummyClass that = (DummyClass) o;
-    return intValue == that.intValue && Objects.equals(stringValue, that.stringValue) && Objects.equals(optionalStringValue, that.optionalStringValue);
+    return intValue == that.intValue
+        && Objects.equals(stringValue, that.stringValue)
+        && Objects.equals(optionalStringValue, that.optionalStringValue);
   }
 
   @Override

--- a/akka-javasdk/src/test/java/akka/javasdk/DummyClass2.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/DummyClass2.java
@@ -4,9 +4,8 @@
 
 package akka.javasdk;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import akka.javasdk.annotations.Migration;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Objects;
 
 @Migration(DummyClass2Migration.class)
@@ -27,7 +26,9 @@ public class DummyClass2 {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     DummyClass2 that = (DummyClass2) o;
-    return intValue == that.intValue && Objects.equals(stringValue, that.stringValue) && Objects.equals(mandatoryStringValue, that.mandatoryStringValue);
+    return intValue == that.intValue
+        && Objects.equals(stringValue, that.stringValue)
+        && Objects.equals(mandatoryStringValue, that.mandatoryStringValue);
   }
 
   @Override
@@ -37,10 +38,15 @@ public class DummyClass2 {
 
   @Override
   public String toString() {
-    return "DummyClass2{" +
-        "stringValue='" + stringValue + '\'' +
-        ", intValue=" + intValue +
-        ", mandatoryStringValue='" + mandatoryStringValue + '\'' +
-        '}';
+    return "DummyClass2{"
+        + "stringValue='"
+        + stringValue
+        + '\''
+        + ", intValue="
+        + intValue
+        + ", mandatoryStringValue='"
+        + mandatoryStringValue
+        + '\''
+        + '}';
   }
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/DummyClass2Migration.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/DummyClass2Migration.java
@@ -7,7 +7,6 @@ package akka.javasdk;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import akka.javasdk.JsonMigration;
 
 public class DummyClass2Migration extends JsonMigration {
   @Override

--- a/akka-javasdk/src/test/java/akka/javasdk/DummyClassMigration.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/DummyClassMigration.java
@@ -6,7 +6,6 @@ package akka.javasdk;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import akka.javasdk.JsonMigration;
 
 public class DummyClassMigration extends JsonMigration {
   @Override

--- a/akka-javasdk/src/test/java/akka/javasdk/DummyClassRenamed.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/DummyClassRenamed.java
@@ -5,7 +5,6 @@
 package akka.javasdk;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-
 import java.util.Objects;
 import java.util.Optional;
 
@@ -26,7 +25,9 @@ public class DummyClassRenamed {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     DummyClassRenamed that = (DummyClassRenamed) o;
-    return intValue == that.intValue && Objects.equals(stringValue, that.stringValue) && Objects.equals(optionalStringValue, that.optionalStringValue);
+    return intValue == that.intValue
+        && Objects.equals(stringValue, that.stringValue)
+        && Objects.equals(optionalStringValue, that.optionalStringValue);
   }
 
   @Override

--- a/akka-javasdk/src/test/java/akka/javasdk/agent/DummyAgent.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/agent/DummyAgent.java
@@ -6,25 +6,20 @@ package akka.javasdk.agent;
 
 import akka.javasdk.annotations.AgentDescription;
 import akka.javasdk.annotations.ComponentId;
-
 import java.util.List;
 
 @ComponentId("dummy1")
 @AgentDescription(name = "Dummy Agent", description = "Not very smart agent")
 class DummyAgent1 extends Agent {
   Effect<String> doSomething(String question) {
-    return effects()
-      .systemMessage("You are a helpful...")
-      .userMessage(question)
-      .thenReply();
+    return effects().systemMessage("You are a helpful...").userMessage(question).thenReply();
   }
 }
 
 @ComponentId("dummy2")
 @AgentDescription(name = "Dummy Agent", description = "Not very smart agent")
 class DummyAgent2 extends Agent {
-  record Response(String result) {
-  }
+  record Response(String result) {}
 
   Effect<Response> doSomething(String question) {
     return effects()
@@ -41,18 +36,20 @@ class DummyAgent2 extends Agent {
 class DummyAgent3 extends Agent {
   Effect<String> doSomethingElse(String question) {
     // customer memory
-    var memory = new SessionMemory() {
+    var memory =
+        new SessionMemory() {
 
-      @Override
-      public void addInteraction(String sessionId, SessionMessage.UserMessage userMessage, List<SessionMessage> messages) {
+          @Override
+          public void addInteraction(
+              String sessionId,
+              SessionMessage.UserMessage userMessage,
+              List<SessionMessage> messages) {}
 
-      }
-
-      @Override
-      public SessionHistory getHistory(String sessionId) {
-        return null;
-      }
-    };
+          @Override
+          public SessionHistory getHistory(String sessionId) {
+            return null;
+          }
+        };
 
     return effects()
         .systemMessage("You are a helpful...")
@@ -73,4 +70,3 @@ class DummyAgent4 extends Agent {
         .thenReply();
   }
 }
-

--- a/akka-javasdk/src/test/java/akka/javasdk/client/ComponentClientTest.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/client/ComponentClientTest.java
@@ -4,18 +4,15 @@
 
 package akka.javasdk.client;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import akka.NotUsed;
-import akka.javasdk.agent.Agent;
-import akka.javasdk.impl.*;
-import akka.javasdk.impl.serialization.JsonSerializer;
-import akka.runtime.sdk.spi.*;
-import akka.runtime.sdk.spi.TimedActionClient;
-import akka.runtime.sdk.spi.ViewClient;
-import akka.runtime.sdk.spi.AgentClient;
-import com.google.protobuf.InvalidProtocolBufferException;
 import akka.javasdk.Metadata;
+import akka.javasdk.impl.*;
 import akka.javasdk.impl.client.ComponentClientImpl;
 import akka.javasdk.impl.client.DeferredCallImpl;
+import akka.javasdk.impl.serialization.JsonSerializer;
 import akka.javasdk.impl.telemetry.Telemetry;
 import akka.javasdk.testmodels.Number;
 import akka.javasdk.testmodels.action.ActionsTestModels.ActionWithOneParam;
@@ -24,14 +21,15 @@ import akka.javasdk.testmodels.keyvalueentity.Counter;
 import akka.javasdk.testmodels.keyvalueentity.User;
 import akka.javasdk.testmodels.view.ViewTestModels;
 import akka.javasdk.testmodels.view.ViewTestModels.UserByEmailWithGet;
+import akka.runtime.sdk.spi.*;
+import akka.runtime.sdk.spi.AgentClient;
+import akka.runtime.sdk.spi.TimedActionClient;
+import akka.runtime.sdk.spi.ViewClient;
+import com.google.protobuf.InvalidProtocolBufferException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import scala.Option;
 import scala.concurrent.ExecutionContext;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 
 class ComponentClientTest {
 
@@ -41,112 +39,125 @@ class ComponentClientTest {
   @BeforeEach
   public void initEach() {
     // FIXME what are we actually testing here?
-    var dummyComponentClients = new ComponentClients() {
+    var dummyComponentClients =
+        new ComponentClients() {
 
-      @Override
-      public EntityClient eventSourcedEntityClient() {
-        return null;
-      }
+          @Override
+          public EntityClient eventSourcedEntityClient() {
+            return null;
+          }
 
-      @Override
-      public EntityClient keyValueEntityClient() {
-        return null;
-      }
+          @Override
+          public EntityClient keyValueEntityClient() {
+            return null;
+          }
 
-      @Override
-      public EntityClient workFlowClient() { return null; }
+          @Override
+          public EntityClient workFlowClient() {
+            return null;
+          }
 
-      @Override
-      public TimerClient timerClient() { return null; }
+          @Override
+          public TimerClient timerClient() {
+            return null;
+          }
 
-      @Override
-      public AgentClient agentClient() {
-        return null;
-      }
+          @Override
+          public AgentClient agentClient() {
+            return null;
+          }
 
-      @Override
-      public ViewClient viewClient() {
-        return null;
-      }
+          @Override
+          public ViewClient viewClient() {
+            return null;
+          }
 
-      @Override
-      public TimedActionClient timedActionClient() {
-        return null;
-      }
-    };
-    componentClient = new ComponentClientImpl(dummyComponentClients, serializer, null, Option.empty(), ExecutionContext.global(), null);
+          @Override
+          public TimedActionClient timedActionClient() {
+            return null;
+          }
+        };
+    componentClient =
+        new ComponentClientImpl(
+            dummyComponentClients,
+            serializer,
+            null,
+            Option.empty(),
+            ExecutionContext.global(),
+            null);
   }
 
   @Test
   public void shouldReturnDeferredCallForCallWithNoParameter() {
-    //given
-    //when
-    DeferredCallImpl<NotUsed, Object> call = (DeferredCallImpl<NotUsed, Object>) componentClient.forTimedAction()
-      .method(ActionWithoutParam::message)
-      .deferred();
+    // given
+    // when
+    DeferredCallImpl<NotUsed, Object> call =
+        (DeferredCallImpl<NotUsed, Object>)
+            componentClient.forTimedAction().method(ActionWithoutParam::message).deferred();
 
-    //then
+    // then
     assertEquals(call.componentType(), TimedActionType$.MODULE$);
   }
 
   @Test
   public void shouldReturnDeferredCallForCallWithOneParameter() {
-    //given
-    //when
-    DeferredCallImpl<String, Object> call = (DeferredCallImpl<String, Object>)
-            componentClient.forTimedAction()
-                    .method(ActionWithOneParam::message)
-                    .deferred("Message");
+    // given
+    // when
+    DeferredCallImpl<String, Object> call =
+        (DeferredCallImpl<String, Object>)
+            componentClient
+                .forTimedAction()
+                .method(ActionWithOneParam::message)
+                .deferred("Message");
 
-    //then
+    // then
     assertEquals("Message", call.message());
   }
 
   @Test
   public void shouldReturnDeferredCallWithTraceParent() {
-    //given
+    // given
     String traceparent = "074c4c8d-d87c-4573-847f-77951ce4e0a4";
     Metadata metadata = MetadataImpl.Empty().set(Telemetry.TRACE_PARENT_KEY(), traceparent);
-    //when
-    DeferredCallImpl<NotUsed, Object> call = (DeferredCallImpl<NotUsed, Object>)
-      componentClient.forTimedAction()
-        .method(ActionWithoutParam::message)
-        .withMetadata(metadata)
-        .deferred();
+    // when
+    DeferredCallImpl<NotUsed, Object> call =
+        (DeferredCallImpl<NotUsed, Object>)
+            componentClient
+                .forTimedAction()
+                .method(ActionWithoutParam::message)
+                .withMetadata(metadata)
+                .deferred();
 
-    //then
+    // then
     assertThat(call.metadata().get(Telemetry.TRACE_PARENT_KEY()).get()).isEqualTo(traceparent);
   }
 
   @Test
   public void shouldReturnDeferredCallForValueEntity() throws InvalidProtocolBufferException {
-    //given
+    // given
     Integer param = 10;
     var id = "abc123";
 
-    //when
-    DeferredCallImpl<Integer, Number> call = (DeferredCallImpl<Integer, Number>)
-      componentClient.forKeyValueEntity(id)
-        .method(Counter::randomIncrease)
-        .deferred(param);
+    // when
+    DeferredCallImpl<Integer, Number> call =
+        (DeferredCallImpl<Integer, Number>)
+            componentClient.forKeyValueEntity(id).method(Counter::randomIncrease).deferred(param);
 
-    //then
-    assertThat(call.componentId()).isEqualTo(ComponentDescriptorFactory.readComponentIdValue(Counter.class));
+    // then
+    assertThat(call.componentId())
+        .isEqualTo(ComponentDescriptorFactory.readComponentIdValue(Counter.class));
     assertEquals(10, call.message());
   }
 
-
-
   @Test
   public void shouldReturnNonDeferrableCallForViewRequest() {
-    //given
+    // given
     String email = "email@example.com";
 
     ViewTestModels.ByEmail body = new ViewTestModels.ByEmail(email);
-    //when
+    // when
     ComponentInvokeOnlyMethodRef1<ViewTestModels.ByEmail, User> call =
-      componentClient.forView()
-      .method(UserByEmailWithGet::getUser);
+        componentClient.forView().method(UserByEmailWithGet::getUser);
 
     // not much to assert here
 

--- a/akka-javasdk/src/test/java/akka/javasdk/eventsourcedentity/Event1Migration.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/eventsourcedentity/Event1Migration.java
@@ -5,7 +5,6 @@
 package akka.javasdk.eventsourcedentity;
 
 import akka.javasdk.JsonMigration;
-
 import java.util.List;
 
 public class Event1Migration extends JsonMigration {

--- a/akka-javasdk/src/test/java/akka/javasdk/eventsourcedentity/Event2Migration.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/eventsourcedentity/Event2Migration.java
@@ -4,11 +4,10 @@
 
 package akka.javasdk.eventsourcedentity;
 
+import akka.javasdk.JsonMigration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import akka.javasdk.JsonMigration;
-
 import java.util.List;
 
 public class Event2Migration extends JsonMigration {

--- a/akka-javasdk/src/test/java/akka/javasdk/eventsourcedentity/Event4Migration.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/eventsourcedentity/Event4Migration.java
@@ -4,10 +4,10 @@
 
 package akka.javasdk.eventsourcedentity;
 
+import akka.javasdk.JsonMigration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import akka.javasdk.JsonMigration;
 
 public class Event4Migration extends JsonMigration {
   @Override

--- a/akka-javasdk/src/test/java/akka/javasdk/eventsourcedentity/OldTestESEvent.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/eventsourcedentity/OldTestESEvent.java
@@ -8,13 +8,10 @@ import akka.javasdk.annotations.TypeName;
 
 public interface OldTestESEvent {
 
-  record OldEvent1(String s) implements OldTestESEvent {
-  }
+  record OldEvent1(String s) implements OldTestESEvent {}
 
-  record OldEvent2(int i) implements OldTestESEvent {
-  }
+  record OldEvent2(int i) implements OldTestESEvent {}
 
   @TypeName("old-event-3")
-  record OldEvent3(boolean b) implements OldTestESEvent {
-  }
+  record OldEvent3(boolean b) implements OldTestESEvent {}
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/eventsourcedentity/TestESEvent.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/eventsourcedentity/TestESEvent.java
@@ -10,18 +10,14 @@ import akka.javasdk.annotations.TypeName;
 public sealed interface TestESEvent {
 
   @Migration(Event1Migration.class)
-  record Event1(String s) implements TestESEvent {
-  }
+  record Event1(String s) implements TestESEvent {}
 
   @Migration(Event2Migration.class)
-  record Event2(int newName) implements TestESEvent {
-  }
+  record Event2(int newName) implements TestESEvent {}
 
   @TypeName("old-event-3")
-  record Event3(boolean b) implements OldTestESEvent, TestESEvent{
-  }
+  record Event3(boolean b) implements OldTestESEvent, TestESEvent {}
 
   @Migration(Event4Migration.class)
-  record Event4(String anotherString) implements OldTestESEvent, TestESEvent {
-  }
+  record Event4(String anotherString) implements OldTestESEvent, TestESEvent {}
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/eventsourcedentity/TestESState.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/eventsourcedentity/TestESState.java
@@ -4,5 +4,4 @@
 
 package akka.javasdk.eventsourcedentity;
 
-public record TestESState(String s, int i, boolean b, String anotherString) {
-}
+public record TestESState(String s, int i, boolean b, String anotherString) {}

--- a/akka-javasdk/src/test/java/akka/javasdk/eventsourcedentity/TestEventSourcedEntity.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/eventsourcedentity/TestEventSourcedEntity.java
@@ -9,12 +9,10 @@ import akka.javasdk.annotations.ComponentId;
 @ComponentId("es")
 public class TestEventSourcedEntity extends EventSourcedEntity<TestESState, TestESEvent> {
 
-
   @Override
   public TestESState emptyState() {
     return new TestESState("", 0, false, "");
   }
-
 
   public ReadOnlyEffect<TestESState> get() {
     return effects().reply(currentState());
@@ -23,13 +21,22 @@ public class TestEventSourcedEntity extends EventSourcedEntity<TestESState, Test
   @Override
   public TestESState applyEvent(TestESEvent event) {
     return switch (event) {
-      case TestESEvent.Event1 event1 -> new TestESState(event1.s(), currentState().i(), currentState().b(), currentState().anotherString());
-      case TestESEvent.Event2 event2 -> new TestESState(currentState().s(), event2.newName(), currentState().b(), currentState().anotherString());
-      case TestESEvent.Event3 event3 -> new TestESState(currentState().s(), currentState().i(), event3.b(), currentState().anotherString());
-      case TestESEvent.Event4 event4 -> new TestESState(currentState().s(), currentState().i(), currentState().b(), event4.anotherString());
+      case TestESEvent.Event1 event1 ->
+          new TestESState(
+              event1.s(), currentState().i(), currentState().b(), currentState().anotherString());
+      case TestESEvent.Event2 event2 ->
+          new TestESState(
+              currentState().s(),
+              event2.newName(),
+              currentState().b(),
+              currentState().anotherString());
+      case TestESEvent.Event3 event3 ->
+          new TestESState(
+              currentState().s(), currentState().i(), event3.b(), currentState().anotherString());
+      case TestESEvent.Event4 event4 ->
+          new TestESState(
+              currentState().s(), currentState().i(), currentState().b(), event4.anotherString());
       default -> throw new IllegalStateException("Unexpected value: " + event);
     };
   }
-
-
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/impl/NotPublicComponents.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/impl/NotPublicComponents.java
@@ -4,19 +4,15 @@
 
 package akka.javasdk.impl;
 
-import akka.javasdk.timedaction.TimedAction;
 import akka.javasdk.annotations.ComponentId;
-import akka.javasdk.annotations.Query;
-import akka.javasdk.annotations.Consume;
 import akka.javasdk.consumer.Consumer;
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
 import akka.javasdk.keyvalueentity.KeyValueEntity;
-import akka.javasdk.view.TableUpdater;
-import akka.javasdk.workflow.Workflow;
 import akka.javasdk.testmodels.keyvalueentity.User;
-import akka.javasdk.testmodels.keyvalueentity.UserEntity;
 import akka.javasdk.testmodels.workflow.StartWorkflow;
 import akka.javasdk.testmodels.workflow.WorkflowState;
+import akka.javasdk.timedaction.TimedAction;
+import akka.javasdk.workflow.Workflow;
 
 // below components are not public and thus need to be in the same package as the corresponding test
 public class NotPublicComponents {
@@ -36,10 +32,12 @@ public class NotPublicComponents {
   }
 
   @ComponentId("counter")
-  static class NotPublicEventSourced extends EventSourcedEntity<Integer, NotPublicEventSourced.Event> {
+  static class NotPublicEventSourced
+      extends EventSourcedEntity<Integer, NotPublicEventSourced.Event> {
 
     public sealed interface Event {
-      public record Created()implements Event {};
+      public record Created() implements Event {}
+      ;
     }
 
     public Integer test() {
@@ -71,5 +69,3 @@ public class NotPublicComponents {
     }
   }
 }
-
-

--- a/akka-javasdk/src/test/java/akka/javasdk/impl/http/TestEndpoints.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/impl/http/TestEndpoints.java
@@ -11,13 +11,12 @@ import akka.javasdk.annotations.Acl;
 import akka.javasdk.annotations.Description;
 import akka.javasdk.annotations.JWT;
 import akka.javasdk.annotations.http.Delete;
-import akka.javasdk.annotations.http.HttpEndpoint;
 import akka.javasdk.annotations.http.Get;
+import akka.javasdk.annotations.http.HttpEndpoint;
 import akka.javasdk.annotations.http.Patch;
 import akka.javasdk.annotations.http.Post;
 import akka.javasdk.annotations.http.Put;
 import akka.javasdk.http.HttpResponses;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -25,245 +24,234 @@ import java.util.concurrent.CompletionStage;
 
 public class TestEndpoints {
 
-    record AThing(String someProperty) {}
+  record AThing(String someProperty) {}
 
-    @HttpEndpoint("prefix")
-    public static class TestEndpoint {
+  @HttpEndpoint("prefix")
+  public static class TestEndpoint {
 
-        public void nonHttpEndpointMethod() {
+    public void nonHttpEndpointMethod() {}
 
-        }
-
-        @Get("/")
-        public String list() {
-            return "some things";
-        }
-
-        @Get("/{it}")
-        public AThing get(String it) {
-            return new AThing("thing for " + it);
-        }
-
-        @Post("/{it}")
-        public String create(String it, AThing theBody) {
-            return "ok";
-        }
-
-        @Delete("/{it}")
-        public void delete(String it) {
-        }
-
-        @Put("/{it}")
-        public CompletionStage<String> update(String it, AThing theBody) {
-            return CompletableFuture.completedFuture("ok");
-        }
-
-        @Patch("/{it}")
-        public HttpResponse patch(String it, AThing theBody) {
-            return HttpResponses.ok();
-        }
+    @Get("/")
+    public String list() {
+      return "some things";
     }
 
-    public record SomeObject(
+    @Get("/{it}")
+    public AThing get(String it) {
+      return new AThing("thing for " + it);
+    }
+
+    @Post("/{it}")
+    public String create(String it, AThing theBody) {
+      return "ok";
+    }
+
+    @Delete("/{it}")
+    public void delete(String it) {}
+
+    @Put("/{it}")
+    public CompletionStage<String> update(String it, AThing theBody) {
+      return CompletableFuture.completedFuture("ok");
+    }
+
+    @Patch("/{it}")
+    public HttpResponse patch(String it, AThing theBody) {
+      return HttpResponses.ok();
+    }
+  }
+
+  public record SomeObject(
       @Description("some string") String someString,
       Optional<String> optionalString,
       boolean someBoolean,
       int someInt,
-      @Description("optional double") Optional<Double> optionalDouble
-    ) {}
+      @Description("optional double") Optional<Double> optionalDouble) {}
 
-    @HttpEndpoint("test-specs")
-    public static class TestEndpointSpecs {
+  @HttpEndpoint("test-specs")
+  public static class TestEndpointSpecs {
 
-      @Get("/parameters-only/{someString}/and/{someInt}")
-      public String parametersOnly(
-        @Description("some string") String someString,
-        @Description("some int") int someInt
-      ) {
-        return "ok";
-      }
+    @Get("/parameters-only/{someString}/and/{someInt}")
+    public String parametersOnly(
+        @Description("some string") String someString, @Description("some int") int someInt) {
+      return "ok";
+    }
 
-      @Post("/parameters-and-body/{someString}/and/{someDouble}")
-      public String parametersAndBody(
-        String someString,
-        double someDouble,
-        SomeObject someBody
-      ) {
-        return "ok";
-      }
+    @Post("/parameters-and-body/{someString}/and/{someDouble}")
+    public String parametersAndBody(String someString, double someDouble, SomeObject someBody) {
+      return "ok";
+    }
 
-      @Post("/body-only")
-      public String bodyOnly(@Description("some body") SomeObject someBody) {
-        return "ok";
-      }
+    @Post("/body-only")
+    public String bodyOnly(@Description("some body") SomeObject someBody) {
+      return "ok";
+    }
 
-      @Post("/parameters-and-text-body/{someInt}")
-      public String parametersAndTextBody(
-        int someInt,
-        @Description("some body") String someBody
-      ) {
-        return "ok";
-      }
+    @Post("/parameters-and-text-body/{someInt}")
+    public String parametersAndTextBody(int someInt, @Description("some body") String someBody) {
+      return "ok";
+    }
 
-      @Post("/text-body-only")
-      public String textBodyOnly(@Description("some body") String someBody) {
-        return "ok";
-      }
+    @Post("/text-body-only")
+    public String textBodyOnly(@Description("some body") String someBody) {
+      return "ok";
+    }
 
-      @Post("/parameters-and-array-body/{someString}/and/{someInt}")
-      public String parametersAndArrayBody(
-        String someString,
-        int someInt,
-        List<String> someBody
-      ) {
-        return "ok";
-      }
+    @Post("/parameters-and-array-body/{someString}/and/{someInt}")
+    public String parametersAndArrayBody(String someString, int someInt, List<String> someBody) {
+      return "ok";
+    }
 
-      @Post("/array-body-only")
-      public String arrayBodyOnly(@Description("some body") List<Double> someBody) {
-        return "ok";
-      }
+    @Post("/array-body-only")
+    public String arrayBodyOnly(@Description("some body") List<Double> someBody) {
+      return "ok";
+    }
 
-      @Post("/parameters-and-low-level-body/{someBoolean}")
-      public String parametersAndLowLevelBody(
+    @Post("/parameters-and-low-level-body/{someBoolean}")
+    public String parametersAndLowLevelBody(
         @Description("some boolean") boolean someBoolean,
-        @Description("some body") HttpEntity.Strict someBody
-      ) {
-        return "ok";
-      }
-
-      @Post("/low-level-body-only")
-      public String lowLevelBodyOnly(HttpRequest request) {
-        return "ok";
-      }
+        @Description("some body") HttpEntity.Strict someBody) {
+      return "ok";
     }
 
-    @Acl(deny = @Acl.Matcher(principal = Acl.Principal.ALL), denyCode = 404)
-    @HttpEndpoint("acls")
-    public static class TestEndpointAcls {
+    @Post("/low-level-body-only")
+    public String lowLevelBodyOnly(HttpRequest request) {
+      return "ok";
+    }
+  }
 
-        @Get("/no-acl")
-        public String noAcl() {
-            return "no-acl";
-        }
+  @Acl(deny = @Acl.Matcher(principal = Acl.Principal.ALL), denyCode = 404)
+  @HttpEndpoint("acls")
+  public static class TestEndpointAcls {
 
-        @Get("/secret")
-        @Acl(
-            allow = @Acl.Matcher(service = "backoffice-service"),
-            deny = @Acl.Matcher(principal = Acl.Principal.INTERNET),
-            denyCode = 401)
-        public String secret() {
-            return "the greatest secret";
-        }
-
-        @Get("/this-and-that")
-        @Acl(allow = { @Acl.Matcher(service = "this"), @Acl.Matcher(service = "that") })
-        public String thisAndThat() {
-            return "this-and-that";
-        }
-
+    @Get("/no-acl")
+    public String noAcl() {
+      return "no-acl";
     }
 
-    @HttpEndpoint("invalid-acl")
-    public static class TestEndpointInvalidAcl {
-        @Get("/invalid")
-        @Acl(allow = @Acl.Matcher(service = "*", principal = Acl.Principal.INTERNET))
-        public String invalid() {
-            return "invalid matcher";
-        }
+    @Get("/secret")
+    @Acl(
+        allow = @Acl.Matcher(service = "backoffice-service"),
+        deny = @Acl.Matcher(principal = Acl.Principal.INTERNET),
+        denyCode = 401)
+    public String secret() {
+      return "the greatest secret";
     }
 
-    @HttpEndpoint("invalid-acl-denycode")
-    public static class TestEndpointInvalidAclDenyCode {
-        @Get("/invalid")
-        @Acl(allow = @Acl.Matcher(service = "*"), denyCode = 123123)
-        public String invalid() {
-            return "invalid matcher";
-        }
+    @Get("/this-and-that")
+    @Acl(allow = {@Acl.Matcher(service = "this"), @Acl.Matcher(service = "that")})
+    public String thisAndThat() {
+      return "this-and-that";
     }
+  }
 
-    @HttpEndpoint("my-endpoint")
-    @JWT(validate =
-            JWT.JwtMethodMode.BEARER_TOKEN,
-            bearerTokenIssuers = {"a", "b"},
-            staticClaims = {
-                        @JWT.StaticClaim(claim = "roles", values = {"viewer", "editor"}),
-                        @JWT.StaticClaim(claim = "aud", values = "${ENV}.kalix.io"),
-                        @JWT.StaticClaim(claim = "sub", pattern = "^sub-\\S+$")
-                })
-    public static class TestEndpointJwtClassLevel {
-        @Get("/my-object/{id}")
-        public String message(String id) {
-            return "OK";
-        }
+  @HttpEndpoint("invalid-acl")
+  public static class TestEndpointInvalidAcl {
+    @Get("/invalid")
+    @Acl(allow = @Acl.Matcher(service = "*", principal = Acl.Principal.INTERNET))
+    public String invalid() {
+      return "invalid matcher";
     }
+  }
+
+  @HttpEndpoint("invalid-acl-denycode")
+  public static class TestEndpointInvalidAclDenyCode {
+    @Get("/invalid")
+    @Acl(allow = @Acl.Matcher(service = "*"), denyCode = 123123)
+    public String invalid() {
+      return "invalid matcher";
+    }
+  }
+
+  @HttpEndpoint("my-endpoint")
+  @JWT(
+      validate = JWT.JwtMethodMode.BEARER_TOKEN,
+      bearerTokenIssuers = {"a", "b"},
+      staticClaims = {
+        @JWT.StaticClaim(
+            claim = "roles",
+            values = {"viewer", "editor"}),
+        @JWT.StaticClaim(claim = "aud", values = "${ENV}.kalix.io"),
+        @JWT.StaticClaim(claim = "sub", pattern = "^sub-\\S+$")
+      })
+  public static class TestEndpointJwtClassLevel {
+    @Get("/my-object/{id}")
+    public String message(String id) {
+      return "OK";
+    }
+  }
+
+  @JWT(
+      validate = JWT.JwtMethodMode.BEARER_TOKEN,
+      bearerTokenIssuers = {"a", "b"},
+      staticClaims = {
+        @JWT.StaticClaim(
+            claim = "roles",
+            values = {"editor", "viewer"}),
+        @JWT.StaticClaim(claim = "aud", values = "${ENV}.kalix.${ENV2}.io"),
+        @JWT.StaticClaim(claim = "sub", pattern = "^sub-\\S+$")
+      })
+  @HttpEndpoint("my-endpoint")
+  public static class TestEndpointJwtClassAndMethodLevel {
 
     @JWT(
-            validate = JWT.JwtMethodMode.BEARER_TOKEN,
-            bearerTokenIssuers = {"a", "b"},
-            staticClaims = {
-                    @JWT.StaticClaim(claim = "roles", values = {"editor", "viewer"}),
-                    @JWT.StaticClaim(claim = "aud", values = "${ENV}.kalix.${ENV2}.io"),
-                    @JWT.StaticClaim(claim = "sub", pattern = "^sub-\\S+$")
-            })
-    @HttpEndpoint("my-endpoint")
-    public static class TestEndpointJwtClassAndMethodLevel {
-
-        @JWT(
-                validate = JWT.JwtMethodMode.BEARER_TOKEN,
-                bearerTokenIssuers = {"c", "d"},
-                staticClaims = {
-                        @JWT.StaticClaim(claim = "roles", values = {"admin"}),
-                        @JWT.StaticClaim(claim = "aud", values = "${ENV}.kalix.dev"),
-                        @JWT.StaticClaim(claim = "sub", pattern = "^-\\S+$")
-                })
-        @Get("/my-object/{id}")
-        public String message(String id) {
-            return "OK";
-        }
+        validate = JWT.JwtMethodMode.BEARER_TOKEN,
+        bearerTokenIssuers = {"c", "d"},
+        staticClaims = {
+          @JWT.StaticClaim(
+              claim = "roles",
+              values = {"admin"}),
+          @JWT.StaticClaim(claim = "aud", values = "${ENV}.kalix.dev"),
+          @JWT.StaticClaim(claim = "sub", pattern = "^-\\S+$")
+        })
+    @Get("/my-object/{id}")
+    public String message(String id) {
+      return "OK";
     }
+  }
 
-    @HttpEndpoint("my-endpoint")
-    public static class TestEndpointJwtOnlyMethodLevel {
+  @HttpEndpoint("my-endpoint")
+  public static class TestEndpointJwtOnlyMethodLevel {
 
-        @JWT(
-                validate = JWT.JwtMethodMode.BEARER_TOKEN,
-                bearerTokenIssuers = {"c", "d"},
-                staticClaims = {
-                        @JWT.StaticClaim(claim = "roles", values = {"admin"}),
-                        @JWT.StaticClaim(claim = "aud", values = "${ENV}.kalix.dev"),
-                        @JWT.StaticClaim(claim = "sub", pattern = "^-\\S+$")
-                })
-        @Get("/my-object/{id}")
-        public String message(String id) {
-            return "OK";
-        }
+    @JWT(
+        validate = JWT.JwtMethodMode.BEARER_TOKEN,
+        bearerTokenIssuers = {"c", "d"},
+        staticClaims = {
+          @JWT.StaticClaim(
+              claim = "roles",
+              values = {"admin"}),
+          @JWT.StaticClaim(claim = "aud", values = "${ENV}.kalix.dev"),
+          @JWT.StaticClaim(claim = "sub", pattern = "^-\\S+$")
+        })
+    @Get("/my-object/{id}")
+    public String message(String id) {
+      return "OK";
     }
+  }
 
-    @HttpEndpoint("/{id}/my-endpoint")
-    public static class InvalidEndpointMethods {
+  @HttpEndpoint("/{id}/my-endpoint")
+  public static class InvalidEndpointMethods {
 
-        // missing parameter
-        @Get("/")
-        public void list1() {}
+    // missing parameter
+    @Get("/")
+    public void list1() {}
 
-        // wrong parameter name
-        @Get("/")
-        public void list2(String bob) {}
+    // wrong parameter name
+    @Get("/")
+    public void list2(String bob) {}
 
-        // ok parameter count, wrong parameter name
-        @Get("/something/{bob}")
-        public void list3(String id, String value) {}
+    // ok parameter count, wrong parameter name
+    @Get("/something/{bob}")
+    public void list3(String id, String value) {}
 
-        // ok parameter count, body as last param
-        @Get("/something")
-        public void list4(String id, String body) {}
+    // ok parameter count, body as last param
+    @Get("/something")
+    public void list4(String id, String body) {}
 
-        // too many parameters
-        @Get("/too-many")
-        public void list5(String id, String value, String body) {}
+    // too many parameters
+    @Get("/too-many")
+    public void list5(String id, String value, String body) {}
 
-        @Get("/wildcard/**/not/last")
-        public void invalidWildcard(String id) {}
-    }
+    @Get("/wildcard/**/not/last")
+    public void invalidWildcard(String id) {}
+  }
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/impl/view/NotPublicView.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/impl/view/NotPublicView.java
@@ -15,14 +15,13 @@ import akka.javasdk.view.TableUpdater;
 @ComponentId("users_view")
 class NotPublicView {
 
- @Consume.FromKeyValueEntity(UserEntity.class)
- public static class Users extends TableUpdater<User> {
- }
+  @Consume.FromKeyValueEntity(UserEntity.class)
+  public static class Users extends TableUpdater<User> {}
 
- public record QueryParameters(String email) {}
+  public record QueryParameters(String email) {}
 
- @Query("SELECT * FROM users WHERE email = :email")
- public User getUser(QueryParameters email) {
-  return null;
- }
+  @Query("SELECT * FROM users WHERE email = :email")
+  public User getUser(QueryParameters email) {
+    return null;
+  }
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/keyvalueentity/TestVEState0.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/keyvalueentity/TestVEState0.java
@@ -4,5 +4,4 @@
 
 package akka.javasdk.keyvalueentity;
 
-public record TestVEState0(String s, int i) {
-}
+public record TestVEState0(String s, int i) {}

--- a/akka-javasdk/src/test/java/akka/javasdk/keyvalueentity/TestVEState1.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/keyvalueentity/TestVEState1.java
@@ -4,5 +4,4 @@
 
 package akka.javasdk.keyvalueentity;
 
-public record TestVEState1(String s, int i) {
-}
+public record TestVEState1(String s, int i) {}

--- a/akka-javasdk/src/test/java/akka/javasdk/keyvalueentity/TestVEState2.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/keyvalueentity/TestVEState2.java
@@ -7,5 +7,4 @@ package akka.javasdk.keyvalueentity;
 import akka.javasdk.annotations.Migration;
 
 @Migration(TestVEState2Migration.class)
-public record TestVEState2(String s, int i, String newValue) {
-}
+public record TestVEState2(String s, int i, String newValue) {}

--- a/akka-javasdk/src/test/java/akka/javasdk/keyvalueentity/TestVEState2Migration.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/keyvalueentity/TestVEState2Migration.java
@@ -4,12 +4,10 @@
 
 package akka.javasdk.keyvalueentity;
 
-
+import akka.javasdk.JsonMigration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import akka.javasdk.JsonMigration;
-
 
 public class TestVEState2Migration extends JsonMigration {
 
@@ -24,7 +22,6 @@ public class TestVEState2Migration extends JsonMigration {
       return ((ObjectNode) json).set("newValue", TextNode.valueOf("newValue"));
     } else {
       return null;
-
     }
   }
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/keyvalueentity/TestValueEntity.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/keyvalueentity/TestValueEntity.java
@@ -17,5 +17,4 @@ public class TestValueEntity extends KeyValueEntity<TestVEState1> {
   public Effect<TestVEState1> get() {
     return effects().reply(currentState());
   }
-
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/keyvalueentity/TestValueEntityMigration.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/keyvalueentity/TestValueEntityMigration.java
@@ -12,5 +12,4 @@ public class TestValueEntityMigration extends KeyValueEntity<TestVEState2> {
   public Effect<TestVEState2> get() {
     return effects().reply(currentState());
   }
-
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/EndpointsTestModels.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/EndpointsTestModels.java
@@ -6,13 +6,12 @@ package akka.javasdk.testmodels;
 
 import akka.http.javadsl.model.HttpResponse;
 import akka.javasdk.annotations.http.Delete;
-import akka.javasdk.annotations.http.HttpEndpoint;
 import akka.javasdk.annotations.http.Get;
+import akka.javasdk.annotations.http.HttpEndpoint;
 import akka.javasdk.annotations.http.Patch;
 import akka.javasdk.annotations.http.Post;
 import akka.javasdk.annotations.http.Put;
 import akka.javasdk.http.HttpResponses;
-
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -29,18 +28,13 @@ public class EndpointsTestModels {
   @HttpEndpoint("/hello")
   public static class GetHelloEndpoint {
 
-    /**
-     * For testing response returning a String
-     */
+    /** For testing response returning a String */
     @Get
     public String hello() {
       return "Hello";
     }
 
-    /**
-     * For testing a response returning a model object
-     * resulting in an application/json response
-     */
+    /** For testing a response returning a model object resulting in an application/json response */
     @Get("/{name}")
     public Name name(String name) {
       return new Name(name);
@@ -53,34 +47,27 @@ public class EndpointsTestModels {
 
     @Get("/{name}/{age}")
     public String nameAndAge(String name, int age) {
-      return "name: " + name + ", age: " +  age;
+      return "name: " + name + ", age: " + age;
     }
 
-    /**
-     * For testing  response returning an Akka HttpResponse directly
-     */
+    /** For testing response returning an Akka HttpResponse directly */
     @Get("/{name}/{age}/http-response")
     public HttpResponse nameAndAgeHttp(String name, int age) {
       return HttpResponses.ok("http => name: " + name + ", age: " + age);
     }
 
-
-    /**
-     * For testing async response
-     */
+    /** For testing async response */
     @Get("/{name}/{age}/async")
     public CompletionStage<String> nameAndAgeAsync(String name, int age) {
-      return CompletableFuture.completedStage("async => name: " + name + ", age: " +  age);
+      return CompletableFuture.completedStage("async => name: " + name + ", age: " + age);
     }
 
-    /**
-     * For testing async response wrapping an Akka HttpResponse
-     */
+    /** For testing async response wrapping an Akka HttpResponse */
     @Get("/{name}/{age}/async/http-response")
     public CompletionStage<HttpResponse> nameAndAgeAsyncHttp(String name, int age) {
-      return CompletableFuture.completedStage(HttpResponses.ok("async http => name: " + name + ", age: " + age));
+      return CompletableFuture.completedStage(
+          HttpResponses.ok("async http => name: " + name + ", age: " + age));
     }
-
   }
 
   @HttpEndpoint("/hello")
@@ -93,16 +80,15 @@ public class EndpointsTestModels {
 
     @Post("/{age}")
     public String nameAndAgePost(int age, Name body) {
-      return "name: " + body.toString() + ", age: " +  age;
+      return "name: " + body.toString() + ", age: " + age;
     }
 
     @Post("/{age}/async")
     public CompletionStage<String> nameAndAgePostAsync(int age, Name body) {
-      return CompletableFuture.completedStage("async => name: " + body.toString() + ", age: " +  age);
+      return CompletableFuture.completedStage(
+          "async => name: " + body.toString() + ", age: " + age);
     }
-
   }
-
 
   @HttpEndpoint("/hello")
   public static class PutHelloEndpoint {
@@ -165,12 +151,10 @@ public class EndpointsTestModels {
 
   public static class TestShort {
     @Get("/short/{num}")
-    public void primitive(short i) {
-    }
+    public void primitive(short i) {}
 
     @Get("/short/{num}/boxed")
-    public void boxed(Short i) {
-    }
+    public void boxed(Short i) {}
   }
 
   public static class FooWithDoubleMapping1 {
@@ -185,103 +169,83 @@ public class EndpointsTestModels {
 
   public static class TestInt {
     @Get("/int/{num}")
-    public void primitive(int i) {
-    }
+    public void primitive(int i) {}
 
     @Get("/int/{num}/boxed")
-    public void boxed(Integer i) {
-    }
+    public void boxed(Integer i) {}
   }
 
   public static class TestLong {
     @Get("/long/{num}")
-    public void primitive(long i) {
-    }
+    public void primitive(long i) {}
 
     @Get("/long/{num}/boxed")
-    public void boxed(Long i) {
-    }
+    public void boxed(Long i) {}
   }
 
   public static class TestShortIntLong {
     @Get("/number/{shortNum}")
-    public void shortNum(short i) {
-    }
+    public void shortNum(short i) {}
 
     @Get("/number/{intNum}")
-    public void intNum(int i) {
-    }
+    public void intNum(int i) {}
 
     @Get("/number/{longNum}")
-    public void longNum(long i) {
-    }
+    public void longNum(long i) {}
   }
 
   public static class TestDouble {
     @Get("/double/{num}")
-    public void primitive(double i) {
-    }
+    public void primitive(double i) {}
 
     @Get("/double/{num}/boxed")
-    public void boxed(Double i) {
-    }
+    public void boxed(Double i) {}
   }
 
   public static class TestFloat {
     @Get("/float/{num}")
-    public void primitive(float i) {
-    }
+    public void primitive(float i) {}
 
     @Get("/float/{num}/boxed")
-    public void boxed(Float i) {
-    }
+    public void boxed(Float i) {}
   }
 
   public static class TestFloatDouble {
     @Get("/number/{floatNum}")
-    public void floatNum(float i) {
-    }
+    public void floatNum(float i) {}
 
     @Get("/number/{doubleNum}")
-    public void doubleNum(double i) {
-    }
+    public void doubleNum(double i) {}
   }
 
   public static class TestString {
     @Get("/string/{name}")
-    public void name(String i) {
-    }
+    public void name(String i) {}
   }
 
   public static class TestChar {
     @Get("/char/{name}")
-    public void name(Character i) {
-    }
+    public void name(Character i) {}
   }
 
   public static class TestBoolean {
     @Get("/bool/{bool}")
-    public void primitive(boolean i) {
-    }
+    public void primitive(boolean i) {}
 
     @Get("/bool/{bool}/boxed")
-    public void boxed(Boolean i) {
-    }
+    public void boxed(Boolean i) {}
   }
 
   public static class TestMultiVar {
     @Get("/multi/{num}/{bool}/{double}")
-    public void intBooleanDouble(int i , boolean s, double d) {
-    }
+    public void intBooleanDouble(int i, boolean s, double d) {}
 
     @Get("/multi/{name}/{long}/{float}")
-    public void stringLongFloat(String s, Long l, Float f) {
-    }
+    public void stringLongFloat(String s, Long l, Float f) {}
   }
 
   public static class TestUnsupportedType {
     @Get("/unsupported/{name}")
-    public void unsupported(Optional<String> i) {
-    }
+    public void unsupported(Optional<String> i) {}
   }
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/InstantEntryForArray.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/InstantEntryForArray.java
@@ -6,4 +6,4 @@ package akka.javasdk.testmodels;
 
 import java.time.Instant;
 
-public record InstantEntryForArray(Instant instant) { }
+public record InstantEntryForArray(Instant instant) {}

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/InstantEntryForList.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/InstantEntryForList.java
@@ -6,4 +6,4 @@ package akka.javasdk.testmodels;
 
 import java.time.Instant;
 
-public record InstantEntryForList(Instant instant) { }
+public record InstantEntryForList(Instant instant) {}

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/InstantWrapper.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/InstantWrapper.java
@@ -6,4 +6,4 @@ package akka.javasdk.testmodels;
 
 import java.time.Instant;
 
-public record InstantWrapper(Instant instant) { }
+public record InstantWrapper(Instant instant) {}

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/Message.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/Message.java
@@ -4,5 +4,4 @@
 
 package akka.javasdk.testmodels;
 
-public record Message(String value) {
-}
+public record Message(String value) {}

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/TimeEnum.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/TimeEnum.java
@@ -6,6 +6,9 @@ package akka.javasdk.testmodels;
 
 import java.time.Instant;
 
-enum Level {HIGH, LOW};
+enum Level {
+  HIGH,
+  LOW
+};
 
-public record TimeEnum(Instant time, Level lev){}
+public record TimeEnum(Instant time, Level lev) {}

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/action/ActionsTestModels.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/action/ActionsTestModels.java
@@ -4,8 +4,8 @@
 
 package akka.javasdk.testmodels.action;
 
-import akka.javasdk.timedaction.TimedAction;
 import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.timedaction.TimedAction;
 
 public class ActionsTestModels {
 

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/action/EchoAction.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/action/EchoAction.java
@@ -4,8 +4,8 @@
 
 package akka.javasdk.testmodels.action;
 
-import akka.javasdk.timedaction.TimedAction;
 import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.timedaction.TimedAction;
 
 @ComponentId("test-echo")
 public class EchoAction extends TimedAction {
@@ -13,5 +13,4 @@ public class EchoAction extends TimedAction {
   public Effect stringMessage(String msg) {
     return effects().done();
   }
-
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/eventsourcedentity/EmployeeCreatedMigration.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/eventsourcedentity/EmployeeCreatedMigration.java
@@ -5,7 +5,6 @@
 package akka.javasdk.testmodels.eventsourcedentity;
 
 import akka.javasdk.JsonMigration;
-
 import java.util.List;
 
 public class EmployeeCreatedMigration extends JsonMigration {

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/eventsourcedentity/EmployeeEvent.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/eventsourcedentity/EmployeeEvent.java
@@ -33,5 +33,4 @@ public sealed interface EmployeeEvent {
       this.email = email;
     }
   }
-
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/eventsourcedentity/EventSourcedEntitiesTestModels.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/eventsourcedentity/EventSourcedEntitiesTestModels.java
@@ -7,119 +7,122 @@ package akka.javasdk.testmodels.eventsourcedentity;
 import akka.javasdk.JsonMigration;
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.annotations.Migration;
-import akka.javasdk.annotations.Acl;
-import akka.javasdk.annotations.JWT;
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
-
 import java.util.List;
 
 public class EventSourcedEntitiesTestModels {
 
-    public sealed interface CounterEvent {
-        record IncrementCounter(int value) implements CounterEvent {
-        }
-        record DecrementCounter(int value) implements CounterEvent {
-        }
+  public sealed interface CounterEvent {
+    record IncrementCounter(int value) implements CounterEvent {}
+
+    record DecrementCounter(int value) implements CounterEvent {}
+  }
+
+  @ComponentId("employee")
+  public static class EmployeeEntity extends EventSourcedEntity<Employee, EmployeeEvent> {
+
+    public Effect<String> createUser(CreateEmployee create) {
+      return effects()
+          .persist(
+              new EmployeeEvent.EmployeeCreated(create.firstName, create.lastName, create.email))
+          .thenReply(__ -> "ok");
     }
 
-    @ComponentId("employee")
-    public static class EmployeeEntity extends EventSourcedEntity<Employee, EmployeeEvent> {
+    public Employee applyEvent(EmployeeEvent event) {
+      EmployeeEvent.EmployeeCreated create = (EmployeeEvent.EmployeeCreated) event;
+      return new Employee(create.firstName, create.lastName, create.email);
+    }
+  }
 
-        public Effect<String> createUser(CreateEmployee create) {
-            return effects()
-                .persist(new EmployeeEvent.EmployeeCreated(create.firstName, create.lastName, create.email))
-                .thenReply(__ -> "ok");
-        }
+  @ComponentId("counter-entity")
+  public static class CounterEventSourcedEntity extends EventSourcedEntity<Integer, CounterEvent> {
 
-        public Employee applyEvent(EmployeeEvent event) {
-            EmployeeEvent.EmployeeCreated create = (EmployeeEvent.EmployeeCreated) event;
-            return new Employee(create.firstName, create.lastName, create.email);
-        }
+    @Migration(EventMigration.class)
+    public record Event(String s) {}
+
+    public static class EventMigration extends JsonMigration {
+
+      public EventMigration() {}
+
+      @Override
+      public int currentVersion() {
+        return 1;
+      }
+
+      @Override
+      public List<String> supportedClassNames() {
+        return List.of("additional-mapping");
+      }
     }
 
-    @ComponentId("counter-entity")
-    public static class CounterEventSourcedEntity extends EventSourcedEntity<Integer, CounterEvent> {
-
-        @Migration(EventMigration.class)
-        public record Event(String s) {
-        }
-
-        public static class EventMigration extends JsonMigration {
-
-            public EventMigration() {
-            }
-
-            @Override
-            public int currentVersion() {
-                return 1;
-            }
-
-            @Override
-            public List<String> supportedClassNames() {
-                return List.of("additional-mapping");
-            }
-        }
-
-        public ReadOnlyEffect<Integer> getInteger() {
-            return effects().reply(currentState());
-        }
-
-        public Effect<Integer> changeInteger(Integer number) {
-            if (number == 0) {
-                return effects().reply(currentState());
-            } else if (number < 0) {
-                return effects().persist(new CounterEvent.DecrementCounter(number)).thenReply(newValue -> newValue);
-            } else {
-                return effects().persist(new CounterEvent.IncrementCounter(number)).thenReply(newValue -> newValue);
-            }
-        }
-
-        @Override
-        public Integer applyEvent(CounterEvent event) {
-            return 0;
-        }
+    public ReadOnlyEffect<Integer> getInteger() {
+      return effects().reply(currentState());
     }
 
-
-    @ComponentId("counter")
-    public static class InvalidEventSourcedEntityWithOverloadedCommandHandler extends EventSourcedEntity<Employee, EmployeeEvent> {
-
-        public Effect<String> createUser(CreateEmployee create) {
-            return effects()
-                    .persist(new EmployeeEvent.EmployeeCreated(create.firstName, create.lastName, create.email))
-                    .thenReply(__ -> "ok");
-        }
-
-        public Effect<String> createUser(String email) {
-            return effects()
-                    .persist(new EmployeeEvent.EmployeeCreated("John", "Doe", email))
-                    .thenReply(__ -> "ok");
-        }
-
-        @Override
-        public Employee applyEvent(EmployeeEvent event) {
-            return null;
-        }
+    public Effect<Integer> changeInteger(Integer number) {
+      if (number == 0) {
+        return effects().reply(currentState());
+      } else if (number < 0) {
+        return effects()
+            .persist(new CounterEvent.DecrementCounter(number))
+            .thenReply(newValue -> newValue);
+      } else {
+        return effects()
+            .persist(new CounterEvent.IncrementCounter(number))
+            .thenReply(newValue -> newValue);
+      }
     }
 
-    @ComponentId("counter")
-    public static class InvalidEventSourcedEntityWithGenericReturnTypeHandler extends EventSourcedEntity<Employee, EmployeeEvent> {
-
-        public Effect<List<String>> createUser(CreateEmployee create) {
-            return effects()
-              .persist(new EmployeeEvent.EmployeeCreated(create.firstName, create.lastName, create.email))
-              .thenReply(__ -> List.of("ok"));
-        }
-
-        public Effect<String> createUser2(CreateEmployee create) {
-            return effects()
-              .persist(new EmployeeEvent.EmployeeCreated(create.firstName, create.lastName, create.email))
-              .thenReply(__ -> "ok");
-        }
-
-        @Override
-        public Employee applyEvent(EmployeeEvent event) {
-            return null;
-        }
+    @Override
+    public Integer applyEvent(CounterEvent event) {
+      return 0;
     }
+  }
+
+  @ComponentId("counter")
+  public static class InvalidEventSourcedEntityWithOverloadedCommandHandler
+      extends EventSourcedEntity<Employee, EmployeeEvent> {
+
+    public Effect<String> createUser(CreateEmployee create) {
+      return effects()
+          .persist(
+              new EmployeeEvent.EmployeeCreated(create.firstName, create.lastName, create.email))
+          .thenReply(__ -> "ok");
+    }
+
+    public Effect<String> createUser(String email) {
+      return effects()
+          .persist(new EmployeeEvent.EmployeeCreated("John", "Doe", email))
+          .thenReply(__ -> "ok");
+    }
+
+    @Override
+    public Employee applyEvent(EmployeeEvent event) {
+      return null;
+    }
+  }
+
+  @ComponentId("counter")
+  public static class InvalidEventSourcedEntityWithGenericReturnTypeHandler
+      extends EventSourcedEntity<Employee, EmployeeEvent> {
+
+    public Effect<List<String>> createUser(CreateEmployee create) {
+      return effects()
+          .persist(
+              new EmployeeEvent.EmployeeCreated(create.firstName, create.lastName, create.email))
+          .thenReply(__ -> List.of("ok"));
+    }
+
+    public Effect<String> createUser2(CreateEmployee create) {
+      return effects()
+          .persist(
+              new EmployeeEvent.EmployeeCreated(create.firstName, create.lastName, create.email))
+          .thenReply(__ -> "ok");
+    }
+
+    @Override
+    public Employee applyEvent(EmployeeEvent event) {
+      return null;
+    }
+  }
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/keyvalueentity/Counter.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/keyvalueentity/Counter.java
@@ -23,20 +23,17 @@ public class Counter extends KeyValueEntity<CounterState> {
   public Effect<Number> increase(Number num) {
     CounterState counterState = currentState();
     logger.info(
-      "Increasing counter '{}' by '{}', current value is '{}'",
-      counterState.id,
-      num.value,
-      counterState.value);
+        "Increasing counter '{}' by '{}', current value is '{}'",
+        counterState.id,
+        num.value,
+        counterState.value);
     CounterState newCounter = counterState.increase(num.value);
     return effects().updateState(newCounter).thenReply(new Number(newCounter.value));
   }
 
   public Effect<Number> randomIncrease(Integer value) {
     CounterState counterState = new CounterState(commandContext().entityId(), value);
-    logger.info(
-      "Increasing counter '{}' to value '{}'",
-      counterState.id,
-      counterState.value);
+    logger.info("Increasing counter '{}' to value '{}'", counterState.id, counterState.value);
     return effects().updateState(counterState).thenReply(new Number(counterState.value));
   }
 
@@ -45,4 +42,3 @@ public class Counter extends KeyValueEntity<CounterState> {
     return effects().reply(new Number(currentState().value));
   }
 }
-

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/keyvalueentity/CounterStateMigration.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/keyvalueentity/CounterStateMigration.java
@@ -5,7 +5,6 @@
 package akka.javasdk.testmodels.keyvalueentity;
 
 import akka.javasdk.JsonMigration;
-
 import java.util.List;
 
 public class CounterStateMigration extends JsonMigration {

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/keyvalueentity/TimeTrackerEntity.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/keyvalueentity/TimeTrackerEntity.java
@@ -6,7 +6,6 @@ package akka.javasdk.testmodels.keyvalueentity;
 
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.keyvalueentity.KeyValueEntity;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,12 +13,11 @@ import java.util.List;
 @ComponentId("timer")
 public class TimeTrackerEntity extends KeyValueEntity<TimeTrackerEntity.TimerState> {
 
-
   public static class TimerState {
 
-    final public String name;
-    final public Instant createdTime;
-    final public List<TimerEntry> entries;
+    public final String name;
+    public final Instant createdTime;
+    public final List<TimerEntry> entries;
 
     public TimerState(String name, Instant createdTime, List<TimerEntry> entries) {
       this.name = name;
@@ -29,8 +27,8 @@ public class TimeTrackerEntity extends KeyValueEntity<TimeTrackerEntity.TimerSta
   }
 
   public static class TimerEntry {
-    final public Instant started;
-    final public Instant stopped = Instant.MAX;
+    public final Instant started;
+    public final Instant stopped = Instant.MAX;
 
     public TimerEntry(Instant started) {
       this.started = started;
@@ -39,8 +37,9 @@ public class TimeTrackerEntity extends KeyValueEntity<TimeTrackerEntity.TimerSta
 
   public Effect<String> start(String timerId) {
     if (currentState() == null)
-      return effects().updateState(new TimerState(timerId, Instant.now(), new ArrayList<>())).thenReply("Created");
-    else
-      return effects().error("Already created");
+      return effects()
+          .updateState(new TimerState(timerId, Instant.now(), new ArrayList<>()))
+          .thenReply("Created");
+    else return effects().error("Already created");
   }
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/keyvalueentity/ValueEntitiesTestModels.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/keyvalueentity/ValueEntitiesTestModels.java
@@ -15,6 +15,7 @@ public class ValueEntitiesTestModels {
     public KeyValueEntity.Effect<Done> createEntity(CreateUser createUser) {
       return effects().reply(Done.instance);
     }
+
     public KeyValueEntity.Effect<Done> createEntity(String user) {
       return effects().reply(Done.instance);
     }

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/subscriptions/PubSubTestModels.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/subscriptions/PubSubTestModels.java
@@ -5,15 +5,12 @@
 package akka.javasdk.testmodels.subscriptions;
 
 import akka.javasdk.annotations.Acl;
+import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.Consume;
 import akka.javasdk.annotations.DeleteHandler;
 import akka.javasdk.annotations.Produce;
 import akka.javasdk.annotations.Query;
-import akka.javasdk.annotations.Consume;
-import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.consumer.Consumer;
-import akka.javasdk.testmodels.workflow.WorkflowTestModels.TransferWorkflow;
-import akka.javasdk.view.View;
-import akka.javasdk.view.TableUpdater;
 import akka.javasdk.testmodels.Done;
 import akka.javasdk.testmodels.Message;
 import akka.javasdk.testmodels.Message2;
@@ -26,8 +23,13 @@ import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels
 import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.EmployeeEntity;
 import akka.javasdk.testmodels.keyvalueentity.Counter;
 import akka.javasdk.testmodels.keyvalueentity.CounterState;
+import akka.javasdk.testmodels.workflow.WorkflowTestModels.TransferWorkflow;
+import akka.javasdk.view.TableUpdater;
+import akka.javasdk.view.View;
 
-public class PubSubTestModels {//TODO shall we remove this class and move things to ActionTestModels and ViewTestModels
+public
+class PubSubTestModels { // TODO shall we remove this class and move things to ActionTestModels and
+  // ViewTestModels
 
   @Consume.FromKeyValueEntity(Counter.class)
   public static class SubscribeToValueEntityTypeLevel extends Consumer {
@@ -85,7 +87,6 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
     }
   }
 
-
   @Consume.FromTopic(value = "topicXYZ", ignoreUnknown = true)
   public static class SubscribeToTopicsActionTypeLevel extends Consumer {
 
@@ -115,7 +116,6 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
     public Effect methodOne(Integer message) {
       return effects().produce(message);
     }
-
   }
 
   @Consume.FromKeyValueEntity(Counter.class)
@@ -294,7 +294,6 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
   @Produce.ToTopic("foobar")
   public static class VEWithPublishToTopic extends Consumer {
 
-
     public Effect messageOne(String msg) {
       return effects().produce(new Message(msg));
     }
@@ -352,7 +351,6 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
     }
   }
 
-
   // common query parameter for views in this file
   public record ByEmail(String email) {}
 
@@ -362,13 +360,13 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
     @Consume.FromEventSourcedEntity(value = EmployeeEntity.class, ignoreUnknown = true)
     public static class Employees extends TableUpdater<Employee> {
       public Effect<Employee> onCreate(EmployeeCreated evt) {
-        return effects()
-            .updateRow(new Employee(evt.firstName, evt.lastName, evt.email));
+        return effects().updateRow(new Employee(evt.firstName, evt.lastName, evt.email));
       }
 
       public Effect<Employee> onEmailUpdate(EmployeeEmailUpdated eeu) {
         var employee = rowState();
-        return effects().updateRow(new Employee(employee.firstName(), employee.lastName(), eeu.email));
+        return effects()
+            .updateRow(new Employee(employee.firstName(), employee.lastName(), eeu.email));
       }
     }
 
@@ -378,23 +376,22 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
     }
   }
 
-
   @Consume.FromEventSourcedEntity(value = EmployeeEntity.class)
   @Produce.ServiceStream(id = "employee_events")
   public static class EventStreamPublishingConsumer extends Consumer {
 
     public Effect transform(EmployeeEvent event) {
-      return switch (event){
-        case EmployeeCreated created ->
-          effects().produce(created.toString());
-        case EmployeeEmailUpdated emailUpdated ->
-          effects().produce(emailUpdated.toString());
+      return switch (event) {
+        case EmployeeCreated created -> effects().produce(created.toString());
+        case EmployeeEmailUpdated emailUpdated -> effects().produce(emailUpdated.toString());
       };
     }
-
   }
 
-  @Consume.FromServiceStream(service = "employee_service", id = "employee_events", ignoreUnknown = true)
+  @Consume.FromServiceStream(
+      service = "employee_service",
+      id = "employee_events",
+      ignoreUnknown = true)
   public static class EventStreamSubscriptionConsumer extends Consumer {
 
     public Effect transform(EmployeeCreated created) {
@@ -412,13 +409,13 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
     @Consume.FromServiceStream(service = "employee_service", id = "employee_events")
     public static class Employees extends TableUpdater<Employee> {
       public Effect<Employee> onCreate(EmployeeCreated evt) {
-        return effects()
-            .updateRow(new Employee(evt.firstName, evt.lastName, evt.email));
+        return effects().updateRow(new Employee(evt.firstName, evt.lastName, evt.email));
       }
 
       public Effect<Employee> onEmailUpdate(EmployeeEmailUpdated eeu) {
         var employee = rowState();
-        return effects().updateRow(new Employee(employee.firstName(), employee.lastName(), eeu.email));
+        return effects()
+            .updateRow(new Employee(employee.firstName(), employee.lastName(), eeu.email));
       }
     }
 

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/view/ByNameAndEmail.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/view/ByNameAndEmail.java
@@ -4,5 +4,4 @@
 
 package akka.javasdk.testmodels.view;
 
-public record ByNameAndEmail(String name, String email) {
-}
+public record ByNameAndEmail(String name, String email) {}

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/view/EmployeeCounters.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/view/EmployeeCounters.java
@@ -4,9 +4,8 @@
 
 package akka.javasdk.testmodels.view;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import akka.javasdk.testmodels.keyvalueentity.CounterState;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Collection;
 
 public class EmployeeCounters {

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/view/UserCollection.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/view/UserCollection.java
@@ -4,10 +4,9 @@
 
 package akka.javasdk.testmodels.view;
 
+import akka.javasdk.testmodels.keyvalueentity.User;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import akka.javasdk.testmodels.keyvalueentity.User;
-
 import java.util.Collection;
 
 public class UserCollection {

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/view/ViewTestModels.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/view/ViewTestModels.java
@@ -8,11 +8,8 @@ import akka.javasdk.annotations.Acl;
 import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.annotations.Consume;
 import akka.javasdk.annotations.DeleteHandler;
-import akka.javasdk.annotations.JWT;
 import akka.javasdk.annotations.Query;
 import akka.javasdk.annotations.Table;
-import akka.javasdk.view.View;
-import akka.javasdk.view.TableUpdater;
 import akka.javasdk.testmodels.eventsourcedentity.Employee;
 import akka.javasdk.testmodels.eventsourcedentity.EmployeeEvent;
 import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.EmployeeEntity;
@@ -23,7 +20,8 @@ import akka.javasdk.testmodels.keyvalueentity.CounterState;
 import akka.javasdk.testmodels.keyvalueentity.TimeTrackerEntity;
 import akka.javasdk.testmodels.keyvalueentity.User;
 import akka.javasdk.testmodels.keyvalueentity.UserEntity;
-
+import akka.javasdk.view.TableUpdater;
+import akka.javasdk.view.View;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -47,19 +45,21 @@ public class ViewTestModels {
       Optional<String> optionalString,
       List<String> repeatedString,
       ByEmail nestedMessage,
-      AnEnum anEnum
-  ) {}
+      AnEnum anEnum) {}
 
   public enum AnEnum {
-    ONE, TWO, THREE
+    ONE,
+    TWO,
+    THREE
   }
 
   // common query parameter for views in this file
-  public record ByEmail(String email) {
-  }
+  public record ByEmail(String email) {}
 
   public record Recursive(String id, Recursive child) {}
+
   public record TwoStepRecursive(TwoStepRecursiveChild child) {}
+
   public record TwoStepRecursiveChild(TwoStepRecursive recursive) {}
 
   @ComponentId("users_view")
@@ -209,7 +209,6 @@ public class ViewTestModels {
     }
   }
 
-
   @ComponentId("users_view")
   public static class TransformedUserView extends View {
 
@@ -242,7 +241,6 @@ public class ViewTestModels {
       public Effect<String> onChange(User user) {
         return effects().updateRow(user.email);
       }
-
     }
 
     @Query("SELECT * FROM users WHERE email = :email")
@@ -269,7 +267,7 @@ public class ViewTestModels {
     }
 
     @Query("SELECT * FROM users WHERE email = :email")
-    public QueryEffect<TransformedUser>  getUser(ByEmail byEmail) {
+    public QueryEffect<TransformedUser> getUser(ByEmail byEmail) {
       return queryResult();
     }
   }
@@ -287,7 +285,7 @@ public class ViewTestModels {
     }
 
     @Query("SELECT * FROM users WHERE email = :email")
-    public QueryEffect<TransformedUser>  getUser(ByEmail byEmail) {
+    public QueryEffect<TransformedUser> getUser(ByEmail byEmail) {
       return queryResult();
     }
   }
@@ -296,11 +294,10 @@ public class ViewTestModels {
   public static class UserViewWithoutTransformation extends View {
 
     @Consume.FromKeyValueEntity(UserEntity.class)
-    public static class TransformedUserUpdater extends TableUpdater<User> {
-    }
+    public static class TransformedUserUpdater extends TableUpdater<User> {}
 
     @Query("SELECT * FROM users WHERE email = :email")
-    public QueryEffect<TransformedUser>  getUser(ByEmail byEmail) {
+    public QueryEffect<TransformedUser> getUser(ByEmail byEmail) {
       return queryResult();
     }
   }
@@ -308,9 +305,8 @@ public class ViewTestModels {
   @ComponentId("users_view")
   public static class ViewWithoutSubscription extends View {
 
-    public static class UserUpdater extends TableUpdater<TransformedUser> {
-    }
-    
+    public static class UserUpdater extends TableUpdater<TransformedUser> {}
+
     @Query("SELECT * FROM users WHERE email = :email")
     public QueryEffect<TransformedUser> getUser(ByEmail byEmail) {
       return queryResult();
@@ -404,10 +400,6 @@ public class ViewTestModels {
     }
   }
 
-
-
-
-
   @ComponentId("employees_view")
   public static class SubscribeToEventSourcedEvents extends View {
 
@@ -438,8 +430,8 @@ public class ViewTestModels {
 
       public Effect<Employee> handle(EmployeeEvent event) {
         return switch (event) {
-          case EmployeeEvent.EmployeeCreated created -> effects()
-              .updateRow(new Employee(created.firstName, created.lastName, created.email));
+          case EmployeeEvent.EmployeeCreated created ->
+              effects().updateRow(new Employee(created.firstName, created.lastName, created.email));
           case EmployeeEvent.EmployeeEmailUpdated updated -> effects().ignore();
         };
       }
@@ -468,7 +460,6 @@ public class ViewTestModels {
     }
   }
 
-
   @ComponentId("users_view")
   public static class TypeLevelSubscribeToEventSourcedEventsWithMissingHandler extends View {
 
@@ -491,7 +482,7 @@ public class ViewTestModels {
   public static class ViewWithServiceLevelAcl extends View {
 
     @Consume.FromKeyValueEntity(UserEntity.class)
-    public static class Users extends TableUpdater<User> { }
+    public static class Users extends TableUpdater<User> {}
 
     @Query("SELECT * FROM users WHERE email = :email")
     public QueryEffect<Employee> getEmployeeByEmail(ByEmail byEmail) {
@@ -503,8 +494,7 @@ public class ViewTestModels {
   public static class ViewWithMethodLevelAcl extends View {
 
     @Consume.FromKeyValueEntity(UserEntity.class)
-    public static class Users extends TableUpdater<User> {
-    }
+    public static class Users extends TableUpdater<User> {}
 
     @Query("SELECT * FROM users WHERE email = :email")
     @Acl(allow = @Acl.Matcher(service = "test"))
@@ -517,7 +507,7 @@ public class ViewTestModels {
   public static class UserByEmailWithCollectionReturn extends View {
 
     @Consume.FromKeyValueEntity(UserEntity.class)
-    public static class UsersTable extends TableUpdater<User> { }
+    public static class UsersTable extends TableUpdater<User> {}
 
     @Query(value = "SELECT * AS users FROM users WHERE name = :name")
     public QueryEffect<UserCollection> getUser(ByEmail name) {
@@ -529,14 +519,13 @@ public class ViewTestModels {
   public static class UserByEmailWithStreamReturn extends View {
 
     @Consume.FromKeyValueEntity(UserEntity.class)
-    public static class UsersTable extends TableUpdater<User> { }
+    public static class UsersTable extends TableUpdater<User> {}
 
     @Query(value = "SELECT * AS users FROM users")
     public QueryStreamEffect<User> getAllUsers() {
       return queryStreamResult();
     }
   }
-
 
   @ComponentId("users_view")
   public static class MultiTableViewValidation extends View {
@@ -583,13 +572,14 @@ public class ViewTestModels {
   @ComponentId("multi-table-view-with-join-query")
   public static class MultiTableViewWithJoinQuery extends View {
 
-    @Query("""
-      SELECT employees.*, counters.* as counters
-      FROM employees
-      JOIN assigned ON assigned.assigneeId = employees.email
-      JOIN counters ON assigned.counterId = counters.id
-      WHERE employees.email = :email
-      """)
+    @Query(
+        """
+        SELECT employees.*, counters.* as counters
+        FROM employees
+        JOIN assigned ON assigned.assigneeId = employees.email
+        JOIN counters ON assigned.counterId = counters.id
+        WHERE employees.email = :email
+        """)
     public QueryEffect<EmployeeCounters> get(ByEmail byEmail) {
       return queryResult();
     }
@@ -629,7 +619,7 @@ public class ViewTestModels {
     public static class Employees extends TableUpdater<Employee> {
       public Effect<Employee> onEvent(EmployeeEvent.EmployeeCreated created) {
         return effects()
-          .updateRow(new Employee(created.firstName, created.lastName, created.email));
+            .updateRow(new Employee(created.firstName, created.lastName, created.email));
       }
     }
 
@@ -663,7 +653,7 @@ public class ViewTestModels {
     public static class Employees extends TableUpdater<Employee> {
       public Effect<Employee> onEvent(EmployeeEvent.EmployeeCreated created) {
         return effects()
-          .updateRow(new Employee(created.firstName, created.lastName, created.email));
+            .updateRow(new Employee(created.firstName, created.lastName, created.email));
       }
     }
 
@@ -688,14 +678,13 @@ public class ViewTestModels {
   public static class TimeTrackerView extends View {
 
     @Consume.FromKeyValueEntity(TimeTrackerEntity.class)
-    public static class TimeTrackers extends TableUpdater<TimeTrackerEntity.TimerState> { }
+    public static class TimeTrackers extends TableUpdater<TimeTrackerEntity.TimerState> {}
 
     @Query(value = "SELECT * FROM time_trackers WHERE name = :name")
     public QueryEffect<TimeTrackerEntity.TimerState> query2() {
       return queryResult();
     }
   }
-
 
   @ComponentId("employee_view")
   public static class TopicTypeLevelSubscriptionView extends View {
@@ -704,13 +693,13 @@ public class ViewTestModels {
     public static class Employees extends TableUpdater<Employee> {
 
       public Effect<Employee> onCreate(EmployeeEvent.EmployeeCreated evt) {
-        return effects()
-            .updateRow(new Employee(evt.firstName, evt.lastName, evt.email));
+        return effects().updateRow(new Employee(evt.firstName, evt.lastName, evt.email));
       }
 
       public Effect<Employee> onEmailUpdate(EmployeeEvent.EmployeeEmailUpdated eeu) {
         var employee = rowState();
-        return effects().updateRow(new Employee(employee.firstName(), employee.lastName(), eeu.email));
+        return effects()
+            .updateRow(new Employee(employee.firstName(), employee.lastName(), eeu.email));
       }
     }
 
@@ -720,13 +709,12 @@ public class ViewTestModels {
     }
   }
 
-
   public record ById(String id) {}
 
   @ComponentId("recursive_view")
   public static class RecursiveViewStateView extends View {
     @Consume.FromTopic(value = "recursivetopic")
-    public static class Events extends TableUpdater<Recursive> { }
+    public static class Events extends TableUpdater<Recursive> {}
 
     @Query("SELECT * FROM events WHERE id = :id")
     public QueryEffect<Employee> getEmployeeByEmail(ById id) {
@@ -737,7 +725,7 @@ public class ViewTestModels {
   @ComponentId("all_the_field_types_view")
   public static class AllTheFieldTypesView extends View {
     @Consume.FromTopic(value = "allthetypestopic")
-    public static class Events extends TableUpdater<EveryType> { }
+    public static class Events extends TableUpdater<EveryType> {}
 
     @Query("SELECT * FROM rows")
     public QueryStreamEffect<Employee> allRows() {

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/workflow/WorkflowTestModels.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/workflow/WorkflowTestModels.java
@@ -5,8 +5,8 @@
 package akka.javasdk.testmodels.workflow;
 
 import akka.javasdk.annotations.Acl;
-import akka.javasdk.annotations.JWT;
 import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.annotations.JWT;
 import akka.javasdk.workflow.Workflow;
 
 public class WorkflowTestModels {
@@ -38,8 +38,8 @@ public class WorkflowTestModels {
         validate = JWT.JwtMethodMode.BEARER_TOKEN,
         bearerTokenIssuers = {"a", "b"},
         staticClaims = {
-            @JWT.StaticClaim(claim = "role", values = "method-admin"),
-            @JWT.StaticClaim(claim = "aud", values = "${ENV}.kalix.io")
+          @JWT.StaticClaim(claim = "role", values = "method-admin"),
+          @JWT.StaticClaim(claim = "aud", values = "${ENV}.kalix.io")
         })
     public Effect<String> startTransfer(StartWorkflow startWorkflow) {
       return null;
@@ -48,12 +48,12 @@ public class WorkflowTestModels {
 
   @ComponentId("transfer-workflow")
   @JWT(
-    validate = JWT.JwtMethodMode.BEARER_TOKEN,
-    bearerTokenIssuers = {"c", "d"},
-    staticClaims = {
+      validate = JWT.JwtMethodMode.BEARER_TOKEN,
+      bearerTokenIssuers = {"c", "d"},
+      staticClaims = {
         @JWT.StaticClaim(claim = "role", values = "admin"),
         @JWT.StaticClaim(claim = "aud", values = "${ENV}")
-    })
+      })
   public static class WorkflowWithServiceLevelJWT extends Workflow<WorkflowState> {
     @Override
     public WorkflowDef<WorkflowState> definition() {

--- a/akka-javasdk/src/test/java/akka/javasdk/timedaction/TestTracing.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/timedaction/TestTracing.java
@@ -4,16 +4,15 @@
 
 package akka.javasdk.timedaction;
 
+import akka.javasdk.annotations.ComponentId;
 import akka.javasdk.annotations.Consume;
 import akka.javasdk.consumer.Consumer;
 import akka.javasdk.eventsourcedentity.TestESEvent;
 import akka.javasdk.eventsourcedentity.TestEventSourcedEntity;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.context.propagation.TextMapSetter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import akka.javasdk.annotations.ComponentId;
 
 @ComponentId("tracing-action")
 @Consume.FromEventSourcedEntity(value = TestEventSourcedEntity.class, ignoreUnknown = true)
@@ -25,18 +24,26 @@ public class TestTracing extends Consumer {
     logger.info("registering a logging event");
 
     // test expects a w3c encoded trace parent so here are some hoops to get that
-    // FIXME if this turns out to be a common need we could provide the w3c encoded traceparent from Tracing
+    // FIXME if this turns out to be a common need we could provide the w3c encoded traceparent from
+    // Tracing
     //       but for now leaving otel hoops to users is fine enough
     String[] w3cEncodedTraceParent = {"not-enabled"};
-    messageContext().tracing().parentSpan().ifPresent(span -> {
-      var contextWithSpan = Context.current().with(span);
-      W3CTraceContextPropagator.getInstance().inject(contextWithSpan, null,
-          (carrier, key, value) -> {
-            if (key.equals("traceparent")) {
-              w3cEncodedTraceParent[0] = value;
-            }
-          });
-    });
+    messageContext()
+        .tracing()
+        .parentSpan()
+        .ifPresent(
+            span -> {
+              var contextWithSpan = Context.current().with(span);
+              W3CTraceContextPropagator.getInstance()
+                  .inject(
+                      contextWithSpan,
+                      null,
+                      (carrier, key, value) -> {
+                        if (key.equals("traceparent")) {
+                          w3cEncodedTraceParent[0] = value;
+                        }
+                      });
+            });
     return effects().produce(w3cEncodedTraceParent[0]);
   }
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/workflow/DummyClassRenamedMigration.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/workflow/DummyClassRenamedMigration.java
@@ -4,10 +4,9 @@
 
 package akka.javasdk.workflow;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import akka.javasdk.DummyClass2;
 import akka.javasdk.JsonMigration;
-
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 
 public class DummyClassRenamedMigration extends JsonMigration {

--- a/akka-javasdk/src/test/java/akka/javasdk/workflow/Result.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/workflow/Result.java
@@ -9,12 +9,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 @JsonSubTypes({
-    @JsonSubTypes.Type(value = Result.Succeed.class),
-    @JsonSubTypes.Type(value = Result.Failed.class)})
+  @JsonSubTypes.Type(value = Result.Succeed.class),
+  @JsonSubTypes.Type(value = Result.Failed.class)
+})
 public interface Result {
-  record Failed(String errorMsg) implements Result {
-  }
+  record Failed(String errorMsg) implements Result {}
 
-  record Succeed() implements Result {
-  }
+  record Succeed() implements Result {}
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/workflow/TestWorkflowSerialization.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/workflow/TestWorkflowSerialization.java
@@ -6,25 +6,21 @@ package akka.javasdk.workflow;
 
 import akka.javasdk.annotations.ComponentId;
 
-import java.util.concurrent.CompletableFuture;
-
 @ComponentId("workflow")
 public class TestWorkflowSerialization extends Workflow<String> {
 
   @Override
   public WorkflowDef<String> definition() {
-    var testStep = step("test")
-        .<Result>call(Result.Succeed::new)
-        .andThen(Result.class, result -> effects().updateState("success").end());
+    var testStep =
+        step("test")
+            .<Result>call(Result.Succeed::new)
+            .andThen(Result.class, result -> effects().updateState("success").end());
 
     return workflow().addStep(testStep);
   }
 
   public Effect<String> start() {
-    return effects()
-        .updateState("empty")
-        .transitionTo("test")
-        .thenReply("ok");
+    return effects().updateState("empty").transitionTo("test").thenReply("ok");
   }
 
   public Effect<String> get() {

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -7,13 +7,15 @@ import org.scalafmt.sbt.ScalafmtPlugin.autoImport.scalafmtOnCompile
 import sbtprotoc.ProtocPlugin
 
 import java.nio.charset.StandardCharsets
+import scala.annotation.nowarn
 import scala.collection.breakOut
-import com.github.sbt.JavaFormatterPlugin
+import com.github.sbt.AutomateJavaFormatterPlugin
 import com.github.sbt.JavaFormatterPlugin.autoImport.javafmtOnCompile
 
 object CommonSettings extends AutoPlugin {
 
-  override def requires = plugins.JvmPlugin && ScalafmtPlugin && JavaFormatterPlugin
+  @nowarn("msg=deprecated") // need to depend on AutomateJavaFormatterPlugin for settings ordering
+  override def requires = plugins.JvmPlugin && ScalafmtPlugin && AutomateJavaFormatterPlugin
   override def trigger = allRequirements
 
   val additionalValidation =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 // Note: akka-grpc must be carefully kept in sync with the version used in the runtime.
 //       Whenever this is bumped, akka-javasdk-maven/akka-javasdk-parent/pom.xml must be bumped to the same version
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.5.5")
-addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.9.0")
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.10.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")
@@ -12,3 +12,6 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.11.0")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.3")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
+
+// align guava version between sbt-akka-grpc and sbt-java-formatter
+libraryDependencies += "com.google.guava" % "guava" % "33.3.1-jre"


### PR DESCRIPTION
Similar to runtime, java formatting has been configured but hasn't actually been working. Fix this while development is quieter.

It's been silently failing on a class not found exception from guava, with the jre version being evicted for the android version from sbt-akka-grpc transitive dependency. Format checks have defaulted to passing. Fixed for now by aligning the dependency.

Also update to latest sbt-java-formatter, and add the needed jvm options for latest jdks.

Apply the formatting in a separate commit. Samples have their own formatting already.