### PR TITLE
fix: content-type fallback for cloud events in metadata

### DIFF
--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/EventingTestKitImpl.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/EventingTestKitImpl.scala
@@ -423,7 +423,7 @@ private[testkit] class OutgoingMessagesImpl(
 
   private def typeUrlFor(metadata: MetadataImpl): String = {
     val ceType = metadata.get("ce-type").toScala
-    val contentType = metadata.get("Content-Type").toScala
+    val contentType = metadata.datacontenttypeScala()
 
     (ceType, contentType) match {
       case (_, Some("text/plain; charset=utf-8")) => "type.kalix.io/string"

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/MetadataImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/MetadataImpl.scala
@@ -265,11 +265,22 @@ object MetadataImpl {
         }
       }
 
-    new MetadataImpl(transformedEntries)
+    ensureContentType(new MetadataImpl(transformedEntries))
   }
 
   def of(metadata: SpiMetadata): MetadataImpl = {
     of(metadata.entries)
+  }
+
+  private def ensureContentType(metadata: MetadataImpl): MetadataImpl = {
+    // NOTE: MetadataImpl currently always uses `Content-Type` for `ce-datacontenttype`.
+    // If the metadata only has `ce-datacontenttype`, also copy it to `Content-Type`.
+    if (metadata.datacontenttype.isEmpty) {
+      metadata.getScala("ce-datacontenttype") match {
+        case Some(contentType) => metadata.withDatacontenttype(contentType)
+        case _                 => metadata
+      }
+    } else metadata
   }
 
 }


### PR DESCRIPTION
A change to test eventing in latest runtime meant that metadata only contained the cloud event attributes, and not the `Content-Type` header. The metadata on the SDK side always uses `Content-Type` for `ce-datacontenttype`. We probably want to have a better separation between cloud events and their encodings that use `Content-Type`. Test eventing in runtime can be adjusted to add the `Content-Type` entry again, but also add a fallback in the metadata implementation here so that things are more robust.