### PR TITLE
chore: run doc gen if samples are modified

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - 'docs/**'
+      - 'samples/**'
 
 #  push:
 #    branches:

--- a/samples/README.md
+++ b/samples/README.md
@@ -17,3 +17,4 @@ The GitHub Actions workflow runs `prettier:check` on all Java samples. Formattin
 - Line length: 94
 - Ident lines with spaces, not tabs
 - Number of spaces per indentation level: 2
+


### PR DESCRIPTION
Trigger doc generation job when files under `samples` are modified. 

In case the tagging or callouts get broken, CI will detect it.