### PR TITLE
doc: improved AGENTS.md regarding http endpoints

### DIFF
--- a/docs/src/modules/ROOT/attachments/AGENTS.md
+++ b/docs/src/modules/ROOT/attachments/AGENTS.md
@@ -486,6 +486,11 @@ public class CounterToTopicConsumer extends Consumer {
   }
 }
 ```
+### HTTP Endpoints
+
+Favor endpoint APIs that follow REST principles. 
+
+When an HTTP method returns an `akka.http.javadsl.model.HttpResponse` instead of a custom type and it can return errors, avoid throwing exceptions. Instead, use HTTP error response methods such as `akka.javasdk.http.HttpResponses.badRequest` or `akka.javasdk.http.HttpResponses.notFound`.
 
 ### Endpoint with web UI
 
@@ -679,4 +684,3 @@ Before presenting code, verify:
 - [ ] View tests use event publishing + `Awaitility`
 - [ ] Endpoint tests use `httpClient` not `componentClient`
 - [ ] Agent tests use `TestModelProvider` with `.fixedResponse()` or `.whenMessage()`
-


### PR DESCRIPTION
Notice that even when returning HttpResponse, code assistant will favour throwing exceptions with `HttpException.badRequest`. It's preferable to return `HttpResponses.badRequest`. 

The stack trace is of no use in such a case.