### PR TITLE
chore: Better error message when wrong component import

### DIFF
--- a/akka-javasdk-annotation-processor/src/main/java/akka/javasdk/tooling/processor/ComponentAnnotationProcessor.java
+++ b/akka-javasdk-annotation-processor/src/main/java/akka/javasdk/tooling/processor/ComponentAnnotationProcessor.java
@@ -178,6 +178,35 @@ public class ComponentAnnotationProcessor extends BaseAkkaProcessor {
 
   private String recurseForComponentType(Element annotatedClass, Element current) {
     var superClassTypeMirror = ((TypeElement) current).getSuperclass();
+
+    if (superClassTypeMirror.getKind() == javax.lang.model.type.TypeKind.NONE) {
+      throw new IllegalArgumentException(
+          "Unknown supertype for class ["
+              + annotatedClass
+              + "] annotated with @Component or @ComponentId. Reached top of hierarchy without"
+              + " finding a known component supertype.");
+    }
+
+    if (superClassTypeMirror.getKind() == javax.lang.model.type.TypeKind.ERROR) {
+      throw new IllegalArgumentException(
+          "Superclass for class ["
+              + current
+              + "] (processing ["
+              + annotatedClass
+              + "]) could not be resolved. Ensure all dependencies and imports are correct.");
+    }
+
+    if (!(superClassTypeMirror instanceof DeclaredType)) {
+      throw new IllegalArgumentException(
+          "Unknown supertype for class ["
+              + annotatedClass
+              + "] annotated with @Component or @ComponentId. Superclass ["
+              + superClassTypeMirror
+              + "] is not a declared type (kind: "
+              + superClassTypeMirror.getKind()
+              + ").");
+    }
+
     var superClassElement = ((DeclaredType) superClassTypeMirror).asElement();
 
     var superClassName = superClassTypeMirror.toString();


### PR DESCRIPTION
Currently it will give a cryptic:
```
Fatal error compiling: java.lang.ClassCastException: class com.sun.tools.javac.code.Type$1 cannot be cast to class javax.lang.model.type.DeclaredType (com.sun.tools.javac.code.Type$1 is in module jdk.compiler of loader 'app'; javax.lang.model.type.DeclaredType is in module java.compiler of loader 'platform')
```

For example when using wrong import:
```
  import akka.javasdk.a.Agent;
  @Component(id = "planner-agent")
  public class PlannerAgent extends Agent {
```  