### PR TITLE
fix: InvocationTargetException causing confusion of workflow logs

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
@@ -8,6 +8,7 @@ import akka.annotation.InternalApi;
 import akka.javasdk.CommandException;
 import akka.javasdk.Metadata;
 import akka.javasdk.client.ComponentClient;
+import akka.javasdk.impl.ErrorHandling;
 import akka.javasdk.impl.client.MethodRefResolver;
 import akka.javasdk.impl.workflow.WorkflowDescriptor;
 import akka.javasdk.impl.workflow.WorkflowEffects;
@@ -926,8 +927,10 @@ public abstract class Workflow<S> {
       try {
         javaMethod.setAccessible(true);
         return (StepEffect) javaMethod.invoke(instance, args);
-      } catch (IllegalAccessException | InvocationTargetException e) {
+      } catch (IllegalAccessException e) {
         throw new RuntimeException(e);
+      } catch (InvocationTargetException e) {
+        throw ErrorHandling.unwrapInvocationTargetException(e);
       }
     }
   }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/ErrorHandling.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/ErrorHandling.scala
@@ -4,6 +4,7 @@
 
 package akka.javasdk.impl
 
+import java.lang.reflect.InvocationTargetException
 import java.util.UUID
 import java.util.concurrent.ExecutionException
 
@@ -31,6 +32,14 @@ private[javasdk] object ErrorHandling {
   }
 
   def unwrapExecutionException(exc: ExecutionException): RuntimeException = {
+    exc.getCause match {
+      case null                => new RuntimeException(exc.getMessage)
+      case e: RuntimeException => e
+      case other               => new RuntimeException(other)
+    }
+  }
+
+  def unwrapInvocationTargetException(exc: InvocationTargetException): RuntimeException = {
     exc.getCause match {
       case null                => new RuntimeException(exc.getMessage)
       case e: RuntimeException => e

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
   // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L31
   val JacksonVersion = "2.19.0"
   val JacksonDatabindVersion = JacksonVersion
-  val Langchain4jVersion = "1.1.0"
+  val Langchain4jVersion = "1.3.0"
   val LogbackVersion = "1.5.18"
   val LogbackContribVersion = "0.1.5"
   val JUnitVersion = "4.13.2"


### PR DESCRIPTION
Looked like this:
```
java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at akka.javasdk.workflow.Workflow$StepMethod.invoke(Workflow.java:930)
	at akka.javasdk.impl.workflow.ReflectiveWorkflowRouter.$anonfun$handleStep$7(ReflectiveWorkflowRouter.scala:204)
	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:687)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:47)
	at java.base/java.util.concurrent.ThreadPerTaskExecutor$TaskRunner.run(ThreadPerTaskExecutor.java:314)
	at java.base/java.lang.VirtualThread.run(VirtualThread.java:309)
Caused by: java.lang.reflect.InvocationTargetException: null
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:118)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at akka.javasdk.workflow.Workflow$StepMethod.invoke(Workflow.java:928)
	... 6 common frames omitted
Caused by: kalix.runtime.CorrelatedRuntimeException: Response mapping error
	at kalix.runtime.ComponentClientsImpl$$anon$2.transformResponse(ComponentClientsImpl.scala:385)
	at kalix.runtime.ComponentClientsImpl$$anon$2.$anonfun$send$2(ComponentClientsImpl.scala:428)
```