### PR TITLE
fix: include 'typesafe' in accepted list

### DIFF
--- a/docs/styles/config/vocabularies/Akka/accept.txt
+++ b/docs/styles/config/vocabularies/Akka/accept.txt
@@ -200,6 +200,7 @@ tokenization
 tokenSecret
 transcoded
 [Tt]ranscoding
+[Tt]ypesafe
 uid
 unary
 unencrypted


### PR DESCRIPTION
Vale failed in #889, but PR was merged. 
Fixing it for the next time.