### PR TITLE
docs: bump current CLI version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ attributes: prepare
 		> "${managed_partials}/attributes.adoc"
 	docs/bin/version.sh | xargs -0  printf ":akka-javasdk-version: %s" \
 		> "${managed_partials}/attributes.adoc"
-	echo ":akka-cli-version: 3.0.49" >> "${managed_partials}/attributes.adoc"
+	echo ":akka-cli-version: 3.0.50" >> "${managed_partials}/attributes.adoc"
 	echo ":akka-cli-min-version: 3.0.4" >> "${managed_partials}/attributes.adoc"
 	# see https://adoptium.net/marketplace/
 	echo ":java-version: 21" \


### PR DESCRIPTION
Missed when 3.0.50 was added in release notes