### PR TITLE
docs: redirects for pages that moved from java/ earlier

### DIFF
--- a/docs/src/modules/getting-started/pages/ask-akka-agent/endpoints.adoc
+++ b/docs/src/modules/getting-started/pages/ask-akka-agent/endpoints.adoc
@@ -1,5 +1,5 @@
 = Adding UI endpoints
-:page-aliases: java:ask-akka/endpoints.adoc
+:page-aliases: java:ask-akka/endpoints.adoc, sdk:ask-akka/endpoints.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/getting-started/pages/ask-akka-agent/indexer.adoc
+++ b/docs/src/modules/getting-started/pages/ask-akka-agent/indexer.adoc
@@ -1,5 +1,5 @@
 = Knowledge indexing with a workflow
-:page-aliases: java:ask-akka/indexer.adoc
+:page-aliases: java:ask-akka/indexer.adoc, sdk:ask-akka/indexer.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/getting-started/pages/ask-akka-agent/rag.adoc
+++ b/docs/src/modules/getting-started/pages/ask-akka-agent/rag.adoc
@@ -1,5 +1,5 @@
 = Executing RAG queries
-:page-aliases: java:ask-akka/rag.adoc
+:page-aliases: java:ask-akka/rag.adoc, sdk:ask-akka/rag.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/getting-started/pages/ask-akka-agent/the-agent.adoc
+++ b/docs/src/modules/getting-started/pages/ask-akka-agent/the-agent.adoc
@@ -1,5 +1,5 @@
 = Creating the agent
-:page-aliases: java:ask-akka/session.adoc
+:page-aliases: java:ask-akka/session.adoc, sdk:ask-akka/session.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/getting-started/pages/author-your-first-service.adoc
+++ b/docs/src/modules/getting-started/pages/author-your-first-service.adoc
@@ -1,5 +1,5 @@
 = Build your first agent
-:page-aliases: java:build-your-first-application.adoc, java:author-your-first-service.adoc
+:page-aliases: java:build-your-first-application.adoc, java:author-your-first-service.adoc, sdk:author-your-first-service.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/getting-started/pages/samples.adoc
+++ b/docs/src/modules/getting-started/pages/samples.adoc
@@ -1,5 +1,5 @@
 = Additional samples
-:page-aliases: java:samples.adoc
+:page-aliases: java:samples.adoc, sdk:samples.adoc
 include::ROOT:partial$include.adoc[]
 
 include::ROOT:partial$new-to-akka-start-here.adoc[]

--- a/docs/src/modules/getting-started/pages/shopping-cart/addview.adoc
+++ b/docs/src/modules/getting-started/pages/shopping-cart/addview.adoc
@@ -1,5 +1,5 @@
 = Authenticated user-specific lookup
-:page-aliases: java:shopping-cart/addview.adoc
+:page-aliases: java:shopping-cart/addview.adoc, sdk:shopping-cart/addview.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/getting-started/pages/shopping-cart/build-and-deploy-shopping-cart.adoc
+++ b/docs/src/modules/getting-started/pages/shopping-cart/build-and-deploy-shopping-cart.adoc
@@ -1,5 +1,5 @@
 = A simple shopping cart service
-:page-aliases: java:shopping-cart-quickstart.adoc
+:page-aliases: java:shopping-cart-quickstart.adoc, sdk:shopping-cart-quickstart.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/sdk/pages/component-and-service-calls.adoc
+++ b/docs/src/modules/sdk/pages/component-and-service-calls.adoc
@@ -1,5 +1,5 @@
 = Component and service calls
-:page-aliases: java:asynchronous.adoc
+:page-aliases: java:asynchronous.adoc, sdk:asynchronous.adoc
 
 include::ROOT:partial$include.adoc[]
 


### PR DESCRIPTION
Pages that moved from the `java/` path before it was renamed to `sdk/` need another explicit redirect set up.