### PR TITLE
docs: Fix API doc links #1208

### DIFF
--- a/docs/src/modules/sdk/pages/access-control.adoc
+++ b/docs/src/modules/sdk/pages/access-control.adoc
@@ -133,7 +133,7 @@ NOTE: Endpoints are stateless and each request is served by a new Endpoint insta
 ----
 include::example$doc-snippets/src/main/java/com/example/acl/UserEndpoint.java[tags=endpoint-class;request-context]
 ----
-<1> Let your endpoint extend link:_attachments/api/akka/javasdk/http/AbstractHttpEndpoint.html[AbstractHttpEndpoint] to get access to the request specific `RequestContext` through `requestContext()`.
+<1> Let your endpoint extend link:{attachmentsdir}/api/akka/javasdk/http/AbstractHttpEndpoint.html[AbstractHttpEndpoint] to get access to the request specific `RequestContext` through `requestContext()`.
 
 You can access the current Principals through method `RequestContext.getPrincipals()`
 

--- a/docs/src/modules/sdk/pages/agents.adoc
+++ b/docs/src/modules/sdk/pages/agents.adoc
@@ -112,7 +112,7 @@ Additionally, these model providers for locally running models are supported:
 
 Each model provider may have different settings and those are described in xref:model-provider-details.adoc[]
 
-It is also possible to plug in a custom model by implementing the link:_attachments/api/akka/javasdk/agent/ModelProvider.Custom.html[`ModelProvider.Custom`] interface and use it with `ModelProvider.custom`. That involves the underlying implementations of LangChain4J `ChatModel` and optionally `StreamingChatModel`. Refer to the  https://docs.langchain4j.dev[Langchain4j, window="new"] documentation or reference implementations for how to implement the `ChatModel` and `StreamingChatModel`.
+It is also possible to plug in a custom model by implementing the link:{attachmentsdir}/api/akka/javasdk/agent/ModelProvider.Custom.html[`ModelProvider.Custom`] interface and use it with `ModelProvider.custom`. That involves the underlying implementations of LangChain4J `ChatModel` and optionally `StreamingChatModel`. Refer to the  https://docs.langchain4j.dev[Langchain4j, window="new"] documentation or reference implementations for how to implement the `ChatModel` and `StreamingChatModel`.
 
 
 == Use ComponentClient in an agent

--- a/docs/src/modules/sdk/pages/agents/guardrails.adoc
+++ b/docs/src/modules/sdk/pages/agents/guardrails.adoc
@@ -6,7 +6,7 @@ Guardrails can protect against harmful inputs, such as jailbreak attempts, and d
 
 NOTE: For protecting sensitive information like PII, see xref:sdk:sanitization.adoc[Sanitization].
 
-A specific guardrail implements the link:_attachments/api/akka/javasdk/agent/TextGuardrail.html[`TextGuardrail` interface]. It takes the input or output text as a parameter and a result if it passed the validation or not, including an explanation of why the decision was made. These results are included in metrics and traces. A guardrail can abort the interaction with the model, or only report the problem and continue anyway.
+A specific guardrail implements the link:{attachmentsdir}/api/akka/javasdk/agent/TextGuardrail.html[`TextGuardrail` interface]. It takes the input or output text as a parameter and a result if it passed the validation or not, including an explanation of why the decision was made. These results are included in metrics and traces. A guardrail can abort the interaction with the model, or only report the problem and continue anyway.
 
 An example of a `Guardrail` implementation:
 
@@ -49,7 +49,7 @@ akka.javasdk.agent.guardrails {
 <6> Where to use the guardrail, such as for the model request or model response.
 <7> If it didn't pass the evaluation criteria, the execution can either be aborted or continue anyway. In both cases, the result is tracked in logs, metrics and traces.
 
-The implementation class of the guardrail is configured with the `class` property. The class must implement the link:_attachments/api/akka/javasdk/agent/TextGuardrail.html[`TextGuardrail` interface]. The class may optionally have a constructor with a link:_attachments/api/akka/javasdk/agent/GuardrailContext.html[`GuardrailContext`] parameter, which includes the name and the config section for the specific guardrail. In above code example of the `ToxicGuard` you can see how the configuration property `search-for` is read from the configuration of the `GuardrailContext` parameter.
+The implementation class of the guardrail is configured with the `class` property. The class must implement the link:{attachmentsdir}/api/akka/javasdk/agent/TextGuardrail.html[`TextGuardrail` interface]. The class may optionally have a constructor with a link:{attachmentsdir}/api/akka/javasdk/agent/GuardrailContext.html[`GuardrailContext`] parameter, which includes the name and the config section for the specific guardrail. In above code example of the `ToxicGuard` you can see how the configuration property `search-for` is read from the configuration of the `GuardrailContext` parameter.
 
 Agents are selected by matching `agent` or `agent-role` configuration.
 
@@ -66,7 +66,7 @@ The guardrail can be enabled for certain inputs or outputs with the `use-for` pr
 
 == Guardrail of similar text
 
-The built-in link:_attachments/api/akka/javasdk/agent/SimilarityGuard.html[`SimilarityGuard`] evaluates the text by making a similarity search in a dataset of "bad examples". If the similarity exceeds a threshold, the result is flagged as blocked.
+The built-in link:{attachmentsdir}/api/akka/javasdk/agent/SimilarityGuard.html[`SimilarityGuard`] evaluates the text by making a similarity search in a dataset of "bad examples". If the similarity exceeds a threshold, the result is flagged as blocked.
 
 This is how to configure the `SimilarityGuard`:
 

--- a/docs/src/modules/sdk/pages/agents/llm_eval.adoc
+++ b/docs/src/modules/sdk/pages/agents/llm_eval.adoc
@@ -12,7 +12,7 @@ For instance, after a test run, you could send the session history to a powerful
 
 You run your agent and then _evaluate_ the results based on a number of criteria like token usage, elapsed time, and the results of using other models to infer quality metrics like accuracy or confidence.
 
-You can implement an LLM-as-judge evaluator as an Akka `Agent`. The result of the agent method should implement the link:_attachments/api/akka/javasdk/agent/EvaluationResult.html[`EvaluationResult`] interface. Essentially a boolean that tells if the input passed the evaluation criteria, and an explanation for the decision. These results are captured and included in metrics and traces.
+You can implement an LLM-as-judge evaluator as an Akka `Agent`. The result of the agent method should implement the link:{attachmentsdir}/api/akka/javasdk/agent/EvaluationResult.html[`EvaluationResult`] interface. Essentially a boolean that tells if the input passed the evaluation criteria, and an explanation for the decision. These results are captured and included in metrics and traces.
 
 [source,java,indent=0]
 .{sample-base-url}/doc-snippets/src/main/java/com/example/evaluator/HumanVsAiEvaluator.java[HumanVsAiEvaluator.java]
@@ -59,7 +59,7 @@ The system and user message prompts for these agents are loaded from a xref:sdk:
 
 === Toxicity evaluator
 
-link:_attachments/api/akka/javasdk/agent/evaluator/ToxicityEvaluator.html[`ToxicityEvaluator`] is an agent that acts as an LLM judge to evaluate if an AI response or other text is racist, biased, or toxic.
+link:{attachmentsdir}/api/akka/javasdk/agent/evaluator/ToxicityEvaluator.html[`ToxicityEvaluator`] is an agent that acts as an LLM judge to evaluate if an AI response or other text is racist, biased, or toxic.
 
 * Model provider configuration: `akka.javasdk.agent.evaluators.toxicity-evaluator.model-provider`
 * System message prompt id: `toxicity-evaluator.system`
@@ -74,7 +74,7 @@ include::example$akka-javasdk/src/main/java/akka/javasdk/agent/evaluator/Toxicit
 
 === Summarization evaluator
 
-link:_attachments/api/akka/javasdk/agent/evaluator/SummarizationEvaluator.html[`SummarizationEvaluator`] is an agent that acts as an LLM judge to evaluate a summarization task.
+link:{attachmentsdir}/api/akka/javasdk/agent/evaluator/SummarizationEvaluator.html[`SummarizationEvaluator`] is an agent that acts as an LLM judge to evaluate a summarization task.
 
 * Model provider configuration: `akka.javasdk.agent.evaluators.summarization-evaluator.model-provider`
 * System message prompt id: `summarization-evaluator.system`
@@ -89,7 +89,7 @@ include::example$akka-javasdk/src/main/java/akka/javasdk/agent/evaluator/Summari
 
 === Hallucination evaluator
 
-link:_attachments/api/akka/javasdk/agent/evaluator/HallucinationEvaluator.html[`HallucinationEvaluator`] is an agent that acts as an LLM judge to evaluate whether an output contains information not available in the reference text given an input question.
+link:{attachmentsdir}/api/akka/javasdk/agent/evaluator/HallucinationEvaluator.html[`HallucinationEvaluator`] is an agent that acts as an LLM judge to evaluate whether an output contains information not available in the reference text given an input question.
 
 * Model provider configuration: `akka.javasdk.agent.evaluators.hallucination-evaluator.model-provider`
 * System message prompt id: `hallucination-evaluator.system`

--- a/docs/src/modules/sdk/pages/agents/memory.adoc
+++ b/docs/src/modules/sdk/pages/agents/memory.adoc
@@ -44,7 +44,7 @@ include::example$doc-snippets/src/main/java/com/example/application/MyAgentMore.
 
 == Different memory providers
 
-The link:_attachments/api/akka/javasdk/agent/MemoryProvider.html[`MemoryProvider`] interface allows you to control how session memory behaves:
+The link:{attachmentsdir}/api/akka/javasdk/agent/MemoryProvider.html[`MemoryProvider`] interface allows you to control how session memory behaves:
 
 * `MemoryProvider.none()` - Disables both reading from and writing to session memory
 * `MemoryProvider.limitedWindow()` - Configures memory with options to, e.g.:
@@ -56,7 +56,7 @@ The link:_attachments/api/akka/javasdk/agent/MemoryProvider.html[`MemoryProvider
 
 === Filtering memory
 
-In multi-agent scenarios, you may want to control which messages from the session history are visible to specific agents. The link:_attachments/api/akka/javasdk/agent/MemoryFilter.html[`MemoryFilter`] API allows you to filter messages based on the agent component ID or role that produced them.
+In multi-agent scenarios, you may want to control which messages from the session history are visible to specific agents. The link:{attachmentsdir}/api/akka/javasdk/agent/MemoryFilter.html[`MemoryFilter`] API allows you to filter messages based on the agent component ID or role that produced them.
 
 The `MemoryFilter` API uses a fluent builder pattern that allows you to chain multiple filters together. When multiple filters are chained, filters of the same type are automatically merged together. The merged filters are then applied in the order that each filter type first appears in the chain, with each filter type operating on the result of the previous filter type.
 

--- a/docs/src/modules/sdk/pages/agents/testing.adoc
+++ b/docs/src/modules/sdk/pages/agents/testing.adoc
@@ -8,7 +8,7 @@ Testing agents built with Generative AI involves two complementary approaches: e
 
 For predictable and repeatable tests of your agent's business logic and component integrations, it's essential to use deterministic responses. This allows you to verify that your agent behaves correctly when it receives a known model output.
 
-Use the `TestKitSupport` and the `ComponentClient` to call the components from the test. The `ModelProvider` of the agents can be replaced with link:_attachments/testkit/akka/javasdk/testkit/TestModelProvider.html[TestModelProvider], which provides ways to mock the responses without using the real AI model.
+Use the `TestKitSupport` and the `ComponentClient` to call the components from the test. The `ModelProvider` of the agents can be replaced with link:{attachmentsdir}/testkit/akka/javasdk/testkit/TestModelProvider.html[TestModelProvider], which provides ways to mock the responses without using the real AI model.
 
 [source,java,indent=0]
 .{sample-base-url}/multi-agent/src/test/java/demo/multiagent/application/AgentTeamWorkflowTest.java[AgentTeamWorkflowTest.java]

--- a/docs/src/modules/sdk/pages/auth-with-jwts.adoc
+++ b/docs/src/modules/sdk/pages/auth-with-jwts.adoc
@@ -90,7 +90,7 @@ include::example$endpoint-jwt/src/main/java/hellojwt/api/HelloJwtEndpoint.java[t
 ----
 
 The token extracted from the bearer token must have one of the two issuers defined in the annotation.
-Akka will place the claims from the validated token in the link:_attachments/api/akka/javasdk/http/RequestContext.html[RequestContext], so you can access them from your service via `getJwtClaims()`. The `RequestContext` is accessed by letting the endpoint extend link:_attachments/api/akka/javasdk/http/AbstractHttpEndpoint.html[AbstractHttpEndpoint] which provides the method `requestContext()`, so you can retrieve the JWT claims like this:
+Akka will place the claims from the validated token in the link:{attachmentsdir}/api/akka/javasdk/http/RequestContext.html[RequestContext], so you can access them from your service via `getJwtClaims()`. The `RequestContext` is accessed by letting the endpoint extend link:{attachmentsdir}/api/akka/javasdk/http/AbstractHttpEndpoint.html[AbstractHttpEndpoint] which provides the method `requestContext()`, so you can retrieve the JWT claims like this:
 
 [source,java,indent=0]
 .{sample-base-url}/endpoint-jwt/src/main/java/hellojwt/api/HelloJwtEndpoint.java[HelloJwtEndpoint.java]

--- a/docs/src/modules/sdk/pages/http-endpoints.adoc
+++ b/docs/src/modules/sdk/pages/http-endpoints.adoc
@@ -69,9 +69,9 @@ Additionally, the request body parameter can be of the following types:
 
 === Request headers ===
 
-Accessing request headers is done through the link:_attachments/api/akka/javasdk/http/RequestContext.html[RequestContext] methods `requestHeader(String headerName)` and `allRequestHeaders()`.
+Accessing request headers is done through the link:{attachmentsdir}/api/akka/javasdk/http/RequestContext.html[RequestContext] methods `requestHeader(String headerName)` and `allRequestHeaders()`.
 
-By letting the endpoint extend link:_attachments/api/akka/javasdk/http/AbstractHttpEndpoint.html[AbstractHttpEndpoint] request context is available through the method `requestContext()`.
+By letting the endpoint extend link:{attachmentsdir}/api/akka/javasdk/http/AbstractHttpEndpoint.html[AbstractHttpEndpoint] request context is available through the method `requestContext()`.
 
 [source,java,indent=0]
 .{sample-base-url}/doc-snippets/src/main/java/com/example/api/ExampleEndpoint.java[ExampleEndpoint.java]
@@ -83,7 +83,7 @@ include::example$doc-snippets/src/main/java/com/example/api/ExampleEndpoint.java
 
 === Query parameters ===
 
-Accessing query parameter is done through the `requestContext()`, inherited from link:_attachments/api/akka/javasdk/http/AbstractHttpEndpoint.html[AbstractHttpEndpoint].
+Accessing query parameter is done through the `requestContext()`, inherited from link:{attachmentsdir}/api/akka/javasdk/http/AbstractHttpEndpoint.html[AbstractHttpEndpoint].
 
 [source,java,indent=0]
 .{sample-base-url}/doc-snippets/src/main/java/com/example/api/ExampleEndpoint.java[ExampleEndpoint.java]
@@ -285,7 +285,7 @@ include::example$doc-snippets/src/main/java/com/example/api/ExampleEndpoint.java
 
 Static resources such as HTML, CSS files can be packaged together with the service. This is done
 by placing the resource files in `src/main/resources/static-resources` and returning them from an endpoint
-method using link:_attachments/api/akka/javasdk/http/HttpResponses.html#staticResource[HttpResponses.staticResource].
+method using link:{attachmentsdir}/api/akka/javasdk/http/HttpResponses.html#staticResource[HttpResponses.staticResource].
 
 This can be done for a single filename:
 

--- a/docs/src/modules/sdk/pages/model-provider-details.adoc
+++ b/docs/src/modules/sdk/pages/model-provider-details.adoc
@@ -75,7 +75,7 @@ The following is a list of all natively supported model configurations. Remember
 |===
 
 
-See link:_attachments/api/akka/javasdk/agent/ModelProvider.Anthropic.html[`ModelProvider.Anthropic`] for programmatic settings.
+See link:{attachmentsdir}/api/akka/javasdk/agent/ModelProvider.Anthropic.html[`ModelProvider.Anthropic`] for programmatic settings.
 
 === Bedrock
 
@@ -134,7 +134,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.Anthropic.html[`Model
 
 |===
 
-See link:_attachments/api/akka/javasdk/agent/ModelProvider.Bedrock.html[`ModelProvider.Bedrock`] for programmatic settings.
+See link:{attachmentsdir}/api/akka/javasdk/agent/ModelProvider.Bedrock.html[`ModelProvider.Bedrock`] for programmatic settings.
 
 === Gemini
 
@@ -172,7 +172,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.Bedrock.html[`ModelPr
 
 |===
 
-See link:_attachments/api/akka/javasdk/agent/ModelProvider.GoogleAIGemini.html[`ModelProvider.GoogleAIGemini`] for programmatic settings.
+See link:{attachmentsdir}/api/akka/javasdk/agent/ModelProvider.GoogleAIGemini.html[`ModelProvider.GoogleAIGemini`] for programmatic settings.
 
 === Hugging Face
 
@@ -210,7 +210,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.GoogleAIGemini.html[`
 
 |===
 
-See link:_attachments/api/akka/javasdk/agent/ModelProvider.HuggingFace.html[`ModelProvider.HuggingFace`] for programmatic settings.
+See link:{attachmentsdir}/api/akka/javasdk/agent/ModelProvider.HuggingFace.html[`ModelProvider.HuggingFace`] for programmatic settings.
 
 === Local AI
 
@@ -244,7 +244,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.HuggingFace.html[`Mod
 
 |===
 
-See link:_attachments/api/akka/javasdk/agent/ModelProvider.LocalAI.html[`ModelProvider.LocalAI`] for programmatic settings.
+See link:{attachmentsdir}/api/akka/javasdk/agent/ModelProvider.LocalAI.html[`ModelProvider.LocalAI`] for programmatic settings.
 
 === Ollama
 
@@ -274,7 +274,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.LocalAI.html[`ModelPr
 
 |===
 
-See link:_attachments/api/akka/javasdk/agent/ModelProvider.Ollama.html[`ModelProvider.Ollama`] for programmatic settings.
+See link:{attachmentsdir}/api/akka/javasdk/agent/ModelProvider.Ollama.html[`ModelProvider.Ollama`] for programmatic settings.
 
 === OpenAI
 
@@ -316,7 +316,7 @@ See link:_attachments/api/akka/javasdk/agent/ModelProvider.Ollama.html[`ModelPro
 
 |===
 
-See link:_attachments/api/akka/javasdk/agent/ModelProvider.OpenAi.html[`ModelProvider.OpenAi`] for programmatic settings.
+See link:{attachmentsdir}/api/akka/javasdk/agent/ModelProvider.OpenAi.html[`ModelProvider.OpenAi`] for programmatic settings.
 
 == Default model configuration
 


### PR DESCRIPTION
A bunch of API/javadoc links had the wrong syntax it seems.
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #1208
