### PR TITLE
docs: typo in code init list

### DIFF
--- a/docs/src/modules/ROOT/attachments/akka-code-init.json
+++ b/docs/src/modules/ROOT/attachments/akka-code-init.json
@@ -146,13 +146,13 @@
       "level": "Advanced"
     },
         {
-      "title": "Event Sourced Counter with Broker Integration",
+      "title": "Event sourced counter with broker integration",
       "description": "This project demonstrates the use of an Event Sourced Entity and the different ways to consume and produce from/to a broker.",
       "language": "java",
       "url": "https://github.com/akka-samples/event-sourced-counter-brokers"
     },
     {
-      "title": "JWT HTTP Endpoint",
+      "title": "JWT HTTP endpoint",
       "description": "This project demonstrates the use of JWT in a HTTP Endpoint.",
       "language": "java",
       "url": "https://github.com/akka-samples/endpoint-jwt"


### PR DESCRIPTION
Should be Akka chess to be consistent with other structures.