### PR TITLE
build: automate organize imports with scalafix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
         with:
           jvm: temurin:1.21
 
+      - name: Start sbt server with build options
+        run: sbt --client -Dbuild.scalafix exit
+
       - name: Run javafmt checks
         run: |
           sbt --client javafmtCheckAll || \
@@ -72,6 +75,16 @@ jobs:
         run: |
           sbt --client "scalafmtCheckAll; scalafmtSbtCheck" || \
             { echo "[error] Code not formatted prior to commit. Run 'sbt scalafmtAll scalafmtSbt' then commit the reformatted code."; false; }
+
+      - name: Run scalafix OrganizeImports check
+        run: |
+          sbt --client "scalafixEnable ; Test/compile ; scalafixAll --check OrganizeImports" || \
+            {
+              echo "[error] Scala imports not organized prior to commit."
+              echo "[error] Run organize imports in your IDE then commit the updated code, or run:"
+              echo "[error]   sbt -Dbuild.scalafix scalafixEnable 'scalafixAll OrganizeImports' scalafmtAll"
+              false
+            }
 
       - name: Run additional validations
         run: |

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,8 @@
+OrganizeImports {
+  targetDialect = Scala2
+  groups = [
+    "re:javax?\\."
+    "scala."
+    "*"
+  ]
+}

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/AbstractTestKitContext.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/AbstractTestKitContext.scala
@@ -4,11 +4,11 @@
 
 package akka.javasdk.testkit.impl
 
+import scala.jdk.OptionConverters.RichOptional
+
 import akka.javasdk.Context
 import akka.javasdk.impl.InternalContext
 import akka.javasdk.testkit.MockRegistry
-
-import scala.jdk.OptionConverters.RichOptional
 
 class AbstractTestKitContext(mockRegistry: MockRegistry) extends Context with InternalContext {
 

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/EventSourcedResultImpl.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/EventSourcedResultImpl.scala
@@ -4,6 +4,11 @@
 
 package akka.javasdk.testkit.impl
 
+import java.util.Collections
+import java.util.{ List => JList }
+
+import scala.jdk.CollectionConverters._
+
 import akka.javasdk.eventsourcedentity.EventSourcedEntity
 import akka.javasdk.impl.effect.ErrorReplyImpl
 import akka.javasdk.impl.effect.MessageReplyImpl
@@ -14,10 +19,6 @@ import akka.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl.EmitEve
 import akka.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl.NoPrimaryEffect
 import akka.javasdk.testkit.EventSourcedResult
 import io.grpc.Status
-
-import java.util.Collections
-import java.util.{ List => JList }
-import scala.jdk.CollectionConverters._
 
 /**
  * INTERNAL API

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/EventingTestKitImpl.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/EventingTestKitImpl.scala
@@ -4,10 +4,27 @@
 
 package akka.javasdk.testkit.impl
 
+import java.time
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.{ List => JList }
+
+import scala.annotation.nowarn
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+import scala.jdk.DurationConverters._
+import scala.jdk.OptionConverters._
+import scala.util.Failure
+import scala.util.Success
+
 import akka.NotUsed
 import akka.actor.ActorRef
-import akka.actor.typed.ActorSystem
 import akka.actor.Props
+import akka.actor.typed.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
@@ -15,6 +32,7 @@ import akka.javasdk.JsonSupport
 import akka.javasdk.Metadata.{ MetadataEntry => SdkMetadataEntry }
 import akka.javasdk.impl.AnySupport
 import akka.javasdk.impl.MetadataImpl
+import akka.javasdk.impl.serialization.JsonSerializer
 import akka.javasdk.testkit.EventingTestKit
 import akka.javasdk.testkit.EventingTestKit.IncomingMessages
 import akka.javasdk.testkit.EventingTestKit.OutgoingMessages
@@ -24,6 +42,8 @@ import akka.javasdk.testkit.impl.TestKitMessageImpl.defaultMetadata
 import akka.javasdk.testkit.impl.TestKitMessageImpl.expectMsgInternal
 import akka.javasdk.{ Metadata => SdkMetadata }
 import akka.pattern._
+import akka.runtime.sdk.spi.SpiMetadata
+import akka.runtime.sdk.spi.SpiMetadataEntry
 import akka.stream.BoundedSourceQueue
 import akka.stream.QueueOfferResult
 import akka.stream.scaladsl.Sink
@@ -49,26 +69,6 @@ import kalix.testkit.protocol.eventing_test_backend.RunSourceCreate
 import kalix.testkit.protocol.eventing_test_backend.SourceElem
 import org.slf4j.LoggerFactory
 import scalapb.GeneratedMessage
-import java.time
-import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
-import java.util.{ List => JList }
-
-import scala.annotation.nowarn
-import scala.jdk.CollectionConverters._
-import scala.jdk.DurationConverters._
-import scala.jdk.OptionConverters._
-import scala.concurrent.Await
-import scala.concurrent.ExecutionContextExecutor
-import scala.concurrent.Future
-import scala.concurrent.Promise
-import scala.concurrent.duration._
-import scala.util.Failure
-import scala.util.Success
-
-import akka.javasdk.impl.serialization.JsonSerializer
-import akka.runtime.sdk.spi.SpiMetadata
-import akka.runtime.sdk.spi.SpiMetadataEntry
 
 object EventingTestKitImpl {
 

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/MockRegistryImpl.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/MockRegistryImpl.scala
@@ -4,10 +4,10 @@
 
 package akka.javasdk.testkit.impl
 
-import akka.javasdk.testkit.MockRegistry
-
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOption
+
+import akka.javasdk.testkit.MockRegistry
 
 private[akka] class MockRegistryImpl(var mocks: Map[Class[_], Any]) extends MockRegistry {
 

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/SourcesHolder.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/SourcesHolder.scala
@@ -4,6 +4,8 @@
 
 package akka.javasdk.testkit.impl
 
+import scala.collection.mutable.ArrayBuffer
+
 import akka.actor.Actor
 import akka.javasdk.testkit.TestKit
 import akka.javasdk.testkit.impl.EventingTestKitImpl.RunningSourceProbe
@@ -12,8 +14,6 @@ import akka.javasdk.testkit.impl.SourcesHolder.Publish
 import akka.javasdk.{ Metadata => SdkMetadata }
 import com.google.protobuf.ByteString
 import org.slf4j.LoggerFactory
-
-import scala.collection.mutable.ArrayBuffer
 
 object SourcesHolder {
 

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/TestKitTracing.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/TestKitTracing.scala
@@ -4,10 +4,10 @@
 
 package akka.javasdk.testkit.impl
 
+import java.util.Optional
+
 import akka.javasdk.Tracing
 import io.opentelemetry.api.trace.Span
-
-import java.util.Optional
 
 /**
  * INTERNAL API

--- a/akka-javasdk-testkit/src/test/scala/akka/javasdk/testkit/impl/IncomingMessagesImplSpec.scala
+++ b/akka-javasdk-testkit/src/test/scala/akka/javasdk/testkit/impl/IncomingMessagesImplSpec.scala
@@ -4,8 +4,11 @@
 
 package akka.javasdk.testkit.impl
 
+import scala.collection.mutable
+
 import akka.actor.ActorSystem
 import akka.actor.Props
+import akka.javasdk.impl.serialization.JsonSerializer
 import akka.javasdk.testkit.impl.EventingTestKitImpl.RunningSourceProbe
 import akka.stream.BoundedSourceQueue
 import akka.stream.QueueOfferResult
@@ -20,9 +23,6 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import scala.collection.mutable
-
-import akka.javasdk.impl.serialization.JsonSerializer
 
 class IncomingMessagesImplSpec
     extends TestKit(ActorSystem("MySpec"))

--- a/akka-javasdk-testkit/src/test/scala/akka/javasdk/testkit/impl/OutgoingMessagesImplSpec.scala
+++ b/akka-javasdk-testkit/src/test/scala/akka/javasdk/testkit/impl/OutgoingMessagesImplSpec.scala
@@ -4,8 +4,13 @@
 
 package akka.javasdk.testkit.impl
 
+import scala.collection.mutable
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.language.existentials
+
 import akka.actor.ActorSystem
 import akka.javasdk.impl.AnySupport
+import akka.javasdk.impl.serialization.JsonSerializer
 import akka.testkit.TestKit
 import akka.testkit.TestProbe
 import com.google.protobuf.ByteString
@@ -20,11 +25,6 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import scala.collection.mutable
-import scala.jdk.CollectionConverters.CollectionHasAsScala
-import scala.language.existentials
-
-import akka.javasdk.impl.serialization.JsonSerializer
 
 class OutgoingMessagesImplSpec
     extends TestKit(ActorSystem("MySpec"))

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/AnySupport.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/AnySupport.scala
@@ -7,11 +7,13 @@ package akka.javasdk.impl
 import java.io.ByteArrayOutputStream
 import java.util.Locale
 
+import scala.collection.compat.immutable.ArraySeq
 import scala.collection.concurrent.TrieMap
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 import scala.util.Try
 
+import akka.annotation.InternalApi
 import com.google.common.base.CaseFormat
 import com.google.protobuf.ByteString
 import com.google.protobuf.CodedInputStream
@@ -22,15 +24,14 @@ import com.google.protobuf.UnsafeByteOperations
 import com.google.protobuf.WireFormat
 import com.google.protobuf.any.{ Any => ScalaPbAny }
 import com.google.protobuf.{ Any => JavaPbAny }
-import AnySupport.Prefer.Java
-import AnySupport.Prefer.Scala
-import ErrorHandling.BadRequestException
-import akka.annotation.InternalApi
 import org.slf4j.LoggerFactory
 import scalapb.GeneratedMessage
 import scalapb.GeneratedMessageCompanion
 import scalapb.options.Scalapb
-import scala.collection.compat.immutable.ArraySeq
+
+import AnySupport.Prefer.Java
+import AnySupport.Prefer.Scala
+import ErrorHandling.BadRequestException
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/CommandSerialization.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/CommandSerialization.scala
@@ -4,13 +4,13 @@
 
 package akka.javasdk.impl
 
-import akka.annotation.InternalApi
 import java.lang.reflect.Method
 import java.lang.reflect.ParameterizedType
 import java.util
 
 import scala.util.control.NonFatal
 
+import akka.annotation.InternalApi
 import akka.javasdk.impl.serialization.JsonSerializer
 import akka.runtime.sdk.spi.BytesPayload
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/ComponentDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/ComponentDescriptorFactory.scala
@@ -24,6 +24,7 @@ import akka.javasdk.consumer.Consumer
 import akka.javasdk.eventsourcedentity.EventSourcedEntity
 import akka.javasdk.impl.agent.AgentDescriptorFactory
 import akka.javasdk.impl.reflection.Reflect
+import akka.javasdk.impl.reflection.Reflect.Syntax._
 import akka.javasdk.impl.serialization.JsonSerializer
 import akka.javasdk.keyvalueentity.KeyValueEntity
 import akka.javasdk.timedaction.TimedAction
@@ -32,7 +33,6 @@ import akka.javasdk.view.View
 import akka.javasdk.workflow.Workflow
 import akka.runtime.sdk.spi.ConsumerDestination
 import akka.runtime.sdk.spi.ConsumerSource
-import akka.javasdk.impl.reflection.Reflect.Syntax._
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/ErrorHandling.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/ErrorHandling.scala
@@ -4,10 +4,11 @@
 
 package akka.javasdk.impl
 
-import akka.annotation.InternalApi
-import org.slf4j.MDC
 import java.util.UUID
 import java.util.concurrent.ExecutionException
+
+import akka.annotation.InternalApi
+import org.slf4j.MDC
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/GrpcEndpointDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/GrpcEndpointDescriptorFactory.scala
@@ -4,6 +4,10 @@
 
 package akka.javasdk.impl
 
+import java.util.concurrent.CompletionException
+
+import scala.concurrent.Future
+
 import akka.actor.typed.ActorSystem
 import akka.grpc.ServiceDescription
 import akka.grpc.Trailers
@@ -20,9 +24,6 @@ import akka.runtime.sdk.spi.ComponentOptions
 import akka.runtime.sdk.spi.GrpcEndpointDescriptor
 import akka.runtime.sdk.spi.GrpcEndpointRequestConstructionContext
 import akka.runtime.sdk.spi.MethodOptions
-
-import java.util.concurrent.CompletionException
-import scala.concurrent.Future
 
 object GrpcEndpointDescriptorFactory {
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/HttpEndpointDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/HttpEndpointDescriptorFactory.scala
@@ -4,6 +4,13 @@
 
 package akka.javasdk.impl
 
+import java.lang.reflect.Method
+
+import scala.annotation.tailrec
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
 import akka.annotation.InternalApi
 import akka.http.javadsl.model.HttpEntity
 import akka.http.javadsl.model.HttpRequest
@@ -31,12 +38,6 @@ import akka.runtime.sdk.spi.HttpEndpointMethodSpec
 import akka.runtime.sdk.spi.MethodOptions
 import akka.runtime.sdk.spi.SpiJsonSchema
 import org.slf4j.LoggerFactory
-
-import java.lang.reflect.Method
-import scala.annotation.tailrec
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/JsonSchema.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/JsonSchema.scala
@@ -4,6 +4,14 @@
 
 package akka.javasdk.impl
 
+import java.lang.annotation.Annotation
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.Parameter
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.util.Optional
+
 import akka.annotation.InternalApi
 import akka.http.javadsl.model.HttpEntity
 import akka.http.javadsl.model.HttpRequest
@@ -15,14 +23,6 @@ import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaInteger
 import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaNumber
 import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaObject
 import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaString
-
-import java.lang.annotation.Annotation
-import java.lang.reflect.Field
-import java.lang.reflect.Method
-import java.lang.reflect.Parameter
-import java.lang.reflect.ParameterizedType
-import java.lang.reflect.Type
-import java.util.Optional
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/JwtDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/JwtDescriptorFactory.scala
@@ -4,6 +4,13 @@
 
 package akka.javasdk.impl
 
+import java.lang.reflect.Method
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import scala.util.matching.Regex
+
 import akka.annotation.InternalApi
 import akka.javasdk.annotations.JWT
 import akka.javasdk.annotations.JWT.JwtMethodMode
@@ -15,12 +22,6 @@ import akka.runtime.sdk.spi.ClaimValues
 import akka.runtime.sdk.spi.StaticClaim
 import akka.runtime.sdk.spi.StaticClaimContent
 import akka.runtime.sdk.spi.{ JWT => RuntimeJWT }
-
-import java.lang.reflect.Method
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
-import scala.util.matching.Regex
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/McpEndpointDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/McpEndpointDescriptorFactory.scala
@@ -4,6 +4,17 @@
 
 package akka.javasdk.impl
 
+import java.lang.annotation.Annotation
+import java.lang.reflect.Method
+import java.lang.reflect.ParameterizedType
+import java.util.Optional
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.jdk.OptionConverters.RichOption
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
+
 import akka.annotation.InternalApi
 import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.Uri
@@ -28,7 +39,6 @@ import akka.runtime.sdk.spi.McpEndpointDescriptor.PromptArgument
 import akka.runtime.sdk.spi.McpEndpointDescriptor.PromptMessage
 import akka.runtime.sdk.spi.McpEndpointDescriptor.PromptMethodDescriptor
 import akka.runtime.sdk.spi.McpEndpointDescriptor.PromptResult
-import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaObject
 import akka.runtime.sdk.spi.McpEndpointDescriptor.Resource
 import akka.runtime.sdk.spi.McpEndpointDescriptor.ResourceMethodDescriptor
 import akka.runtime.sdk.spi.McpEndpointDescriptor.ResourceTemplateMethodDescriptor
@@ -43,22 +53,13 @@ import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaBoolean
 import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaDataType
 import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaInteger
 import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaNumber
+import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaObject
 import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaString
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.slf4j.LoggerFactory
-
-import java.lang.annotation.Annotation
-import java.lang.reflect.Method
-import java.lang.reflect.ParameterizedType
-import java.util.Optional
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.jdk.OptionConverters.RichOption
-import scala.reflect.ClassTag
-import scala.util.control.NonFatal
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/MethodInvoker.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/MethodInvoker.scala
@@ -4,11 +4,12 @@
 
 package akka.javasdk.impl
 
-import akka.annotation.InternalApi
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
 import scala.util.control.Exception.Catcher
+
+import akka.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -10,6 +10,7 @@ import java.lang.reflect.Method
 import java.util
 import java.util.Optional
 import java.util.concurrent.CompletionStage
+import java.util.concurrent.Executor
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -35,10 +36,17 @@ import akka.javasdk.Principals
 import akka.javasdk.Retries
 import akka.javasdk.ServiceSetup
 import akka.javasdk.Tracing
+import akka.javasdk.agent.Agent
+import akka.javasdk.agent.AgentContext
+import akka.javasdk.agent.AgentRegistry
+import akka.javasdk.agent.PromptTemplate
+import akka.javasdk.agent.SessionMemoryEntity
+import akka.javasdk.annotations.AgentDescription
 import akka.javasdk.annotations.ComponentId
 import akka.javasdk.annotations.GrpcEndpoint
 import akka.javasdk.annotations.Setup
 import akka.javasdk.annotations.http.HttpEndpoint
+import akka.javasdk.annotations.mcp.McpEndpoint
 import akka.javasdk.client.ComponentClient
 import akka.javasdk.consumer.Consumer
 import akka.javasdk.eventsourcedentity.EventSourcedEntity
@@ -56,6 +64,11 @@ import akka.javasdk.impl.Sdk.StartupContext
 import akka.javasdk.impl.Validations.Invalid
 import akka.javasdk.impl.Validations.Valid
 import akka.javasdk.impl.Validations.Validation
+import akka.javasdk.impl.agent.AgentImpl
+import akka.javasdk.impl.agent.AgentImpl.AgentContextImpl
+import akka.javasdk.impl.agent.AgentRegistryImpl
+import akka.javasdk.impl.agent.OverrideModelProvider
+import akka.javasdk.impl.agent.PromptTemplateClient
 import akka.javasdk.impl.client.ComponentClientImpl
 import akka.javasdk.impl.consumer.ConsumerImpl
 import akka.javasdk.impl.eventsourcedentity.EventSourcedEntityImpl
@@ -72,9 +85,12 @@ import akka.javasdk.impl.telemetry.TraceInstrumentation
 import akka.javasdk.impl.timedaction.TimedActionImpl
 import akka.javasdk.impl.timer.TimerSchedulerImpl
 import akka.javasdk.impl.view.ViewDescriptorFactory
+import akka.javasdk.impl.workflow.WorkflowContextImpl
 import akka.javasdk.impl.workflow.WorkflowImpl
 import akka.javasdk.keyvalueentity.KeyValueEntity
 import akka.javasdk.keyvalueentity.KeyValueEntityContext
+import akka.javasdk.mcp.AbstractMcpEndpoint
+import akka.javasdk.mcp.McpRequestContext
 import akka.javasdk.timedaction.TimedAction
 import akka.javasdk.timer.TimerScheduler
 import akka.javasdk.view.View
@@ -82,13 +98,16 @@ import akka.javasdk.workflow.Workflow
 import akka.javasdk.workflow.Workflow.RunnableStep
 import akka.javasdk.workflow.WorkflowContext
 import akka.runtime.sdk.spi
+import akka.runtime.sdk.spi.AgentDescriptor
 import akka.runtime.sdk.spi.ComponentClients
 import akka.runtime.sdk.spi.ConsumerDescriptor
 import akka.runtime.sdk.spi.EventSourcedEntityDescriptor
 import akka.runtime.sdk.spi.GrpcEndpointRequestConstructionContext
 import akka.runtime.sdk.spi.HttpEndpointConstructionContext
+import akka.runtime.sdk.spi.McpEndpointConstructionContext
 import akka.runtime.sdk.spi.RegionInfo
 import akka.runtime.sdk.spi.RemoteIdentification
+import akka.runtime.sdk.spi.SpiAgent
 import akka.runtime.sdk.spi.SpiComponents
 import akka.runtime.sdk.spi.SpiDevModeSettings
 import akka.runtime.sdk.spi.SpiEventSourcedEntity
@@ -111,26 +130,6 @@ import io.opentelemetry.context.{ Context => OtelContext }
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.event.Level
-import java.util.concurrent.Executor
-
-import akka.javasdk.agent.Agent
-import akka.javasdk.agent.AgentContext
-import akka.javasdk.agent.AgentRegistry
-import akka.javasdk.impl.agent.AgentImpl
-import akka.runtime.sdk.spi.AgentDescriptor
-import akka.runtime.sdk.spi.SpiAgent
-import akka.javasdk.agent.PromptTemplate
-import akka.javasdk.agent.SessionMemoryEntity
-import akka.javasdk.annotations.AgentDescription
-import akka.javasdk.impl.agent.AgentRegistryImpl
-import akka.javasdk.impl.agent.PromptTemplateClient
-import akka.javasdk.annotations.mcp.McpEndpoint
-import akka.javasdk.impl.agent.OverrideModelProvider
-import akka.javasdk.impl.agent.AgentImpl.AgentContextImpl
-import akka.javasdk.mcp.AbstractMcpEndpoint
-import akka.javasdk.mcp.McpRequestContext
-import akka.runtime.sdk.spi.McpEndpointConstructionContext
-import akka.javasdk.impl.workflow.WorkflowContextImpl
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/Settings.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/Settings.scala
@@ -5,8 +5,9 @@
 package akka.javasdk.impl
 
 import akka.annotation.InternalApi
-import Settings.DevModeSettings
 import com.typesafe.config.Config
+
+import Settings.DevModeSettings
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentEffectImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentEffectImpl.scala
@@ -4,11 +4,14 @@
 
 package akka.javasdk.impl.agent
 
+import java.util
 import java.util.function
 
+import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.jdk.FunctionConverters.enrichAsScalaFromFunction
 
 import akka.annotation.InternalApi
+import akka.javasdk.CommandException
 import akka.javasdk.Metadata
 import akka.javasdk.agent.Agent.Effect
 import akka.javasdk.agent.Agent.Effect.Builder
@@ -25,11 +28,6 @@ import akka.javasdk.impl.effect.ErrorReplyImpl
 import akka.javasdk.impl.effect.MessageReplyImpl
 import akka.javasdk.impl.effect.NoSecondaryEffectImpl
 import akka.javasdk.impl.effect.SecondaryEffectImpl
-import java.util
-
-import scala.jdk.CollectionConverters.ListHasAsScala
-
-import akka.javasdk.CommandException
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
@@ -4,8 +4,17 @@
 
 package akka.javasdk.impl.agent
 
+import java.time.Instant
+
+import scala.annotation.tailrec
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters.SeqHasAsJava
+import scala.util.control.NonFatal
+
 import akka.annotation.InternalApi
 import akka.http.scaladsl.model.HttpHeader
+import akka.javasdk.CommandException
 import akka.javasdk.DependencyProvider
 import akka.javasdk.Metadata
 import akka.javasdk.Tracing
@@ -69,15 +78,6 @@ import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
-import java.time.Instant
-
-import scala.annotation.tailrec
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.jdk.CollectionConverters.SeqHasAsJava
-import scala.util.control.NonFatal
-
-import akka.javasdk.CommandException
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentStreamEffectImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentStreamEffectImpl.scala
@@ -4,7 +4,10 @@
 
 package akka.javasdk.impl.agent
 
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
 import akka.annotation.InternalApi
+import akka.javasdk.CommandException
 import akka.javasdk.Metadata
 import akka.javasdk.agent.Agent.StreamEffect
 import akka.javasdk.agent.MemoryProvider
@@ -14,9 +17,6 @@ import akka.javasdk.impl.effect.ErrorReplyImpl
 import akka.javasdk.impl.effect.MessageReplyImpl
 import akka.javasdk.impl.effect.NoSecondaryEffectImpl
 import akka.javasdk.impl.effect.SecondaryEffectImpl
-import scala.jdk.CollectionConverters.CollectionHasAsScala
-
-import akka.javasdk.CommandException
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/FunctionTools.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/FunctionTools.scala
@@ -5,6 +5,10 @@
 package akka.javasdk.impl.agent
 
 import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import java.lang.reflect.Type
+
+import scala.util.control.Exception.Catcher
 
 import akka.annotation.InternalApi
 import akka.javasdk.DependencyProvider
@@ -14,11 +18,6 @@ import akka.javasdk.impl.JsonSchema
 import akka.javasdk.impl.reflection.Reflect.Syntax.AnnotatedElementOps
 import akka.javasdk.impl.reflection.Reflect.Syntax.MethodOps
 import akka.runtime.sdk.spi.SpiAgent
-
-import java.lang.reflect.Method
-import java.lang.reflect.Type
-
-import scala.util.control.Exception.Catcher
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ReflectiveAgentRouter.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ReflectiveAgentRouter.scala
@@ -4,6 +4,8 @@
 
 package akka.javasdk.impl.agent
 
+import java.util.Optional
+
 import akka.annotation.InternalApi
 import akka.javasdk.agent.Agent
 import akka.javasdk.agent.AgentContext
@@ -12,8 +14,6 @@ import akka.javasdk.impl.HandlerNotFoundException
 import akka.javasdk.impl.MethodInvoker
 import akka.javasdk.impl.serialization.JsonSerializer
 import akka.runtime.sdk.spi.BytesPayload
-
-import java.util.Optional
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/RemoteMcpToolsImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/RemoteMcpToolsImpl.scala
@@ -4,12 +4,12 @@
 
 package akka.javasdk.impl.agent
 
+import java.util
+import java.util.function.Predicate
+
 import akka.annotation.InternalApi
 import akka.http.javadsl.model.HttpHeader
 import akka.javasdk.agent.RemoteMcpTools
-
-import java.util
-import java.util.function.Predicate
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ToolExecutor.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ToolExecutor.scala
@@ -4,12 +4,12 @@
 
 package akka.javasdk.impl.agent
 
+import java.util.Optional
+
 import akka.annotation.InternalApi
 import akka.javasdk.impl.agent.FunctionTools.FunctionToolInvoker
 import akka.javasdk.impl.serialization.JsonSerializer
 import akka.runtime.sdk.spi.SpiAgent
-
-import java.util.Optional
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ComponentClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ComponentClientImpl.scala
@@ -4,8 +4,13 @@
 
 package akka.javasdk.impl.client
 
+import scala.concurrent.ExecutionContext
+
+import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.javasdk.Metadata
+import akka.javasdk.agent.Agent
+import akka.javasdk.client.AgentClient
 import akka.javasdk.client.ComponentClient
 import akka.javasdk.client.EventSourcedEntityClient
 import akka.javasdk.client.KeyValueEntityClient
@@ -13,13 +18,8 @@ import akka.javasdk.client.TimedActionClient
 import akka.javasdk.client.ViewClient
 import akka.javasdk.client.WorkflowClient
 import akka.javasdk.impl.MetadataImpl
-import akka.runtime.sdk.spi.{ ComponentClients => RuntimeComponentClients }
-import scala.concurrent.ExecutionContext
-
-import akka.actor.typed.ActorSystem
-import akka.javasdk.agent.Agent
-import akka.javasdk.client.AgentClient
 import akka.javasdk.impl.serialization.JsonSerializer
+import akka.runtime.sdk.spi.{ ComponentClients => RuntimeComponentClients }
 import io.opentelemetry.api.trace.Span
 
 /**

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ComponentMethodRefImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ComponentMethodRefImpl.scala
@@ -4,6 +4,10 @@
 
 package akka.javasdk.impl.client
 
+import java.util.concurrent.CompletionStage
+
+import scala.concurrent.ExecutionException
+
 import akka.NotUsed
 import akka.annotation.InternalApi
 import akka.javasdk.DeferredCall
@@ -12,11 +16,8 @@ import akka.javasdk.client.ComponentInvokeOnlyMethodRef
 import akka.javasdk.client.ComponentInvokeOnlyMethodRef1
 import akka.javasdk.client.ComponentMethodRef
 import akka.javasdk.client.ComponentMethodRef1
-import akka.javasdk.impl.ErrorHandling
-import java.util.concurrent.CompletionStage
-
-import scala.concurrent.ExecutionException
 import akka.javasdk.client.DynamicMethodRef
+import akka.javasdk.impl.ErrorHandling
 import akka.pattern.RetrySettings
 
 /**

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/EntityClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/EntityClientImpl.scala
@@ -4,6 +4,13 @@
 
 package akka.javasdk.impl.client
 
+import scala.concurrent.ExecutionContext
+import scala.jdk.FutureConverters.FutureOps
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.japi.function
 import akka.javasdk.Metadata
@@ -19,27 +26,20 @@ import akka.javasdk.eventsourcedentity.EventSourcedEntity
 import akka.javasdk.impl.ComponentDescriptorFactory
 import akka.javasdk.impl.MetadataImpl
 import akka.javasdk.impl.reflection.Reflect
+import akka.javasdk.impl.serialization.JsonSerializer
 import akka.javasdk.keyvalueentity.KeyValueEntity
 import akka.javasdk.timedaction.TimedAction
 import akka.javasdk.workflow.Workflow
-import akka.runtime.sdk.spi.TimedActionRequest
-import akka.runtime.sdk.spi.TimedActionType
+import akka.runtime.sdk.spi.BytesPayload
 import akka.runtime.sdk.spi.ComponentType
 import akka.runtime.sdk.spi.EntityRequest
 import akka.runtime.sdk.spi.EventSourcedEntityType
 import akka.runtime.sdk.spi.KeyValueEntityType
+import akka.runtime.sdk.spi.TimedActionRequest
+import akka.runtime.sdk.spi.TimedActionType
 import akka.runtime.sdk.spi.WorkflowType
-import akka.runtime.sdk.spi.{ TimedActionClient => RuntimeTimedActionClient }
 import akka.runtime.sdk.spi.{ EntityClient => RuntimeEntityClient }
-import scala.concurrent.ExecutionContext
-import scala.jdk.FutureConverters.FutureOps
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
-
-import akka.actor.typed.ActorSystem
-import akka.javasdk.impl.serialization.JsonSerializer
-import akka.runtime.sdk.spi.BytesPayload
+import akka.runtime.sdk.spi.{ TimedActionClient => RuntimeTimedActionClient }
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ViewCallValidator.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ViewCallValidator.scala
@@ -4,15 +4,15 @@
 
 package akka.javasdk.impl.client
 
+import java.lang.reflect.Method
+
 import akka.annotation.InternalApi
+import akka.javasdk.agent.Agent
 import akka.javasdk.annotations.Query
 import akka.javasdk.eventsourcedentity.EventSourcedEntity
 import akka.javasdk.keyvalueentity.KeyValueEntity
 import akka.javasdk.timedaction.TimedAction
 import akka.javasdk.workflow.Workflow
-import java.lang.reflect.Method
-
-import akka.javasdk.agent.Agent
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ViewClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ViewClientImpl.scala
@@ -4,6 +4,16 @@
 
 package akka.javasdk.impl.client
 
+import java.lang.reflect.Method
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.util.Optional
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.jdk.FutureConverters.FutureOps
+
+import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.japi.function
 import akka.javasdk.Metadata
@@ -15,25 +25,13 @@ import akka.javasdk.client.NoEntryFoundException
 import akka.javasdk.client.ViewClient
 import akka.javasdk.impl.ComponentDescriptorFactory
 import akka.javasdk.impl.MetadataImpl
+import akka.javasdk.impl.serialization.JsonSerializer
 import akka.javasdk.view.View
+import akka.runtime.sdk.spi.BytesPayload
+import akka.runtime.sdk.spi.SpiMetadata
 import akka.runtime.sdk.spi.ViewRequest
 import akka.runtime.sdk.spi.ViewType
 import akka.runtime.sdk.spi.{ ViewClient => RuntimeViewClient }
-import java.lang.reflect.Method
-import java.lang.reflect.ParameterizedType
-
-import scala.concurrent.ExecutionContext
-import scala.jdk.FutureConverters.FutureOps
-
-import akka.javasdk.impl.serialization.JsonSerializer
-import akka.runtime.sdk.spi.BytesPayload
-import akka.runtime.sdk.spi.SpiMetadata
-import java.lang.reflect.Type
-import java.util.Optional
-
-import scala.concurrent.Future
-
-import akka.actor.typed.ActorSystem
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/consumer/ConsumerEffectImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/consumer/ConsumerEffectImpl.scala
@@ -5,9 +5,11 @@
 package akka.javasdk.impl.consumer
 
 import java.util.concurrent.CompletionStage
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.jdk.FutureConverters.CompletionStageOps
+
 import akka.Done
 import akka.annotation.InternalApi
 import akka.javasdk.Metadata

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/consumer/ConsumerImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/consumer/ConsumerImpl.scala
@@ -5,10 +5,12 @@
 package akka.javasdk.impl.consumer
 
 import java.util.Optional
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.jdk.OptionConverters.RichOption
 import scala.util.control.NonFatal
+
 import akka.actor.ActorSystem
 import akka.annotation.InternalApi
 import akka.javasdk.JsonSupport

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/consumer/ReflectiveConsumerRouter.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/consumer/ReflectiveConsumerRouter.scala
@@ -5,6 +5,7 @@
 package akka.javasdk.impl.consumer
 
 import java.util.Optional
+
 import akka.annotation.InternalApi
 import akka.javasdk.JsonSupport
 import akka.javasdk.consumer.Consumer

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/eventsourcedentity/EventSourcedEntityEffectImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/eventsourcedentity/EventSourcedEntityEffectImpl.scala
@@ -4,21 +4,22 @@
 
 package akka.javasdk.impl.eventsourcedentity
 
-import akka.annotation.InternalApi
-import akka.javasdk.Metadata
-import akka.javasdk.impl.effect.ErrorReplyImpl
-import akka.javasdk.impl.effect.MessageReplyImpl
-import akka.javasdk.impl.effect.NoSecondaryEffectImpl
-import akka.javasdk.impl.effect.SecondaryEffectImpl
 import java.util
 import java.util.function.{ Function => JFunction }
 
 import scala.jdk.CollectionConverters._
+
+import akka.annotation.InternalApi
 import akka.javasdk.CommandException
+import akka.javasdk.Metadata
 import akka.javasdk.eventsourcedentity.EventSourcedEntity.Effect
 import akka.javasdk.eventsourcedentity.EventSourcedEntity.Effect.Builder
 import akka.javasdk.eventsourcedentity.EventSourcedEntity.Effect.OnSuccessBuilder
 import akka.javasdk.eventsourcedentity.EventSourcedEntity.ReadOnlyEffect
+import akka.javasdk.impl.effect.ErrorReplyImpl
+import akka.javasdk.impl.effect.MessageReplyImpl
+import akka.javasdk.impl.effect.NoSecondaryEffectImpl
+import akka.javasdk.impl.effect.SecondaryEffectImpl
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/eventsourcedentity/ReflectiveEventSourcedEntityRouter.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/eventsourcedentity/ReflectiveEventSourcedEntityRouter.scala
@@ -6,9 +6,9 @@ package akka.javasdk.impl.eventsourcedentity
 
 import akka.annotation.InternalApi
 import akka.javasdk.eventsourcedentity.EventSourcedEntity
-import akka.javasdk.impl.MethodInvoker
 import akka.javasdk.impl.CommandSerialization
 import akka.javasdk.impl.HandlerNotFoundException
+import akka.javasdk.impl.MethodInvoker
 import akka.javasdk.impl.serialization.JsonSerializer
 import akka.runtime.sdk.spi.BytesPayload
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/grpc/GrpcClientProviderImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/grpc/GrpcClientProviderImpl.scala
@@ -4,6 +4,17 @@
 
 package akka.javasdk.impl.grpc
 
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executor
+
+import scala.annotation.nowarn
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
+import scala.util.control.NonFatal
+
 import akka.Done
 import akka.actor.ClassicActorSystemProvider
 import akka.actor.CoordinatedShutdown
@@ -18,18 +29,8 @@ import akka.javasdk.impl.grpc.GrpcClientProviderImpl.AuthHeaders
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
-import org.slf4j.LoggerFactory
-
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executor
-import scala.annotation.nowarn
-import scala.concurrent.Await
-import scala.concurrent.Future
-import scala.concurrent.duration.DurationInt
-import scala.jdk.CollectionConverters._
-import scala.jdk.FutureConverters._
-import scala.util.control.NonFatal
 import io.opentelemetry.context.{ Context => OtelContext }
+import org.slf4j.LoggerFactory
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/http/HttpClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/http/HttpClientImpl.scala
@@ -4,6 +4,21 @@
 
 package akka.javasdk.impl.http
 
+import java.io.IOException
+import java.lang.{ Iterable => JIterable }
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.util
+import java.util.concurrent.CompletionStage
+import java.util.function.Function
+
+import scala.concurrent.ExecutionException
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.CollectionConverters.SeqHasAsJava
+import scala.jdk.DurationConverters.JavaDurationOps
+
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.http.javadsl.Http
@@ -29,20 +44,6 @@ import akka.stream.Materializer
 import akka.stream.SystemMaterializer
 import akka.util.ByteString
 import com.fasterxml.jackson.core.JsonProcessingException
-
-import java.io.IOException
-import java.lang.{ Iterable => JIterable }
-import java.nio.charset.Charset
-import java.nio.charset.StandardCharsets
-import java.time.Duration
-import java.util
-import java.util.concurrent.CompletionStage
-import java.util.function.Function
-import scala.concurrent.ExecutionException
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.duration.FiniteDuration
-import scala.jdk.CollectionConverters.SeqHasAsJava
-import scala.jdk.DurationConverters.JavaDurationOps
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/http/HttpClientProviderImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/http/HttpClientProviderImpl.scala
@@ -4,6 +4,10 @@
 
 package akka.javasdk.impl.http
 
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+import scala.util.control.NonFatal
+
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.discovery.Discovery
@@ -15,10 +19,6 @@ import akka.javasdk.impl.Settings
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.{ Context => OtelContext }
 import org.slf4j.LoggerFactory
-
-import scala.concurrent.Await
-import scala.concurrent.duration.DurationInt
-import scala.util.control.NonFatal
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/http/HttpExceptionImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/http/HttpExceptionImpl.scala
@@ -4,11 +4,11 @@
 
 package akka.javasdk.impl.http
 
+import scala.util.control.NoStackTrace
+
 import akka.annotation.InternalApi
 import akka.http.scaladsl.model.StatusCode
 import akka.runtime.sdk.spi.HttpEndpointInvocationException
-
-import scala.util.control.NoStackTrace
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/http/JwtClaimsImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/http/JwtClaimsImpl.scala
@@ -4,20 +4,21 @@
 
 package akka.javasdk.impl.http
 
+import java.lang
+import java.time.Instant
+import java.util
+import java.util.Optional
+import java.util.stream.Collectors
+
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOption
+
 import akka.javasdk.JsonSupport
 import akka.javasdk.JwtClaims
 import akka.runtime.sdk.spi.{ JwtClaims => RuntimeJwtClaims }
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.`type`.TypeFactory
-
-import java.lang
-import java.time.Instant
-import java.util
-import java.util.Optional
-import java.util.stream.Collectors
-import scala.jdk.CollectionConverters._
-import scala.jdk.OptionConverters.RichOption
 
 class JwtClaimsImpl(jwtClaims: RuntimeJwtClaims) extends JwtClaims {
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/http/QueryParamsImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/http/QueryParamsImpl.scala
@@ -6,12 +6,12 @@ package akka.javasdk.impl.http
 
 import java.util.Optional
 
+import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOption
 
 import akka.annotation.InternalApi
 import akka.http.scaladsl.model.Uri.Query
 import akka.javasdk.http.QueryParams
-import scala.jdk.CollectionConverters._
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/keyvalueentity/ReflectiveKeyValueEntityRouter.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/keyvalueentity/ReflectiveKeyValueEntityRouter.scala
@@ -5,9 +5,9 @@
 package akka.javasdk.impl.keyvalueentity
 
 import akka.annotation.InternalApi
-import akka.javasdk.impl.MethodInvoker
 import akka.javasdk.impl.CommandSerialization
 import akka.javasdk.impl.HandlerNotFoundException
+import akka.javasdk.impl.MethodInvoker
 import akka.javasdk.impl.serialization.JsonSerializer
 import akka.javasdk.keyvalueentity.KeyValueEntity
 import akka.runtime.sdk.spi.BytesPayload

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/reflection/Reflect.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/reflection/Reflect.scala
@@ -4,19 +4,6 @@
 
 package akka.javasdk.impl.reflection
 
-import akka.annotation.InternalApi
-import akka.javasdk.annotations.GrpcEndpoint
-import akka.javasdk.annotations.http.HttpEndpoint
-import akka.javasdk.annotations.mcp.McpEndpoint
-import akka.javasdk.client.ComponentClient
-import akka.javasdk.consumer.Consumer
-import akka.javasdk.eventsourcedentity.EventSourcedEntity
-import akka.javasdk.impl.client.ComponentClientImpl
-import akka.javasdk.keyvalueentity.KeyValueEntity
-import akka.javasdk.timedaction.TimedAction
-import akka.javasdk.view.TableUpdater
-import akka.javasdk.view.View
-import akka.javasdk.workflow.Workflow
 import java.lang.annotation.Annotation
 import java.lang.reflect.AnnotatedElement
 import java.lang.reflect.Method
@@ -29,7 +16,20 @@ import java.util.Optional
 import scala.annotation.tailrec
 import scala.reflect.ClassTag
 
+import akka.annotation.InternalApi
 import akka.javasdk.agent.Agent
+import akka.javasdk.annotations.GrpcEndpoint
+import akka.javasdk.annotations.http.HttpEndpoint
+import akka.javasdk.annotations.mcp.McpEndpoint
+import akka.javasdk.client.ComponentClient
+import akka.javasdk.consumer.Consumer
+import akka.javasdk.eventsourcedentity.EventSourcedEntity
+import akka.javasdk.impl.client.ComponentClientImpl
+import akka.javasdk.keyvalueentity.KeyValueEntity
+import akka.javasdk.timedaction.TimedAction
+import akka.javasdk.view.TableUpdater
+import akka.javasdk.view.View
+import akka.javasdk.workflow.Workflow
 
 /**
  * Class extension to facilitate some reflection common usages.

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/reflection/ServiceIntrospectionException.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/reflection/ServiceIntrospectionException.scala
@@ -4,10 +4,10 @@
 
 package akka.javasdk.impl.reflection
 
-import akka.annotation.InternalApi
-
 import java.lang.reflect.AnnotatedElement
 import java.lang.reflect.Method
+
+import akka.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/serialization/JsonSerializer.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/serialization/JsonSerializer.scala
@@ -4,15 +4,19 @@
 
 package akka.javasdk.impl.serialization
 
-import akka.Done
-import akka.annotation.InternalApi
 import java.io.IOException
 import java.lang
 import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
 import java.util
+import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 
+import akka.Done
+import akka.annotation.InternalApi
+import akka.javasdk.CommandException
 import akka.javasdk.JsonMigration
 import akka.javasdk.annotations.Migration
 import akka.javasdk.annotations.TypeName
@@ -37,11 +41,6 @@ import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer
 import com.fasterxml.jackson.databind.module.SimpleModule
-import java.lang.reflect.ParameterizedType
-import java.lang.reflect.Type
-import java.util.Optional
-
-import akka.javasdk.CommandException
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/telemetry/SpanTracingImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/telemetry/SpanTracingImpl.scala
@@ -4,14 +4,15 @@
 
 package akka.javasdk.impl.telemetry
 
+import java.util.Optional
+
+import scala.jdk.OptionConverters.RichOption
+
 import akka.annotation.InternalApi
 import akka.javasdk.Tracing
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.{ Context => OtelContext }
-
-import java.util.Optional
-import scala.jdk.OptionConverters.RichOption
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/timedaction/ReflectiveTimedActionRouter.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/timedaction/ReflectiveTimedActionRouter.scala
@@ -7,9 +7,9 @@ package akka.javasdk.impl.timedaction
 import java.util.Optional
 
 import akka.annotation.InternalApi
-import akka.javasdk.impl.MethodInvoker
 import akka.javasdk.impl.CommandSerialization
 import akka.javasdk.impl.HandlerNotFoundException
+import akka.javasdk.impl.MethodInvoker
 import akka.javasdk.impl.serialization.JsonSerializer
 import akka.javasdk.timedaction.CommandContext
 import akka.javasdk.timedaction.CommandEnvelope

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/timedaction/TimedActionEffectImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/timedaction/TimedActionEffectImpl.scala
@@ -4,14 +4,15 @@
 
 package akka.javasdk.impl.timedaction
 
-import akka.Done
-import akka.annotation.InternalApi
-import akka.javasdk.timedaction.TimedAction
-
 import java.util.concurrent.CompletionStage
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.jdk.FutureConverters.CompletionStageOps
+
+import akka.Done
+import akka.annotation.InternalApi
+import akka.javasdk.timedaction.TimedAction
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/timer/TimerSchedulerImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/timer/TimerSchedulerImpl.scala
@@ -4,20 +4,20 @@
 
 package akka.javasdk.impl.timer
 
-import akka.Done
-
 import java.time.Duration
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.ExecutionException
+
+import scala.jdk.DurationConverters.JavaDurationOps
 import scala.jdk.FutureConverters.FutureOps
+
+import akka.Done
 import akka.annotation.InternalApi
 import akka.javasdk.DeferredCall
 import akka.javasdk.Metadata
 import akka.javasdk.impl.ErrorHandling
 import akka.javasdk.impl.client.DeferredCallImpl
 import akka.javasdk.timer.TimerScheduler
-
-import java.util.concurrent.CompletionStage
-import java.util.concurrent.ExecutionException
-import scala.jdk.DurationConverters.JavaDurationOps
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewSchema.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewSchema.scala
@@ -4,8 +4,12 @@
 
 package akka.javasdk.impl.view
 
+import java.lang.reflect.AccessFlag
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.util.Optional
+
 import akka.annotation.InternalApi
-import akka.runtime.sdk.spi.SpiSchema.SpiType
 import akka.runtime.sdk.spi.SpiSchema.SpiBoolean
 import akka.runtime.sdk.spi.SpiSchema.SpiByteString
 import akka.runtime.sdk.spi.SpiSchema.SpiClass
@@ -21,11 +25,7 @@ import akka.runtime.sdk.spi.SpiSchema.SpiNestableType
 import akka.runtime.sdk.spi.SpiSchema.SpiOptional
 import akka.runtime.sdk.spi.SpiSchema.SpiString
 import akka.runtime.sdk.spi.SpiSchema.SpiTimestamp
-
-import java.lang.reflect.AccessFlag
-import java.lang.reflect.ParameterizedType
-import java.lang.reflect.Type
-import java.util.Optional
+import akka.runtime.sdk.spi.SpiSchema.SpiType
 
 @InternalApi
 private[view] object ViewSchema {

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/ReflectiveWorkflowRouter.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/ReflectiveWorkflowRouter.scala
@@ -13,9 +13,9 @@ import scala.jdk.FutureConverters.CompletionStageOps
 import scala.jdk.OptionConverters.RichOptional
 
 import akka.annotation.InternalApi
-import akka.javasdk.impl.MethodInvoker
 import akka.javasdk.impl.CommandSerialization
 import akka.javasdk.impl.HandlerNotFoundException
+import akka.javasdk.impl.MethodInvoker
 import akka.javasdk.impl.serialization.JsonSerializer
 import akka.javasdk.impl.workflow.ReflectiveWorkflowRouter.CommandResult
 import akka.javasdk.impl.workflow.ReflectiveWorkflowRouter.TransitionalResult
@@ -24,8 +24,10 @@ import akka.javasdk.impl.workflow.ReflectiveWorkflowRouter.WorkflowStepNotSuppor
 import akka.javasdk.timer.TimerScheduler
 import akka.javasdk.workflow.CommandContext
 import akka.javasdk.workflow.Workflow
-import akka.javasdk.workflow.Workflow.{ AsyncCallStep, CallStep, RunnableStep }
+import akka.javasdk.workflow.Workflow.AsyncCallStep
+import akka.javasdk.workflow.Workflow.CallStep
 import akka.javasdk.workflow.Workflow.Effect.TransitionalEffect
+import akka.javasdk.workflow.Workflow.RunnableStep
 import akka.javasdk.workflow.WorkflowContext
 import akka.runtime.sdk.spi.BytesPayload
 import akka.runtime.sdk.spi.SpiWorkflow

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/WorkflowEffectImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/WorkflowEffectImpl.scala
@@ -4,6 +4,17 @@
 
 package akka.javasdk.impl.workflow
 
+import akka.annotation.InternalApi
+import akka.javasdk.CommandException
+import akka.javasdk.Metadata
+import akka.javasdk.impl.workflow.WorkflowEffectImpl.Delete
+import akka.javasdk.impl.workflow.WorkflowEffectImpl.ReadOnlyEffectImpl
+import akka.javasdk.workflow.Workflow.Effect
+import akka.javasdk.workflow.Workflow.Effect.Builder
+import akka.javasdk.workflow.Workflow.Effect.PersistenceEffectBuilder
+import akka.javasdk.workflow.Workflow.Effect.TransitionalEffect
+import akka.javasdk.workflow.Workflow.ReadOnlyEffect
+
 import WorkflowEffectImpl.End
 import WorkflowEffectImpl.ErrorEffectImpl
 import WorkflowEffectImpl.NoPersistence
@@ -15,16 +26,6 @@ import WorkflowEffectImpl.StepTransition
 import WorkflowEffectImpl.Transition
 import WorkflowEffectImpl.TransitionalEffectImpl
 import WorkflowEffectImpl.UpdateState
-import akka.annotation.InternalApi
-import akka.javasdk.CommandException
-import akka.javasdk.Metadata
-import akka.javasdk.impl.workflow.WorkflowEffectImpl.Delete
-import akka.javasdk.impl.workflow.WorkflowEffectImpl.ReadOnlyEffectImpl
-import akka.javasdk.workflow.Workflow.Effect
-import akka.javasdk.workflow.Workflow.Effect.Builder
-import akka.javasdk.workflow.Workflow.Effect.PersistenceEffectBuilder
-import akka.javasdk.workflow.Workflow.Effect.TransitionalEffect
-import akka.javasdk.workflow.Workflow.ReadOnlyEffect
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/WorkflowImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/WorkflowImpl.scala
@@ -4,6 +4,7 @@
 
 package akka.javasdk.impl.workflow
 
+import scala.annotation.nowarn
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters.ListHasAsScala
@@ -14,6 +15,7 @@ import scala.util.Success
 import scala.util.control.NonFatal
 
 import akka.annotation.InternalApi
+import akka.javasdk.CommandException
 import akka.javasdk.Metadata
 import akka.javasdk.Tracing
 import akka.javasdk.impl.AbstractContext
@@ -60,9 +62,6 @@ import io.opentelemetry.api.trace.Tracer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
-import scala.annotation.nowarn
-
-import akka.javasdk.CommandException
 
 /**
  * INTERNAL API

--- a/akka-javasdk/src/test/scala/akka/javasdk/JsonSupportSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/JsonSupportSpec.scala
@@ -6,7 +6,9 @@ package akka.javasdk
 
 import java.util
 import java.util.Optional
+
 import scala.beans.BeanProperty
+
 import akka.Done
 import akka.javasdk.impl.AnySupport
 import akka.javasdk.impl.ByteStringEncoding

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/AnySupportSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/AnySupportSpec.scala
@@ -4,9 +4,9 @@
 
 package akka.javasdk.impl
 
+import com.google.protobuf.ByteString
 import com.google.protobuf.any.{ Any => ScalaPbAny }
 import com.google.protobuf.{ Any => JavaPbAny }
-import com.google.protobuf.ByteString
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ToolExecutorSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ToolExecutorSpec.scala
@@ -4,22 +4,22 @@
 
 package akka.javasdk.impl.agent
 
+import java.lang.reflect.Type
+import java.util.Optional
+
+import scala.jdk.CollectionConverters._
+
 import akka.javasdk.JsonSupport
 import akka.javasdk.impl.agent.FunctionTools.FunctionToolInvoker
+import akka.javasdk.impl.agent.ToolExecutorSpec.Bar
+import akka.javasdk.impl.agent.ToolExecutorSpec.Foo
+import akka.javasdk.impl.agent.ToolExecutorSpec.Foobar
 import akka.javasdk.impl.serialization.JsonSerializer
 import akka.runtime.sdk.spi.SpiAgent
+import akka.runtime.sdk.spi.SpiMetadata
 import org.scalatest.TestSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-
-import java.lang.reflect.Type
-import scala.jdk.CollectionConverters._
-import akka.javasdk.impl.agent.ToolExecutorSpec.Foo
-import akka.javasdk.impl.agent.ToolExecutorSpec.Bar
-import akka.javasdk.impl.agent.ToolExecutorSpec.Foobar
-import akka.runtime.sdk.spi.SpiMetadata
-
-import java.util.Optional
 
 object ToolExecutorSpec {
   // Test data classes for complex type tests

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/reflection/ReflectSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/reflection/ReflectSpec.scala
@@ -4,14 +4,14 @@
 
 package akka.javasdk.impl.reflection
 
+import scala.concurrent.ExecutionContext
+
 import akka.javasdk.client.ComponentClient
 import akka.javasdk.impl.client.ComponentClientImpl
 import akka.javasdk.impl.reflection.Reflect
+import akka.javasdk.impl.serialization.JsonSerializer
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import scala.concurrent.ExecutionContext
-
-import akka.javasdk.impl.serialization.JsonSerializer
 
 class SomeClass {
   def a(): Unit = {}

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/view/ViewDescriptorFactorySpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/view/ViewDescriptorFactorySpec.scala
@@ -4,6 +4,8 @@
 
 package akka.javasdk.impl.view
 
+import scala.reflect.ClassTag
+
 import akka.dispatch.ExecutionContexts
 import akka.javasdk.impl.ValidationException
 import akka.javasdk.impl.Validations
@@ -11,6 +13,7 @@ import akka.javasdk.impl.serialization.JsonSerializer
 import akka.javasdk.testmodels.view.ViewTestModels
 import akka.runtime.sdk.spi.ConsumerSource
 import akka.runtime.sdk.spi.Principal
+import akka.runtime.sdk.spi.RegionInfo
 import akka.runtime.sdk.spi.ServiceNamePattern
 import akka.runtime.sdk.spi.SpiSchema.SpiClass
 import akka.runtime.sdk.spi.SpiSchema.SpiInteger
@@ -20,9 +23,6 @@ import akka.runtime.sdk.spi.SpiSchema.SpiTimestamp
 import akka.runtime.sdk.spi.ViewDescriptor
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import scala.reflect.ClassTag
-
-import akka.runtime.sdk.spi.RegionInfo
 
 class ViewDescriptorFactorySpec extends AnyWordSpec with Matchers {
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,16 @@ addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 
 // align guava version between sbt-akka-grpc and sbt-java-formatter
 libraryDependencies += "com.google.guava" % "guava" % "33.3.1-jre"
+
+// optional scalafix plugin for organize imports
+optionalSbtPlugin(sys.props.contains("build.scalafix"))("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
+
+def optionalSbtPlugin(predicate: Boolean)(module: ModuleID): Setting[Seq[ModuleID]] = {
+  libraryDependencies ++= {
+    if (predicate) {
+      val sbtV = (pluginCrossBuild / sbtBinaryVersion).value
+      val scalaV = (update / scalaBinaryVersion).value
+      Seq(Defaults.sbtPluginExtra(module, sbtV, scalaV))
+    } else Seq.empty
+  }
+}


### PR DESCRIPTION
Same as runtime. Add optional scalafix plugin to check organize imports in CI.

First running CI with only the check, applying changes in separate commit.