### PR TITLE
Update instructions for cloning Akka sample project

### DIFF
--- a/samples/ask-akka-agent/src/main/resources/md-docs/author-your-first-service.html.md
+++ b/samples/ask-akka-agent/src/main/resources/md-docs/author-your-first-service.html.md
@@ -77,7 +77,7 @@ Alternatively, you can clone the [GitHub Repository](https://github.com/akka-sam
 ```command
 git clone https://github.com/akka-samples/helloworld-agent.git --depth 1
 ```
-Then navigate to the new project directory and open it in your preferred IDE / Editor.
+Then navigate to the new project directory and open it in your preferred IDE / Editor, making sure to add [your Akka token](https://account.akka.io/token) to the pom.xml.
 
 ## <a href="about:blank#_explore_the_agent"></a> Explore the Agent
 


### PR DESCRIPTION
Added note to include Akka token in pom.xml after cloning the project.

Since this is a deviation from the akka setup that does this for you - if you opt to git clone then they should know as it will fail otherwise.
