### PR TITLE
chore: improved multi-module mvn projects

### DIFF
--- a/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-parent/pom.xml
@@ -70,8 +70,8 @@
         <akka-runtime.version>REPLACED_BY_BUILD</akka-runtime.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <skip.docker>false</skip.docker>
         <skip.deploy>true</skip.deploy>
+        <non-akka-service>false</non-akka-service>
 
         <!-- plugin versions -->
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
@@ -128,7 +128,7 @@
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>${docker-maven-plugin.version}</version>
                     <configuration>
-                        <skip>${skip.docker}</skip>
+                        <skip>${non-akka-service}</skip>
                         <images>
                             <image>
                                 <name>${docker.image}:%l</name>
@@ -352,6 +352,7 @@
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>3.4.1</version>
                     <configuration>
+                        <skip>${non-akka-service}</skip>
                         <mainClass>kalix.runtime.AkkaRuntimeMain</mainClass>
                         <cleanupDaemonThreads>false</cleanupDaemonThreads>
                         <systemProperties>
@@ -606,7 +607,7 @@
                             <artifactId>docker-maven-plugin</artifactId>
                             <version>${docker-maven-plugin.version}</version>
                             <configuration combine.self="override">
-                                <skip>${skip.docker}</skip>
+                                <skip>${non-akka-service}</skip>
                                 <images>
                                     <image>
                                         <name>${docker.image}:%l</name>
@@ -649,6 +650,21 @@
                     </plugins>
                 </pluginManagement>
             </build>
+        </profile>
+        <profile>
+            <id>pom-packaging</id>
+            <activation>
+                <file>
+                    <!--
+                    POMs without a source directory are typically a pom aggregator
+                     for those projects we can skip docker and run configuration
+                    -->
+                    <missing>src</missing>
+                </file>
+            </activation>
+            <properties>
+                <non-akka-service>true</non-akka-service>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
I run into this while testing an akka project composed of different mvn sub-modules. 

First, the build will try to create a docker image for the aggregator pom. This is useless because it's a pom without source folder.

Then, in my case, there were an API module with an event class shared by the other modules. This one was not an akka service, but just some shared library. 

We do have a `skip.docker` flag (undocumented as far as I can tell) that will skip the docker generation for the `api` module. But that's not enough. 

Such a setup, requires you to first install the `api` with `mvn compile install` and then run the other modules, with `mvn compile exec:java -pl other-module`. 

This is awkward way of doing it. 
Instead, one should do `mvn compile exec:java -am -pl other-module`.
When using `-am`, we don't need to first build and install the `api` module. 

However, when running with `-am`, the `exec:java` config is activated for all modules. 

So, for example: if you have a multi-module with `api`, `foo` and `bar`, when running `mvn compile exec:java -am -pl foo`, maven will try to run `exec:java` on the aggregator pom, then on `api` sub-module and finally on `foo`. 

Foo will start, but the aggregator module and `api` will throw some exceptions.
