### PR TITLE
fix: registering all sealed interface subtypes for view table updater

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewDescriptorFactory.scala
@@ -429,7 +429,11 @@ private[impl] object ViewDescriptorFactory {
         methods.map { m =>
           // register each possible input to deserialize correctly an input
           val inputType = m.getParameterTypes.head
-          serializer.registerTypeHints(m.getParameterTypes.head)
+          if (inputType.isSealed) {
+            inputType.getPermittedSubclasses.foreach(serializer.registerTypeHints)
+          } else {
+            serializer.registerTypeHints(m.getParameterTypes.head)
+          }
 
           inputType -> m
         }.toMap

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/view/ViewTestModels.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/view/ViewTestModels.java
@@ -11,6 +11,7 @@ import akka.javasdk.annotations.DeleteHandler;
 import akka.javasdk.annotations.FunctionTool;
 import akka.javasdk.annotations.Query;
 import akka.javasdk.annotations.Table;
+import akka.javasdk.annotations.TypeName;
 import akka.javasdk.testmodels.eventsourcedentity.Employee;
 import akka.javasdk.testmodels.eventsourcedentity.EmployeeEvent;
 import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.EmployeeEntity;
@@ -228,6 +229,30 @@ public class ViewTestModels {
 
     @Consume.FromKeyValueEntity(UserEntity.class)
     public static class UsersTable extends TableUpdater<User> {}
+
+    @Query(value = "SELECT * AS users FROM users WHERE name = :name")
+    public QueryEffect<UserCollection> getUser(ByEmail name) {
+      return queryResult();
+    }
+  }
+
+  @Component(id = "users_view")
+  public static class UserByEmailWithSealedInput extends View {
+
+    public sealed interface Message {
+      @TypeName("a")
+      record A() implements Message {}
+
+      @TypeName("b")
+      record B() implements Message {}
+    }
+
+    @Consume.FromEventSourcedEntity(EmployeeEntity.class)
+    public static class Employees extends TableUpdater<Employee> {
+      public Effect<Employee> onEvent(Message message) {
+        return effects().ignore();
+      }
+    }
 
     @Query(value = "SELECT * AS users FROM users WHERE name = :name")
     public QueryEffect<UserCollection> getUser(ByEmail name) {

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/view/ViewDescriptorFactorySpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/view/ViewDescriptorFactorySpec.scala
@@ -26,9 +26,10 @@ class ViewDescriptorFactorySpec extends AnyWordSpec with Matchers {
 
   import ViewTestModels._
   import akka.javasdk.testmodels.subscriptions.PubSubTestModels._
+  val serializer = new JsonSerializer
 
   def assertDescriptor[T](test: ViewDescriptor => Any)(implicit tag: ClassTag[T]): Unit = {
-    test(ViewDescriptorFactory(tag.runtimeClass, new JsonSerializer, new RegionInfo(""), ExecutionContexts.global()))
+    test(ViewDescriptorFactory(tag.runtimeClass, serializer, new RegionInfo(""), ExecutionContexts.global()))
   }
 
   "View descriptor factory" should {
@@ -75,6 +76,13 @@ class ViewDescriptorFactorySpec extends AnyWordSpec with Matchers {
 
         query.query shouldBe "SELECT * AS users FROM users WHERE name = :name"
         query.streamUpdates shouldBe false
+      }
+    }
+
+    "register all updater handler subtypes" in {
+      assertDescriptor[UserByEmailWithSealedInput] { _ =>
+        serializer.reversedTypeHints.get("a") shouldBe classOf[UserByEmailWithSealedInput.Message.A]
+        serializer.reversedTypeHints.get("b") shouldBe classOf[UserByEmailWithSealedInput.Message.B]
       }
     }
 


### PR DESCRIPTION
References: https://github.com/lightbend/akka-runtime/issues/4706
