### PR TITLE
chore: WorkflowSettings in ai assistant guidelines

### DIFF
--- a/docs/src/modules/ROOT/attachments/AGENTS.md
+++ b/docs/src/modules/ROOT/attachments/AGENTS.md
@@ -564,6 +564,7 @@ public class MyEndpointIntegrationTest extends TestKitSupport {
 - Use deprecated `testKit.call`  -> use `testKit.method(...).invoke(...)`
 - Create multiple command handlers in Agent
 - Return protobuf types from domain layer
+- Import `WorkflowSettings` -> WorkflowSettings is an inner class of Workflow, so no additional import is needed
 
 ✅ **DO:**
 - Use Java records for immutable data


### PR DESCRIPTION
I have noticed that assistants struggle with the import of WorkflowSettings. It typically solves it after compilation error but would be nice to avoid that round of struggle for workflows.