### PR TITLE
docs: CLI URLs

### DIFF
--- a/docs/bin/generate_cli_docs.sh
+++ b/docs/bin/generate_cli_docs.sh
@@ -16,7 +16,7 @@ then
 else
   echo akka does not exist
   echo Please follow instruction page to install it.
-  echo [Instruction Page] https://doc.akka.io/akka-cli/installation.html
+  echo [Instruction Page] https://doc.akka.io/operations/cli/index.html
   exit 1
 fi
 

--- a/docs/bin/rsync-docs.sh
+++ b/docs/bin/rsync-docs.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 if [ -z ${SCP_SECRET} ]; then
   echo "No SCP_SECRET found."
   exit 1;
@@ -17,9 +18,14 @@ if [ -z "${TARGET}" ]; then
 fi
 
 eval "$(ssh-agent -s)"
+trap 'rm -f .github/id_rsa' EXIT
 echo "${SCP_SECRET}" | base64 -di > .github/id_rsa
 chmod 600 .github/id_rsa
-ssh-add .github/id_rsa
+ssh-add .github/id_rsa || { echo "Failed to add SSH key."; exit 1; }
 rm .github/id_rsa
 export RSYNC_RSH="ssh -o UserKnownHostsFile=docs/bin/gustav_known_hosts.txt "
-rsync -azP ${SOURCE} ${TARGET}
+# -r (recursive): Copies directories and their contents.
+# -t (times): Preserves modification times, which is crucial for rsync's efficiency, as it uses timestamps to determine which files need to be updated.
+# -l (links): Copies symbolic links as links.
+# -z (compress): Compresses data during the transfer.
+rsync -rtlz ${SOURCE} ${TARGET}

--- a/docs/src-static/.htaccess
+++ b/docs/src-static/.htaccess
@@ -52,14 +52,6 @@ RedirectMatch 301 ^/docs/akka/2.5.(\d+)/scala.html$      https://doc.akka.io/lib
 RedirectMatch 301 ^/docs/akka/2.5.(\d+)/java.html$       https://doc.akka.io/libraries/akka-core/2.5/?language=java
 
 # ===================================
-# Akka CLI docs, https://github.com/akka/akka-sdk/pull/324
-# ===================================
-Redirect 301 /reference/cli/index.html                https://doc.akka.io/operations/cli/index.html
-Redirect 301 /reference/cli/installation.html         https://doc.akka.io/operations/cli/index.html
-Redirect 301 /reference/cli/using-cli.html            https://doc.akka.io/operations/cli/using-cli.html
-Redirect 301 /reference/cli/command-completion.html   https://doc.akka.io/operations/cli/command-completion.html
-
-# ===================================
 # Akka core
 # ===================================
 Redirect 301 /docs/akka/current/contrib/cluster-singleton.html   https://doc.akka.io/libraries/akka-core/current/cluster-singleton.html

--- a/docs/src-static/.htaccess
+++ b/docs/src-static/.htaccess
@@ -52,6 +52,14 @@ RedirectMatch 301 ^/docs/akka/2.5.(\d+)/scala.html$      https://doc.akka.io/lib
 RedirectMatch 301 ^/docs/akka/2.5.(\d+)/java.html$       https://doc.akka.io/libraries/akka-core/2.5/?language=java
 
 # ===================================
+# Akka CLI docs, https://github.com/akka/akka-sdk/pull/324
+# ===================================
+Redirect 301 /reference/cli/index.html                https://doc.akka.io/operations/cli/index.html
+Redirect 301 /reference/cli/installation.html         https://doc.akka.io/operations/cli/index.html
+Redirect 301 /reference/cli/using-cli.html            https://doc.akka.io/operations/cli/using-cli.html
+Redirect 301 /reference/cli/command-completion.html   https://doc.akka.io/operations/cli/command-completion.html
+
+# ===================================
 # Akka core
 # ===================================
 Redirect 301 /docs/akka/current/contrib/cluster-singleton.html   https://doc.akka.io/libraries/akka-core/current/cluster-singleton.html
@@ -421,6 +429,3 @@ RedirectMatch 301 ^/libraries/(a[^/]+)/?$  https://doc.akka.io/libraries/$1/curr
 
 # All: /docs/{module}/.*    -> /libraries/{module}/.*
 RedirectMatch 301 ^/docs/([^/]+)/(.*)$       https://doc.akka.io/libraries/$1/$2
-
-# TODO remove once the real docs are published
-RedirectMatch 301 ^/akka-cli(/?|/.*)$      https://doc.akka.io/snapshots/akka-documentation/akka-cli$1

--- a/docs/src/modules/java/pages/component-and-service-calls.adoc
+++ b/docs/src/modules/java/pages/component-and-service-calls.adoc
@@ -1,5 +1,5 @@
 = Component and service calls
-:page-aliases: java:asynchronous.adoc[]
+:page-aliases: java:asynchronous.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/operations/pages/cli/command-completion.adoc
+++ b/docs/src/modules/operations/pages/cli/command-completion.adoc
@@ -1,4 +1,5 @@
 = Enable CLI command completion
+:page-aliases: reference:cli/command-completion.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/operations/pages/cli/index.adoc
+++ b/docs/src/modules/operations/pages/cli/index.adoc
@@ -1,5 +1,5 @@
 = CLI
-:page-aliases: reference:cli/index.adoc[]
+:page-aliases: reference:cli/index.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/operations/pages/cli/index.adoc
+++ b/docs/src/modules/operations/pages/cli/index.adoc
@@ -1,5 +1,5 @@
 = CLI
-:page-aliases: cli:index.adoc[]
+:page-aliases: reference:cli/index.adoc[]
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/operations/pages/cli/installation.adoc
+++ b/docs/src/modules/operations/pages/cli/installation.adoc
@@ -1,4 +1,5 @@
 = Install the Akka CLI
+:page-aliases: reference:cli/installation.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/operations/pages/cli/using-cli.adoc
+++ b/docs/src/modules/operations/pages/cli/using-cli.adoc
@@ -1,4 +1,5 @@
 = Using the Akka CLI
+:page-aliases: reference:cli/using-cli.adoc
 :page-supergroup-browser-cli: Interface
 
 include::ROOT:partial$include.adoc[]

--- a/docs/src/modules/operations/pages/observability-and-monitoring/index.adoc
+++ b/docs/src/modules/operations/pages/observability-and-monitoring/index.adoc
@@ -1,5 +1,5 @@
 = Observability and monitoring
-:page-aliases: observability:index.adoc[]
+:page-aliases: observability:index.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/operations/pages/projects/container-registries.adoc
+++ b/docs/src/modules/operations/pages/projects/container-registries.adoc
@@ -1,5 +1,5 @@
 = Configure a container registry
-:page-aliases: projects:projects/container-registries.adoc[]
+:page-aliases: projects:projects/container-registries.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/operations/pages/services/index.adoc
+++ b/docs/src/modules/operations/pages/services/index.adoc
@@ -1,5 +1,5 @@
 = Services
-:page-aliases: services:index.adoc[]
+:page-aliases: services:index.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/samples/ask-akka-agent/README.md
+++ b/samples/ask-akka-agent/README.md
@@ -84,7 +84,7 @@ Contact support to know which IPs to allow.
 mvn clean install -DskipTests
 ```
 
-2. Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+2. Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 3. Let's setup up a secret containing both the OpenAI API key and the MongoDB Atlas Uri.
 

--- a/samples/choreography-saga-quickstart/README.md
+++ b/samples/choreography-saga-quickstart/README.md
@@ -135,7 +135,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image tag from above `mvn install`:
 

--- a/samples/endpoint-jwt/README.md
+++ b/samples/endpoint-jwt/README.md
@@ -54,7 +54,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image name and tag from above `mvn install`:
 

--- a/samples/event-sourced-counter-brokers/README.md
+++ b/samples/event-sourced-counter-brokers/README.md
@@ -98,7 +98,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image tag from above `mvn install`:
 

--- a/samples/event-sourced-customer-registry-subscriber/README.md
+++ b/samples/event-sourced-customer-registry-subscriber/README.md
@@ -75,7 +75,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image tag from above `mvn install`:
 

--- a/samples/event-sourced-customer-registry/README.md
+++ b/samples/event-sourced-customer-registry/README.md
@@ -189,7 +189,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image tag from above `mvn install`:
 

--- a/samples/helloworld-agent-kotlin/README.md
+++ b/samples/helloworld-agent-kotlin/README.md
@@ -54,7 +54,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Set up secret containing OpenAI API key:
 

--- a/samples/helloworld-agent/README.md
+++ b/samples/helloworld-agent/README.md
@@ -54,7 +54,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Set up secret containing OpenAI API key:
 

--- a/samples/key-value-counter/README.md
+++ b/samples/key-value-counter/README.md
@@ -51,7 +51,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image tag from above `mvn install`:
 

--- a/samples/key-value-customer-registry/README.md
+++ b/samples/key-value-customer-registry/README.md
@@ -169,7 +169,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image tag from above `mvn install`:
 

--- a/samples/key-value-shopping-cart/README.md
+++ b/samples/key-value-shopping-cart/README.md
@@ -68,7 +68,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image tag from above `mvn install`:
 

--- a/samples/multi-agent/README.md
+++ b/samples/multi-agent/README.md
@@ -151,7 +151,7 @@ Build container image:
 ```shell
 mvn clean install -DskipTests
 ```
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Set up secret containing OpenAI API key:
 ```shell

--- a/samples/reliable-timers/README.md
+++ b/samples/reliable-timers/README.md
@@ -51,7 +51,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image tag from above `mvn install`:
 

--- a/samples/shopping-cart-quickstart/README.md
+++ b/samples/shopping-cart-quickstart/README.md
@@ -67,7 +67,7 @@ curl -i -XPOST localhost:9000/carts/123/checkout
 
 ## Explore the local console
 
-To get a clear view of your locally running service, [install the Akka CLI](https://doc.akka.io/reference/cli/index.html). It provides a local web-based management console.
+To get a clear view of your locally running service, [install the Akka CLI](https://doc.akka.io/operations/cli/installation.html). It provides a local web-based management console.
 
 After you have installed the CLI, start the local console:
 
@@ -99,7 +99,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image name and tag from above `mvn install`:
 

--- a/samples/spring-dependency-injection/README.md
+++ b/samples/spring-dependency-injection/README.md
@@ -36,7 +36,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image tag from above `mvn install`:
 

--- a/samples/tracing/README.md
+++ b/samples/tracing/README.md
@@ -63,7 +63,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image tag from above `mvn install`:
 

--- a/samples/transfer-workflow-compensation/README.md
+++ b/samples/transfer-workflow-compensation/README.md
@@ -129,7 +129,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image tag from above `mvn install`:
 

--- a/samples/transfer-workflow-orchestration/README.md
+++ b/samples/transfer-workflow-orchestration/README.md
@@ -125,7 +125,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image tag from above `mvn install`:
 

--- a/samples/transfer-workflow/README.md
+++ b/samples/transfer-workflow/README.md
@@ -137,7 +137,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image tag from above `mvn install`:
 

--- a/samples/view-store/README.md
+++ b/samples/view-store/README.md
@@ -127,7 +127,7 @@ Build container image:
 mvn clean install -DskipTests
 ```
 
-Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/reference/cli/index.html).
+Install the `akka` CLI as documented in [Install Akka CLI](https://doc.akka.io/operations/cli/installation.html).
 
 Deploy the service using the image tag from above `mvn install`:
 


### PR DESCRIPTION
The CLI pages were moved, but not functioning redirect was added. Old pages stayed on the server and sample readmes still had links pointing to those URLs. As a consequence, those pages also showed a broken design.

Refs
- #324