### PR TITLE
build: Pin alpine to Akka specific docker repo

### DIFF
--- a/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-parent/pom.xml
@@ -56,8 +56,8 @@
         <docker.image>${project.artifactId}</docker.image>
         <docker.tag>${project.version}-${build.timestamp}</docker.tag>
 
-        <!-- note that this image does never actually run the service, it's just a means for distribution -->
-        <docker.base.image>alpine:3.23.3</docker.base.image>
+        <!-- note that this image does never actually run the service in a JVM, it's just a means for distribution -->
+        <docker.base.image>us-docker.pkg.dev/kalix-images/infrastructure/alpine:3.23.3</docker.base.image>
         <docker.platform>linux/amd64</docker.platform>
 
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Follow up to #1356 

We were still observing sha mismatches, we expect this is because of using docker hub, instead, use it from our own repository, this should ensure the checksum in images are always the same as seen by the platform.


References:
* https://github.com/lightbend/kalix/issues/15232