### PR TITLE
feat: TestNotificationPublisher for EventSourcedTestKit

### DIFF
--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventSourcedTestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventSourcedTestKit.java
@@ -25,7 +25,8 @@ import java.util.function.Supplier;
  * EventSourcedTestKit.of} methods. The returned testkit is stateful, and it holds internally the
  * state of the entity.
  *
- * The {@link TestNotificationPublisher} can be used when entity constructor requires {@link akka.javasdk.NotificationPublisher}.
+ * <p>The {@link TestNotificationPublisher} can be used when entity constructor requires {@link
+ * akka.javasdk.NotificationPublisher}.
  *
  * <p>Use the {@code call} methods to interact with the testkit.
  */

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestNotificationPublisher.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestNotificationPublisher.java
@@ -5,7 +5,6 @@
 package akka.javasdk.testkit;
 
 import akka.javasdk.NotificationPublisher;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
refs: [#4931](https://github.com/lightbend/akka-runtime/issues/4931)
Tested and Claude was able to figure out that it can use TestNotificationPublisher only by reading the sources jar. Adding the comment in EventSourcedTestKit improves the search.
