### PR TITLE
Add containerized dev environment docs page

### DIFF
--- a/docs/src/modules/getting-started/nav.adoc
+++ b/docs/src/modules/getting-started/nav.adoc
@@ -18,4 +18,5 @@
 ** xref:getting-started:shopping-cart/index.adoc[Shopping cart]
 *** xref:getting-started:shopping-cart/build-and-deploy-shopping-cart.adoc[]
 *** xref:getting-started:shopping-cart/addview.adoc[]
+** xref:getting-started:dev-container.adoc[Containerized dev environment]
 ** xref:getting-started:samples.adoc[]

--- a/docs/src/modules/getting-started/pages/dev-container.adoc
+++ b/docs/src/modules/getting-started/pages/dev-container.adoc
@@ -1,0 +1,102 @@
+= Containerized dev environment
+:page-summary: Get started with Akka using a pre-built Docker container, no local Java, Maven, or CLI installation required.
+:page-persona: builder-developer, builder-ai-ml
+
+include::ROOT:partial$include.adoc[]
+
+If you want to try Akka without installing Java, Maven, and the Akka CLI on your machine, the Akka dev container gives you a ready-to-use environment inside Docker. It bundles everything you need: Java {java-version}, Maven, the Akka CLI, and pre-cached SDK dependencies. You can start building in minutes.
+
+TIP: The dev container is ideal for getting started quickly. For long-term development, we recommend installing the tools directly on your machine. See xref:getting-started:index.adoc[] for the standard setup path.
+
+== Prerequisites
+
+* https://www.docker.com/products/docker-desktop/[Docker Desktop, window="new"]
+* An link:https://account.akka.io/token[Akka download token, window="new"] (free, used to download SDK dependencies)
+
+== Set environment variables
+
+The Akka download token is required. AI provider keys are optional and only needed if you plan to build agent samples.
+
+[source,bash]
+----
+export AKKA_RESOLVER_TOKEN=<your-token>       # required
+export GOOGLE_AI_GEMINI_API_KEY=<your-key>    # optional, for agent samples
+export ANTHROPIC_API_KEY=<your-key>           # optional, for agent samples
+export OPENAI_API_KEY=<your-key>              # optional, for agent samples
+----
+
+== Create a project and start the container
+
+. Use the Akka CLI to create a new project from a sample:
++
+[source,bash]
+----
+akka code init --name helloworld-agent --repo akka-samples/helloworld-agent.git
+----
++
+. Start the dev container with the project directory mounted:
++
+[source,bash]
+----
+docker run -d --name akka-dev \
+  -v "$(pwd)/helloworld-agent":/workspace \
+  -p 9000:9000 \
+  -p 9889:9889 \
+  -e AKKA_RESOLVER_TOKEN \
+  -e GOOGLE_AI_GEMINI_API_KEY \
+  -e ANTHROPIC_API_KEY \
+  -e OPENAI_API_KEY \
+  jaydeeeee/akka-dev:latest
+----
++
+This starts the container in the background with two forwarded ports:
++
+* `localhost:9000` for your Akka service endpoint
+* `localhost:9889` for the Akka local console
+
+== Run the service
+
+All build commands run inside the container using `docker exec`. Your files are on the host. You edit them with your normal editor, and the container picks up changes immediately through the bind mount.
+
+Run the service:
+
+[source,bash]
+----
+docker exec -w /workspace akka-dev mvn compile exec:java
+----
+
+Once the service is running, test it from your host:
+
+[source,bash]
+----
+curl -i -XPOST http://localhost:9000/hello \
+  --header "Content-Type: application/json" \
+  --data '{"user": "alice", "text": "Hello, I am Alice"}'
+----
+
+== Start the local console
+
+The Akka local console provides a web UI for inspecting your running service. Start it with:
+
+[source,bash]
+----
+docker exec -t -w /workspace akka-dev akka local console --bind-address 0.0.0.0
+----
+
+Then open http://localhost:9889[localhost:9889, window="new"] in your browser.
+
+== How it works
+
+**Host-mounted workspace**:: Your project directory is bind-mounted to `/workspace` in the container. You edit files on the host, the container runs builds. No file syncing needed.
+
+**Pre-cached dependencies**:: Most Akka SDK dependencies are baked into the image, significantly reducing download times on first run.
+
+**Forwarded ports**:: Port `9000` (Akka service) and `9889` (local console) are exposed to your host machine.
+
+== Next steps
+
+Once you are comfortable with Akka, install the tools directly on your machine for the best development experience:
+
+* xref:getting-started:quick-install-cli.adoc[Install the Akka CLI]
+* Follow the xref:getting-started:author-your-first-service.adoc[Hello world agent] tutorial
+* Explore xref:sdk:spec-driven-development.adoc[Spec-Driven Development] for AI-assisted workflows

--- a/docs/src/modules/getting-started/pages/dev-container.adoc
+++ b/docs/src/modules/getting-started/pages/dev-container.adoc
@@ -46,7 +46,7 @@ docker run -d --name akka-dev \
   -e GOOGLE_AI_GEMINI_API_KEY \
   -e ANTHROPIC_API_KEY \
   -e OPENAI_API_KEY \
-  jaydeeeee/akka-dev:latest
+  registry.akka.io/akka-dev-container:latest
 ----
 +
 This starts the container in the background with two forwarded ports:


### PR DESCRIPTION
## Summary
- Add a new getting-started page documenting the pre-built Docker dev container
- The container bundles Java, Maven, and the Akka CLI with pre-cached SDK dependencies
- Provides an alternative setup path for users who want to try Akka without installing dependencies locally
- Add navigation entry under Getting Started > Tutorials

Open TODOs
- [x] Move the Docker Image to a Container Registry managed by Akka
