### PR TITLE
fix: Handle null in KVE stateToBytes

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/keyvalueentity/KeyValueEntityEffectImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/keyvalueentity/KeyValueEntityEffectImpl.scala
@@ -46,11 +46,15 @@ private[javasdk] final class KeyValueEntityEffectImpl[S]
   def secondaryEffect: SecondaryEffectImpl = _secondaryEffect
 
   override def updateState(newState: S): KeyValueEntityEffectImpl[S] = {
+    if (newState == null)
+      throw new IllegalStateException("Updated state must not be null")
     _primaryEffect = UpdateState(newState, metadata = None)
     this
   }
 
   override def updateStateWithMetadata(newState: S, metadata: Metadata): OnSuccessBuilder[S] = {
+    if (newState == null)
+      throw new IllegalStateException("Updated state must not be null")
     _primaryEffect = UpdateState(newState, Option(metadata))
     this
   }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/keyvalueentity/KeyValueEntityImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/keyvalueentity/KeyValueEntityImpl.scala
@@ -203,8 +203,12 @@ private[impl] final class KeyValueEntityImpl[S, KV <: KeyValueEntity[S]](
     throw new IllegalStateException("handleEvent not expected for KeyValueEntity")
   }
 
-  override def stateToBytes(obj: SpiEventSourcedEntity.State): BytesPayload =
-    serializer.toBytes(obj)
+  override def stateToBytes(obj: SpiEventSourcedEntity.State): BytesPayload = {
+    if (obj eq null)
+      BytesPayload.empty
+    else
+      serializer.toBytes(obj)
+  }
 
   override def stateFromBytes(pb: BytesPayload): SpiEventSourcedEntity.State =
     serializer.fromBytes(entityStateType, pb).asInstanceOf[SpiEventSourcedEntity.State]


### PR DESCRIPTION
* it can be null after delete of the entity, and runtime may call stateToBytes
* also fail fast with better exception for `updateState(null)`
