### PR TITLE
fix: avoid creating agentCapabilityConverter early

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/CoordinatorAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/CoordinatorAgent.java
@@ -9,20 +9,9 @@ import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.agent.autonomous.capability.Delegation;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
-import akka.javasdk.client.ComponentClient;
 
 @Component(id = "coordinator-agent")
 public class CoordinatorAgent extends AutonomousAgent {
-
-  // Injected to exercise the SdkRunner scan-time wiring path: a ComponentClient
-  // dependency on a non-last-scanned AutonomousAgent used to force the lazy
-  // capability converter mid-scan, snapshotting an incomplete agent registry.
-  @SuppressWarnings("unused")
-  private final ComponentClient componentClient;
-
-  public CoordinatorAgent(ComponentClient componentClient) {
-    this.componentClient = componentClient;
-  }
 
   @Override
   public AgentDefinition definition() {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/CoordinatorAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/CoordinatorAgent.java
@@ -9,9 +9,20 @@ import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.agent.autonomous.capability.Delegation;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
+import akka.javasdk.client.ComponentClient;
 
 @Component(id = "coordinator-agent")
 public class CoordinatorAgent extends AutonomousAgent {
+
+  // Injected to exercise the SdkRunner scan-time wiring path: a ComponentClient
+  // dependency on a non-last-scanned AutonomousAgent used to force the lazy
+  // capability converter mid-scan, snapshotting an incomplete agent registry.
+  @SuppressWarnings("unused")
+  private final ComponentClient componentClient;
+
+  public CoordinatorAgent(ComponentClient componentClient) {
+    this.componentClient = componentClient;
+  }
 
   @Override
   public AgentDefinition definition() {

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestAutonomousAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestAutonomousAgent.java
@@ -8,9 +8,20 @@ import akka.javasdk.agent.autonomous.AgentDefinition;
 import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
+import akka.javasdk.client.ComponentClient;
 
 @Component(id = "test-autonomous-agent")
 public class TestAutonomousAgent extends AutonomousAgent {
+
+  // Injected to exercise the SdkRunner scan-time wiring path: a ComponentClient
+  // dependency on a non-last-scanned AutonomousAgent used to force the lazy
+  // capability converter mid-scan, snapshotting an incomplete agent registry.
+  @SuppressWarnings("unused")
+  private final ComponentClient componentClient;
+
+  public TestAutonomousAgent(ComponentClient componentClient) {
+    this.componentClient = componentClient;
+  }
 
   @Override
   public AgentDefinition definition() {

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -552,20 +552,22 @@ private final class Sdk(
   }
 
   // Restricted injector for the throwaway temp instance used to read definition().
-  // Supplies a ComponentClient that does NOT reference agentCapabilityConverter,
-  // so reading definition() cannot force the lazy val with an incomplete registry.
+  // The supplied dependencies are never invoked (the temp instance is discarded),
+  // so they must not touch lazy state still being populated by the scanning loop
+  // (agentCapabilityConverter, agentRegistry).
   private def scanTimeAutonomousAgentInjects: PartialFunction[Class[_], Any] = {
     val scanTimeComponentClient: ComponentClient =
       ComponentClientImpl(
         runtimeComponentClients,
         serializer,
-        agentRegistry.agentClassById,
+        agentClassById = Map.empty,
         agentCapabilityConverter = None,
         telemetryContext = None)(sdkExecutionContext, system)
+    val scanTimeAgentRegistry: AgentRegistry = new AgentRegistryImpl(Set.empty)
 
     val overrides: PartialFunction[Class[_], Any] = {
-      case p if p == classOf[ComponentClient] =>
-        scanTimeComponentClient
+      case p if p == classOf[ComponentClient] => scanTimeComponentClient
+      case r if r == classOf[AgentRegistry]   => scanTimeAgentRegistry
     }
     overrides.orElse(sideEffectingComponentInjects(None))
   }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -539,7 +539,8 @@ private final class Sdk(
   // guardrail name => component ids
   private var guardrailEnabledForComponent = Map.empty[String, Set[String]]
 
-  /** Lazy capability converter — constructed on first use, after all autonomous agents are registered. */
+  // Lazy: snapshots the var registries above. Must not be forced before scanning
+  // completes; see scanTimeAutonomousAgentInjects for the only scan-time path.
   private lazy val agentCapabilityConverter: CapabilityConverter = {
     val autonomousConfig = applicationConfig.getConfig("akka.javasdk.agent.autonomous")
     new CapabilityConverter(
@@ -548,6 +549,25 @@ private final class Sdk(
       requestBasedAgentDescriptors = agentDescriptors,
       defaultMaxIterationsPerTask = autonomousConfig.getInt("max-iterations-per-task"),
       defaultMaxParallelWorkers = autonomousConfig.getInt("delegation.max-parallel-workers"))
+  }
+
+  // Restricted injector for the throwaway temp instance used to read definition().
+  // Supplies a ComponentClient that does NOT reference agentCapabilityConverter,
+  // so reading definition() cannot force the lazy val with an incomplete registry.
+  private def scanTimeAutonomousAgentInjects: PartialFunction[Class[_], Any] = {
+    val scanTimeComponentClient: ComponentClient =
+      ComponentClientImpl(
+        runtimeComponentClients,
+        serializer,
+        agentRegistry.agentClassById,
+        agentCapabilityConverter = None,
+        telemetryContext = None)(sdkExecutionContext, system)
+
+    val overrides: PartialFunction[Class[_], Any] = {
+      case p if p == classOf[ComponentClient] =>
+        scanTimeComponentClient
+    }
+    overrides.orElse(sideEffectingComponentInjects(None))
   }
 
   private def isProvided(clz: Class[_]): Boolean = {
@@ -776,10 +796,11 @@ private final class Sdk(
             guardrailEnabledForComponent.getOrElse(guardrailName, Set.empty) + componentId)
         }
 
-        // Definition is required for AutonomousAgent — instantiate to read it
+        // Throwaway instance to read definition() — uses scan-time injects so
+        // ComponentClient injection cannot force agentCapabilityConverter mid-scan.
         val agentDefinition: AgentDefinitionImpl = {
           val tempAgent = wiredInstance("AutonomousAgent", autonomousAgentClass) {
-            sideEffectingComponentInjects(None)
+            scanTimeAutonomousAgentInjects
           }
           tempAgent.definition() match {
             case impl: AgentDefinitionImpl =>

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AutonomousAgentClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AutonomousAgentClientImpl.scala
@@ -24,8 +24,8 @@ import akka.javasdk.impl.agent.autonomous.CapabilityConverter
 import akka.javasdk.impl.serialization.Serializer
 import akka.runtime.sdk.spi.SpiAutonomousAgent.{ Notification => SpiNotification }
 import akka.runtime.sdk.spi.{ ComponentClients => RuntimeComponentClients }
-import akka.stream.javadsl.Source
 import akka.stream.Materializer
+import akka.stream.javadsl.Source
 import org.slf4j.LoggerFactory
 
 /**

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/CapabilityConverterSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/CapabilityConverterSpec.scala
@@ -231,4 +231,5 @@ class CapabilityConverterSpec extends AnyWordSpec with Matchers {
       teamLead.memberTypes(1).maxInstances shouldBe 1
     }
   }
+
 }


### PR DESCRIPTION
If an agent injected component client it would initialize agentCapabilityConverter before the descriptors and autonomousAgentDefinitionMap was initialized and see things as if there were no autonomous agents defined.

References https://github.com/lightbend/akka-runtime/issues/4836
