### PR TITLE
chore: Use tagged sdk version in update job

### DIFF
--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -44,7 +44,6 @@ jobs:
 
       - name: Create PR to update all sdk versions (samples, sbt and maven)
         env:
-          SDK_VERSION: ${{ steps.determine_sdk_version.outputs.sdk_version || steps.determine_sdk_version_manual_triggered.outputs.sdk_version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |-
           sdk_version=`./docs/bin/version.sh`


### PR DESCRIPTION
Something went wrong in https://github.com/akka/akka-sdk/pull/1055
Probably because something else was merged and determine-sdk-version.sh was used

https://github.com/akka/akka-sdk/actions/runs/18532994985/job/52820541197

It was also overly complicated, in my opinion.