### PR TITLE
chore: simplifying workflow's transition/failover APIs

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflow.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflow.java
@@ -57,8 +57,7 @@ public class TransferWorkflow extends Workflow<TransferState> {
       if (currentState() == null) {
         return effects()
             .updateState(new TransferState(transfer, "started"))
-            .transitionTo(TransferWorkflow::withdraw)
-            .withInput(new Withdraw(transfer.from(), transfer.amount()))
+            .transitionTo(TransferWorkflow::withdraw, new Withdraw(transfer.from(), transfer.amount()))
             .thenReply(new Message("transfer started"));
       } else {
         return effects().reply(new Message("transfer started already"));
@@ -80,8 +79,7 @@ public class TransferWorkflow extends Workflow<TransferState> {
     var state = currentState().withLastStep("withdrawn").asAccepted();
     return stepEffects()
         .updateState(state)
-        .thenTransitionTo(TransferWorkflow::deposit)
-        .withInput(new Deposit(currentState().transfer().to(), currentState().transfer().amount()));
+        .thenTransitionTo(TransferWorkflow::deposit, new Deposit(currentState().transfer().to(), currentState().transfer().amount()));
   }
 
   @StepName("deposit-step")

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflowWithFraudDetection.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/TransferWorkflowWithFraudDetection.java
@@ -28,8 +28,7 @@ public class TransferWorkflowWithFraudDetection extends Workflow<TransferState> 
       if (currentState() == null) {
         return effects()
             .updateState(new TransferState(transfer, "started"))
-            .transitionTo(TransferWorkflowWithFraudDetection::detectFraud)
-            .withInput(transfer)
+            .transitionTo(TransferWorkflowWithFraudDetection::detectFraud, transfer)
             .thenReply(new Message("transfer started"));
       } else {
         return effects().reply(new Message("transfer started already"));
@@ -46,8 +45,7 @@ public class TransferWorkflowWithFraudDetection extends Workflow<TransferState> 
           new Withdraw(currentState().transfer().from(), currentState().transfer().amount());
       return effects()
           .updateState(currentState().asAccepted())
-          .transitionTo(TransferWorkflowWithFraudDetection::withdraw)
-          .withInput(withdrawInput)
+          .transitionTo(TransferWorkflowWithFraudDetection::withdraw, withdrawInput)
           .thenReply(new Message("transfer accepted"));
 
     } else {
@@ -85,8 +83,7 @@ public class TransferWorkflowWithFraudDetection extends Workflow<TransferState> 
 
         return stepEffects()
             .updateState(state)
-            .thenTransitionTo(TransferWorkflowWithFraudDetection::withdraw)
-            .withInput(withdrawInput);
+            .thenTransitionTo(TransferWorkflowWithFraudDetection::withdraw, withdrawInput);
       }
       case TransferRequiresManualAcceptation __ -> {
         return stepEffects().updateState(state).thenPause();
@@ -110,8 +107,7 @@ public class TransferWorkflowWithFraudDetection extends Workflow<TransferState> 
 
     return stepEffects()
         .updateState(state)
-        .thenTransitionTo(TransferWorkflowWithFraudDetection::deposit)
-        .withInput(depositInput);
+        .thenTransitionTo(TransferWorkflowWithFraudDetection::deposit, depositInput);
   }
 
   private StepEffect deposit(Deposit deposit) {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/hierarchy/AbstractTextKvWorkflow.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/hierarchy/AbstractTextKvWorkflow.java
@@ -13,8 +13,7 @@ public abstract class AbstractTextKvWorkflow extends Workflow<AbstractTextKvWork
 
   protected StepEffect dummyStepInParent(String text) {
     return stepEffects()
-        .thenTransitionTo(AbstractTextKvWorkflow::dummyStepInInterface)
-        .withInput(text + "[abstract]");
+        .thenTransitionTo(AbstractTextKvWorkflow::dummyStepInInterface, text + "[abstract]");
   }
 
   @Override

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/hierarchy/TextWorkflow.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/hierarchy/TextWorkflow.java
@@ -14,14 +14,13 @@ public class TextWorkflow extends AbstractTextKvWorkflow {
     // this Workflow will call a series of steps defined in
     // the concrete class, its parent and an interface
     // each call appends a text to the original message
-    return effects().transitionTo(TextWorkflow::dummyStep).withInput(text).thenReply("ok");
+    return effects().transitionTo(TextWorkflow::dummyStep, text).thenReply("ok");
   }
 
   private StepEffect dummyStep(String text) {
     // step defined in parent should be callable
     return stepEffects()
-        .thenTransitionTo(TextWorkflow::dummyStepInParent)
-        .withInput(text + "[concrete]");
+        .thenTransitionTo(TextWorkflow::dummyStepInParent, text + "[concrete]");
   }
 
   public Effect<Optional<String>> getText() {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/protobuf/ProtobufOrderWorkflow.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/protobuf/ProtobufOrderWorkflow.java
@@ -60,8 +60,7 @@ public class ProtobufOrderWorkflow extends Workflow<OrderWorkflowState> {
 
     return effects()
         .updateState(newState)
-        .transitionTo(ProtobufOrderWorkflow::validateOrder)
-        .withInput(validateInput)
+        .transitionTo(ProtobufOrderWorkflow::validateOrder, validateInput)
         .thenReply("Order created");
   }
 
@@ -96,8 +95,7 @@ public class ProtobufOrderWorkflow extends Workflow<OrderWorkflowState> {
 
     return stepEffects()
         .updateState(state)
-        .thenTransitionTo(ProtobufOrderWorkflow::processPayment)
-        .withInput(paymentInput);
+        .thenTransitionTo(ProtobufOrderWorkflow::processPayment, paymentInput);
   }
 
   @StepName("process-payment")
@@ -121,8 +119,7 @@ public class ProtobufOrderWorkflow extends Workflow<OrderWorkflowState> {
 
     return stepEffects()
         .updateState(state)
-        .thenTransitionTo(ProtobufOrderWorkflow::shipOrder)
-        .withInput(shipInput);
+        .thenTransitionTo(ProtobufOrderWorkflow::shipOrder, shipInput);
   }
 
   @StepName("ship-order")

--- a/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
@@ -1532,9 +1532,15 @@ public abstract class Workflow<S> {
       Optional<T> failoverStepInput,
       Optional<StepHandler> stepHandler) {
 
+    /**
+     * @deprecated Use the overloaded failoverTo methods that accept the input parameter directly
+     *     instead.
+     */
+    @Deprecated
     public record RecoveryInput<I>(
         int maxRetries, String stepName, akka.japi.function.Function2<?, I, StepEffect> lambda)
         implements WithInput<I, RecoverStrategy<I>> {
+      @SuppressWarnings("deprecation")
       public RecoverStrategy<I> withInput(I input) {
         return new RecoverStrategy<>(
             maxRetries,
@@ -1586,10 +1592,34 @@ public abstract class Workflow<S> {
        * Once max retries are exceeded, transition to a given step method with input parameter.
        *
        * @param lambda Reference to the step method to transition to
+       * @param input The input parameter for the failover step
+       * @param <W> The workflow type containing the step method
+       * @param <I> The input parameter type for the step
+       * @return A recovery strategy transitioning to the specified step with input
+       */
+      public <W, I> RecoverStrategy<I> failoverTo(
+          akka.japi.function.Function2<W, I, StepEffect> lambda, I input) {
+        var method = MethodRefResolver.resolveMethodRef(lambda);
+        var stepName = WorkflowDescriptor.stepMethodName(method);
+        return new RecoverStrategy<>(
+            maxRetries,
+            stepName,
+            Optional.of(input),
+            Optional.of(new StepHandler.OneArgStepHandler(lambda, input)));
+      }
+
+      /**
+       * Once max retries are exceeded, transition to a given step method with input parameter.
+       *
+       * @param lambda Reference to the step method to transition to
        * @param <W> The workflow type containing the step method
        * @param <I> The input parameter type for the step
        * @return A builder to provide the input parameter for the recovery strategy
+       * @deprecated Use {@link MaxRetries#failoverTo(akka.japi.function.Function2, Object)}
+       *     instead.
        */
+      @Deprecated
+      @SuppressWarnings("deprecation")
       public <W, I> RecoveryInput<I> failoverTo(
           akka.japi.function.Function2<W, I, StepEffect> lambda) {
         var method = MethodRefResolver.resolveMethodRef(lambda);
@@ -1642,10 +1672,35 @@ public abstract class Workflow<S> {
      * parameter.
      *
      * @param lambda Reference to the step method to transition to
+     * @param input The input parameter for the failover step
+     * @param <W> The workflow type containing the step method
+     * @param <I> The input parameter type for the step
+     * @return A recovery strategy transitioning to the specified step with input
+     */
+    public static <W, I> RecoverStrategy<I> failoverTo(
+        akka.japi.function.Function2<W, I, StepEffect> lambda, I input) {
+      var method = MethodRefResolver.resolveMethodRef(lambda);
+      var stepName = WorkflowDescriptor.stepMethodName(method);
+      return new RecoverStrategy<>(
+          0,
+          stepName,
+          Optional.of(input),
+          Optional.of(new StepHandler.OneArgStepHandler(lambda, input)));
+    }
+
+    /**
+     * In case of a step fails, don't retry but transition to a given step method with input
+     * parameter.
+     *
+     * @param lambda Reference to the step method to transition to
      * @param <W> The workflow type containing the step method
      * @param <I> The input parameter type for the step
      * @return A builder to provide the input parameter for the recovery strategy
+     * @deprecated Use {@link RecoverStrategy#failoverTo(akka.japi.function.Function2, Object)}
+     *     instead.
      */
+    @Deprecated
+    @SuppressWarnings("deprecation")
     public static <W, I> RecoveryInput<I> failoverTo(
         akka.japi.function.Function2<W, I, StepEffect> lambda) {
       var method = MethodRefResolver.resolveMethodRef(lambda);

--- a/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
@@ -302,10 +302,26 @@ public abstract class Workflow<S> {
        * <p>The step is identified by a method reference that accepts an input parameter.
        *
        * @param methodRef Reference to the step method
+       * @param input The input parameter for the next step
+       * @param <W> The workflow type containing the step method
+       * @param <I> The input parameter type for the step
+       * @return A transitional effect
+       */
+      <W, I> Transitional transitionTo(
+          akka.japi.function.Function2<W, I, StepEffect> methodRef, I input);
+
+      /**
+       * Defines the next step to which the workflow should transition to.
+       *
+       * <p>The step is identified by a method reference that accepts an input parameter.
+       *
+       * @param methodRef Reference to the step method
        * @param <W> The workflow type containing the step method
        * @param <I> The input parameter type for the step
        * @return A builder to provide the input parameter
+       * @deprecated Use {@link Builder#transitionTo(akka.japi.function.Function2, Object)} instead.
        */
+      @Deprecated
       <W, I> WithInput<I, Transitional> transitionTo(
           akka.japi.function.Function2<W, I, StepEffect> methodRef);
 
@@ -500,9 +516,26 @@ public abstract class Workflow<S> {
        * @param <W> The workflow type containing the step method
        * @param <I> The input parameter type for the step
        * @return A builder to provide the input parameter
+       * @deprecated Use {@link PersistenceEffectBuilder#transitionTo(akka.japi.function.Function2,
+       *     Object)} instead.
        */
+      @Deprecated
       <W, I> WithInput<I, Transitional> transitionTo(
           akka.japi.function.Function2<W, I, StepEffect> lambda);
+
+      /**
+       * Defines the next step to which the workflow should transition to.
+       *
+       * <p>The step is identified by a method reference that accepts an input parameter.
+       *
+       * @param lambda Reference to the step method
+       * @param input The input parameter for the next step
+       * @param <W> The workflow type containing the step method
+       * @param <I> The input parameter type for the step
+       * @return A transitional effect
+       */
+      <W, I> Transitional transitionTo(
+          akka.japi.function.Function2<W, I, StepEffect> lambda, I input);
 
       /**
        * Finish the workflow execution. After transition to {@code end}, no more transitions are
@@ -586,10 +619,27 @@ public abstract class Workflow<S> {
        * <p>The step is identified by a method reference that accepts an input parameter.
        *
        * @param lambda Reference to the step method
+       * @param input The input parameter for the next step
+       * @param <W> The workflow type containing the step method
+       * @param <I> The input parameter type for the step
+       * @return A step effect
+       */
+      <W, I> StepEffect thenTransitionTo(
+          akka.japi.function.Function2<W, I, Workflow.StepEffect> lambda, I input);
+
+      /**
+       * Defines the next step to which the workflow should transition to.
+       *
+       * <p>The step is identified by a method reference that accepts an input parameter.
+       *
+       * @param lambda Reference to the step method
        * @param <W> The workflow type containing the step method
        * @param <I> The input parameter type for the step
        * @return A builder to provide the input parameter
+       * @deprecated Use {@link Builder#thenTransitionTo(akka.japi.function.Function2, Object)}
+       *     instead.
        */
+      @Deprecated
       <W, I> WithInput<I, StepEffect> thenTransitionTo(
           akka.japi.function.Function2<W, I, Workflow.StepEffect> lambda);
 
@@ -666,9 +716,27 @@ public abstract class Workflow<S> {
        * @param <W> The workflow type containing the step method
        * @param <I> The input parameter type for the step
        * @return A builder to provide the input parameter
+       * @deprecated Use {@link
+       *     PersistenceEffectBuilder#thenTransitionTo(akka.japi.function.Function2, Object)}
+       *     instead.
        */
+      @Deprecated
       <W, I> WithInput<I, StepEffect> thenTransitionTo(
           akka.japi.function.Function2<W, I, Workflow.StepEffect> methodRef);
+
+      /**
+       * Defines the next step to which the workflow should transition to.
+       *
+       * <p>The step is identified by a method reference that accepts an input parameter.
+       *
+       * @param methodRef Reference to the step method
+       * @param input The input parameter for the next step
+       * @param <W> The workflow type containing the step method
+       * @param <I> The input parameter type for the step
+       * @return A step effect
+       */
+      <W, I> StepEffect thenTransitionTo(
+          akka.japi.function.Function2<W, I, Workflow.StepEffect> methodRef, I input);
 
       /**
        * Finish the workflow execution. After transition to {@code end}, no more transitions are
@@ -701,7 +769,10 @@ public abstract class Workflow<S> {
   /**
    * Represents an operation that accepts an input of type I and produces a result of type R. This
    * is used by internal builders accepting {@link akka.japi.function.Function2}
+   *
+   * @deprecated Use the overloaded methods that accept the input parameter directly instead.
    */
+  @Deprecated
   public interface WithInput<I, R> {
     R withInput(I input);
   }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/WorkflowEffects.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/workflow/WorkflowEffects.scala
@@ -4,6 +4,7 @@
 
 package akka.javasdk.impl.workflow
 
+import scala.annotation.nowarn
 import scala.concurrent.duration.FiniteDuration
 import scala.jdk.DurationConverters.JavaDurationOps
 
@@ -109,6 +110,13 @@ object WorkflowEffects {
         TransitionalEffectImpl(persistence, StepTransition(stepName, None, Some(method.getDeclaringClass)))
       }
 
+      override def transitionTo[W, I](lambda: function.Function2[W, I, Workflow.StepEffect], input: I): Transitional = {
+        val method = MethodRefResolver.resolveMethodRef(lambda)
+        val stepName = WorkflowDescriptor.stepMethodName(method)
+        TransitionalEffectImpl(persistence, StepTransition(stepName, Some(input), Some(method.getDeclaringClass)))
+      }
+
+      @nowarn("msg=deprecated")
       override def transitionTo[W, I](
           lambda: function.Function2[W, I, Workflow.StepEffect]): WithInput[I, Transitional] = {
         val method = MethodRefResolver.resolveMethodRef(lambda)
@@ -246,6 +254,13 @@ object WorkflowEffects {
       TransitionalEffectImpl(persistence, StepTransition(stepName, None, Some(method.getDeclaringClass)))
     }
 
+    override def transitionTo[W, I](lambda: function.Function2[W, I, Workflow.StepEffect], input: I): Transitional = {
+      val method = MethodRefResolver.resolveMethodRef(lambda)
+      val stepName = WorkflowDescriptor.stepMethodName(method)
+      TransitionalEffectImpl(persistence, StepTransition(stepName, Some(input), Some(method.getDeclaringClass)))
+    }
+
+    @nowarn("msg=deprecated")
     override def transitionTo[W, I](
         lambda: function.Function2[W, I, Workflow.StepEffect]): WithInput[I, Transitional] = {
       val method = MethodRefResolver.resolveMethodRef(lambda)
@@ -261,6 +276,7 @@ object WorkflowEffects {
 
   }
 
+  @nowarn("msg=deprecated")
   private final case class EffectCallWithInputImpl[I, S](
       persistence: Persistence[S],
       stepName: String,
@@ -284,6 +300,13 @@ object WorkflowEffects {
         val stepName = WorkflowDescriptor.stepMethodName(method)
         WorkflowStepEffectImpl(persistence, StepTransition(stepName, None, Some(method.getDeclaringClass)))
       }
+      override def thenTransitionTo[W, I](lambda: function.Function2[W, I, StepEffect], input: I): StepEffect = {
+        val method = MethodRefResolver.resolveMethodRef(lambda)
+        val stepName = WorkflowDescriptor.stepMethodName(method)
+        WorkflowStepEffectImpl(persistence, StepTransition(stepName, Some(input), Some(method.getDeclaringClass)))
+      }
+
+      @nowarn("msg=deprecated")
       override def thenTransitionTo[W, I](lambda: function.Function2[W, I, StepEffect]): WithInput[I, StepEffect] = {
         val method = MethodRefResolver.resolveMethodRef(lambda)
         val stepName = WorkflowDescriptor.stepMethodName(method)
@@ -359,6 +382,13 @@ object WorkflowEffects {
       WorkflowStepEffectImpl(persistence, StepTransition(stepName, None, Some(method.getDeclaringClass)))
     }
 
+    override def thenTransitionTo[W, I](lambda: function.Function2[W, I, StepEffect], input: I): StepEffect = {
+      val method = MethodRefResolver.resolveMethodRef(lambda)
+      val stepName = WorkflowDescriptor.stepMethodName(method)
+      WorkflowStepEffectImpl(persistence, StepTransition(stepName, Some(input), Some(method.getDeclaringClass)))
+    }
+
+    @nowarn("msg=deprecated")
     override def thenTransitionTo[W, I](lambda: function.Function2[W, I, StepEffect]): WithInput[I, StepEffect] = {
       val method = MethodRefResolver.resolveMethodRef(lambda)
       val stepName = WorkflowDescriptor.stepMethodName(method)
@@ -383,6 +413,7 @@ object WorkflowEffects {
 
   }
 
+  @nowarn("msg=deprecated")
   private final case class StepEffectCallWithInputImpl[I, S](
       persistence: Persistence[S],
       stepName: String,

--- a/samples/doc-snippets/src/main/java/com/example/application/ActivityWorkflow.java
+++ b/samples/doc-snippets/src/main/java/com/example/application/ActivityWorkflow.java
@@ -101,8 +101,7 @@ public class ActivityWorkflow extends Workflow<ActivityWorkflow.State> {
 
   public Effect<String> start(String request) {
     return effects()
-      .transitionTo(ActivityWorkflow::summarizeStep)
-      .withInput(request)
+      .transitionTo(ActivityWorkflow::summarizeStep, request)
       .thenReply("Started");
   }
 

--- a/samples/multi-agent/src/main/java/demo/multiagent/application/AgentTeamWorkflow.java
+++ b/samples/multi-agent/src/main/java/demo/multiagent/application/AgentTeamWorkflow.java
@@ -191,8 +191,7 @@ public class AgentTeamWorkflow extends Workflow<AgentTeamWorkflow.State> { // <1
       return stepEffects().updateState(newState).thenEnd(); // terminate workflow
     } else {
       return stepEffects()
-        .thenTransitionTo(AgentTeamWorkflow::createPlanStep)
-        .withInput(selection); // <5>
+        .thenTransitionTo(AgentTeamWorkflow::createPlanStep, selection); // <5>
     }
   }
 

--- a/samples/transfer-workflow-compensation/src/main/java/com/example/transfer/application/TransferWorkflow.java
+++ b/samples/transfer-workflow-compensation/src/main/java/com/example/transfer/application/TransferWorkflow.java
@@ -83,8 +83,7 @@ public class TransferWorkflow extends Workflow<TransferState> {
         );
         yield stepEffects()
           .updateState(currentState().withStatus(WITHDRAW_SUCCEEDED))
-          .thenTransitionTo(TransferWorkflow::depositStep)
-          .withInput(depositInput);
+          .thenTransitionTo(TransferWorkflow::depositStep, depositInput);
       }
       case Failure failure -> {
         logger.warn("Withdraw failed with msg: {}", failure.errorMsg());
@@ -175,8 +174,7 @@ public class TransferWorkflow extends Workflow<TransferState> {
         Withdraw withdrawInput = new Withdraw(initialState.withdrawId(), transfer.amount());
         yield stepEffects()
           .updateState(initialState)
-          .thenTransitionTo(TransferWorkflow::withdrawStep)
-          .withInput(withdrawInput);
+          .thenTransitionTo(TransferWorkflow::withdrawStep, withdrawInput);
       }
       case MANUAL_ACCEPTANCE_REQUIRED -> { // <3>
         // end::detect-frauds[]
@@ -226,8 +224,7 @@ public class TransferWorkflow extends Workflow<TransferState> {
         Withdraw withdrawInput = new Withdraw(initialState.withdrawId(), transfer.amount());
         return effects()
           .updateState(initialState)
-          .transitionTo(TransferWorkflow::withdrawStep)
-          .withInput(withdrawInput)
+          .transitionTo(TransferWorkflow::withdrawStep, withdrawInput)
           .thenReply("transfer started");
       }
     }
@@ -258,8 +255,7 @@ public class TransferWorkflow extends Workflow<TransferState> {
       // tag::resuming[]
       Withdraw withdrawInput = new Withdraw(currentState().withdrawId(), transfer.amount());
       return effects()
-        .transitionTo(TransferWorkflow::withdrawStep)
-        .withInput(withdrawInput)
+        .transitionTo(TransferWorkflow::withdrawStep, withdrawInput)
         .thenReply("transfer accepted");
     } else { // <2>
       return effects()

--- a/samples/transfer-workflow/src/main/java/com/example/transfer/application/TransferWorkflow.java
+++ b/samples/transfer-workflow/src/main/java/com/example/transfer/application/TransferWorkflow.java
@@ -43,8 +43,7 @@ public class TransferWorkflow extends Workflow<TransferState> { // <2>
 
     return stepEffects()
       .updateState(currentState().withStatus(WITHDRAW_SUCCEEDED))
-      .thenTransitionTo(TransferWorkflow::depositStep) // <5>
-      .withInput(depositInput);
+      .thenTransitionTo(TransferWorkflow::depositStep, depositInput); // <5>
   }
 
   @StepName("deposit") // <2>
@@ -75,8 +74,7 @@ public class TransferWorkflow extends Workflow<TransferState> { // <2>
 
       return effects()
         .updateState(initialState) // <6>
-        .transitionTo(TransferWorkflow::withdrawStep) // <7>
-        .withInput(withdrawInput)
+        .transitionTo(TransferWorkflow::withdrawStep, withdrawInput) // <7>
         .thenReply(done()); // <8>
     }
   }


### PR DESCRIPTION
Simplifies how we pass input params when defining transitions and failover. 

I don't know why we (I) introduced `withInput`. I was convinced that the type inference wouldn't work properly and that it was required to have two steps in the builder. 
But @aludwiko proved me wrong when he introduced the APIs for [pausing with timeout](https://github.com/akka/akka-sdk/pull/1203#discussion_r2610694295). 

I believe this comes from a very old assumption, because we did the same in the ComponentClient. We have `.method(Component::methodToCall).invoke(input)`, but it's enough to have `.invoke(Component::methodToCall, input)`. 

Anyway, this PR is only changing the workflow. 
We could consider improving the ComponentClient as well, but first let's let the idea mature a bit more.