### PR TITLE
Docs: rewrite llms.txt per llmstxt.org standard

### DIFF
--- a/docs/src/modules/sdk/nav.adoc
+++ b/docs/src/modules/sdk/nav.adoc
@@ -42,7 +42,6 @@
 *** xref:sdk:integrations/apis-and-protocols.adoc[]
 *** xref:sdk:integrations/identity-and-security.adoc[]
 *** xref:sdk:integrations/observability.adoc[]
-*** xref:sdk:message-brokers.adoc[]
 *** xref:sdk:streaming.adoc[]
 ** xref:sdk:setup-and-configuration/index.adoc[]
 *** xref:sdk:setup-and-dependency-injection.adoc[]


### PR DESCRIPTION
## Summary

Depends on #1454 (use cases PR).

Rewrites the hand-maintained `llms.txt` to follow the llmstxt.org specification:

- **H1 + blockquote** with elevator pitch
- **Positioning paragraphs** — three barriers, three dimensions, key differentiators, personas, competitive landscape
- **H2 sections as link indexes** — Getting Started, SDK Components, Use Cases, Concepts, Operating, Reference
- **## Optional section** — customer stories, Reactive Manifesto, Reactive Principles, Akkademy, blog, cross-reference to corporate llms.txt
- **Examples section** preserved with all sample projects

Note: This is an interim hand-maintained file. Per the spec, it should eventually be auto-generated at build time from page metadata attributes.

## Test plan

- [ ] Antora build succeeds
- [ ] llms.txt is accessible at the expected path
- [ ] All links in llms.txt point to valid .html.md paths
- [ ] Positioning context is practitioner-filtered (no buying personas, pricing, partners)
- [ ] ## Optional section contains supplementary content that agents can skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)