### PR TITLE
Docs: traceSampling to spec level in observability descriptor

### DIFF
--- a/docs/src/modules/operations/pages/observability-and-monitoring/observability-exports.adoc
+++ b/docs/src/modules/operations/pages/observability-and-monitoring/observability-exports.adoc
@@ -106,12 +106,19 @@ Another possible use is to add a `traceparent` header when calling your Akka end
 
 By default, Akka filters traces and exports them to your Akka Console. You'll get 1% of the traces produced by your services. You can adjust this percentage according to your needs.
 
-This filtering is known as https://opentelemetry.io/docs/concepts/sampling/#head-sampling[head sampling, window="new"]. To configure it, you need to set your observability descriptor as follows and xref:_updating_the_observability_configuration[update the observability configuration]:
+This filtering is known as https://opentelemetry.io/docs/concepts/sampling/#head-sampling[head sampling, window="new"]. Sampling is configured at the top level of the observability descriptor using `traceSampling` and applies to all configured trace exporters. To configure it, set your observability descriptor as follows and xref:_updating_the_observability_configuration[update the observability configuration]:
 
 [source,yaml]
 ----
-traces:
-  sampling:
+resource: Observability
+resourceVersion: v2
+spec:
+  exporters:
+    - kalixConsole: {}
+  traces:
+    - otlp:
+        endpoint: traces.example.com:4317
+  traceSampling:
     probabilistic:
       percentage: "2"
 ----


### PR DESCRIPTION
traceSampling now applies to all trace exporters and is configured at the spec level rather than nested under one trace.


References 
https://github.com/lightbend/kalix/issues/15168
