### PR TITLE
chore: deprecate instance maxRetries

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowSettingCallingOtherWorkflowStep.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowSettingCallingOtherWorkflowStep.java
@@ -24,7 +24,8 @@ public class WorkflowSettingCallingOtherWorkflowStep extends Workflow<String> {
     return WorkflowSettings.builder()
         .stepRecovery(
             WorkflowWithTimeout::counterStep,
-            RecoverStrategy.maxRetries(10).failoverTo(WorkflowSettingCallingOtherWorkflowStep::someStep))
+            RecoverStrategy.maxRetries(10)
+                .failoverTo(WorkflowSettingCallingOtherWorkflowStep::someStep))
         .build();
   }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowSettingCallingOtherWorkflowStep.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowSettingCallingOtherWorkflowStep.java
@@ -9,6 +9,7 @@ import static akka.Done.done;
 import akka.Done;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.Workflow.RecoverStrategy;
 
 @Component(id = "workflow-setting-calling-other-workflow")
 public class WorkflowSettingCallingOtherWorkflowStep extends Workflow<String> {
@@ -23,7 +24,7 @@ public class WorkflowSettingCallingOtherWorkflowStep extends Workflow<String> {
     return WorkflowSettings.builder()
         .stepRecovery(
             WorkflowWithTimeout::counterStep,
-            maxRetries(10).failoverTo(WorkflowSettingCallingOtherWorkflowStep::someStep))
+            RecoverStrategy.maxRetries(10).failoverTo(WorkflowSettingCallingOtherWorkflowStep::someStep))
         .build();
   }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithDefaultRecoverStrategy.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithDefaultRecoverStrategy.java
@@ -26,7 +26,8 @@ public class WorkflowWithDefaultRecoverStrategy extends Workflow<FailingCounterS
     return WorkflowSettings.builder()
         .defaultStepTimeout(ofSeconds(10))
         .defaultStepRecovery(
-            RecoverStrategy.maxRetries(1).failoverTo(WorkflowWithDefaultRecoverStrategy::counterStepFailover))
+            RecoverStrategy.maxRetries(1)
+                .failoverTo(WorkflowWithDefaultRecoverStrategy::counterStepFailover))
         .build();
   }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithDefaultRecoverStrategy.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithDefaultRecoverStrategy.java
@@ -9,6 +9,7 @@ import static java.time.Duration.ofSeconds;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.Workflow.RecoverStrategy;
 import akkajavasdk.components.actions.echo.Message;
 
 @Component(id = "workflow-with-default-recover-strategy")
@@ -25,7 +26,7 @@ public class WorkflowWithDefaultRecoverStrategy extends Workflow<FailingCounterS
     return WorkflowSettings.builder()
         .defaultStepTimeout(ofSeconds(10))
         .defaultStepRecovery(
-            maxRetries(1).failoverTo(WorkflowWithDefaultRecoverStrategy::counterStepFailover))
+            RecoverStrategy.maxRetries(1).failoverTo(WorkflowWithDefaultRecoverStrategy::counterStepFailover))
         .build();
   }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithRecoverStrategy.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithRecoverStrategy.java
@@ -27,7 +27,8 @@ public class WorkflowWithRecoverStrategy extends Workflow<FailingCounterState> {
         .defaultStepTimeout(ofSeconds(10))
         .stepRecovery(
             WorkflowWithRecoverStrategy::counterStep,
-            RecoverStrategy.maxRetries(1).failoverTo(WorkflowWithRecoverStrategy::counterStepFailover))
+            RecoverStrategy.maxRetries(1)
+                .failoverTo(WorkflowWithRecoverStrategy::counterStepFailover))
         .build();
   }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithRecoverStrategy.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithRecoverStrategy.java
@@ -9,6 +9,7 @@ import static java.time.Duration.ofSeconds;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.Workflow.RecoverStrategy;
 import akkajavasdk.components.actions.echo.Message;
 
 @Component(id = "workflow-with-recover-strategy")
@@ -26,7 +27,7 @@ public class WorkflowWithRecoverStrategy extends Workflow<FailingCounterState> {
         .defaultStepTimeout(ofSeconds(10))
         .stepRecovery(
             WorkflowWithRecoverStrategy::counterStep,
-            maxRetries(1).failoverTo(WorkflowWithRecoverStrategy::counterStepFailover))
+            RecoverStrategy.maxRetries(1).failoverTo(WorkflowWithRecoverStrategy::counterStepFailover))
         .build();
   }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithStepTimeout.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/WorkflowWithStepTimeout.java
@@ -10,6 +10,7 @@ import static java.time.Duration.ofMillis;
 import akka.Done;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.Workflow.RecoverStrategy;
 import akkajavasdk.components.actions.echo.Message;
 
 @Component(id = "workflow-with-step-timeout")
@@ -21,7 +22,7 @@ public class WorkflowWithStepTimeout extends Workflow<FailingCounterState> {
         .defaultStepTimeout(ofMillis(20))
         .stepRecovery(
             WorkflowWithStepTimeout::counterStep,
-            maxRetries(1).failoverTo(WorkflowWithStepTimeout::counterFailover))
+            RecoverStrategy.maxRetries(1).failoverTo(WorkflowWithStepTimeout::counterFailover))
         .build();
   }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/legacy/WorkflowWithDefaultRecoverStrategy.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/legacy/WorkflowWithDefaultRecoverStrategy.java
@@ -9,6 +9,7 @@ import static java.time.Duration.ofSeconds;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.Workflow.RecoverStrategy;
 import akkajavasdk.components.actions.echo.Message;
 import akkajavasdk.components.workflowentities.FailingCounterEntity;
 import akkajavasdk.components.workflowentities.FailingCounterState;
@@ -49,7 +50,7 @@ public class WorkflowWithDefaultRecoverStrategy extends Workflow<FailingCounterS
     return workflow()
         .timeout(ofSeconds(30))
         .defaultStepTimeout(ofSeconds(10))
-        .defaultStepRecoverStrategy(maxRetries(1).failoverTo(counterFailoverStepName))
+        .defaultStepRecoverStrategy(RecoverStrategy.maxRetries(1).failoverTo(counterFailoverStepName))
         .addStep(counterInc)
         .addStep(counterIncFailover);
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/legacy/WorkflowWithDefaultRecoverStrategy.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/legacy/WorkflowWithDefaultRecoverStrategy.java
@@ -50,7 +50,8 @@ public class WorkflowWithDefaultRecoverStrategy extends Workflow<FailingCounterS
     return workflow()
         .timeout(ofSeconds(30))
         .defaultStepTimeout(ofSeconds(10))
-        .defaultStepRecoverStrategy(RecoverStrategy.maxRetries(1).failoverTo(counterFailoverStepName))
+        .defaultStepRecoverStrategy(
+            RecoverStrategy.maxRetries(1).failoverTo(counterFailoverStepName))
         .addStep(counterInc)
         .addStep(counterIncFailover);
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/legacy/WorkflowWithRecoverStrategy.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/legacy/WorkflowWithRecoverStrategy.java
@@ -9,6 +9,7 @@ import static java.time.Duration.ofSeconds;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.Workflow.RecoverStrategy;
 import akkajavasdk.components.actions.echo.Message;
 import akkajavasdk.components.workflowentities.FailingCounterEntity;
 import akkajavasdk.components.workflowentities.FailingCounterState;
@@ -49,7 +50,7 @@ public class WorkflowWithRecoverStrategy extends Workflow<FailingCounterState> {
     return workflow()
         .timeout(ofSeconds(30))
         .defaultStepTimeout(ofSeconds(10))
-        .addStep(counterInc, maxRetries(1).failoverTo(counterFailoverStepName))
+        .addStep(counterInc, RecoverStrategy.maxRetries(1).failoverTo(counterFailoverStepName))
         .addStep(counterIncFailover);
   }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/legacy/WorkflowWithRecoverStrategyAndAsyncCall.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/legacy/WorkflowWithRecoverStrategyAndAsyncCall.java
@@ -9,6 +9,7 @@ import static java.time.Duration.ofSeconds;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.Workflow.RecoverStrategy;
 import akkajavasdk.components.actions.echo.Message;
 import akkajavasdk.components.workflowentities.FailingCounterEntity;
 import akkajavasdk.components.workflowentities.FailingCounterState;
@@ -50,7 +51,7 @@ public class WorkflowWithRecoverStrategyAndAsyncCall extends Workflow<FailingCou
     return workflow()
         .timeout(ofSeconds(30))
         .defaultStepTimeout(ofSeconds(10))
-        .addStep(counterInc, maxRetries(1).failoverTo(counterFailoverStepName))
+        .addStep(counterInc, RecoverStrategy.maxRetries(1).failoverTo(counterFailoverStepName))
         .addStep(counterIncFailover);
   }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/legacy/WorkflowWithStepTimeout.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/legacy/WorkflowWithStepTimeout.java
@@ -9,6 +9,7 @@ import static java.time.Duration.ofSeconds;
 
 import akka.javasdk.annotations.Component;
 import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.Workflow.RecoverStrategy;
 import akkajavasdk.components.actions.echo.Message;
 import akkajavasdk.components.workflowentities.FailingCounterState;
 import java.util.concurrent.CompletableFuture;
@@ -55,7 +56,7 @@ public class WorkflowWithStepTimeout extends Workflow<FailingCounterState> {
     return workflow()
         .timeout(ofSeconds(8))
         .defaultStepTimeout(ofMillis(20))
-        .addStep(counterInc, maxRetries(1).failoverTo(counterFailoverStepName))
+        .addStep(counterInc, RecoverStrategy.maxRetries(1).failoverTo(counterFailoverStepName))
         .addStep(counterIncFailover);
   }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/legacy/WorkflowWithTimeout.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/workflowentities/legacy/WorkflowWithTimeout.java
@@ -10,6 +10,7 @@ import static java.time.Duration.ofSeconds;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.Workflow.RecoverStrategy;
 import akkajavasdk.components.actions.echo.Message;
 import akkajavasdk.components.workflowentities.FailingCounterEntity;
 import akkajavasdk.components.workflowentities.FailingCounterState;
@@ -59,8 +60,8 @@ public class WorkflowWithTimeout extends Workflow<FailingCounterState> {
     return workflow()
         .timeout(ofSeconds(1))
         .defaultStepTimeout(ofMillis(999))
-        .failoverTo(counterFailoverStepName, 3, maxRetries(1))
-        .addStep(counterInc, maxRetries(1).failoverTo(counterStepName))
+        .failoverTo(counterFailoverStepName, 3, RecoverStrategy.maxRetries(1))
+        .addStep(counterInc, RecoverStrategy.maxRetries(1).failoverTo(counterStepName))
         .addStep(counterIncFailover);
   }
 

--- a/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/workflow/Workflow.java
@@ -1450,7 +1450,9 @@ public abstract class Workflow<S> {
    *
    * @param maxRetries number of retries before giving up.
    * @return MaxRetries strategy.
+   * @deprecated Use the static method {@link RecoverStrategy#maxRetries(int)} instead.
    */
+  @Deprecated
   public MaxRetries maxRetries(int maxRetries) {
     return RecoverStrategy.maxRetries(maxRetries);
   }

--- a/akka-javasdk/src/test/java/akka/javasdk/workflow/WorkflowSettingsBuilderTest.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/workflow/WorkflowSettingsBuilderTest.java
@@ -31,7 +31,8 @@ public class WorkflowSettingsBuilderTest {
               RecoverStrategy.maxRetries(1).failoverTo(TestWorkflow::interruptStep))
           .stepTimeout(TestWorkflow::stepWithTimeout, Duration.ofSeconds(3))
           .stepRecovery(
-              TestWorkflow::stepWithRecovery, RecoverStrategy.maxRetries(1).failoverTo(TestWorkflow::interruptStep))
+              TestWorkflow::stepWithRecovery,
+              RecoverStrategy.maxRetries(1).failoverTo(TestWorkflow::interruptStep))
           .build();
     }
 

--- a/akka-javasdk/src/test/java/akka/javasdk/workflow/WorkflowSettingsBuilderTest.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/workflow/WorkflowSettingsBuilderTest.java
@@ -23,15 +23,15 @@ public class WorkflowSettingsBuilderTest {
           .stepTimeout(TestWorkflow::stepWithTimeoutAndRecovery, Duration.ofSeconds(3))
           .stepRecovery(
               TestWorkflow::stepWithTimeoutAndRecovery,
-              maxRetries(2).failoverTo(TestWorkflow::interruptStep))
+              RecoverStrategy.maxRetries(2).failoverTo(TestWorkflow::interruptStep))
           // redefine settings for stepWithTimeoutAndRecovery
           .stepTimeout(TestWorkflow::stepWithTimeoutAndRecovery, Duration.ofSeconds(4))
           .stepRecovery(
               TestWorkflow::stepWithTimeoutAndRecovery,
-              maxRetries(1).failoverTo(TestWorkflow::interruptStep))
+              RecoverStrategy.maxRetries(1).failoverTo(TestWorkflow::interruptStep))
           .stepTimeout(TestWorkflow::stepWithTimeout, Duration.ofSeconds(3))
           .stepRecovery(
-              TestWorkflow::stepWithRecovery, maxRetries(1).failoverTo(TestWorkflow::interruptStep))
+              TestWorkflow::stepWithRecovery, RecoverStrategy.maxRetries(1).failoverTo(TestWorkflow::interruptStep))
           .build();
     }
 

--- a/docs/src/modules/ROOT/attachments/AGENTS.md
+++ b/docs/src/modules/ROOT/attachments/AGENTS.md
@@ -270,8 +270,6 @@ private StepEffect compensateWithdrawStep() {
 }
 ```
 
-Note: `maxRetries()` for the WorkflowSettings is inherited from Workflow — NO static import needed
-
 ### Agent with Tools
 
 ```java

--- a/docs/src/modules/ROOT/attachments/AGENTS.md
+++ b/docs/src/modules/ROOT/attachments/AGENTS.md
@@ -72,7 +72,7 @@ Access these documentation files for detailed patterns:
 - Structured responses: use `responseConformsTo(Class)` (preferred) or `responseAs(Class)` with manual JSON instructions
 - Model config: prefer default in config, override with `.model(ModelProvider.openAi()...)` if needed
 - Error handling with `.onFailure(throwable -> fallbackValue)`
-- When calling from workflow: use long timeouts (60s), limited retries (maxRetries(2))
+- When calling from workflow: use long timeouts (60s), limited retries (RecoverStrategy.maxRetries(2))
 
 **Event Sourced Entity**
 - Extends `EventSourcedEntity<State, Event>`, has `@Component(id = "...")`
@@ -253,7 +253,7 @@ public WorkflowSettings settings() {
     .defaultStepTimeout(ofSeconds(2))
     .stepRecovery(
       TransferWorkflow::depositStep,
-      maxRetries(2).failoverTo(TransferWorkflow::compensateWithdrawStep))
+      RecoverStrategy.maxRetries(2).failoverTo(TransferWorkflow::compensateWithdrawStep))
     .build();
 }
 
@@ -324,7 +324,7 @@ public class AgentTeamWorkflow extends Workflow<AgentTeamWorkflow.State> {
   public WorkflowSettings settings() {
     return WorkflowSettings.builder()
       .stepTimeout(AgentTeamWorkflow::askWeather, ofSeconds(60)) // Long timeout for AI
-      .defaultStepRecovery(maxRetries(2).failoverTo(AgentTeamWorkflow::errorStep))
+      .defaultStepRecovery(RecoverStrategy.maxRetries(2).failoverTo(AgentTeamWorkflow::errorStep))
       .build();
   }
 
@@ -396,7 +396,7 @@ public class DynamicAgentWorkflow extends Workflow<DynamicAgentWorkflow.State> {
   public WorkflowSettings settings() {
     return WorkflowSettings.builder()
       .defaultStepTimeout(ofSeconds(60))
-      .defaultStepRecovery(maxRetries(1).failoverTo(DynamicAgentWorkflow::summarizeStep))
+      .defaultStepRecovery(RecoverStrategy.maxRetries(1).failoverTo(DynamicAgentWorkflow::summarizeStep))
       .build();
   }
 
@@ -621,7 +621,7 @@ public class MyEndpointIntegrationTest extends TestKitSupport {
 - Create multiple command handlers in Agent
 - Return protobuf types from domain layer
 - Import `WorkflowSettings` -> WorkflowSettings is an inner class of Workflow, so no additional import is needed
-- Static import `maxRetries` -> `maxRetries()` is inherited from `Workflow`, just call it directly without any import
+- Static import `maxRetries` -> use `RecoverStrategy.maxRetries()` (import `Workflow.RecoverStrategy`)
 
 ✅ **DO:**
 - Use Java records for immutable data

--- a/docs/src/modules/sdk/pages/agents/calling.adoc
+++ b/docs/src/modules/sdk/pages/agents/calling.adoc
@@ -54,7 +54,7 @@ Additionally, you should define a workflow recovery strategy so that it doesn't 
 
 [source,java,indent=0]
 ----
-.defaultStepRecovery(maxRetries(2).failoverTo(ActivityAgentManager::error))
+.defaultStepRecovery(RecoverStrategy.maxRetries(2).failoverTo(ActivityAgentManager::error))
 ----
 
 More details in xref:workflows.adoc#_error_handling[Workflow timeouts and recovery strategy].

--- a/samples/doc-snippets/src/main/java/agent_guide/part4/AgentTeamWorkflow.java
+++ b/samples/doc-snippets/src/main/java/agent_guide/part4/AgentTeamWorkflow.java
@@ -10,6 +10,7 @@ import akka.javasdk.annotations.Component;
 import akka.javasdk.annotations.StepName;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.Workflow.RecoverStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +56,7 @@ public class AgentTeamWorkflow extends Workflow<AgentTeamWorkflow.State> {
     return WorkflowSettings.builder()
       .stepTimeout(AgentTeamWorkflow::askWeather, ofSeconds(60))
       .stepTimeout(AgentTeamWorkflow::suggestActivities, ofSeconds(60))
-      .defaultStepRecovery(maxRetries(2).failoverTo(AgentTeamWorkflow::error))
+      .defaultStepRecovery(RecoverStrategy.maxRetries(2).failoverTo(AgentTeamWorkflow::error))
       .build();
   }
 

--- a/samples/doc-snippets/src/main/java/com/example/application/ActivityAgentManager.java
+++ b/samples/doc-snippets/src/main/java/com/example/application/ActivityAgentManager.java
@@ -7,6 +7,7 @@ import akka.javasdk.annotations.Component;
 import akka.javasdk.annotations.StepName;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.Workflow.RecoverStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,7 @@ public class ActivityAgentManager extends Workflow<ActivityAgentManager.State> {
   public WorkflowSettings settings() { // <6>
     return WorkflowSettings.builder()
       .stepTimeout(ActivityAgentManager::suggestActivities, ofSeconds(60))
-      .defaultStepRecovery(maxRetries(2).failoverTo(ActivityAgentManager::error))
+      .defaultStepRecovery(RecoverStrategy.maxRetries(2).failoverTo(ActivityAgentManager::error))
       .build();
   }
 

--- a/samples/doc-snippets/src/main/java/com/example/application/ActivityAgentManager.java
+++ b/samples/doc-snippets/src/main/java/com/example/application/ActivityAgentManager.java
@@ -54,7 +54,9 @@ public class ActivityAgentManager extends Workflow<ActivityAgentManager.State> {
   public WorkflowSettings settings() { // <6>
     return WorkflowSettings.builder()
       .stepTimeout(ActivityAgentManager::suggestActivities, ofSeconds(60))
-      .defaultStepRecovery(RecoverStrategy.maxRetries(2).failoverTo(ActivityAgentManager::error))
+      .defaultStepRecovery(
+        RecoverStrategy.maxRetries(2).failoverTo(ActivityAgentManager::error)
+      )
       .build();
   }
 

--- a/samples/doc-snippets/src/main/java/com/example/application/AgentTeamWorkflow.java
+++ b/samples/doc-snippets/src/main/java/com/example/application/AgentTeamWorkflow.java
@@ -7,6 +7,7 @@ import akka.javasdk.annotations.Component;
 import akka.javasdk.annotations.StepName;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.Workflow.RecoverStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,7 @@ public class AgentTeamWorkflow extends Workflow<AgentTeamWorkflow.State> {
     return WorkflowSettings.builder()
       .stepTimeout(AgentTeamWorkflow::askWeather, ofSeconds(60))
       .stepTimeout(AgentTeamWorkflow::suggestActivities, ofSeconds(60))
-      .defaultStepRecovery(maxRetries(2).failoverTo(AgentTeamWorkflow::error))
+      .defaultStepRecovery(RecoverStrategy.maxRetries(2).failoverTo(AgentTeamWorkflow::error))
       .build();
   }
 

--- a/samples/multi-agent/src/main/java/demo/multiagent/application/AgentTeamWorkflow.java
+++ b/samples/multi-agent/src/main/java/demo/multiagent/application/AgentTeamWorkflow.java
@@ -13,6 +13,7 @@ import akka.javasdk.annotations.StepName;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.client.DynamicMethodRef;
 import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.Workflow.RecoverStrategy;
 import akka.stream.Materializer;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -126,10 +127,10 @@ public class AgentTeamWorkflow extends Workflow<AgentTeamWorkflow.State> { // <1
   public WorkflowSettings settings() {
     return WorkflowSettings.builder()
       .defaultStepTimeout(ofSeconds(30))
-      .defaultStepRecovery(maxRetries(1).failoverTo(AgentTeamWorkflow::interruptStep))
+      .defaultStepRecovery(RecoverStrategy.maxRetries(1).failoverTo(AgentTeamWorkflow::interruptStep))
       .stepRecovery(
         AgentTeamWorkflow::selectAgentsStep,
-        maxRetries(1).failoverTo(AgentTeamWorkflow::summarizeStep)
+        RecoverStrategy.maxRetries(1).failoverTo(AgentTeamWorkflow::summarizeStep)
       )
       .build();
   }

--- a/samples/multi-agent/src/main/java/demo/multiagent/application/AgentTeamWorkflow.java
+++ b/samples/multi-agent/src/main/java/demo/multiagent/application/AgentTeamWorkflow.java
@@ -127,7 +127,9 @@ public class AgentTeamWorkflow extends Workflow<AgentTeamWorkflow.State> { // <1
   public WorkflowSettings settings() {
     return WorkflowSettings.builder()
       .defaultStepTimeout(ofSeconds(30))
-      .defaultStepRecovery(RecoverStrategy.maxRetries(1).failoverTo(AgentTeamWorkflow::interruptStep))
+      .defaultStepRecovery(
+        RecoverStrategy.maxRetries(1).failoverTo(AgentTeamWorkflow::interruptStep)
+      )
       .stepRecovery(
         AgentTeamWorkflow::selectAgentsStep,
         RecoverStrategy.maxRetries(1).failoverTo(AgentTeamWorkflow::summarizeStep)

--- a/samples/transfer-workflow-compensation/src/main/java/com/example/transfer/application/TransferWorkflow.java
+++ b/samples/transfer-workflow-compensation/src/main/java/com/example/transfer/application/TransferWorkflow.java
@@ -16,6 +16,7 @@ import akka.Done;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.Workflow.RecoverStrategy;
 import com.example.transfer.domain.TransferState;
 import com.example.transfer.domain.TransferState.Transfer;
 import com.example.wallet.application.WalletEntity;
@@ -55,10 +56,10 @@ public class TransferWorkflow extends Workflow<TransferState> {
       .stepTimeout(TransferWorkflow::failoverHandlerStep, ofSeconds(1)) // <3>
       // end::step-timeout[]
       // tag::recover-strategy[]
-      .defaultStepRecovery(maxRetries(1).failoverTo(TransferWorkflow::failoverHandlerStep)) // <1>
+      .defaultStepRecovery(RecoverStrategy.maxRetries(1).failoverTo(TransferWorkflow::failoverHandlerStep)) // <1>
       .stepRecovery(
         TransferWorkflow::depositStep,
-        maxRetries(2).failoverTo(TransferWorkflow::compensateWithdrawStep)
+        RecoverStrategy.maxRetries(2).failoverTo(TransferWorkflow::compensateWithdrawStep)
       ) // <2>
       // tag::step-timeout[]
       .build();

--- a/samples/transfer-workflow-compensation/src/main/java/com/example/transfer/application/TransferWorkflow.java
+++ b/samples/transfer-workflow-compensation/src/main/java/com/example/transfer/application/TransferWorkflow.java
@@ -56,7 +56,9 @@ public class TransferWorkflow extends Workflow<TransferState> {
       .stepTimeout(TransferWorkflow::failoverHandlerStep, ofSeconds(1)) // <3>
       // end::step-timeout[]
       // tag::recover-strategy[]
-      .defaultStepRecovery(RecoverStrategy.maxRetries(1).failoverTo(TransferWorkflow::failoverHandlerStep)) // <1>
+      .defaultStepRecovery(
+        RecoverStrategy.maxRetries(1).failoverTo(TransferWorkflow::failoverHandlerStep)
+      ) // <1>
       .stepRecovery(
         TransferWorkflow::depositStep,
         RecoverStrategy.maxRetries(2).failoverTo(TransferWorkflow::compensateWithdrawStep)


### PR DESCRIPTION
We have seen that code assistants get confused with the static `RecoveryStrategy.maxRetries` and the `Workflow.maxRetries`. 

`RecoveryStrategy.maxRetries` is a legacy method that were useful with the old Workflow API.  

This PR deprecates the static one..