### PR TITLE
fix: done deserialization

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/serialization/JsonSerializer.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/serialization/JsonSerializer.scala
@@ -210,12 +210,17 @@ final class JsonSerializer(val objectMapper: ObjectMapper) {
     validateIsJson(bytesPayload)
 
     val typeName = removeVersion(stripJsonContentTypePrefix(bytesPayload.contentType))
-    val typeClass = reversedTypeHints.get(typeName).asInstanceOf[Class[AnyRef]]
-    if (typeClass eq null)
-      throw new IllegalStateException(
-        s"Cannot decode [${bytesPayload.contentType}] message type. Class mapping not found.")
-    else
-      fromBytes(typeClass, bytesPayload)
+    if (typeName == classOf[Done.type].getName || typeName == classOf[Done].getName) {
+      // small optimization for Done, which does not need to be deserialized
+      Done.done()
+    } else {
+      val typeClass = reversedTypeHints.get(typeName).asInstanceOf[Class[AnyRef]]
+      if (typeClass eq null)
+        throw new IllegalStateException(
+          s"Cannot decode [${bytesPayload.contentType}] message type. Class mapping not found.")
+      else
+        fromBytes(typeClass, bytesPayload)
+    }
   }
 
   def exceptionFromBytes(exceptionPayload: BytesPayload): CommandException = {

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/serialization/JsonSerializationSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/serialization/JsonSerializationSpec.scala
@@ -178,9 +178,14 @@ class JsonSerializationSpec extends AnyWordSpec with Matchers {
     }
 
     "serialize and deserialize Akka Done class" in {
-      val bytesPayload = serializer.toBytes(Done.getInstance())
+      val bytesPayload = serializer.toBytes(Done.done())
       bytesPayload.contentType shouldBe jsonContentTypeWith(Done.getClass.getName)
-      serializer.fromBytes(classOf[Done], bytesPayload) shouldBe Done.getInstance()
+      serializer.fromBytes(classOf[Done], bytesPayload) shouldBe Done.done()
+    }
+
+    "serialize and deserialize without a given type Akka Done class" in {
+      val bytesPayload = serializer.toBytes(Done.done())
+      serializer.fromBytes(bytesPayload) shouldBe Done.done()
     }
 
     "serialize and deserialize a List of objects" in {


### PR DESCRIPTION
Besides the optimization, it also fixes this issue:
```
java.lang.IllegalStateException: Cannot decode [json.akka.io/akka.Done$] message type. Class mapping not found.
	at akka.javasdk.impl.serialization.JsonSerializer.fromBytes(JsonSerializer.scala:215)
	at akka.javasdk.impl.workflow.ReflectiveWorkflowRouter.decodeInput(ReflectiveWorkflowRouter.scala:73)
	at akka.javasdk.impl.workflow.ReflectiveWorkflowRouter.applyTransitionFunc$1(ReflectiveWorkflowRouter.scala:194)
	at akka.javasdk.impl.workflow.ReflectiveWorkflowRouter.getNextStep(ReflectiveWorkflowRouter.scala:204)
	at akka.javasdk.impl.workflow.WorkflowImpl.liftedTree1$1(WorkflowImpl.scala:301)
	at akka.javasdk.impl.workflow.WorkflowImpl.transition(WorkflowImpl.scala:299)
	at kalix.runtime.EmbeddedSdkDispatch$$anon$4.$anonfun$transition$1(EmbeddedSdkDispatch.scala:147)
	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:687)
```

it's because we register a mapping for `json.akka.io/akka.Done` (without $), we could extend the `reversedTypeHints` with additional mapping, but we don't need all the complex deserialization logic for `Done`, we can return the payload immediately. 
