### PR TITLE
fix: pin fastcore to avoid bug (#1268)

### DIFF
--- a/.github/workflows/docs-wip.yml
+++ b/.github/workflows/docs-wip.yml
@@ -66,6 +66,8 @@ jobs:
       - name: llm-ctx.txt
         run: |
           sudo chmod a+w target/site
+          # https://github.com/AnswerDotAI/llms-txt/issues/103
+          pip install fastcore==1.12.1
           pip install llms-txt
           sudo cp docs/src/modules/ROOT/pages/llms.txt target/site/
           llms_txt2ctx target/site/llms.txt > target/site/llms-ctx.txt


### PR DESCRIPTION
Seems it is 🟢 on `main` [build](https://github.com/akka/akka-sdk/actions/runs/21175332284/job/60902512232), so this is the backport of https://github.com/akka/akka-sdk/pull/1268 into `docs-current`.