### PR TITLE
fix: full telemetry context propagation

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/consumer/ConsumerImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/consumer/ConsumerImpl.scala
@@ -43,10 +43,10 @@ import akka.runtime.sdk.spi.RegionInfo
 import akka.runtime.sdk.spi.SpiConsumer
 import akka.runtime.sdk.spi.SpiConsumer.Effect
 import akka.runtime.sdk.spi.SpiConsumer.Message
-import akka.runtime.sdk.spi.SpiMetadataEntry
 import akka.runtime.sdk.spi.TimerClient
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.context.{ Context => OtelContext }
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
@@ -91,21 +91,21 @@ private[impl] final class ConsumerImpl[C <: Consumer](
   override def handleMessage(message: Message): Future[Effect] = {
     val metadata = MetadataImpl.of(message.metadata)
 
+    // FIXME(tracing): move this tracing to runtime
     // FIXME would be good if we could record the chosen method in the span
     val span: Option[Span] =
       traceInstrumentation.buildSpan(ComponentType.Consumer, componentId, metadata.subjectScala, message.metadata)
-
-    val updatedMetadata = span.map(metadata.withTracing).getOrElse(metadata)
+    val telemetryContext = span.map(OtelContext.root.`with`)
 
     span.foreach(s => MDC.put(Telemetry.TRACE_ID, s.getSpanContext.getTraceId))
     val fut =
       try {
         val messageContext =
           new MessageContextImpl(
-            updatedMetadata,
+            metadata,
             timerClient,
             tracerFactory,
-            span,
+            telemetryContext,
             regionInfo.selfRegion,
             message.originRegion.toJava)
 
@@ -180,7 +180,7 @@ private[impl] final class MessageContextImpl(
     override val metadata: Metadata,
     timerClient: TimerClient,
     tracerFactory: () => Tracer,
-    val span: Option[Span],
+    val telemetryContext: Option[OtelContext],
     override val selfRegion: String,
     override val originRegion: Optional[String])
     extends AbstractContext
@@ -195,14 +195,9 @@ private[impl] final class MessageContextImpl(
       Optional.empty()
 
   override def componentCallMetadata: MetadataImpl = {
-    if (metadata.has(Telemetry.TRACE_PARENT_KEY)) {
-      MetadataImpl.of(
-        List(new SpiMetadataEntry(Telemetry.TRACE_PARENT_KEY, metadata.get(Telemetry.TRACE_PARENT_KEY).get())))
-    } else {
-      MetadataImpl.Empty
-    }
+    telemetryContext.fold(MetadataImpl.Empty)(MetadataImpl.Empty.withTelemetryContext)
   }
 
-  override def tracing(): Tracing = new SpanTracingImpl(span, tracerFactory)
+  override def tracing(): Tracing = new SpanTracingImpl(telemetryContext, tracerFactory)
 
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/grpc/GrpcClientProviderImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/grpc/GrpcClientProviderImpl.scala
@@ -226,13 +226,14 @@ private[akka] final class GrpcClientProviderImpl(
     }
   }
 
-  def withTraceContext(traceContext: OtelContext): GrpcClientProvider = {
+  // FIXME(tracing): have context propagators provided by the runtime
+  def withTelemetryContext(telemetryContext: OtelContext): GrpcClientProvider = {
     val otelTraceHeaders: Vector[(String, String)] = {
       val builder = Vector.newBuilder[(String, String)]
       W3CTraceContextPropagator
         .getInstance()
         .inject(
-          traceContext,
+          telemetryContext,
           null,
           // Note: side-effecting instead of mutable collection
           (_: scala.Any, key: String, value: String) => {

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/http/HttpClientProviderImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/http/HttpClientProviderImpl.scala
@@ -26,16 +26,17 @@ import org.slf4j.LoggerFactory
 @InternalApi
 private[akka] final class HttpClientProviderImpl(
     system: ActorSystem[_],
-    traceContext: Option[OtelContext],
+    telemetryContext: Option[OtelContext],
     remoteIdentificationHeader: Option[RawHeader],
     settings: Settings)
     extends HttpClientProvider {
 
   private val log = LoggerFactory.getLogger(classOf[HttpClientProvider])
 
+  // FIXME(tracing): have context propagators provided by the runtime
   private val otelTraceHeaders: Vector[HttpHeader] = {
     val builder = Vector.newBuilder[HttpHeader]
-    traceContext.foreach(context =>
+    telemetryContext.foreach(context =>
       W3CTraceContextPropagator
         .getInstance()
         .inject(
@@ -100,7 +101,7 @@ private[akka] final class HttpClientProviderImpl(
     new HttpClientImpl(system, baseUrl, defaultHeaders)
   }
 
-  def withTraceContext(traceContext: OtelContext): HttpClientProvider =
-    new HttpClientProviderImpl(system, Some(traceContext), remoteIdentificationHeader, settings)
+  def withTelemetryContext(telemetryContext: OtelContext): HttpClientProvider =
+    new HttpClientProviderImpl(system, Some(telemetryContext), remoteIdentificationHeader, settings)
 
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/telemetry/SpanTracingImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/telemetry/SpanTracingImpl.scala
@@ -18,15 +18,15 @@ import io.opentelemetry.context.{ Context => OtelContext }
  * INTERNAL API
  */
 @InternalApi
-final class SpanTracingImpl(span: Option[Span], tracerFactory: () => Tracer) extends Tracing {
+final class SpanTracingImpl(context: Option[OtelContext], tracerFactory: () => Tracer) extends Tracing {
   override def startSpan(name: String): Optional[Span] =
-    span.map { s =>
-      val parent = OtelContext.current().`with`(s)
+    context.map { parent =>
       tracerFactory()
-        .spanBuilder("ad-hoc span")
+        .spanBuilder(name)
         .setParent(parent)
         .startSpan()
     }.toJava
 
-  override def parentSpan(): Optional[Span] = span.toJava
+  override def parentSpan(): Optional[Span] =
+    context.flatMap(context => Option(Span.fromContextOrNull(context))).toJava
 }

--- a/akka-javasdk/src/test/java/akka/javasdk/client/ComponentClientTest.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/client/ComponentClientTest.java
@@ -13,7 +13,6 @@ import akka.javasdk.impl.*;
 import akka.javasdk.impl.client.ComponentClientImpl;
 import akka.javasdk.impl.client.DeferredCallImpl;
 import akka.javasdk.impl.serialization.JsonSerializer;
-import akka.javasdk.impl.telemetry.Telemetry;
 import akka.javasdk.testmodels.Number;
 import akka.javasdk.testmodels.action.ActionsTestModels.ActionWithOneParam;
 import akka.javasdk.testmodels.action.ActionsTestModels.ActionWithoutParam;
@@ -118,7 +117,7 @@ class ComponentClientTest {
   public void shouldReturnDeferredCallWithTraceParent() {
     // given
     String traceparent = "074c4c8d-d87c-4573-847f-77951ce4e0a4";
-    Metadata metadata = MetadataImpl.Empty().set(Telemetry.TRACE_PARENT_KEY(), traceparent);
+    Metadata metadata = MetadataImpl.Empty().set("traceparent", traceparent);
     // when
     DeferredCallImpl<NotUsed, Object> call =
         (DeferredCallImpl<NotUsed, Object>)
@@ -129,7 +128,7 @@ class ComponentClientTest {
                 .deferred();
 
     // then
-    assertThat(call.metadata().get(Telemetry.TRACE_PARENT_KEY()).get()).isEqualTo(traceparent);
+    assertThat(call.metadata().get("traceparent").get()).isEqualTo(traceparent);
   }
 
   @Test


### PR DESCRIPTION
We need the whole trace context for debug tracing (including trace state). Use the telemetry context rather than just the span, and start supporting full context propagation. Can then also support other distributed contexts, like w3c baggage propagation. The telemetry context is already passed for some SPI contexts. `FIXME(tracing)` comments added for other parts that will be updated next.