### PR TITLE
chore: stripIndent and trim component description

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/ComponentDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/ComponentDescriptorFactory.scala
@@ -166,7 +166,7 @@ private[impl] object ComponentDescriptorFactory {
   def readComponentDescription(annotated: AnnotatedElement): Option[String] = {
     val componentAnnotation = annotated.getAnnotation(classOf[Component])
     if (componentAnnotation ne null) {
-      val description = componentAnnotation.description()
+      val description = componentAnnotation.description().stripIndent().trim()
       if (description.nonEmpty) Some(description) else None
     } else {
       None

--- a/akka-javasdk/src/test/java/akka/javasdk/impl/ComponentAnnotationTest.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/impl/ComponentAnnotationTest.java
@@ -25,6 +25,16 @@ public class ComponentAnnotationTest {
   @ComponentId("old-component")
   static class OldComponentEntity extends KeyValueEntity<String> {}
 
+  @Component(
+      id = "multiline-component",
+      name = "Test Component",
+      description =
+          """
+          A test component with
+          multiline description
+          """)
+  static class MultiLineComponentDescriptionEntity extends KeyValueEntity<String> {}
+
   static class NoAnnotationEntity extends KeyValueEntity<String> {}
 
   @Test
@@ -51,6 +61,15 @@ public class ComponentAnnotationTest {
 
     var description = ComponentDescriptorFactory.readComponentDescription(OldComponentEntity.class);
     assertFalse(description.isDefined());
+  }
+
+  @Test
+  public void testMultiLineComponentDescription() {
+    var description =
+        ComponentDescriptorFactory.readComponentDescription(
+            MultiLineComponentDescriptionEntity.class);
+    assertTrue(description.isDefined());
+    assertEquals("A test component with\nmultiline description", description.get());
   }
 
   @Test


### PR DESCRIPTION
* for multi-line strings
* not possible to do in the annotation declaration itself since it must be a constant

Rather common for agent descriptions to be multi-line, and when using with AgentRegistry it's not good to have the additional indentation (and not for console either)