### PR TITLE
chore: use full telemetry context for agent commands

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
@@ -75,6 +75,7 @@ import akka.runtime.sdk.spi.SpiMetadata
 import akka.util.ByteString
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.{ Context => OtelContext }
 import org.slf4j.LoggerFactory
@@ -167,9 +168,12 @@ private[impl] final class AgentImpl[A <: Agent](
   override def handleCommand(command: SpiAgent.Command): Future[SpiAgent.Effect] =
     Future {
 
-      // FIXME(tracing): add full telemetry context to SpiAgent.Command
-      val telemetryContext = command.span.map(OtelContext.root.`with`)
-      command.span.foreach(s => MDC.put(Telemetry.TRACE_ID, s.getSpanContext.getTraceId))
+      val telemetryContext = Option(command.telemetryContext)
+      val traceId = telemetryContext.flatMap { context =>
+        Option(Span.fromContextOrNull(context)).map(_.getSpanContext.getTraceId)
+      }
+      traceId.foreach(id => MDC.put(Telemetry.TRACE_ID, id))
+
       // smuggling 0 arity methods called from the component client through here
       val cmdPayload = command.payload.getOrElse(BytesPayload.empty)
       val metadata: Metadata = MetadataImpl.of(command.metadata)
@@ -285,9 +289,7 @@ private[impl] final class AgentImpl[A <: Agent](
         case NonFatal(error) =>
           throw AgentException(command.name, s"Unexpected failure: $error", Some(error))
       } finally {
-        command.span.foreach { _ =>
-          MDC.remove(Telemetry.TRACE_ID)
-        }
+        if (traceId.isDefined) MDC.remove(Telemetry.TRACE_ID)
       }
 
     }(sdkExecutionContext)

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ToolExecutorSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ToolExecutorSpec.scala
@@ -17,6 +17,7 @@ import akka.javasdk.impl.agent.ToolExecutorSpec.Foobar
 import akka.javasdk.impl.serialization.JsonSerializer
 import akka.runtime.sdk.spi.SpiAgent
 import akka.runtime.sdk.spi.SpiMetadata
+import io.opentelemetry.context.{ Context => TelemetryContext }
 import org.scalatest.TestSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -46,7 +47,7 @@ class ToolExecutorSpec extends AnyWordSpecLike with TestSuite with Matchers {
   }
 
   private def toolRequest(name: String, args: String): SpiAgent.ToolCallCommand =
-    new SpiAgent.ToolCallCommand("001", name, args, SpiMetadata.empty, None)
+    new SpiAgent.ToolCallCommand("001", name, args, SpiMetadata.empty, TelemetryContext.root)
 
   "The ToolExecutor" should {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val ProtocolVersionMajor = 1
     val ProtocolVersionMinor = 1
   }
-  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.5.13")
+  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.5.14-1-0727a65a-SNAPSHOT")
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned
   // for prod code, they are marked as Provided, but testkit still requires the alignment


### PR DESCRIPTION
Depends on https://github.com/lightbend/akka-runtime/pull/4246