### PR TITLE
chore: Wrong sbt name in akka-javasdk-tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val akkaJavaSdkTests =
     .enablePlugins(AkkaGrpcPlugin)
     .dependsOn(akkaJavaSdk, akkaJavaSdkTestKit)
     .settings(
-      name := "akka-javasdk-testkit",
+      name := "akka-javasdk-tests",
       crossPaths := false,
       Test / parallelExecution := false,
       Test / fork := true,


### PR DESCRIPTION
I have always wondered why it was "swapping" to testkit 😄 