### PR TITLE
chore: removes StepEffect.error()

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
@@ -512,10 +512,6 @@ public abstract class Workflow<S> {
        * delay to allow downstream consumers to observe that fact.
        */
       StepEffect thenDelete();
-
-      StepEffect error(String description);
-
-      // TODO: add support for CommandException
     }
 
     interface PersistenceEffectBuilder {
@@ -560,10 +556,6 @@ public abstract class Workflow<S> {
        * delay to allow downstream consumers to observe that fact.
        */
       StepEffect thenDelete();
-
-      StepEffect error(String description);
-
-      // TODO: add support for CommandException
     }
   }
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/WorkflowEffects.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/WorkflowEffects.scala
@@ -16,7 +16,6 @@ import akka.javasdk.impl.workflow.WorkflowEffects.WorkflowEffectImpl.Persistence
 import akka.javasdk.impl.workflow.WorkflowEffects.WorkflowEffectImpl.ReadOnlyEffectImpl
 import akka.javasdk.impl.workflow.WorkflowEffects.WorkflowEffectImpl.Reply
 import akka.javasdk.impl.workflow.WorkflowEffects.WorkflowEffectImpl.TransitionalEffectImpl
-import akka.javasdk.impl.workflow.WorkflowEffects.WorkflowStepEffectImpl.ErrorStepEffectImpl
 import akka.javasdk.workflow.Workflow
 import akka.javasdk.workflow.Workflow.Effect
 import akka.javasdk.workflow.Workflow.Effect.PersistenceEffectBuilder
@@ -206,12 +205,7 @@ object WorkflowEffects {
       override def thenEnd(): StepEffect =
         WorkflowStepEffectImpl(persistence, End)
 
-      override def error(description: String): StepEffect =
-        ErrorStepEffectImpl(description)
-
     }
-
-    final case class ErrorStepEffectImpl[R](description: String) extends StepEffect
   }
 
   /**
@@ -245,9 +239,6 @@ object WorkflowEffects {
 
     override def thenDelete(): StepEffect =
       WorkflowStepEffectImpl(NoPersistence, Delete)
-
-    override def error(description: String): StepEffect =
-      ErrorStepEffectImpl(description)
   }
 
   private final case class StepEffectCallWithInputImpl[I, S](persistence: Persistence[S], stepName: String)


### PR DESCRIPTION
It doesn't make sense to have a `.error()` in the `StepEffect`. 

A `StepEffect` is solely handled by the runtime and the runtime doesn't care about what the user throws. It will simply retry the step (or failover). 

