### PR TITLE
bump: opentelemetry 1.51.0 (runtime aligned)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,11 +76,11 @@ object Dependencies {
   private val deps = libraryDependencies
 
   private val sdkDeps = Seq(
-    opentelemetryApi % Provided,
-    opentelemetrySdk % Provided,
-    opentelemetryExporterOtlp % Provided,
-    opentelemetryContext % Provided,
-    opentelemetrySemConv % Provided,
+    opentelemetryApi,
+    opentelemetrySdk,
+    opentelemetryExporterOtlp,
+    opentelemetryContext,
+    opentelemetrySemConv,
     // akka-http is pulling akka-pki and akka-discovery, we need to force it to be same version
     akkaDependency("akka-pki"),
     akkaDependency("akka-discovery"),


### PR DESCRIPTION
Was a bit confused when testing local tracing and it was using a much older version of OpenTelemetry. Align versions with runtime versions.

Also mark as provided, so that the runtime dev transitive dependencies will be used when running locally, and this doesn't always need to be in sync. OpenTelemetry dependencies already filtered for deployments.