### PR TITLE
docs: drop Certification menu item

### DIFF
--- a/docs/supplemental_ui/partials/drop-down-developers.hbs
+++ b/docs/supplemental_ui/partials/drop-down-developers.hbs
@@ -20,7 +20,6 @@
             <h3>Architecture</h3>
             <a data-context="Mega Menu - Developers - Docs" href="https://www.reactiveprinciples.org/">Principles</a>
             <a data-context="Mega Menu - Developers - Docs" href="https://akkademy.akka.io/">Free Training</a>
-            <a data-context="Mega Menu - Developers - Docs" href="https://www.akka.io/certified-reactive-architect">Certification</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
The link is being redirected to akka.io anyway.