### PR TITLE
docs: Clarify Null State in AGENTS.md

### DIFF
--- a/docs/src/modules/ROOT/attachments/AGENTS.md
+++ b/docs/src/modules/ROOT/attachments/AGENTS.md
@@ -554,9 +554,9 @@ public class MyEndpointIntegrationTest extends TestKitSupport {
 - Use `definition()` in Workflow → use `settings()` + step methods
 - Use string step names → use method references (`::`)
 - Create a `Main` class for bootstrapping → use a `Bootstrap` class that implements `ServiceSetup`
-- Inject `ComponentClient` into Entities → `ComponentClient` is only allowed in ServiceSetup, Endpoints, Agents, Consumers, TimedActions, and Workflows
+- Inject `ComponentClient` into Entities and Views → `ComponentClient` is only allowed in ServiceSetup, Endpoints, Agents, Consumers, TimedActions, and Workflows
 - Create empty command record classes without fields → causes serialization errors; if no fields needed, make the command handler method parameterless
-- Return `null` in `emptyState()` or after delete commands → causes NullPointerExceptions; use an empty or deleted state in the state record instead
+- Return `null` in the event handler → Only the `emptyState()` method is allowed to return `null`; Add a method to the State record class to model an empty or deleted state instead
 - Perform side effects in `.thenReply()` in Entities → use a Consumer to react to events for side effects
 - Use deprecated `@ComponentId`  -> use `@Component(id = ")`
 - Use deprecated `@AgentDescription`  -> use `@Component(id = ")` and `@AgentRole`


### PR DESCRIPTION
Follow-Up of PR: https://github.com/akka/akka-sdk/pull/1230

- Explicitly stated which components are allowed to have the `componentClient` injected
- Clarified Null State