### PR TITLE
build: silence some sbt unused key linting

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,7 +1,7 @@
 import akka.grpc.sbt.AkkaGrpcPlugin
 import sbt.*
 import sbt.Keys.*
-import de.heikoseeberger.sbtheader.{AutomateHeaderPlugin, HeaderPlugin}
+import de.heikoseeberger.sbtheader.{ AutomateHeaderPlugin, HeaderPlugin }
 import org.scalafmt.sbt.ScalafmtPlugin
 import org.scalafmt.sbt.ScalafmtPlugin.autoImport.scalafmtOnCompile
 import sbtprotoc.ProtocPlugin


### PR DESCRIPTION
Doesn't seem important and is annoying to have printed on each sbt start