### PR TITLE
feat: Include key values from log entries in log json

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/logging/LogbackJsonLayout.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/logging/LogbackJsonLayout.java
@@ -4,6 +4,9 @@
 
 package akka.javasdk.logging;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * This Logback JSON layout uses the name {@code severity} (instead of {@code level}).
  *
@@ -15,6 +18,8 @@ package akka.javasdk.logging;
  */
 public final class LogbackJsonLayout extends ch.qos.logback.contrib.json.classic.JsonLayout {
 
+  private static final String KVP_ATTR_NAME = "kvpList";
+
   public LogbackJsonLayout() {
     setIncludeLevel(false);
   }
@@ -23,5 +28,13 @@ public final class LogbackJsonLayout extends ch.qos.logback.contrib.json.classic
   public void addCustomDataToJsonMap(
       java.util.Map<String, Object> map, ch.qos.logback.classic.spi.ILoggingEvent event) {
     add("severity", true, String.valueOf(event.getLevel()), map);
+
+    if (event.getKeyValuePairs() != null && !event.getKeyValuePairs().isEmpty()) {
+      Map<String, Object> kvp = new HashMap<>();
+      event
+          .getKeyValuePairs()
+          .forEach(keyValuePair -> kvp.put(keyValuePair.key, keyValuePair.value));
+      addMap(KVP_ATTR_NAME, true, kvp, map);
+    }
   }
 }


### PR DESCRIPTION
Not very important but this aligns our logging json format with what `ch.qos.logback.classic.encoder.JsonEncoder` would output in case users use the logging API like this: `logger.atInfo().addKeyValue("size", 5).log("Some important log stuff");`