### PR TITLE
fix: context propagation from consumer and timed action

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -71,6 +71,7 @@ import akka.javasdk.impl.agent.OverrideModelProvider
 import akka.javasdk.impl.agent.PromptTemplateClient
 import akka.javasdk.impl.client.ComponentClientImpl
 import akka.javasdk.impl.consumer.ConsumerImpl
+import akka.javasdk.impl.consumer.MessageContextImpl
 import akka.javasdk.impl.eventsourcedentity.EventSourcedEntityImpl
 import akka.javasdk.impl.grpc.GrpcClientProviderImpl
 import akka.javasdk.impl.http.HttpClientProviderImpl
@@ -639,7 +640,10 @@ private final class Sdk(
         val timedActionSpi =
           new TimedActionImpl[TimedAction](
             componentId,
-            () => wiredInstance(timedActionClass)(sideEffectingComponentInjects(None)),
+            context =>
+              wiredInstance(timedActionClass)(
+                sideEffectingComponentInjects(
+                  context.asInstanceOf[TimedActionImpl.CommandContextImpl].telemetryContext)),
             timedActionClass,
             system.classicSystem,
             runtimeComponentClients.timerClient,
@@ -659,7 +663,9 @@ private final class Sdk(
         val consumerSpi =
           new ConsumerImpl[Consumer](
             componentId,
-            () => wiredInstance(consumerClass)(sideEffectingComponentInjects(None)),
+            context =>
+              wiredInstance(consumerClass)(
+                sideEffectingComponentInjects(context.asInstanceOf[MessageContextImpl].telemetryContext)),
             consumerClass,
             consumerSrc,
             consumerDest,

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ComponentClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ComponentClientImpl.scala
@@ -35,8 +35,7 @@ private[javasdk] final case class ComponentClientImpl(
     telemetryContext: Option[OtelContext])(implicit ec: ExecutionContext, system: ActorSystem[_])
     extends ComponentClient {
 
-  // Volatile since the component client could be accessed in nested/composed futures and is mutated by the reflective action router
-  @volatile var callMetadata: Option[Metadata] = telemetryContext.map { context =>
+  private val callMetadata: Option[Metadata] = telemetryContext.map { context =>
     MetadataImpl.Empty.withTelemetryContext(context)
   }
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/consumer/ReflectiveConsumerRouter.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/consumer/ReflectiveConsumerRouter.scala
@@ -14,7 +14,6 @@ import akka.javasdk.consumer.MessageEnvelope
 import akka.javasdk.impl.AnySupport.ProtobufEmptyTypeUrl
 import akka.javasdk.impl.MethodInvoker
 import akka.javasdk.impl.reflection.ParameterExtractors
-import akka.javasdk.impl.reflection.Reflect
 import akka.javasdk.impl.serialization.JsonSerializer
 import akka.runtime.sdk.spi.BytesPayload
 
@@ -43,11 +42,6 @@ private[impl] class ReflectiveConsumerRouter[A <: Consumer](
     val payload = message.payload()
     // make sure we route based on the new type url if we get an old json type url message
     val inputTypeUrl = internalSerializer.removeVersion(internalSerializer.replaceLegacyJsonPrefix(payload.contentType))
-
-    // FIXME drop this because we don't really support field injection of the component client in the Akka SDK?
-    // lookup ComponentClient
-    val componentClients = Reflect.lookupComponentClientFields(consumer)
-    componentClients.foreach(_.callMetadata = Some(message.metadata()))
 
     val methodInvoker = methodInvokers.get(inputTypeUrl)
     methodInvoker match {

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/timedaction/TimedActionImplSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/timedaction/TimedActionImplSpec.scala
@@ -56,7 +56,7 @@ class TimedActionImplSpec
   def create(componentDescriptor: ComponentDescriptor): TimedActionImpl[TestTimedAction] = {
     new TimedActionImpl(
       "dummy-id",
-      () => new TestTimedAction,
+      _ => new TestTimedAction,
       classOf[TestTimedAction],
       classicSystem,
       timerClient,


### PR DESCRIPTION
Context propagation from consumer to components was working, by setting a volatile var directly, but no telemetry context for other clients. Timed actions didn't have any context propagation. Fix both using the context injection approach used for other components, and we now get connected traces.