### PR TITLE
bump: Alpine base image 3.23.3

### DIFF
--- a/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-parent/pom.xml
@@ -57,7 +57,7 @@
         <docker.tag>${project.version}-${build.timestamp}</docker.tag>
 
         <!-- note that this image does never actually run the service, it's just a means for distribution -->
-        <docker.base.image>alpine:3.14</docker.base.image>
+        <docker.base.image>alpine:3.23.3</docker.base.image>
         <docker.platform>linux/amd64</docker.platform>
 
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>


### PR DESCRIPTION
Bump to a more recent version, and also pin to a patch version. The minor version used before was not stable/immutable (new patch versions would change it) which can lead to SHA mismatches failing image pull on service deploy.