### PR TITLE
feat: backoffice services

### DIFF
--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -964,7 +964,7 @@ public class TestKit {
   @SuppressWarnings("unchecked")
   public <T extends AkkaGrpcClient> T getGrpcEndpointClient(
       Class<T> grpcClientClass, Principal requestPrincipal) {
-    var client = grpcClientProvider.createNewClientFor(grpcClientClass, serviceName, false);
+    var client = grpcClientProvider.createNewClientFor(grpcClientClass, serviceName);
     if (requestPrincipal == Principal.SELF) {
       // no need to use this method, but let's allow it
       return getGrpcEndpointClient(grpcClientClass);

--- a/akka-javasdk/src/main/proto/kalix/auth/v1alpha/auth.proto
+++ b/akka-javasdk/src/main/proto/kalix/auth/v1alpha/auth.proto
@@ -1,0 +1,49 @@
+// Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+
+syntax = "proto3";
+
+package kalix.auth.v1alpha;
+
+import "google/protobuf/timestamp.proto";
+
+option java_multiple_files = true;
+option java_outer_classname = "AuthProto";
+option java_package = "kalix.api.auth.v1alpha";
+
+service Auth {
+  // Create an access token
+  rpc CreateAccessToken (CreateAccessTokenRequest) returns (AccessToken);
+}
+
+message CreateAccessTokenRequest {
+}
+
+message AccessToken {
+  // The subject of the access token
+  // This will be the name of the refresh, service or session token that was used to create this token
+  string subject = 1;
+  string token = 2;
+  google.protobuf.Timestamp created_time = 3;
+  google.protobuf.Timestamp expire_time = 4;
+  repeated TokenScope scopes = 5;
+}
+
+enum TokenScope {
+  // Can do everything
+  ALL = 0;
+
+  // Can read/write projects
+  PROJECTS = 1;
+
+  // Can read/write the user, including create new tokens
+  USER = 2;
+
+  // Can access the execution servers (ie, kubernetes). Only works with session tokens.
+  EXECUTION = 3;
+
+  // Can access organizations
+  ORGANIZATIONS = 4;
+
+  // Can access container registry
+  CONTAINER_REGISTRY = 5;
+}

--- a/akka-javasdk/src/main/proto/kalix/projects/v1alpha/projects.proto
+++ b/akka-javasdk/src/main/proto/kalix/projects/v1alpha/projects.proto
@@ -1,0 +1,78 @@
+// Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+
+syntax = "proto3";
+
+package kalix.projects.v1alpha;
+
+option java_multiple_files = true;
+option java_outer_classname = "ProjectsProto";
+option java_package = "kalix.api.projects.v1alpha";
+
+service Projects {
+
+  // List projects that a user is part of.
+  //
+  // Authentication required: yes
+  rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse);
+
+  // Get a list of regions available to the project.
+  //
+  // Authentication required: yes
+  rpc ListRegions(ListRegionsRequest) returns (ListRegionsResponse);
+}
+
+message ListProjectsRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+  bool include_deleted = 3;
+  bool include_system_deleted = 4;
+  string organization_filter = 5; // blank for no filter
+}
+
+message ListProjectsResponse {
+  repeated Project projects = 1;
+  string next_page_token = 2;
+}
+
+message Project {
+  string name = 1;
+  string friendly_name = 2;
+  oneof owner {
+    UserOwner user_owner = 4;
+    OrganizationOwner organization_owner = 5;
+  };
+  repeated string execution_cluster_names = 11;
+}
+
+message UserOwner {
+  // The user ID, e.g. "1a3fefd0-79e2-468b-b776-16ca1a16ffde" (UUID)
+  string id = 1;
+  string friendly_name = 2;
+}
+
+message OrganizationOwner {
+  // The organization ID, e.g. "1a3fefd0-79e2-468b-b776-16ca1a16ffde" (UUID)
+  string id = 1;
+  string friendly_name = 2;
+}
+
+message ListRegionsRequest {
+  string parent = 1;
+  int32 page_size = 2;
+  string page_token = 3;
+}
+
+message ListRegionsResponse {
+  repeated Region regions = 1;
+  string next_page_token = 2;
+}
+
+message Region {
+  string name = 1;
+
+  // This is the hostname for the backoffice proxy
+  string backoffice_proxy_hostname = 10;
+
+  // Whether this is the primary region
+  bool primary = 15;
+}

--- a/akka-javasdk/src/main/resources/reference.conf
+++ b/akka-javasdk/src/main/resources/reference.conf
@@ -48,6 +48,52 @@ akka.javasdk {
       # Whether persistence is enabled
       enabled = false
     }
+
+    backoffice {
+      # The refresh token. Will attempt to read it by running the Akka CLI command if not set
+      refresh-token = ""
+      refresh-token = ${?AKKA_REFRESH_TOKEN}
+
+      # The api server. If not set, will detect it by running the Akka CLI, or default to api.kalix.io:443
+      api-server = ""
+      api-server = ${?AKKA_API_SERVER}
+
+      # The context to use when running Akka CLI commands. Uses the default context if not set.
+      cli-context = ""
+
+      # The path of the Akka CLI. If not set, will default to looking for akka.exe on Windows and akka on other OS's on
+      # the systems configured PATH.
+      cli-path = ""
+
+      # Whether backoffice services are enabled. This is true by default so that all a user needs to do is
+      # configure the backoffice services to enable it. This flag then serves as a convenient means to disable
+      # backoffice support when backoffice services are configured.
+      enabled = true
+      enabled = ${?AKKA_BACKOFFICE_SERVICES_ENABLED}
+
+      # Timeout for making requests on the API server
+      request-timeout = 10s
+
+      services {
+        # Specify services that should delegate to the cloud
+        # "some-service-name" {
+        #    # Optional, if set will override the service name to use in the cloud
+        #    # service-name = "my-service"
+        #
+        #    # The project to use. May be a project id, or friendly name.
+        #    project = "my-project"
+        #
+        #    # The organization. Only needed if referring to a project by friendly name, but multiple projects
+        #    # from different organizations that the user is a member of have the same friendly name. May be the
+        #    # organization id or friendly name
+        #    # organization = "my-organization"
+        #
+        #    # The region. Optional, only needed for multi-region projects if a region other than the primary region
+        #    # should be used.
+        #    # region = "my-region"
+        # }
+      }
+    }
   }
 
   testkit {

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/BackofficeSettingsLoader.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/BackofficeSettingsLoader.scala
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl
+
+import scala.annotation.tailrec
+import scala.concurrent.Await
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.CollectionConverters._
+import scala.jdk.DurationConverters._
+import scala.util.Try
+import scala.util.control.NonFatal
+
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import akka.annotation.InternalApi
+import akka.grpc.GrpcClientSettings
+import akka.javasdk.impl.backoffice.BackofficeAccessTokenCache
+import akka.runtime.sdk.spi.SpiBackofficeServiceSettings
+import akka.runtime.sdk.spi.SpiBackofficeSettings
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import kalix.api.projects.v1alpha.projects.ListProjectsRequest
+import kalix.api.projects.v1alpha.projects.ListRegionsRequest
+import kalix.api.projects.v1alpha.projects.Project
+import kalix.api.projects.v1alpha.projects.ProjectsClient
+import kalix.api.projects.v1alpha.projects.Region
+import org.slf4j.LoggerFactory
+
+/**
+ * Loading backoffice settings requires making gRPC calls on the backend, however, settings must be loaded
+ * synchronously. So, we block here. It's ok, this only happens in dev mode, because backoffice settings are only loaded
+ * in dev mode.
+ *
+ * Also, we need to start our own Actor system for this in order to use Akka gRPC.
+ */
+@InternalApi
+private[impl] object BackofficeSettingsLoader {
+
+  private val log = LoggerFactory.getLogger(getClass)
+
+  def loadBackofficeSettings(applicationConfig: Config): SpiBackofficeSettings = {
+    val config = applicationConfig.getConfig("akka.javasdk.dev-mode.backoffice")
+    val servicesConfig = config.getObject("services")
+    val enabled = config.getBoolean("enabled")
+    val cliPath = config.getString("cli-path")
+    val akkaPath = if (cliPath.nonEmpty) {
+      cliPath
+    } else if (sys.props("os.name").contains("Windows")) {
+      "akka.exe"
+    } else {
+      "akka"
+    }
+
+    // Check if there is a backoffice service configuration, if there's not, there's no need to do any of the rest
+    // of the work
+    if (enabled && !servicesConfig.isEmpty) {
+      val refreshTokenFromConfig = Some(config.getString("refresh-token")).filter(_.nonEmpty)
+      val apiServerFromConfig = Some(config.getString("api-server")).filter(_.nonEmpty)
+      val cliContext = Some(config.getString("cli-context")).filter(_.nonEmpty)
+      val requestTimeout = config.getDuration("request-timeout").toScala
+
+      val refreshToken = refreshTokenFromConfig
+        .orElse(getCliConfig(akkaPath, cliContext, "refresh-token"))
+        .getOrElse {
+          sys.error(
+            "Akka CLI is not logged in, either log in, or set refresh-token in application config or using AKKA_REFRESH_TOKEN environment variable.")
+        }
+
+      // Ignore errors looking up service host from CLI, ensures you can authenticate by passing AKKA_REFRESH_TOKEN
+      // environment variable without the CLI installed, and we'll just default to api.kalix.io:443.
+      val apiServer = apiServerFromConfig
+        .orElse(Try(getCliConfig(akkaPath, cliContext, "api-server-host")).toOption.flatten)
+        .getOrElse("api.kalix.io:443")
+      val (apiServerHost, apiServerPort) = apiServer.split(":", 2) match {
+        case Array(host)       => (host, 443)
+        case Array(host, port) => (host, port.toInt)
+        case _                 => (apiServer, 443)
+      }
+
+      implicit val system: ActorSystem[_] =
+        ActorSystem[Nothing](Behaviors.empty, "backoffice-settings-loader", ConfigFactory.defaultReference())
+
+      try {
+        val accessTokenCache = BackofficeAccessTokenCache(system)
+        accessTokenCache.init(apiServerHost, apiServerPort, refreshToken)
+        val accessToken = Await.result(accessTokenCache.accessToken(), requestTimeout)
+        val projectsClient = ProjectsClient(GrpcClientSettings.connectToServiceAt(apiServerHost, apiServerPort))
+
+        // Only load projects if we need them
+        lazy val projects = loadProjects(projectsClient, accessToken, requestTimeout)
+        var projectRegions = Map.empty[String, Seq[Region]]
+
+        val servicesSettings = servicesConfig
+          .keySet()
+          .asScala
+          .map { service =>
+            val serviceConfig = config.getConfig("services").getConfig(service)
+            val projectIdOrFriendlyName = serviceConfig.getString("project")
+            val projectName = if (isUuid(projectIdOrFriendlyName)) {
+              s"projects/$projectIdOrFriendlyName"
+            } else {
+              projects.filter(_.friendlyName == projectIdOrFriendlyName) match {
+                case Nil =>
+                  sys.error(s"Could not find project with friendly name $projectIdOrFriendlyName")
+                case Seq(single) =>
+                  single.name
+                case multiple =>
+                  val orgIdOrFriendlyName = getOpt(serviceConfig, "organization")
+                    .getOrElse(sys.error(
+                      s"organization is needed for backoffice service $service because there are multiple projects with a friendly name of $projectIdOrFriendlyName"))
+                  multiple.find(_.owner.organizationOwner.exists(org =>
+                    org.id == orgIdOrFriendlyName || org.friendlyName == orgIdOrFriendlyName)) match {
+                    case Some(project) => project.name
+                    case None =>
+                      sys.error(
+                        s"Could not find project with friendly name $projectIdOrFriendlyName owned by organization $orgIdOrFriendlyName")
+                  }
+              }
+
+            }
+            val regions = projectRegions.get(projectName) match {
+              case Some(regions) =>
+                regions
+              case None =>
+                val regions = loadRegions(projectsClient, accessToken, requestTimeout, projectName)
+                projectRegions = projectRegions.updated(projectName, regions)
+                regions
+            }
+
+            val region = regions match {
+              case Nil =>
+                sys.error(s"Project $projectIdOrFriendlyName has no regions")
+              case Seq(region) =>
+                region
+              case multiple =>
+                getOpt(serviceConfig, "region") match {
+                  case None =>
+                    regions.find(_.primary).getOrElse {
+                      sys.error(s"Project $projectIdOrFriendlyName has no primary region")
+                    }
+                  case Some(regionName) =>
+                    val name = s"$projectName/regions/$regionName"
+                    multiple.find(_.name == name) match {
+                      case None =>
+                        sys.error(s"Region $regionName not found for project $projectIdOrFriendlyName")
+                      case Some(region) =>
+                        region
+                    }
+                }
+            }
+
+            val regionName = region.name.stripPrefix(s"$projectName/regions/")
+            val serviceName = getOpt(serviceConfig, "service-name").getOrElse(service)
+            val projectId = projectName.stripPrefix("projects/")
+
+            log.info(s"Resolved service $service to use service $service in project $projectId in region $regionName")
+
+            service -> new SpiBackofficeServiceSettings(
+              serviceName = serviceName,
+              projectId = projectId,
+              regionName = regionName,
+              backofficeProxyHost = region.backofficeProxyHostname)
+          }
+          .toMap
+
+        new SpiBackofficeSettings(apiServer = apiServer, refreshToken = refreshToken, services = servicesSettings)
+      } finally {
+        system.terminate()
+      }
+
+    } else {
+      SpiBackofficeSettings.empty
+    }
+  }
+
+  private val UuidRegex = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$".r
+  private def isUuid(value: String) =
+    UuidRegex.matches(value)
+
+  private def getOpt(config: Config, key: String) = {
+    if (config.hasPath(key)) {
+      Some(config.getString(key))
+    } else {
+      None
+    }
+  }
+
+  private def loadProjects(
+      projectsClient: ProjectsClient,
+      accessToken: String,
+      requestTimeout: FiniteDuration): List[Project] = {
+    @tailrec
+    def doLoadProjects(pageToken: String, projects: List[Project]): List[Project] = {
+      val response = Await.result(
+        projectsClient
+          .listProjects()
+          .setDeadline(requestTimeout)
+          .addHeader("Authorization", s"Bearer $accessToken")
+          .invoke(ListProjectsRequest(pageToken = pageToken)),
+        requestTimeout)
+
+      if (response.nextPageToken.isEmpty) {
+        projects ++ response.projects
+      } else {
+        doLoadProjects(response.nextPageToken, projects ++ response.projects)
+      }
+    }
+
+    doLoadProjects("", Nil)
+  }
+
+  private def loadRegions(
+      projectsClient: ProjectsClient,
+      accessToken: String,
+      requestTimeout: FiniteDuration,
+      projectName: String): List[Region] = {
+    @tailrec
+    def doLoadRegions(pageToken: String, regions: List[Region]): List[Region] = {
+      val response = Await.result(
+        projectsClient
+          .listRegions()
+          .setDeadline(requestTimeout)
+          .addHeader("Authorization", s"Bearer $accessToken")
+          .invoke(ListRegionsRequest(parent = projectName, pageToken = pageToken)),
+        requestTimeout)
+
+      if (response.nextPageToken.isEmpty) {
+        regions ++ response.regions
+      } else {
+        doLoadRegions(response.nextPageToken, regions ++ response.regions)
+      }
+    }
+
+    doLoadRegions("", Nil)
+  }
+
+  private def getCliConfig(path: String, context: Option[String], setting: String): Option[String] = {
+    executeCli(path, context, Seq("config", "get") :+ setting).trim match {
+      case ""    => None
+      case value => Some(value)
+    }
+  }
+
+  private def executeCli(path: String, context: Option[String], args: Seq[String]): String = {
+    import sys.process._
+    val contextArgs = context.toSeq.flatMap { ctx =>
+      Seq("--context", ctx)
+    }
+    val stderr = new StringBuilder
+
+    try {
+      Process(Seq(path) ++ contextArgs ++ args)
+        .!!(ProcessLogger(line => stderr.append(line).append("\n")))
+    } catch {
+      case NonFatal(e) =>
+        val stderrStr = stderr.result()
+        if (stderrStr.nonEmpty) {
+          throw new RuntimeException(s"Error executing Akka CLI: ${stderrStr.trim}", e)
+        } else {
+          throw new RuntimeException("Error executing Akka CLI", e)
+        }
+    }
+  }
+
+}

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -68,6 +68,7 @@ import akka.javasdk.impl.agent.AgentRegistryImpl
 import akka.javasdk.impl.agent.GuardrailProvider
 import akka.javasdk.impl.agent.OverrideModelProvider
 import akka.javasdk.impl.agent.PromptTemplateClient
+import akka.javasdk.impl.backoffice.BackofficeAccessTokenCache
 import akka.javasdk.impl.client.ComponentClientImpl
 import akka.javasdk.impl.consumer.ConsumerImpl
 import akka.javasdk.impl.consumer.MessageContextImpl
@@ -111,7 +112,6 @@ import akka.runtime.sdk.spi.McpEndpointConstructionContext
 import akka.runtime.sdk.spi.RegionInfo
 import akka.runtime.sdk.spi.RemoteIdentification
 import akka.runtime.sdk.spi.SpiAgent
-import akka.runtime.sdk.spi.SpiBackofficeSettings
 import akka.runtime.sdk.spi.SpiComponents
 import akka.runtime.sdk.spi.SpiConfiguredGuardrail
 import akka.runtime.sdk.spi.SpiDeployedEventingSettings
@@ -167,7 +167,8 @@ object SdkRunner {
     val sanitizationSettings = Sanitization.loadSettings(applicationConf)
 
     val devModeSettings =
-      if (applicationConf.getBoolean("akka.javasdk.dev-mode.enabled"))
+      if (applicationConf.getBoolean("akka.javasdk.dev-mode.enabled")) {
+        val backofficeSettings = BackofficeSettingsLoader.loadBackofficeSettings(applicationConf)
         Some(
           new SpiDevModeSettings(
             httpPort = applicationConf.getInt("akka.javasdk.dev-mode.http-port"),
@@ -178,9 +179,8 @@ object SdkRunner {
             mockedEventing = SpiMockedEventingSettings.empty,
             testSetting = new SpiTestSettings(testMode = false, debugTracing = false),
             selfServiceName = None,
-            backoffice = new SpiBackofficeSettings("", "", Map.empty)))
-      else
-        None
+            backoffice = backofficeSettings))
+      } else None
 
     val agentInteractionLogEnabled =
       devModeSettings.isDefined || // always enabled in dev mode
@@ -246,7 +246,7 @@ class SdkRunner private (
   def applicationConfig: Config =
     ApplicationConfig.loadApplicationConf
 
-  override def getSettings: SpiSettings =
+  override lazy val getSettings: SpiSettings =
     extractSpiSettings(applicationConfig)
 
   override def start(startContext: StartContext): Future[SpiComponents] = {
@@ -264,7 +264,7 @@ class SdkRunner private (
         disabledComponents,
         overrideDisabledComponents,
         startedPromise,
-        getSettings.devMode.map(_.serviceName),
+        getSettings,
         startContext.sanitizer)
       Future.successful(app.spiComponents)
     } catch {
@@ -346,7 +346,7 @@ private final class Sdk(
     disabledComponents: Set[Class[_]],
     overrideDisabledComponents: Boolean,
     startedPromise: Promise[StartupContext],
-    serviceNameOverride: Option[String],
+    spiSettings: SpiSettings,
     runtimeSanitizer: SpiSanitizerEngine) {
 
   import Sdk._
@@ -359,7 +359,19 @@ private final class Sdk(
   @volatile private var dependencyProviderOpt: Option[DependencyProvider] = dependencyProviderOverride
 
   private val applicationConfig = ApplicationConfig(system).getConfig
-  private val sdkSettings = Settings(applicationConfig.getConfig("akka.javasdk"))
+  private val sdkSettings = Settings(applicationConfig.getConfig("akka.javasdk"), spiSettings)
+
+  spiSettings.devMode.foreach { devMode =>
+    if (devMode.backoffice.refreshToken.nonEmpty) {
+      val (apiServerHost, apiServerPort) = devMode.backoffice.apiServer.split(":", 2) match {
+        case Array(host)       => (host, 443)
+        case Array(host, port) => (host, port.toInt)
+        case _                 => (devMode.backoffice.apiServer, 443)
+      }
+      BackofficeAccessTokenCache(system)
+        .init(apiServerHost, apiServerPort, devMode.backoffice.refreshToken)
+    }
+  }
 
   private val sdkTracerFactory: () => Tracer = () => tracerFactory(TraceInstrumentation.InstrumentationScopeName)
 
@@ -921,6 +933,8 @@ private final class Sdk(
         useFor = g.useFor.map(_.toString),
         config = g.config)
     })
+
+    val serviceNameOverride = sdkSettings.devModeSettings.map(_.serviceName)
 
     new SpiComponents(
       serviceInfo = new SpiServiceInfo(

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/Settings.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/Settings.scala
@@ -5,6 +5,8 @@
 package akka.javasdk.impl
 
 import akka.annotation.InternalApi
+import akka.runtime.sdk.spi.SpiBackofficeSettings
+import akka.runtime.sdk.spi.SpiSettings
 import com.typesafe.config.Config
 
 import Settings.DevModeSettings
@@ -15,7 +17,7 @@ import Settings.DevModeSettings
 @InternalApi
 private[impl] object Settings {
 
-  def apply(sdkConfig: Config): Settings = {
+  def apply(sdkConfig: Config, spiSettings: SpiSettings): Settings = {
     val showProvidedComponents = {
       val key = "dev-mode.show-hidden-components"
       // hidden config, not in reference.conf
@@ -26,10 +28,15 @@ private[impl] object Settings {
       DevModeSettings(
         serviceName = sdkConfig.getString("dev-mode.service-name"),
         httpPort = sdkConfig.getInt("dev-mode.http-port"),
-        showProvidedComponents)))
+        showProvidedComponents = showProvidedComponents,
+        backoffice = spiSettings.devMode.map(_.backoffice).getOrElse(SpiBackofficeSettings.empty))))
   }
 
-  final case class DevModeSettings(serviceName: String, httpPort: Int, showProvidedComponents: Boolean)
+  final case class DevModeSettings(
+      serviceName: String,
+      httpPort: Int,
+      showProvidedComponents: Boolean,
+      backoffice: SpiBackofficeSettings)
 }
 
 /**

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/backoffice/BackofficeAccessTokenCache.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/backoffice/BackofficeAccessTokenCache.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl.backoffice
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.DurationConverters.JavaDurationOps
+import scala.util.Failure
+import scala.util.Success
+
+import akka.actor.typed._
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.AskPattern.Askable
+import akka.actor.typed.scaladsl.Behaviors
+import akka.annotation.InternalApi
+import akka.grpc.GrpcClientSettings
+import akka.pattern.StatusReply
+import akka.util.Timeout
+import kalix.api.auth.v1alpha.auth.AuthClient
+import kalix.api.auth.v1alpha.auth.CreateAccessTokenRequest
+import org.slf4j.LoggerFactory
+
+/**
+ * This is primarily used in dev mode, when interacting with other services via the backoffice proxy.
+ */
+@InternalApi
+private[impl] object BackofficeAccessTokenCache extends ExtensionId[BackofficeAccessTokenCache] {
+
+  override def createExtension(system: ActorSystem[_]): BackofficeAccessTokenCache = {
+    val requestTimeout = system.settings.config.getDuration("akka.javasdk.dev-mode.backoffice.request-timeout").toScala
+    new BackofficeAccessTokenCache(requestTimeout)(system)
+  }
+
+  def get(system: ActorSystem[_]): BackofficeAccessTokenCache = apply(system)
+
+  private sealed trait Protocol
+  private case class Init(apiServerHost: String, apiServerPort: Int, refreshToken: String) extends Protocol
+  private case class GetAccessToken(replyTo: ActorRef[StatusReply[String]]) extends Protocol
+  private case class AccessToken(token: String, expiry: Instant) extends Protocol
+  private case class GetFailed(exception: Throwable) extends Protocol
+}
+
+@InternalApi
+private[impl] class BackofficeAccessTokenCache private (requestTimeout: FiniteDuration)(implicit sys: ActorSystem[_])
+    extends Extension {
+
+  import BackofficeAccessTokenCache._
+
+  private val log = LoggerFactory.getLogger(getClass)
+
+  private val actor = sys.systemActorOf(awaitingInit, "sdk-backoffice-access-token-cache")
+  // Slightly longer than request timeout so that the request timeout failure should be propagated before the ask
+  // times out
+  private implicit val askTimeout: Timeout = Timeout(requestTimeout.plus(100.millis))
+  private implicit val scheduler: Scheduler = sys.scheduler
+
+  def init(apiServerHost: String, apiServerPort: Int, refreshToken: String): Unit = {
+    actor ! Init(apiServerHost, apiServerPort, refreshToken)
+  }
+
+  def accessToken(): Future[String] = {
+    actor.askWithStatus[String](reply => GetAccessToken(reply))
+  }
+
+  private def awaitingInit: Behavior[Protocol] = Behaviors.receiveMessage {
+    case Init(apiServerHost, apiServerPort, refreshToken) =>
+      // We log the first 4 characters of the refresh token, which is not sensitive, it should be "kxr_", this will
+      // verify that it is a refresh token.
+      log.debug(
+        s"BackofficeAccessTokenCache initialized with refresh token starting with {}... using server {}:{}",
+        refreshToken.take(4),
+        apiServerHost,
+        apiServerPort)
+      val authClient = AuthClient(GrpcClientSettings.connectToServiceAt(apiServerHost, apiServerPort))
+      new Initialized(authClient, refreshToken).idle
+
+    case GetAccessToken(replyTo) =>
+      replyTo ! StatusReply.error("Cannot use BackofficeAccessTokenCache until it has been initialized")
+      Behaviors.same
+
+    case other =>
+      log.debug("Unexpected message while awaiting init: {}", other)
+      Behaviors.same
+  }
+
+  private class Initialized(authClient: AuthClient, refreshToken: String) {
+    def idle: Behavior[Protocol] = Behaviors.receive {
+      case (ctx, GetAccessToken(replyTo)) =>
+        log.debug("Fetching access token")
+        fetchAccessToken(ctx)
+        loading(Seq(replyTo))
+      case (_, msg) =>
+        log.debug("Unexpected message while idle: {}", msg)
+        Behaviors.same
+    }
+
+    private def loading(waiting: Seq[ActorRef[StatusReply[String]]]): Behavior[Protocol] = Behaviors.receiveMessage {
+      case GetAccessToken(replyTo) =>
+        loading(waiting :+ replyTo)
+
+      case AccessToken(token, expiry) =>
+        log.debug("Access token fetched with expiry at {}", expiry)
+        waiting.foreach { replyTo =>
+          replyTo ! StatusReply.success(token)
+        }
+        caching(token, expiry)
+
+      case GetFailed(throwable) =>
+        log.debug("Access token failed to load", throwable)
+        waiting.foreach { replyTo =>
+          replyTo ! StatusReply.error(throwable)
+        }
+        idle
+
+      case msg =>
+        log.debug("Unexpected message while loading: {}", msg)
+        Behaviors.same
+    }
+
+    private def caching(token: String, expiry: Instant): Behavior[Protocol] = Behaviors.receive {
+      case (_, GetAccessToken(replyTo)) if expiry.isAfter(Instant.now().plus(1, ChronoUnit.MINUTES)) =>
+        replyTo ! StatusReply.Success(token)
+        Behaviors.same
+      case (ctx, GetAccessToken(replyTo)) =>
+        log.debug("Access token expired at {}, fetching new one", expiry)
+        fetchAccessToken(ctx)
+        loading(Seq(replyTo))
+      case (_, msg) =>
+        log.debug("Unexpected message while caching: {}", msg)
+        Behaviors.same
+    }
+
+    private def fetchAccessToken(ctx: ActorContext[Protocol]): Unit = {
+      import ctx.executionContext
+      authClient
+        .createAccessToken()
+        .addHeader("Authorization", s"Bearer $refreshToken")
+        .setDeadline(requestTimeout)
+        .invoke(CreateAccessTokenRequest())
+        .onComplete {
+          case Success(token) =>
+            ctx.self ! AccessToken(
+              token.token,
+              token.expireTime
+                .map(_.asJavaInstant)
+                .getOrElse(Instant.now().plus(30, ChronoUnit.MINUTES)))
+          case Failure(exception) =>
+            ctx.self ! GetFailed(exception)
+        }
+    }
+  }
+
+}

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/grpc/GrpcClientProviderImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/grpc/GrpcClientProviderImpl.scala
@@ -7,10 +7,11 @@ package akka.javasdk.impl.grpc
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
 
-import scala.annotation.nowarn
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 import scala.jdk.FutureConverters._
+import scala.util.Failure
+import scala.util.Success
 import scala.util.control.NonFatal
 
 import akka.Done
@@ -23,9 +24,14 @@ import akka.grpc.javadsl.AkkaGrpcClient
 import akka.javasdk.grpc.GrpcClientProvider
 import akka.javasdk.impl.ErrorHandling.unwrapInvocationTargetExceptionCatcher
 import akka.javasdk.impl.Settings
+import akka.javasdk.impl.backoffice.BackofficeAccessTokenCache
 import akka.javasdk.impl.grpc.GrpcClientProviderImpl.AuthHeaders
+import akka.runtime.sdk.spi.SpiBackofficeServiceSettings
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+import io.grpc.CallCredentials
+import io.grpc.Metadata
+import io.grpc.Status
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.{ Context => OtelContext }
 import org.slf4j.LoggerFactory
@@ -39,25 +45,6 @@ private[akka] object GrpcClientProviderImpl {
   private final case class ClientKey(clientClass: Class[_], serviceName: String)
 
   private def isAkkaService(serviceName: String): Boolean = !(serviceName.contains('.') || serviceName.contains(':'))
-
-  @nowarn("msg=deprecated")
-  private def settingsWithCallCredentials(key: String, value: String)(
-      settings: GrpcClientSettings): GrpcClientSettings = {
-
-    import io.grpc.{ CallCredentials, Metadata }
-    val headers = new Metadata()
-    headers.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value)
-    settings.withCallCredentials(new CallCredentials {
-      override def applyRequestMetadata(
-          requestInfo: CallCredentials.RequestInfo,
-          appExecutor: Executor,
-          applier: CallCredentials.MetadataApplier): Unit = {
-        applier.apply(headers)
-      }
-      override def thisUsesUnstableApi(): Unit = ()
-    })
-
-  }
 
   /**
    * Picks up the service specific config from the client config block, sanitizes to allowed config and makes sure the
@@ -92,6 +79,8 @@ private[akka] object GrpcClientProviderImpl {
     safeConfig
   }
 
+  private val KalixProxyHost = Metadata.Key.of("kalix-proxy-host", Metadata.ASCII_STRING_MARSHALLER)
+  private val KalixProxyAuthorization = Metadata.Key.of("kalix-proxy-authorization", Metadata.ASCII_STRING_MARSHALLER)
 }
 
 /**
@@ -134,41 +123,38 @@ private[akka] final class GrpcClientProviderImpl(
       .asInstanceOf[T]
   }
 
-  private[akka] def createNewClientFor[T <: AkkaGrpcClient](
-      clientClass: Class[T],
-      serviceName: String,
-      addAuthHeaders: Boolean = true): T = {
+  private[akka] def createNewClientFor[T <: AkkaGrpcClient](clientClass: Class[T], serviceName: String): T = {
     val clientSettings = {
       if (isAkkaService(serviceName)) {
-        val akkaServiceClientSettings = if (settings.devModeSettings.isDefined) {
-          // special cases in dev mode:
-          // Allow config to override services to talk to services running wherever (auth headers won't work though)
-          if (clientConfig.hasPath(serviceName)) {
-            log.info("Using explicit dev mode config gRPC client override for service [{}]", serviceName)
-            clientSettingsFromConfig(serviceName)
-          } else {
-            // Normally: local service discovery when running locally and trying to use gRPC
-            localDevModeDiscovery(serviceName)
-          }
-        } else {
-          // in production, we rely on DNS and service mesh transports, no overrides allowed
-          if (clientConfig.hasPath(serviceName)) {
-            log.warn(
-              s"Configuration override for [${serviceName}] found in 'application.conf'. This is not supported and is ignored.")
-          }
+        // special cases in dev mode:
+        settings.devModeSettings match {
+          case Some(devModeSettings) =>
+            // First check for dev backoffice config
+            devModeSettings.backoffice.services.get(serviceName) match {
+              case Some(backofficeServiceSettings) =>
+                clientSettingsFromBackofficeSettings(backofficeServiceSettings)
 
-          log.debug("Creating gRPC client for Akka service [{}]", serviceName)
-          GrpcClientSettings
-            .connectToServiceAt(serviceName, 80)(system)
-            // (TLS is handled for us by Kalix infra)
-            .withTls(false)
-        }
+              // Allow config to override services to talk to services running wherever (auth headers won't work though)
+              case None if clientConfig.hasPath(serviceName) =>
+                log.info("Using explicit dev mode config gRPC client override for service [{}]", serviceName)
+                clientSettingsFromConfig(serviceName)
+              case _ =>
+                // Normally: local service discovery when running locally and trying to use gRPC
+                localDevModeDiscovery(serviceName)
+            }
 
-        // auth headers for Akka ACLs
-        remoteIdentificationHeader match {
-          case _ if !addAuthHeaders => akkaServiceClientSettings // used by testkit to specify its own calling principal
-          case Some(auth) => settingsWithCallCredentials(auth.headerName, auth.headerValue)(akkaServiceClientSettings)
-          case None       => akkaServiceClientSettings
+          case None =>
+            // in production, we rely on DNS and service mesh transports, no overrides allowed
+            if (clientConfig.hasPath(serviceName)) {
+              log.warn(
+                s"Configuration override for [${serviceName}] found in 'application.conf'. This is not supported and is ignored.")
+            }
+
+            log.debug("Creating gRPC client for Akka service [{}]", serviceName)
+            GrpcClientSettings
+              .connectToServiceAt(serviceName, 80)(system)
+              // (TLS is handled for us by Kalix infra)
+              .withTls(false)
         }
       } else {
         // external/public gRPC service
@@ -198,16 +184,53 @@ private[akka] final class GrpcClientProviderImpl(
     GrpcClientSettings.fromConfig(serviceName, serviceConfig)(system)
   }
 
+  private def clientSettingsFromBackofficeSettings(settings: SpiBackofficeServiceSettings): GrpcClientSettings = {
+    val accessTokenCache = BackofficeAccessTokenCache(system)
+    GrpcClientSettings
+      .connectToServiceAt(settings.backofficeProxyHost, 443)(system)
+      .withCallCredentials(new CallCredentials {
+        override def applyRequestMetadata(
+            requestInfo: CallCredentials.RequestInfo,
+            appExecutor: Executor,
+            applier: CallCredentials.MetadataApplier): Unit = {
+          accessTokenCache.accessToken().onComplete {
+            case Success(accessToken) =>
+              val headers = new Metadata()
+              val host = s"${settings.serviceName}.${settings.projectId}.svc.kalix.local"
+              headers.put(KalixProxyHost, host)
+              headers.put(KalixProxyAuthorization, accessToken)
+              applier(headers)
+            case Failure(exception) =>
+              applier.fail(Status.INTERNAL.withCause(exception))
+          }
+        }
+      })
+  }
+
   private def localDevModeDiscovery(serviceName: String): GrpcClientSettings = {
     try {
       // The runtime has set up an Akka discovery mechanism that finds locally running
       // services. Since in dev mode only blocking is fine for now.
       log.debug("Creating dev mode gRPC client for Akka service [{}] using local discovery", serviceName)
-      GrpcClientSettings
+      val settings = GrpcClientSettings
         .usingServiceDiscovery(serviceName)(system)
         // (No TLS locally)
         .withTls(false)
 
+      remoteIdentificationHeader match {
+        case Some(auth) =>
+          val headers = new Metadata()
+          headers.put(Metadata.Key.of(auth.headerName, Metadata.ASCII_STRING_MARSHALLER), auth.headerValue)
+          settings.withCallCredentials(new CallCredentials {
+            override def applyRequestMetadata(
+                requestInfo: CallCredentials.RequestInfo,
+                appExecutor: Executor,
+                applier: CallCredentials.MetadataApplier): Unit = {
+              applier.apply(headers)
+            }
+          })
+        case None => settings
+      }
     } catch {
       case NonFatal(ex) =>
         throw new RuntimeException(

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/http/HttpClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/http/HttpClientImpl.scala
@@ -14,10 +14,12 @@ import java.util.concurrent.CompletionStage
 import java.util.concurrent.Executor
 import java.util.function.Function
 
+import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters.SeqHasAsJava
 import scala.jdk.DurationConverters.JavaDurationOps
+import scala.jdk.FutureConverters.FutureOps
 
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
@@ -56,6 +58,7 @@ private[akka] final class HttpClientImpl private (
     materializer: Materializer,
     timeout: FiniteDuration,
     defaultHeaders: Seq[HttpHeader],
+    headerProvider: Option[() => Future[Seq[HttpHeader]]],
     sdkExecutor: Executor,
     connectionPoolSettings: Option[ConnectionPoolSettings])
     extends HttpClient {
@@ -64,6 +67,7 @@ private[akka] final class HttpClientImpl private (
       system: ActorSystem[_],
       baseUrl: String,
       defaultHeaders: Seq[HttpHeader],
+      headerProvider: Option[() => Future[Seq[HttpHeader]]],
       sdkExecutor: Executor,
       connectionPoolSettings: Option[ConnectionPoolSettings]) =
     this(
@@ -73,11 +77,12 @@ private[akka] final class HttpClientImpl private (
       // 10s higher than configured timeout, so configured timeout always win
       system.settings.config.getDuration("akka.http.server.request-timeout").toScala + 10.seconds,
       defaultHeaders,
+      headerProvider,
       sdkExecutor,
       connectionPoolSettings)
 
   def this(system: ActorSystem[_], baseUrl: String, sdkExecutor: Executor) =
-    this(system, baseUrl, Seq.empty, sdkExecutor, None)
+    this(system, baseUrl, Seq.empty, None, sdkExecutor, None)
 
   override def GET(uri: String): RequestBuilder[ByteString] = forMethod(uri, HttpMethods.GET)
 
@@ -96,6 +101,7 @@ private[akka] final class HttpClientImpl private (
       materializer,
       timeout,
       req.withHeaders(defaultHeaders.asJava),
+      headerProvider,
       new StrictResponse[ByteString](_, _),
       None,
       sdkExecutor,
@@ -112,6 +118,7 @@ private[akka] final case class RequestBuilderImpl[R](
     materializer: Materializer,
     timeout: FiniteDuration,
     request: HttpRequest,
+    headerProvider: Option[() => Future[Seq[HttpHeader]]],
     bodyParser: (HttpResponse, ByteString) => StrictResponse[R],
     retrySettings: Option[RetrySettings],
     sdkExecutor: Executor,
@@ -167,6 +174,16 @@ private[akka] final case class RequestBuilderImpl[R](
   override def invokeAsync: CompletionStage[StrictResponse[R]] = {
 
     def callHttp(): CompletionStage[StrictResponse[R]] = {
+      headerProvider match {
+        case Some(provider) =>
+          provider().asJava.thenComposeAsync { headers =>
+            executeRequest(request.addHeaders(headers.asJava))
+          }
+        case None => executeRequest(request)
+      }
+    }
+
+    def executeRequest(request: HttpRequest): CompletionStage[StrictResponse[R]] = {
       (connectionPoolSettings match {
         case Some(poolSettings) =>
           http.singleRequest(request, http.defaultClientHttpsContext, poolSettings, materializer.system.log)
@@ -274,6 +291,7 @@ private[akka] final case class RequestBuilderImpl[R](
       materializer,
       timeout,
       request,
+      headerProvider,
       parser,
       retrySettings,
       sdkExecutor,

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/http/HttpClientProviderImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/http/HttpClientProviderImpl.scala
@@ -21,6 +21,7 @@ import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.javasdk.http.HttpClient
 import akka.javasdk.http.HttpClientProvider
 import akka.javasdk.impl.Settings
+import akka.javasdk.impl.backoffice.BackofficeAccessTokenCache
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.{ Context => OtelContext }
 import org.slf4j.LoggerFactory
@@ -63,38 +64,48 @@ private[akka] final class HttpClientProviderImpl(
     val nameIsService = isServiceName(name)
     val (baseUrl, connectionPoolSettings) =
       if (nameIsService) {
-        if (settings.devModeSettings.isDefined) {
-          val devModeResolverTransport = ClientTransport.withCustomResolver((name, port) =>
-            // dev mode, other service name, use Akka discovery to find it
-            // the runtime has set up a mechanism that finds locally running
-            // services. Since in dev mode blocking is probably fine for now.
-            Discovery(system.classicSystem).discovery
-              .lookup(name, 5.seconds)
-              .map { resolved =>
-                try {
-                  val resolvedTarget = resolved.addresses.head
-                  log.debug("Local service resolution found service [{}] at [{}:{}]", name, resolvedTarget.host, port)
-                  InetSocketAddress.createUnresolved(resolvedTarget.host, resolvedTarget.port.getOrElse(port))
-                } catch {
-                  case NonFatal(ex) =>
-                    throw new RuntimeException(
-                      s"Failed to look up service [$name] in dev-mode, make sure that it is also running " +
-                      "with a separate port and service name correctly defined in its application.conf under 'akka.javasdk.dev-mode.service-name' " +
-                      "if it differs from the maven project name.",
-                      ex)
-                }
-              }(system.executionContext))
+        settings.devModeSettings match {
+          case Some(devModeSettings) =>
+            devModeSettings.backoffice.services.get(name) match {
+              case Some(backofficeSettings) =>
+                (s"https://${backofficeSettings.backofficeProxyHost}", None)
+              case None =>
+                val devModeResolverTransport = ClientTransport.withCustomResolver((name, port) =>
+                  // dev mode, other service name, use Akka discovery to find it
+                  // the runtime has set up a mechanism that finds locally running
+                  // services. Since in dev mode blocking is probably fine for now.
+                  Discovery(system.classicSystem).discovery
+                    .lookup(name, 5.seconds)
+                    .map { resolved =>
+                      try {
+                        val resolvedTarget = resolved.addresses.head
+                        log.debug(
+                          "Local service resolution found service [{}] at [{}:{}]",
+                          name,
+                          resolvedTarget.host,
+                          port)
+                        InetSocketAddress.createUnresolved(resolvedTarget.host, resolvedTarget.port.getOrElse(port))
+                      } catch {
+                        case NonFatal(ex) =>
+                          throw new RuntimeException(
+                            s"Failed to look up service [$name] in dev-mode, make sure that it is also running " +
+                            "with a separate port and service name correctly defined in its application.conf under 'akka.javasdk.dev-mode.service-name' " +
+                            "if it differs from the maven project name.",
+                            ex)
+                      }
+                    }(system.executionContext))
 
-          val connectionSettings = ClientConnectionSettings(system).withTransport(devModeResolverTransport)
-          val poolSettings = ConnectionPoolSettings(system).withConnectionSettings(connectionSettings)
+                val connectionSettings = ClientConnectionSettings(system).withTransport(devModeResolverTransport)
+                val poolSettings = ConnectionPoolSettings(system).withConnectionSettings(connectionSettings)
 
-          (
-            // always http because local
-            s"http://$name",
-            Some(poolSettings))
-        } else {
-          // production, request to other service, service mesh manages TLS
-          (s"http://$name", None)
+                (
+                  // always http because local
+                  s"http://$name",
+                  Some(poolSettings))
+            }
+          case None =>
+            // production, request to other service, service mesh manages TLS
+            (s"http://$name", None)
         }
       } else {
         // if it isn't a service, we expect it is arbitrary http or https server including the protocol part
@@ -114,7 +125,20 @@ private[akka] final class HttpClientProviderImpl(
       else
         // arbitrary http request
         otelTraceHeaders
-    new HttpClientImpl(system, baseUrl, defaultHeaders, sdkExecutor, connectionPoolSettings)
+
+    val headerProvider = for {
+      devModeSettings <- settings.devModeSettings if nameIsService
+      settings <- devModeSettings.backoffice.services.get(name)
+    } yield () => {
+      BackofficeAccessTokenCache(system)
+        .accessToken()
+        .map { token =>
+          val host = s"${settings.serviceName}.${settings.projectId}.svc.kalix.local"
+          Seq(RawHeader.create("kalix-proxy-host", host), RawHeader.create("kalix-proxy-authorization", token))
+        }(system.executionContext)
+    }
+
+    new HttpClientImpl(system, baseUrl, defaultHeaders, headerProvider, sdkExecutor, connectionPoolSettings)
   }
 
   def withTelemetryContext(telemetryContext: OtelContext): HttpClientProvider =

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/http/HttpClientImplSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/http/HttpClientImplSpec.scala
@@ -91,7 +91,7 @@ trait HttpClientImplSuite {
   val path = "/test"
   val headers: Seq[HttpHeader] = Seq.empty
 
-  private def client = new HttpClientImpl(system, baseUrl, headers, system.executionContext, None)
+  private def client = new HttpClientImpl(system, baseUrl, headers, None, system.executionContext, None)
 
   private def get(url: String)(
       builder: RequestBuilder[ByteString] => RequestBuilder[ByteString]): RequestBuilderImpl[ByteString] = {

--- a/docs/src/modules/sdk/pages/http-endpoints.adoc
+++ b/docs/src/modules/sdk/pages/http-endpoints.adoc
@@ -171,6 +171,7 @@ include::example$shopping-cart-quickstart/src/main/java/shoppingcart/api/Shoppin
 
 For more details see xref:component-and-service-calls.adoc[]
 
+[#http_client_provider]
 == Interacting with other HTTP services
 
 It is also possible to interact with other services over HTTP. This is done through the `akka.javasdk.http.HttpClientProvider`.

--- a/docs/src/modules/sdk/pages/running-locally.adoc
+++ b/docs/src/modules/sdk/pages/running-locally.adoc
@@ -126,6 +126,33 @@ include::sdk:example$event-sourced-customer-registry-subscriber/src/main/resourc
 
 With both services configured, we can start them independently by running `mvn compile exec:java` in two separate terminals.
 
+== Invoking cloud based services from local services
+
+Sometimes, when developing services locally that depend on other services, rather than running those services locally as well, it's more convenient to use instances of those services running in the cloud. Akka allows this through its backoffice proxy. The cloud services do not need to be exposed to the internet, rather, requests are forwarded through a proxy that authenticates and authorizes developers using their Akka platform credentials.
+
+To do this, you will need to have the xref:operations:cli/index.adoc[Akka CLI] installed on your path, and be logged in with the backoffice or admin role on the project you wish to use. Alternatively, if the Akka CLI is not installed, the `AKKA_REFRESH_TOKEN` environment variable can be set with a valid refresh or service token.
+
+Backoffice services can be configured in `src/main/resources/application.conf`, by specifying the project that the services run in:
+
+[source,json,indent=0]
+----
+include::sdk:example$doc-snippets/src/main/resources/application.conf[tags=backoffice-service-configuration]
+----
+
+With the above configuration, all calls made to `my-service-a` and `my-service-b` from your locally running service will be proxied to the project `my-akka-project` hosted in the cloud. This includes invoking other services using the xref:http-endpoints.adoc#http_client_provider[HTTP client provider] or gRPC client provider, consuming events from xref:consuming-producing.adoc#s2s-eventing[Service to Service Eventing] producers hosted in other services, and invoking xref:mcp-endpoints.adoc[MCP Endpoints] hosted in other services.
+
+Other configuration options are shown here:
+
+[source,json,indent=0]
+----
+include::sdk:example$doc-snippets/src/main/resources/application.conf[tags=backoffice-service-configuration-custom]
+----
+
+* `project` - This can either be the project UUID, or the project name.
+* `organization` - This is usually not necessary, however if you ar referring to the project by its name, and you are a member of two organizations that have projects with that same name, this will be used to disambiguate them. Either an organization UUID or an organization name can be set here.
+* `service-name` - Can be used if you wish to use a service with a different name running in the cloud to the one referenced from your locally running service.
+* `region` - If you have a multi-region project, and you don't want to use the primary region, this can be used to select the region.
+
 [#local_cluster]
 == Running a local cluster
 

--- a/docs/styles/config/vocabularies/Akka/accept.txt
+++ b/docs/styles/config/vocabularies/Akka/accept.txt
@@ -165,6 +165,7 @@ prepending
 [Pp]ropagations
 proto
 [Pp]rotobuf
+proxied
 Qodo
 [Qq]uantiles
 Quatrini

--- a/samples/doc-snippets/src/main/resources/application.conf
+++ b/samples/doc-snippets/src/main/resources/application.conf
@@ -67,3 +67,32 @@ akka.javasdk {
 }
 // end::agent-custom-model-config[]
 
+// tag::backoffice-service-configuration[]
+akka.javasdk {
+  dev-mode {
+    backoffice.services {
+      my-service-a {
+        project = "my-akka-project"
+      }
+      my-service-b {
+        project = "my-akka-project"
+      }
+    }
+  }
+}
+// end::backoffice-service-configuration[]
+
+// tag::backoffice-service-configuration-custom[]
+akka.javasdk {
+  dev-mode {
+    backoffice.services {
+      my-service-a {
+        project = "my-akka-project"
+        organization = "my-organization"
+        service-name = "service-a"
+        region = "gcp-us-east1"
+      }
+    }
+  }
+}
+// end::backoffice-service-configuration-custom[]


### PR DESCRIPTION
Depends on https://github.com/lightbend/akka-runtime/pull/4619 (currently depending on unpublished snapshot version).

This adds support for backoffice services to the SDK.

It allows users to configure backoffice service configuration in their `application.conf`. This is then resolved, and passed to the runtime via the SPI. It's also used by both the HTTP client and gRPC client providers, to proxy requests through the backoffice proxy.

A few concerns:

* We need to look up the backoffice proxy hostname and resolve project names to project ids. These are done using gRPC, however because this is required to build the SPI settings passed to the runtime, and because the SPI `Runner.getSettings` method is synchronous, we must block to get the settings. Since this only happens in dev mode on startup, I don't think this is the end of the world.
* We also don't have access to the runners actor system in the context of `Runner.getSettings`, so we need to start our own actor system to do this.  The actor system is started and shutdown in a `finally` block. Care is taken to ensure the actor system is only started when necessary, that means only in dev mode, and only if there is a backoffice service configuration to resolve.  Also, because all the blocking above is done on futures being redeemed by threads provided by this actor system, I don't think we need to be too worried about thread starvation etc.
* As you may see I cache and load the access token in an extension. This extension is duplicated in the runtime, since they can't really be shared unless I put the extension in the SPI artifact. The consequence of this is that the runtime and the SDK are unable to share the access token cache, and will create their own tokens. Furthermore, the config resolution, beacuse it creates its own actor system, also can't share its access token with either of those.