### PR TITLE
fix: fetch latest tag even if on another branch

### DIFF
--- a/docs/bin/version.sh
+++ b/docs/bin/version.sh
@@ -9,5 +9,6 @@ git fetch --tags --quiet 2> /dev/null || true
 
 readonly prefix="v"
 # Get the latest tag from all tags (not just those reachable from current commit)
-readonly tag=$(git tag -l "$prefix[0-9]*" 2> /dev/null | sort -V | tail -n 1)
+# Exclude milestone releases (tags ending with -M followed by a number)
+readonly tag=$(git tag -l "$prefix[0-9]*" 2> /dev/null | grep -v -- '-M[0-9]\+$' | sort -V | tail -n 1)
 [ -n "$tag" ] && echo "${tag#$prefix}" || echo "0.0.0"


### PR DESCRIPTION
We released 3.5.7 and 3.5.8 from a branch, but when we run the doc generation, we fetch the latest tag on the `main` branch. As a result, the current docs is saying that the current version is 3.5.6.

<img width="1114" height="682" alt="CleanShot 2025-11-14 at 12 31 59@2x" src="https://github.com/user-attachments/assets/9ceecce0-066e-4280-b991-a71246546f96" />


With this PR, the script will fetch all tags and then pick the latest even if on another branch.