### PR TITLE
build: Publish parent pom.xml with sbt

### DIFF
--- a/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-parent/pom.xml
@@ -1,0 +1,653 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- FIXME This can be removed, right?
+    <parent>
+        <groupId>io.akka</groupId>
+        <artifactId>akka-javasdk-maven</artifactId>
+        <version>3.5.0</version>
+    </parent>
+    -->
+
+    <groupId>io.akka</groupId>
+    <artifactId>akka-javasdk-parent</artifactId>
+    <version>3.5.0</version>
+    <packaging>pom</packaging>
+
+
+    <name>Akka SDK for Java Parent pom</name>
+    <description>
+        This is the parent pom for Akka services.
+        It contains all dependencies and plugins to build an Akka service using the Akka SDK for Java.
+    </description>
+
+    <properties>
+        <logback.configurationFile>logback-runtime-dev-mode.xml</logback.configurationFile>
+
+        <docker.image>${project.artifactId}</docker.image>
+        <docker.tag>${project.version}-${build.timestamp}</docker.tag>
+
+        <!-- note that this image does never actually run the service, it's just a means for distribution -->
+        <docker.base.image>alpine:3.14</docker.base.image>
+        <docker.platform>linux/amd64</docker.platform>
+
+        <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
+
+        <akka-javasdk.version>3.5.0</akka-javasdk.version>
+        <!-- must be carefully kept in sync with sdk and runtime version -->
+        <akka.grpc.version>2.5.5</akka.grpc.version>
+
+        <!-- These are dependent on runtime environment and cannot be customized by users -->
+        <maven.compiler.release>21</maven.compiler.release>
+        <akka-runtime.version>1.5.9</akka-runtime.version>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <skip.docker>false</skip.docker>
+        <skip.deploy>true</skip.deploy>
+
+        <!-- plugin versions -->
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
+        <docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>
+        <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
+        <maven-failsafe-plugin.version>3.1.2</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+
+    </properties>
+
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>akka-repository</id>
+            <url>https://repo.akka.io/maven</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <repositories>
+        <repository>
+            <id>akka-repository</id>
+            <name>Akka repository</name>
+            <url>https://repo.akka.io/maven</url>
+        </repository>
+    </repositories>
+
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-Xlint:deprecation</arg>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                        <annotationProcessors>
+                            <annotationProcessor>
+                                akka.javasdk.tooling.processor.ComponentAnnotationProcessor
+                            </annotationProcessor>
+                        </annotationProcessors>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>io.akka</groupId>
+                                <artifactId>akka-javasdk-annotation-processor</artifactId>
+                                <version>${akka-javasdk.version}</version>
+                            </path>
+                        </annotationProcessorPaths>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${docker-maven-plugin.version}</version>
+                    <configuration>
+                        <skip>${skip.docker}</skip>
+                        <images>
+                            <image>
+                                <name>${docker.image}:%l</name>
+                                <build>
+                                    <!-- Base Docker image which contains jre-->
+                                    <from>${docker.base.image}</from>
+                                    <buildOptions>
+                                        <platform>${docker.platform}</platform>
+                                    </buildOptions>
+                                    <tags>
+                                        <!-- tag for generated image -->
+                                        <tag>${docker.tag}</tag>
+                                    </tags>
+                                    <assembly>
+                                        <inline>
+                                            <dependencySets>
+                                                <dependencySet>
+                                                    <outputDirectory>.</outputDirectory>
+                                                    <useProjectArtifact>true</useProjectArtifact>
+                                                    <scope>compile</scope>
+                                                    <excludes>
+                                                        <!-- Dependencies of SDK and or available as API for users
+                                                             but already provided by runtime. Since runtime versions
+                                                             will always be preferred, there is no need to package up
+                                                             these.
+
+                                                             Avoid using wildcards here, since those may easily block
+                                                             inclusion of jars not provided by the runtime.
+
+                                                             List can be verified by building a runtime image and cross-
+                                                             referencing the list of packaged jars.
+
+                                                             Watch out for this log from mvn clean install:
+                                                               [WARNING] The following patterns were never triggered in this artifact exclusion filter
+
+                                                             Debug logging can be enabled with:
+                                                             mvn clean install -DskipTests -Dorg.slf4j.simpleLogger.showLogName=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.assembly.archive.phase.DependencySetAssemblyPhase=debug
+                                                             -->
+                                                        <exclude>com.typesafe:config</exclude>
+                                                        <exclude>com.typesafe.akka:akka-actor_2.13</exclude>
+                                                        <exclude>com.typesafe.akka:akka-discovery_2.13</exclude>
+                                                        <exclude>com.typesafe.akka:akka-parsing_2.13</exclude>
+                                                        <exclude>com.typesafe.akka:akka-pki_2.13</exclude>
+                                                        <exclude>com.typesafe.akka:akka-protobuf-v3_2.13</exclude>
+                                                        <exclude>com.typesafe.akka:akka-stream_2.13</exclude>
+                                                        <exclude>com.typesafe.akka:akka-http-core_2.13</exclude>
+                                                        <exclude>com.typesafe.akka:akka-http_2.13</exclude>
+                                                        <exclude>com.hierynomus:asn-one</exclude>
+                                                        <exclude>org.reactivestreams:reactive-streams</exclude>
+                                                        <!-- Scala stdlib -->
+                                                        <exclude>org.scala-lang.modules:scala-collection-compat_2.13
+                                                        </exclude>
+                                                        <exclude>org.scala-lang:scala-library</exclude>
+                                                        <!-- Protobuf/gRPC
+                                                            Note: scalapb validation is still provided from with service (for now) -->
+                                                        <exclude>com.thesamet.scalapb:lenses_2.13</exclude>
+                                                        <exclude>com.thesamet.scalapb:scalapb-runtime_2.13</exclude>
+                                                        <exclude>io.grpc:grpc-stub</exclude>
+                                                        <exclude>io.grpc:grpc-api</exclude>
+                                                        <exclude>io.grpc:grpc-core</exclude>
+                                                        <exclude>io.grpc:grpc-netty-shaded</exclude>
+                                                        <exclude>io.grpc:grpc-protobuf</exclude>
+                                                        <exclude>com.google.protobuf:protobuf-java</exclude>
+                                                        <exclude>com.google.api.grpc:proto-google-common-protos
+                                                        </exclude>
+                                                        <exclude>com.lightbend.akka.grpc:akka-grpc-runtime_2.13
+                                                        </exclude>
+                                                        <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
+                                                        <!-- guava and related -->
+                                                        <exclude>com.google.guava:guava</exclude>
+                                                        <exclude>com.google.guava:failureaccess</exclude>
+                                                        <exclude>com.google.guava:listenablefuture</exclude>
+                                                        <exclude>com.google.errorprone:error_prone_annotations</exclude>
+                                                        <exclude>com.google.code.findbugs:jsr305</exclude>
+                                                        <exclude>org.checkerframework:checker-qual</exclude>
+                                                        <exclude>com.google.j2objc:j2objc-annotations</exclude>
+                                                        <!-- open telemetry -->
+                                                        <exclude>io.opentelemetry:opentelemetry-api</exclude>
+                                                        <exclude>io.opentelemetry:opentelemetry-context</exclude>
+                                                        <exclude>io.opentelemetry:opentelemetry-sdk</exclude>
+                                                        <exclude>io.opentelemetry:opentelemetry-sdk-common</exclude>
+                                                        <exclude>io.opentelemetry:opentelemetry-sdk-logs</exclude>
+                                                        <exclude>io.opentelemetry:opentelemetry-sdk-metrics</exclude>
+                                                        <exclude>io.opentelemetry:opentelemetry-sdk-trace</exclude>
+                                                        <exclude>io.opentelemetry:opentelemetry-exporter-otlp</exclude>
+                                                        <exclude>io.opentelemetry.semconv:opentelemetry-semconv
+                                                        </exclude>
+                                                        <!-- logging -->
+                                                        <exclude>org.slf4j:slf4j-api</exclude>
+                                                        <exclude>ch.qos.logback:logback-classic</exclude>
+                                                        <exclude>ch.qos.logback:logback-core</exclude>
+                                                        <exclude>ch.qos.logback.contrib:logback-json-classic</exclude>
+                                                        <exclude>ch.qos.logback.contrib:logback-json-core</exclude>
+                                                        <exclude>ch.qos.logback.contrib:logback-jackson</exclude>
+                                                        <!-- serialization/jackson -->
+                                                        <exclude>com.fasterxml.jackson.core:jackson-annotations
+                                                        </exclude>
+                                                        <exclude>com.fasterxml.jackson.core:jackson-core</exclude>
+                                                        <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
+                                                        <exclude>com.fasterxml.jackson.datatype:jackson-datatype-jdk8
+                                                        </exclude>
+                                                        <exclude>
+                                                            com.fasterxml.jackson.datatype:jackson-datatype-jsr310
+                                                        </exclude>
+                                                        <exclude>
+                                                            com.fasterxml.jackson.module:jackson-module-parameter-names
+                                                        </exclude>
+                                                        <!-- SDK spi -->
+                                                        <exclude>io.akka:akka-sdk-spi_2.13</exclude>
+                                                        <!-- langchain -->
+                                                        <exclude>dev.langchain4j:langchain4j</exclude>
+                                                    </excludes>
+                                                </dependencySet>
+                                            </dependencySets>
+                                        </inline>
+                                    </assembly>
+                                    <entryPoint>
+                                        <shell>echo "Listing dependencies copied:"; cp --verbose /maven/*.jar
+                                            /opt/local-lib/
+                                        </shell>
+                                    </entryPoint>
+                                </build>
+                            </image>
+                        </images>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>build-docker-image</id>
+                            <phase>install</phase>
+                            <goals>
+                                <goal>build</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>${build-helper-maven-plugin.version}</version>
+                    <executions>
+                        <!-- configure src/it/java and src/it/resources legacy paths for integration tests -->
+                        <execution>
+                            <id>add-integration-test-source</id>
+                            <phase>generate-test-sources</phase>
+                            <goals>
+                                <goal>add-test-source</goal>
+                            </goals>
+                            <configuration>
+                                <sources>
+                                    <source>src/it/java</source>
+                                </sources>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>add-integration-test-resource</id>
+                            <phase>generate-test-resources</phase>
+                            <goals>
+                                <goal>add-test-resource</goal>
+                            </goals>
+                            <configuration>
+                                <resources>
+                                    <resource>
+                                        <directory>${basedir}/src/it/resources</directory>
+                                    </resource>
+                                </resources>
+                            </configuration>
+                        </execution>
+                        <!-- add generated protobuf and gRPC sources so that IntelliJ finds them automatically -->
+                        <execution>
+                            <id>add-java-source</id>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>add-source</goal>
+                            </goals>
+                            <configuration>
+                                <sources>
+                                    <source>${project.build.directory}/generated-sources/akka-grpc-java</source>
+                                </sources>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                    <configuration>
+                        <excludes>
+                            <!-- ignore integration test classes -->
+                            <exclude>**/*IntegrationTest</exclude>
+                        </excludes>
+                        <systemPropertyVariables>
+                            <logback.configurationFile>${logback.configurationFile}</logback.configurationFile>
+                            <akka.javasdk.dev-mode.project-artifact-id>${project.artifactId}
+                            </akka.javasdk.dev-mode.project-artifact-id>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-failsafe-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                            <configuration>
+                                <includes>
+                                    <include>**/*IntegrationTest.java</include>
+                                    <include>**/*IT.java</include>
+                                    <include>**/IT*.java</include>
+                                    <include>**/*ITCase.java</include>
+                                </includes>
+                                <argLine>-Dlogback.configurationFile=${logback.configurationFile}
+                                    -Dakka.javasdk.dev-mode.project-artifact-id=${project.artifactId}
+                                </argLine>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven-deploy-plugin.version}</version>
+                    <configuration>
+                        <skip>${skip.deploy}</skip>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>3.4.1</version>
+                    <configuration>
+                        <mainClass>kalix.runtime.AkkaRuntimeMain</mainClass>
+                        <cleanupDaemonThreads>false</cleanupDaemonThreads>
+                        <systemProperties>
+                            <systemProperty>
+                                <key>akka.javasdk.dev-mode.enabled</key>
+                                <value>true</value>
+                            </systemProperty>
+                            <systemProperty>
+                                <key>logback.configurationFile</key>
+                                <value>${logback.configurationFile}</value>
+                            </systemProperty>
+                            <systemProperty>
+                                <key>akka.javasdk.dev-mode.project-artifact-id</key>
+                                <value>${project.artifactId}</value>
+                            </systemProperty>
+                        </systemProperties>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <profiles>
+
+        <profile>
+            <id>it</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.gmaven</groupId>
+                        <artifactId>groovy-maven-plugin</artifactId>
+                        <version>2.1.1</version>
+                        <executions>
+                            <execution>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <source>
+                                        log.warn('The ' it ' profile is deprecated. It will be removed in future versions. Integration tests only need `mvn verify` to run.')
+                                    </source>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>formatting</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.hubspot.maven.plugins</groupId>
+                        <artifactId>prettier-maven-plugin</artifactId>
+                        <version>0.22</version>
+                        <configuration>
+                            <prettierJavaVersion>2.6.0</prettierJavaVersion>
+                            <printWidth>94</printWidth>
+                            <tabWidth>2</tabWidth>
+                            <useTabs>false</useTabs>
+                            <ignoreConfigFile>true</ignoreConfigFile>
+                            <ignoreEditorConfig>true</ignoreEditorConfig>
+                            <inputGlobs>
+                                <!-- These are the default patterns, you can omit <inputGlobs> entirely unless you want to override them -->
+                                <inputGlob>src/main/java/**/*.java</inputGlob>
+                                <inputGlob>src/test/java/**/*.java</inputGlob>
+                            </inputGlobs>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>write</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>clean-on-missing-descriptor</id>
+            <activation>
+                <file>
+                    <missing>target/classes/META-INF/akka-javasdk-components.conf</missing>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <version>3.4.0</version>
+                        <executions>
+                            <execution>
+                                <id>clean-on-missing-descriptor</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>generate-protobuf-endpoints</id>
+            <activation>
+                <file>
+                    <exists>src/main/proto</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.lightbend.akka.grpc</groupId>
+                        <artifactId>akka-grpc-maven-plugin</artifactId>
+                        <version>${akka.grpc.version}</version>
+                        <configuration>
+                            <generatorSettings>
+                                <!-- required to generate the instance-per-request handler -->
+                                <generateScalaHandlerFactory>true</generateScalaHandlerFactory>
+                                <blockingApis>true</blockingApis>
+                            </generatorSettings>
+                        </configuration>
+                        <!-- Hook the generate goal into the lifecycle, automatically tied to generate-sources -->
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>standalone</id>
+            <properties>
+                <docker.base.image>eclipse-temurin:21.0.1_12-jre-jammy</docker.base.image>
+            </properties>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.kalix</groupId>
+                        <artifactId>akka-runtime-core_2.13</artifactId>
+                        <version>${akka-runtime.version}</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+
+            <dependencies>
+                <dependency>
+                    <groupId>io.kalix</groupId>
+                    <artifactId>akka-runtime-core_2.13</artifactId>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>io.fabric8</groupId>
+                            <artifactId>docker-maven-plugin</artifactId>
+                            <version>${docker-maven-plugin.version}</version>
+                            <configuration combine.self="override">
+                                <skip>${skip.docker}</skip>
+                                <images>
+                                    <image>
+                                        <name>${docker.image}:%l</name>
+                                        <build>
+                                            <!-- Base Docker image which contains jre-->
+                                            <from>${docker.base.image}</from>
+                                            <buildOptions>
+                                                <platform>${docker.platform}</platform>
+                                            </buildOptions>
+                                            <tags>
+                                                <!-- tag for generated image -->
+                                                <tag>${docker.tag}</tag>
+                                            </tags>
+                                            <entryPoint>
+                                                <exec>
+                                                    <arg>java</arg>
+                                                    <arg>-cp</arg>
+                                                    <arg>/maven/*</arg>
+                                                    <arg>-Dconfig.resource=runtime-standalone.conf</arg>
+                                                    <arg>kalix.runtime.AkkaRuntimeMain</arg>
+                                                </exec>
+                                            </entryPoint>
+                                            <assembly>
+                                                <descriptorRef>artifact-with-dependencies</descriptorRef>
+                                            </assembly>
+                                        </build>
+                                    </image>
+                                </images>
+                            </configuration>
+                            <executions>
+                                <execution>
+                                    <id>build-docker-image</id>
+                                    <phase>install</phase>
+                                    <goals>
+                                        <goal>build</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.akka</groupId>
+                <artifactId>akka-javasdk</artifactId>
+                <version>${akka-javasdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.akka</groupId>
+                <artifactId>akka-javasdk-testkit</artifactId>
+                <version>${akka-javasdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.kalix</groupId>
+                <artifactId>kalix-dev-runtime_2.13</artifactId>
+                <version>${akka-runtime.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.akka</groupId>
+            <artifactId>akka-javasdk</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.akka</groupId>
+            <artifactId>akka-javasdk-testkit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kalix</groupId>
+            <artifactId>kalix-dev-runtime_2.13</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Dependencies.AkkaRuntimeVersion
 
 lazy val `akka-javasdk-root` = project
   .in(file("."))
-  .aggregate(akkaJavaSdkAnnotationProcessor, akkaJavaSdk, akkaJavaSdkTestKit, akkaJavaSdkTests)
+  .aggregate(akkaJavaSdkAnnotationProcessor, akkaJavaSdk, akkaJavaSdkTestKit, akkaJavaSdkTests, akkaJavaSdkParent)
   // samplesCompilationProject and annotationProcessorTestProject are composite project
   // to aggregate them we need to map over them
   .aggregate(samplesCompilationProject.componentProjects.map(p => p: ProjectReference): _*)
@@ -104,5 +104,18 @@ lazy val annotationProcessorTestProject: CompositeProject =
         libraryDependencies += Dependencies.scalaTest % Test,
         Compile / javacOptions ++= Seq("-processor", "akka.javasdk.tooling.processor.ComponentAnnotationProcessor"))
   }
+
+lazy val akkaJavaSdkParent =
+  Project(id = "akka-javasdk-parent", base = file("akka-javasdk-parent"))
+    .enablePlugins(BuildInfoPlugin, Publish)
+    .disablePlugins(CiReleasePlugin) // we use publishSigned, but use a pgp utility from CiReleasePlugin
+    .settings(
+      name := "akka-javasdk-parent",
+      crossPaths := false,
+      scalaVersion := Dependencies.ScalaVersion,
+      pomPostProcess := { (node: scala.xml.Node) =>
+        // completely replace with our pom.xml
+        scala.xml.XML.loadFile(baseDirectory.value / "pom.xml")
+      })
 
 addCommandAlias("formatAll", "scalafmtAll; javafmtAll")


### PR DESCRIPTION
Now, when we don't have the maven archetype any more we can publish the parent pom to the same place as the jars, instead of special maven central publishing.

Then I was thinking that we could perhaps simplify the build by publishing everything with sbt. Here is an attempt for discussion.