### PR TITLE
doc: fix custom labels/annotations note UI rendering

### DIFF
--- a/docs/src/modules/reference/pages/descriptors/project-descriptor.adoc
+++ b/docs/src/modules/reference/pages/descriptors/project-descriptor.adoc
@@ -99,7 +99,7 @@ spec:
       value: true
 ----
 
-NOTE:: Custom labels and annotations are disabled by default. Contact Akka Support to enable.
+NOTE: Custom labels and annotations are disabled by default. Contact Akka Support to enable.
 
 [#route]
 === Route


### PR DESCRIPTION
I assume this `::` was causing the note section not to be highlighted as others are.