### PR TITLE
docs: Improve JavaDoc of Consumer

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/consumer/Consumer.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/consumer/Consumer.java
@@ -43,9 +43,9 @@ import java.util.concurrent.CompletionStage;
  *
  *   public Effect onEvent(CounterEvent event) {
  *     return switch (event) {
- *       case ValueIncreased valueIncreased -> 
-                 //processing the event
-                 effects().done();
+ *       case ValueIncreased valueIncreased ->
+ * //processing the event
+ * effects().done();
  *       case ValueMultiplied valueMultiplied -> effects().ignore();
  *     };
  *   }


### PR DESCRIPTION
prompt:
```
@akka-context Read the documentation from akka-context/java/consuming-producing.html.md

Improve the javadoc of the @Consumer.java classes based on the other documentation.

Don't include multi-line code snippets (<pre>) in JavaDoc aside from one single example in the Consumer class javadoc.
```

