### PR TITLE
chore: Remove the akka-docs command for context7

### DIFF
--- a/docs/src/modules/ROOT/attachments/claude/commands/akka-docs.md
+++ b/docs/src/modules/ROOT/attachments/claude/commands/akka-docs.md
@@ -1,8 +1,0 @@
-Use the context7 MCP to fetch the latest Akka documentation on the following topic: {TOPIC}
-
-Fetch documentation using mcp__context7__get-library-docs with:
-- context7CompatibleLibraryID: /llmstxt/doc_akka_io-llms.txt
-- topic: {TOPIC}
-- tokens: 3000
-
-After retrieving the documentation, provide a concise summary of the key patterns, code examples, and best practices relevant to the topic.

--- a/docs/src/modules/ROOT/attachments/mcp.json
+++ b/docs/src/modules/ROOT/attachments/mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "context7": {
-      "type": "http",
-      "url": "https://mcp.context7.com/mcp"
-    }
-  }
-}


### PR DESCRIPTION
When looking more in detail what context7 returns it isn't serving the purpose I had with this.