### PR TITLE
feat: add support to install akka cli in arm64 linux environments

### DIFF
--- a/docs/src-static/install-cli.sh
+++ b/docs/src-static/install-cli.sh
@@ -161,8 +161,7 @@ detect_arch() {
         arch=amd64
       fi
     elif [ "${arch}" = "aarch64" ]; then
-      error "Detected aarch64"
-      exit 1
+      arch=arm64
     fi
 
     # `uname -m` in some cases mis-reports 32-bit OS as 64-bit, so double check


### PR DESCRIPTION
Now that we have `akka_linux_arm64` support from version `3.0.45` and beyond (see [here](https://downloads.akka.io/)) we can now install it if it gets detected running the `install-cli.sh` script.