### PR TITLE
fix: context propagation from agents to memory and template entities

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -696,8 +696,8 @@ private final class Sdk(
             serializer,
             ComponentDescriptor.descriptorFor(agentClass, serializer),
             regionInfo,
-            new PromptTemplateClient(componentClient(None)),
-            componentClient(None),
+            telemetryContext => new PromptTemplateClient(componentClient(telemetryContext)),
+            telemetryContext => componentClient(telemetryContext),
             overrideModelProvider,
             dependencyProviderOpt,
             applicationConfig)


### PR DESCRIPTION
We weren't connecting traces for internal component calls to the session memory and prompt template entities. So these were all recorded as separate traces.

<img width="1437" height="1541" alt="separate-traces" src="https://github.com/user-attachments/assets/1b916db7-1d09-40dd-9801-644b7fa737b9" />

---

By setting the telemetry context on the component clients, we now get a single trace:

<img width="1398" height="297" alt="one-trace" src="https://github.com/user-attachments/assets/bb423ac0-901f-452f-8b0e-171cc469e162" />

---

And the entity interactions within the command spans:

<img width="1850" height="968" alt="session-memory-spans" src="https://github.com/user-attachments/assets/e0fcb5a9-cc74-4d2b-847f-fc7da94649cd" />

---

If we've subscribed to the session memory events, then consumer trace spans will be connected from there.