### PR TITLE
docs: keep URL for Runtime version check (2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ apidocs: prepare
 	rsync -a akka-javasdk-testkit/target/api/ "${java_managed_attachments}/testkit/"
 	docs/bin/version.sh > "${java_managed_attachments}/latest-version.txt"
 	# also keep version in previous location for the Runtime version check (Runtimes < 1.5.21)
-	docs/bin/version.sh > "${src_managed}/modules/sdk/attachments/latest-version.txt"
+	mkdir -p "${src_managed}/modules/java/attachments"
+	docs/bin/version.sh > "${src_managed}/modules/java/attachments/latest-version.txt"
 
 examples: prepare
 	mkdir -p "${java_managed_examples}"


### PR DESCRIPTION
As the directory didn't exist, this was failing CI and get changed by a coworker.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References
- https://github.com/akka/akka-sdk/pull/1110
- https://github.com/akka/akka-sdk/pull/1120#issuecomment-3497391798
- https://github.com/akka/akka-sdk/pull/1121