### PR TITLE
feat: autonomous agent moderation capability

### DIFF
--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestModelProvider.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestModelProvider.java
@@ -514,79 +514,13 @@ public final class TestModelProvider implements ModelProvider.Custom {
 
     private AutonomousAgentTools() {}
 
-    // --- Tool name constants ---
+    // --- Task lifecycle ---
 
     /** Tool name for completing a task. */
     public static final String COMPLETE_TASK = "complete_task";
 
     /** Tool name for failing a task. */
     public static final String FAIL_TASK = "fail_task";
-
-    /** Tool name for creating a team. */
-    public static final String CREATE_TEAM = "create_team";
-
-    /** Tool name for getting team status. */
-    public static final String GET_TEAM_STATUS = "get_team_status";
-
-    /** Tool name for disbanding a team. */
-    public static final String DISBAND_TEAM = "disband_team";
-
-    /** Tool name for getting managed backlog status (lead side). */
-    public static final String GET_MANAGED_BACKLOG_STATUS = "get_managed_backlog_status";
-
-    /** Tool name for cancelling unclaimed tasks from backlog (lead side). */
-    public static final String CANCEL_UNCLAIMED_TASKS_FROM_BACKLOG =
-        "cancel_unclaimed_tasks_from_backlog";
-
-    /** Tool name for getting backlog status (member side). */
-    public static final String GET_BACKLOG_STATUS = "get_backlog_status";
-
-    /** Tool name for claiming a task (member side). */
-    public static final String CLAIM_TASK = "claim_task";
-
-    /** Tool name for releasing a task (member side). */
-    public static final String RELEASE_TASK = "release_task";
-
-    /** Tool name for transferring a task (member side). */
-    public static final String TRANSFER_TASK = "transfer_task";
-
-    /** Tool name for sending a message. */
-    public static final String SEND_MESSAGE = "send_message";
-
-    /**
-     * Returns the tool name for a {@code handoff_to_<agent>} tool, derived from the target agent's
-     * component ID.
-     */
-    public static String handoffToToolName(Class<?> agentClass) {
-      return "handoff_to_" + sanitize(componentId(agentClass));
-    }
-
-    /**
-     * Returns the tool name for a {@code delegate_<task>_to_<agent>} tool, derived from the task
-     * definition and target agent's component ID.
-     */
-    public static String delegateToToolName(TaskDefinition<?> task, Class<?> agentClass) {
-      return "delegate_" + sanitize(task.name()) + "_to_" + sanitize(componentId(agentClass));
-    }
-
-    /**
-     * Returns the tool name for a {@code create_<taskType>_task_for_backlog} tool, derived from the
-     * task definition name.
-     */
-    public static String createTaskForBacklogToolName(TaskDefinition<?> task) {
-      return "create_" + sanitize(task.name()) + "_task_for_backlog";
-    }
-
-    /**
-     * Returns the tool name for a {@code send_<Method>_to_<agent>} tool, derived from the method
-     * name and target agent's component ID.
-     */
-    public static String sendToToolName(Class<?> agentClass, String methodName) {
-      var capitalizedMethod = Character.toUpperCase(methodName.charAt(0)) + methodName.substring(1);
-      return "send_" + sanitize(capitalizedMethod) + "_to_" + sanitize(componentId(agentClass));
-    }
-
-    // --- Tool invocation request factory methods ---
 
     /**
      * Creates a {@link ToolInvocationRequest} for the {@code complete_task} tool, with the given
@@ -618,6 +552,16 @@ public final class TestModelProvider implements ModelProvider.Custom {
       return new ToolInvocationRequest("fail_task", "{\"reason\":" + toJsonString(reason) + "}");
     }
 
+    // --- Handoff ---
+
+    /**
+     * Returns the tool name for a {@code handoff_to_<agent>} tool, derived from the target agent's
+     * component ID.
+     */
+    public static String handoffToToolName(Class<?> agentClass) {
+      return "handoff_to_" + sanitize(componentId(agentClass));
+    }
+
     /**
      * Creates a {@link ToolInvocationRequest} for a {@code handoff_to_<agent>} tool, deriving the
      * tool name from the target agent's component ID.
@@ -629,6 +573,25 @@ public final class TestModelProvider implements ModelProvider.Custom {
     public static ToolInvocationRequest handoffTo(Class<?> agentClass, String context) {
       var toolName = "handoff_to_" + sanitize(componentId(agentClass));
       return new ToolInvocationRequest(toolName, "{\"context\":" + toJsonString(context) + "}");
+    }
+
+    // --- Delegation ---
+
+    /**
+     * Returns the tool name for a {@code delegate_<task>_to_<agent>} tool, derived from the task
+     * definition and target agent's component ID.
+     */
+    public static String delegateToToolName(TaskDefinition<?> task, Class<?> agentClass) {
+      return "delegate_" + sanitize(task.name()) + "_to_" + sanitize(componentId(agentClass));
+    }
+
+    /**
+     * Returns the tool name for a {@code send_<Method>_to_<agent>} tool, derived from the method
+     * name and target agent's component ID.
+     */
+    public static String sendToToolName(Class<?> agentClass, String methodName) {
+      var capitalizedMethod = Character.toUpperCase(methodName.charAt(0)) + methodName.substring(1);
+      return "send_" + sanitize(capitalizedMethod) + "_to_" + sanitize(componentId(agentClass));
     }
 
     /**
@@ -683,6 +646,15 @@ public final class TestModelProvider implements ModelProvider.Custom {
     }
 
     // --- Team capability ---
+
+    /** Tool name for creating a team. */
+    public static final String CREATE_TEAM = "create_team";
+
+    /** Tool name for getting team status. */
+    public static final String GET_TEAM_STATUS = "get_team_status";
+
+    /** Tool name for disbanding a team. */
+    public static final String DISBAND_TEAM = "disband_team";
 
     /** Specifies a team member type and count for a {@code create_team} tool invocation. */
     public record TeamMemberSpec(Class<?> agentClass, int count) {
@@ -745,6 +717,21 @@ public final class TestModelProvider implements ModelProvider.Custom {
     }
 
     // --- Backlog capability (managed/orchestrator side) ---
+
+    /** Tool name for getting managed backlog status (lead side). */
+    public static final String GET_MANAGED_BACKLOG_STATUS = "get_managed_backlog_status";
+
+    /** Tool name for cancelling unclaimed tasks from backlog (lead side). */
+    public static final String CANCEL_UNCLAIMED_TASKS_FROM_BACKLOG =
+        "cancel_unclaimed_tasks_from_backlog";
+
+    /**
+     * Returns the tool name for a {@code create_<taskType>_task_for_backlog} tool, derived from the
+     * task definition name.
+     */
+    public static String createTaskForBacklogToolName(TaskDefinition<?> task) {
+      return "create_" + sanitize(task.name()) + "_task_for_backlog";
+    }
 
     /**
      * Creates a {@link ToolInvocationRequest} for a {@code create_<taskType>_task_for_backlog}
@@ -852,6 +839,18 @@ public final class TestModelProvider implements ModelProvider.Custom {
     }
 
     // --- Backlog capability (worker/consumer side) ---
+
+    /** Tool name for getting backlog status (member side). */
+    public static final String GET_BACKLOG_STATUS = "get_backlog_status";
+
+    /** Tool name for claiming a task (member side). */
+    public static final String CLAIM_TASK = "claim_task";
+
+    /** Tool name for releasing a task (member side). */
+    public static final String RELEASE_TASK = "release_task";
+
+    /** Tool name for transferring a task (member side). */
+    public static final String TRANSFER_TASK = "transfer_task";
 
     /**
      * Creates a {@link ToolInvocationRequest} for the {@code get_backlog_status} tool. The {@code
@@ -962,6 +961,9 @@ public final class TestModelProvider implements ModelProvider.Custom {
 
     // --- Messaging capability ---
 
+    /** Tool name for sending a message. */
+    public static final String SEND_MESSAGE = "send_message";
+
     /**
      * Creates a {@link ToolInvocationRequest} for the fixed {@code send_message} tool.
      *
@@ -970,6 +972,176 @@ public final class TestModelProvider implements ModelProvider.Custom {
     public static ToolInvocationRequest sendMessage(String message) {
       return new ToolInvocationRequest(
           "send_message", "{\"message\":" + toJsonString(message) + "}");
+    }
+
+    // --- Moderation capability (moderator side) ---
+
+    /** Tool name for starting a moderated conversation. */
+    public static final String START_CONVERSATION = "start_conversation";
+
+    /** Tool name for providing a prompt during a scripted conversation step. */
+    public static final String PROVIDE_PROMPT = "provide_prompt";
+
+    /** Tool name for directing a participant in a conversation (directed mode). */
+    public static final String DIRECT = "direct";
+
+    /** Tool name for broadcasting a message to a conversation. */
+    public static final String BROADCAST = "broadcast";
+
+    /** Tool name for ending a moderated conversation (directed mode). */
+    public static final String END_CONVERSATION = "end_conversation";
+
+    // --- Moderation capability (participant/turn side) ---
+
+    /**
+     * Tool name for submitting a turn response. Used by participants when they have the floor, and
+     * by the moderator for their own turns in scripted conversations.
+     */
+    public static final String SUBMIT_TURN = "submit_turn";
+
+    /** Participant reference for scripted conversations, with type and reference name. */
+    public record ParticipantRef(String type, String as) {
+      public ParticipantRef(String type) {
+        this(type, type);
+      }
+    }
+
+    /** A step in a scripted conversation, specifying speaker and guidance. */
+    public record ScriptStep(String speaker, String guidance) {}
+
+    /**
+     * Creates a {@link ToolInvocationRequest} for the {@code start_conversation} tool with a
+     * scripted pattern. The moderator defines participants and a turn script upfront.
+     *
+     * @param topic the conversation topic
+     * @param participants the participant references (type and reference name)
+     * @param script the ordered turn sequence
+     */
+    public static ToolInvocationRequest startScriptedConversation(
+        String topic,
+        java.util.List<ParticipantRef> participants,
+        java.util.List<ScriptStep> script) {
+      var participantsJson =
+          participants.stream()
+              .map(
+                  p ->
+                      "{\"type\":"
+                          + toJsonString(p.type())
+                          + ",\"as\":"
+                          + toJsonString(p.as())
+                          + "}")
+              .collect(java.util.stream.Collectors.joining(",", "[", "]"));
+      var scriptJson =
+          script.stream()
+              .map(
+                  s ->
+                      "{\"speaker\":"
+                          + toJsonString(s.speaker())
+                          + ",\"guidance\":"
+                          + toJsonString(s.guidance())
+                          + "}")
+              .collect(java.util.stream.Collectors.joining(",", "[", "]"));
+      return new ToolInvocationRequest(
+          START_CONVERSATION,
+          "{\"pattern\":"
+              + toJsonString("scripted")
+              + ",\"topic\":"
+              + toJsonString(topic)
+              + ",\"participants\":"
+              + participantsJson
+              + ",\"script\":"
+              + scriptJson
+              + "}");
+    }
+
+    /**
+     * Creates a {@link ToolInvocationRequest} for the {@code start_conversation} tool with a
+     * directed pattern. The moderator controls each turn dynamically.
+     *
+     * @param topic the conversation topic
+     * @param maxRounds safety limit on conversation rounds
+     * @param participants the participant references (type and reference name)
+     */
+    public static ToolInvocationRequest startDirectedConversation(
+        String topic, int maxRounds, java.util.List<ParticipantRef> participants) {
+      var participantsJson =
+          participants.stream()
+              .map(
+                  p ->
+                      "{\"type\":"
+                          + toJsonString(p.type())
+                          + ",\"as\":"
+                          + toJsonString(p.as())
+                          + "}")
+              .collect(java.util.stream.Collectors.joining(",", "[", "]"));
+      return new ToolInvocationRequest(
+          START_CONVERSATION,
+          "{\"pattern\":"
+              + toJsonString("directed")
+              + ",\"topic\":"
+              + toJsonString(topic)
+              + ",\"rounds\":"
+              + maxRounds
+              + ",\"participants\":"
+              + participantsJson
+              + "}");
+    }
+
+    /**
+     * Creates a {@link ToolInvocationRequest} for the {@code provide_prompt} tool (scripted mode).
+     * Provides a contextual prompt for the current participant step.
+     *
+     * @param prompt the prompt to give to the participant
+     */
+    public static ToolInvocationRequest providePrompt(String prompt) {
+      return new ToolInvocationRequest(PROVIDE_PROMPT, "{\"prompt\":" + toJsonString(prompt) + "}");
+    }
+
+    /**
+     * Creates a {@link ToolInvocationRequest} for the {@code direct} tool (directed mode only).
+     * Grants the floor to a named participant with a direction message.
+     *
+     * @param participantRef the reference name of the participant to direct
+     * @param message the direction message for the participant
+     */
+    public static ToolInvocationRequest direct(String participantRef, String message) {
+      return new ToolInvocationRequest(
+          DIRECT,
+          "{\"participant\":"
+              + toJsonString(participantRef)
+              + ",\"message\":"
+              + toJsonString(message)
+              + "}");
+    }
+
+    /**
+     * Creates a {@link ToolInvocationRequest} for the {@code broadcast} tool. Posts a message to
+     * the conversation without granting the floor.
+     *
+     * @param message the message to broadcast
+     */
+    public static ToolInvocationRequest broadcast(String message) {
+      return new ToolInvocationRequest(BROADCAST, "{\"message\":" + toJsonString(message) + "}");
+    }
+
+    /**
+     * Creates a {@link ToolInvocationRequest} for the {@code end_conversation} tool (directed mode
+     * only). Ends the conversation and receives the full transcript.
+     */
+    public static ToolInvocationRequest endConversation() {
+      return new ToolInvocationRequest(END_CONVERSATION, "{}");
+    }
+
+    /**
+     * Creates a {@link ToolInvocationRequest} for the {@code submit_turn} tool. Used by
+     * participants to submit their response, and by the moderator for their own turns in scripted
+     * conversations.
+     *
+     * @param response the response message
+     */
+    public static ToolInvocationRequest submitTurn(String response) {
+      return new ToolInvocationRequest(
+          SUBMIT_TURN, "{\"response\":" + toJsonString(response) + "}");
     }
 
     private static String componentId(Class<?> agentClass) {

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/capability/Moderation.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/capability/Moderation.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.agent.autonomous.capability;
+
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.impl.agent.autonomous.capability.ModerationImpl;
+
+/**
+ * Declares that an agent can moderate turn-taking conversations between participant agents.
+ * Supports patterns like debates, peer reviews, and negotiations.
+ *
+ * <p>Created via {@link Moderation#of}.
+ */
+public interface Moderation extends AgentCapability {
+
+  /** Create a moderation capability with the given participant agent types. */
+  @SafeVarargs
+  static Moderation of(
+      Class<? extends AutonomousAgent> first, Class<? extends AutonomousAgent>... rest) {
+    return ModerationImpl.create(first, rest);
+  }
+
+  /** Maximum number of conversation rounds. Defaults to 5. */
+  Moderation maxRounds(int max);
+
+  /** Maximum LLM iterations a participant gets per turn before auto-submitting. Defaults to 10. */
+  Moderation maxIterationsPerTurn(int max);
+
+  /** Maximum number of concurrent conversations for this group. Defaults to 1. */
+  Moderation maxConcurrentConversations(int max);
+}

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/autonomous/CapabilityConverter.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/autonomous/CapabilityConverter.scala
@@ -14,6 +14,7 @@ import akka.javasdk.agent.task.TaskDefinition
 import akka.javasdk.agent.task.TaskTemplate
 import akka.javasdk.impl.JsonSchema
 import akka.javasdk.impl.agent.autonomous.capability.DelegationImpl
+import akka.javasdk.impl.agent.autonomous.capability.ModerationImpl
 import akka.javasdk.impl.agent.autonomous.capability.TaskAcceptanceImpl
 import akka.javasdk.impl.agent.autonomous.capability.TeamLeadershipImpl
 import akka.javasdk.impl.agent.autonomous.capability.TeamMemberImpl
@@ -66,7 +67,17 @@ private[javasdk] class CapabilityConverter(
         new SpiAutonomousAgent.TeamLead(t.members.map(resolveTeamMember), t.maxConcurrentTeamsValue)
       }
 
-    spiTaskAcceptances ++ spiDelegationOrchestrators ++ spiTeamLeads
+    val moderations = allCapabilities.collect { case m: ModerationImpl => m }
+    val spiModerations: Seq[SpiAutonomousAgent.Capability] =
+      moderations.map { m =>
+        new SpiAutonomousAgent.Moderation(
+          m.participants.map(resolveModerationParticipant),
+          m.maxRoundsValue,
+          m.maxIterationsPerTurnValue,
+          m.maxConcurrentConversationsValue)
+      }
+
+    spiTaskAcceptances ++ spiDelegationOrchestrators ++ spiTeamLeads ++ spiModerations
   }
 
   private def resolveHandoffTargets(
@@ -84,6 +95,20 @@ private[javasdk] class CapabilityConverter(
         description = targetDescriptor.flatMap(_.description),
         acceptedTasks = targetTaskDefinitions)
     }
+
+  private def resolveModerationParticipant(
+      participantClass: Class[_ <: AutonomousAgent]): SpiAutonomousAgent.ModerationParticipant = {
+    val targetComponentId = Reflect.readComponentId(participantClass)
+    agentDefinitionMap.getOrElse(
+      targetComponentId,
+      throw new IllegalStateException(
+        s"Moderation participant [$targetComponentId] (${participantClass.getName}) not found. " +
+        "Ensure the target agent is a registered AutonomousAgent component."))
+    val targetDescriptor = agentDescriptors.find(_.componentId == targetComponentId)
+    new SpiAutonomousAgent.ModerationParticipant(
+      agentComponentId = targetComponentId,
+      description = targetDescriptor.flatMap(_.description))
+  }
 
   private def resolveTeamMember(teamMember: TeamMemberImpl): SpiAutonomousAgent.TeamMemberType = {
     val targetComponentId = Reflect.readComponentId(teamMember.agentClass)

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/autonomous/capability/ModerationImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/autonomous/capability/ModerationImpl.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl.agent.autonomous.capability
+
+import akka.annotation.InternalApi
+import akka.javasdk.agent.autonomous.AutonomousAgent
+import akka.javasdk.agent.autonomous.capability.Moderation
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+final case class ModerationImpl(
+    participants: Seq[Class[_ <: AutonomousAgent]],
+    maxRoundsValue: Int = 5,
+    maxIterationsPerTurnValue: Int = 10,
+    maxConcurrentConversationsValue: Int = 1)
+    extends Moderation {
+
+  override def maxRounds(max: Int): Moderation =
+    copy(maxRoundsValue = max)
+
+  override def maxIterationsPerTurn(max: Int): Moderation =
+    copy(maxIterationsPerTurnValue = max)
+
+  override def maxConcurrentConversations(max: Int): Moderation =
+    copy(maxConcurrentConversationsValue = max)
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+object ModerationImpl {
+  def create(first: Class[_ <: AutonomousAgent], rest: Array[Class[_ <: AutonomousAgent]]): ModerationImpl =
+    ModerationImpl(first +: rest.toSeq)
+}

--- a/akka-javasdk/src/test/java/akka/javasdk/impl/agent/autonomous/TestModerationAgents.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/impl/agent/autonomous/TestModerationAgents.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl.agent.autonomous;
+
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.annotations.Component;
+
+/** Test fixtures for moderation converter tests. */
+public class TestModerationAgents {
+
+  @Component(id = "test-advocate", description = "A test advocate agent")
+  public abstract static class TestAdvocate extends AutonomousAgent {}
+
+  @Component(id = "test-critic", description = "A test critic agent")
+  public abstract static class TestCritic extends AutonomousAgent {}
+}

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/AutonomousAgentImplSupport.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/AutonomousAgentImplSupport.scala
@@ -7,9 +7,11 @@ package akka.javasdk.impl.agent.autonomous
 import akka.javasdk.agent.autonomous.AgentSetup
 import akka.javasdk.agent.autonomous.capability.AgentCapability
 import akka.javasdk.agent.autonomous.capability.Delegation
+import akka.javasdk.agent.autonomous.capability.Moderation
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance
 import akka.javasdk.agent.autonomous.capability.TeamLeadership
 import akka.javasdk.impl.agent.autonomous.capability.DelegationImpl
+import akka.javasdk.impl.agent.autonomous.capability.ModerationImpl
 import akka.javasdk.impl.agent.autonomous.capability.TaskAcceptanceImpl
 import akka.javasdk.impl.agent.autonomous.capability.TeamLeadershipImpl
 
@@ -34,9 +36,14 @@ trait AutonomousAgentImplSupport {
     def impl: TeamLeadershipImpl = teamLeadership.asInstanceOf[TeamLeadershipImpl]
   }
 
+  implicit class ModerationOps(moderation: Moderation) {
+    def impl: ModerationImpl = moderation.asInstanceOf[ModerationImpl]
+  }
+
   implicit class AgentCapabilityOps(capability: AgentCapability) {
     def asTaskAcceptance: TaskAcceptanceImpl = capability.asInstanceOf[TaskAcceptanceImpl]
     def asDelegation: DelegationImpl = capability.asInstanceOf[DelegationImpl]
     def asTeamLeadership: TeamLeadershipImpl = capability.asInstanceOf[TeamLeadershipImpl]
+    def asModeration: ModerationImpl = capability.asInstanceOf[ModerationImpl]
   }
 }

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/CapabilityConverterSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/CapabilityConverterSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.javasdk.impl.agent.autonomous
 
+import akka.javasdk.agent.autonomous.capability.Moderation
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance
 import akka.javasdk.agent.autonomous.capability.TeamLeadership
 import akka.javasdk.agent.task.Task
@@ -190,6 +191,93 @@ class CapabilityConverterSpec extends AnyWordSpec with Matchers {
       orchestrators.head.delegationGroups should have size 2
       orchestrators.head.delegationGroups(0).maxParallelWorkers shouldBe 2
       orchestrators.head.delegationGroups(1).maxParallelWorkers shouldBe 4
+    }
+
+    // Converter with moderation participant agents registered
+    val moderationConverter = new CapabilityConverter(
+      agentDefinitionMap = Map(
+        "test-advocate" -> (AgentDefinitionImpl.empty(), Seq.empty[SpiTask.SpiTaskDefinition]),
+        "test-critic" -> (AgentDefinitionImpl.empty(), Seq.empty[SpiTask.SpiTaskDefinition])),
+      agentDescriptors = Seq(
+        new AutonomousAgentDescriptor(
+          "test-advocate",
+          classOf[TestModerationAgents.TestAdvocate].getName,
+          None,
+          Some("A test advocate agent"),
+          dummyFactory,
+          provided = false),
+        new AutonomousAgentDescriptor(
+          "test-critic",
+          classOf[TestModerationAgents.TestCritic].getName,
+          None,
+          Some("A test critic agent"),
+          dummyFactory,
+          provided = false)),
+      requestBasedAgentDescriptors = Seq.empty,
+      defaultMaxIterationsPerTask = 10,
+      defaultMaxParallelWorkers = 3)
+
+    "convert moderation with default values" in {
+      val moderation = Moderation
+        .of(classOf[TestModerationAgents.TestAdvocate])
+
+      val capabilities = moderationConverter.toSpiCapabilities(java.util.List.of(moderation))
+
+      capabilities should have size 1
+      val spiModeration = capabilities.head.asInstanceOf[SpiAutonomousAgent.Moderation]
+      spiModeration.participantTypes should have size 1
+      spiModeration.participantTypes.head.agentComponentId shouldBe "test-advocate"
+      spiModeration.participantTypes.head.description shouldBe Some("A test advocate agent")
+      spiModeration.maxRounds shouldBe 5
+      spiModeration.maxIterationsPerTurn shouldBe 10
+      spiModeration.maxConcurrentConversations shouldBe 1
+    }
+
+    "convert moderation with explicit maxRounds" in {
+      val moderation = Moderation
+        .of(classOf[TestModerationAgents.TestAdvocate])
+        .maxRounds(10)
+
+      val capabilities = moderationConverter.toSpiCapabilities(java.util.List.of(moderation))
+
+      val spiModeration = capabilities.head.asInstanceOf[SpiAutonomousAgent.Moderation]
+      spiModeration.maxRounds shouldBe 10
+    }
+
+    "convert moderation with explicit maxIterationsPerTurn" in {
+      val moderation = Moderation
+        .of(classOf[TestModerationAgents.TestAdvocate])
+        .maxIterationsPerTurn(3)
+
+      val capabilities = moderationConverter.toSpiCapabilities(java.util.List.of(moderation))
+
+      val spiModeration = capabilities.head.asInstanceOf[SpiAutonomousAgent.Moderation]
+      spiModeration.maxIterationsPerTurn shouldBe 3
+    }
+
+    "convert moderation with explicit maxConcurrentConversations" in {
+      val moderation = Moderation
+        .of(classOf[TestModerationAgents.TestAdvocate])
+        .maxConcurrentConversations(4)
+
+      val capabilities = moderationConverter.toSpiCapabilities(java.util.List.of(moderation))
+
+      val spiModeration = capabilities.head.asInstanceOf[SpiAutonomousAgent.Moderation]
+      spiModeration.maxConcurrentConversations shouldBe 4
+    }
+
+    "convert moderation with multiple participant types" in {
+      val moderation =
+        Moderation.of(classOf[TestModerationAgents.TestAdvocate], classOf[TestModerationAgents.TestCritic])
+
+      val capabilities = moderationConverter.toSpiCapabilities(java.util.List.of(moderation))
+
+      val spiModeration = capabilities.head.asInstanceOf[SpiAutonomousAgent.Moderation]
+      spiModeration.participantTypes should have size 2
+      spiModeration.participantTypes(0).agentComponentId shouldBe "test-advocate"
+      spiModeration.participantTypes(0).description shouldBe Some("A test advocate agent")
+      spiModeration.participantTypes(1).agentComponentId shouldBe "test-critic"
+      spiModeration.participantTypes(1).description shouldBe Some("A test critic agent")
     }
 
     "convert team leadership with default maxConcurrentTeams" in {

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/capability/CapabilityBuildersSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/capability/CapabilityBuildersSpec.scala
@@ -9,6 +9,7 @@ import scala.jdk.CollectionConverters._
 import akka.javasdk.agent.Agent
 import akka.javasdk.agent.autonomous.AutonomousAgent
 import akka.javasdk.agent.autonomous.capability.Delegation
+import akka.javasdk.agent.autonomous.capability.Moderation
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance
 import akka.javasdk.agent.task.Task
 import akka.javasdk.impl.agent.autonomous.AutonomousAgentImplSupport
@@ -98,6 +99,89 @@ class CapabilityBuildersSpec extends AnyWordSpec with Matchers with AutonomousAg
 
   abstract class DummyAgent extends Agent
   abstract class DummyAutonomousAgent extends AutonomousAgent
+
+  "Moderation" should {
+
+    abstract class DummyAdvocate extends AutonomousAgent
+    abstract class DummyCritic extends AutonomousAgent
+
+    "create with participant types" in {
+      val moderation = ModerationImpl.create(classOf[DummyAdvocate], Array(classOf[DummyCritic]))
+
+      moderation.participants should have size 2
+      moderation.participants.head shouldBe classOf[DummyAdvocate]
+      moderation.participants(1) shouldBe classOf[DummyCritic]
+    }
+
+    "default maxRounds to 5" in {
+      val moderation = ModerationImpl.create(classOf[DummyAdvocate], Array())
+
+      moderation.maxRoundsValue shouldBe 5
+    }
+
+    "set explicit maxRounds" in {
+      val moderation = Moderation
+        .of(classOf[DummyAdvocate])
+        .maxRounds(10)
+        .impl
+
+      moderation.maxRoundsValue shouldBe 10
+    }
+
+    "default maxIterationsPerTurn to 10" in {
+      val moderation = ModerationImpl.create(classOf[DummyAdvocate], Array())
+
+      moderation.maxIterationsPerTurnValue shouldBe 10
+    }
+
+    "set explicit maxIterationsPerTurn" in {
+      val moderation = Moderation
+        .of(classOf[DummyAdvocate])
+        .maxIterationsPerTurn(3)
+        .impl
+
+      moderation.maxIterationsPerTurnValue shouldBe 3
+    }
+
+    "default maxConcurrentConversations to 1" in {
+      val moderation = ModerationImpl.create(classOf[DummyAdvocate], Array())
+
+      moderation.maxConcurrentConversationsValue shouldBe 1
+    }
+
+    "set explicit maxConcurrentConversations" in {
+      val moderation = Moderation
+        .of(classOf[DummyAdvocate])
+        .maxConcurrentConversations(4)
+        .impl
+
+      moderation.maxConcurrentConversationsValue shouldBe 4
+    }
+
+    "be immutable — maxRounds returns new instance" in {
+      val original = Moderation.of(classOf[DummyAdvocate])
+      val modified = original.maxRounds(8)
+
+      original.impl.maxRoundsValue shouldBe 5
+      modified.impl.maxRoundsValue shouldBe 8
+    }
+
+    "be immutable — maxIterationsPerTurn returns new instance" in {
+      val original = Moderation.of(classOf[DummyAdvocate])
+      val modified = original.maxIterationsPerTurn(20)
+
+      original.impl.maxIterationsPerTurnValue shouldBe 10
+      modified.impl.maxIterationsPerTurnValue shouldBe 20
+    }
+
+    "be immutable — maxConcurrentConversations returns new instance" in {
+      val original = Moderation.of(classOf[DummyAdvocate])
+      val modified = original.maxConcurrentConversations(3)
+
+      original.impl.maxConcurrentConversationsValue shouldBe 1
+      modified.impl.maxConcurrentConversationsValue shouldBe 3
+    }
+  }
 
   "TeamLeadership" should {
 

--- a/docs/src/modules/sdk/pages/autonomous-agents.html.md
+++ b/docs/src/modules/sdk/pages/autonomous-agents.html.md
@@ -523,7 +523,7 @@ Many agents operate in parallel with minimal individual context, following simpl
 
 ## <a href="about:blank#_coordination_capabilities"></a> Coordination capabilities
 
-The coordination patterns above are implemented through capabilities — each adds tools to the agent's LLM loop. The agent's LLM sees domain tools alongside coordination tools and decides which to call. Capabilities map to the patterns: `canHandoffTo` enables sequential patterns, `Delegation` enables delegative patterns, and `TeamLeadership` enables collaborative and emergent patterns.
+The coordination patterns above are implemented through capabilities — each adds tools to the agent's LLM loop. The agent's LLM sees domain tools alongside coordination tools and decides which to call. Capabilities map to the patterns: `canHandoffTo` enables sequential patterns, `Delegation` enables delegative patterns, `TeamLeadership` enables collaborative and emergent patterns, and `Moderation` enables structured turn-taking conversations.
 
 ### Delegation
 
@@ -697,6 +697,107 @@ define()
 
 **When to use:** Interdependent work where agents need to see each other's contributions, or when quality benefits from peer review. Good for collaborative problem-solving where different expertise needs to be actively integrated.
 
+### Moderation
+
+A moderator agent orchestrates turn-taking conversations between participant agents. The moderator declares which agent types can participate, and the framework manages conversation setup, turn-taking, and transcript collection. Participant agents are simple — they define a goal and the framework handles the conversation mechanics automatically.
+
+```java
+import akka.javasdk.agent.autonomous.capability.Moderation;
+
+define()
+  .capability(Moderation.of(TechnicalReviewer.class, StyleReviewer.class, ComplianceReviewer.class))
+```
+
+Configuration options:
+
+```java
+Moderation.of(Buyer.class, Seller.class)
+  .maxRounds(5)                    // safety limit for directed mode (default 5)
+  .maxIterationsPerTurn(10)        // max LLM iterations per participant turn (default 10)
+  .maxConcurrentConversations(1)   // max simultaneous conversations (default 1)
+```
+
+**Context flow:** Structured turn-taking. The moderator sees the full conversation history and generates contextual prompts for each participant. Participants see the moderator's prompt along with new entries from the conversation since their last turn, so they can respond to what others have said.
+
+**When to use:** Multi-perspective analysis where different specialists contribute sequentially (peer review, compliance checks), or adaptive discussions where the moderator reads responses and decides the next step (negotiations, interviews).
+
+Two conversation modes shape how the moderator controls the flow:
+
+#### Scripted conversations
+
+In scripted mode, the moderator's LLM defines a turn sequence upfront — who speaks, in what order, and what each turn should cover. The framework then drives execution step by step. At each participant step, the moderator generates a contextual prompt informed by the conversation so far. At moderator steps, the moderator contributes its own message (for example, a synthesis or summary). After all steps complete, the conversation finishes and the moderator receives the full transcript.
+
+This mode suits structured processes with a known sequence — peer reviews where each specialist reviews in order, multi-stage assessments, or any workflow where the moderator knows the steps ahead of time but wants to generate contextual prompts as the conversation unfolds.
+
+```java
+@Component(
+  id = "review-moderator",
+  description = "Coordinates peer review of documents through specialist reviewers")
+public class ReviewModerator extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+      .goal("Coordinate document peer review and synthesize reviewer findings.")
+      .capability(TaskAcceptance.of(ReviewTasks.REVIEW))
+      .capability(
+        Moderation.of(TechnicalReviewer.class, StyleReviewer.class, ComplianceReviewer.class));
+  }
+}
+```
+
+Participant agents need only a goal — the framework provides the conversation tools:
+
+```java
+@Component(id = "technical-reviewer", description = "Reviews documents for technical accuracy")
+public class TechnicalReviewer extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define().goal("Review documents for technical accuracy, correctness, and completeness.");
+  }
+}
+```
+
+The `description` in the `@Component` annotation is shown to the moderator's LLM so it understands each participant's expertise when generating prompts.
+
+#### Directed conversations
+
+In directed mode, the moderator's LLM has full dynamic control over the conversation. It decides who speaks next, what direction to give them, and when to end the conversation — all based on the responses received so far. This enables adaptive flows where the conversation shape depends on its content.
+
+`maxRounds` acts as a safety limit in directed mode — the conversation ends automatically if the round limit is reached, preventing runaway conversations.
+
+```java
+@Component(id = "facilitator", description = "Facilitates negotiations between parties")
+public class Facilitator extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+      .goal("Facilitate negotiations and help parties reach agreement.")
+      .capability(TaskAcceptance.of(NegotiationTasks.NEGOTIATE))
+      .capability(Moderation.of(Buyer.class, Seller.class).maxRounds(5));
+  }
+}
+```
+
+#### Multiple participants of the same type
+
+The moderator's LLM can use multiple instances of the same participant type with different reference names. For example, two critics with different review focuses — the reference name distinguishes them in the conversation:
+
+```java
+@Component(id = "critic", description = "Reviews and critiques from a specific perspective")
+public class Critic extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define().goal("Provide critical analysis from the assigned perspective.");
+  }
+}
+```
+
+The moderator declares `Critic.class` once in its `Moderation.of(...)` capability. At runtime, the moderator's LLM can create multiple participant references — for example, a "technical-reviewer" and a "financial-reviewer" — both backed by the same `Critic` agent type but operating with different context based on the prompts the moderator generates for each.
+
 ### External input
 
 <!-- TODO: External input capability is defined in design notes but not yet implemented in the SDK API. The following describes the planned design. -->
@@ -714,6 +815,7 @@ Capabilities compose freely. An agent can combine:
 - **Delegation with handoff** — delegate to specialists for most work, hand off edge cases to a different agent type
 - **Delegation with external input** — delegate writing and editing to specialists, request editorial approval for the final output
 - **Teams with external input** — team members collaborate, with human approval required for final publication
+- **Moderation with delegation** — moderate a conversation between specialists, then delegate follow-up work based on the outcome
 
 ```java
 @Component(id = "consulting-coordinator")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val ProtocolVersionMajor = 1
     val ProtocolVersionMinor = 1
   }
-  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.5.46-77-c28f9fc7-SNAPSHOT")
+  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.5.46-81-7b5cc192-SNAPSHOT")
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned
   // for prod code, they are marked as Provided, but testkit still requires the alignment

--- a/samples/autonomous-agent-playground/pom.xml
+++ b/samples/autonomous-agent-playground/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.akka</groupId>
     <artifactId>akka-javasdk-parent</artifactId>
-    <version>3.5.16-64-8f02bb81-dev-SNAPSHOT</version>
+    <version>3.5.16-74-e2fd6353-dev-SNAPSHOT</version>
   </parent>
 
   <groupId>demo</groupId>

--- a/samples/autonomous-agent-playground/src/main/java/demo/debate/api/DebateEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/debate/api/DebateEndpoint.java
@@ -1,0 +1,39 @@
+package demo.debate.api;
+
+import akka.javasdk.annotations.Acl;
+import akka.javasdk.annotations.http.Get;
+import akka.javasdk.annotations.http.HttpEndpoint;
+import akka.javasdk.annotations.http.Post;
+import akka.javasdk.client.ComponentClient;
+import demo.debate.application.DebateModerator;
+import demo.debate.application.DebateTasks;
+import demo.debate.application.DebateTasks.DebateResult;
+import java.util.UUID;
+
+@Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET))
+@HttpEndpoint("/debate")
+public class DebateEndpoint {
+
+  public record DebateRequest(String topic) {}
+
+  public record DebateResponse(String taskId) {}
+
+  private final ComponentClient componentClient;
+
+  public DebateEndpoint(ComponentClient componentClient) {
+    this.componentClient = componentClient;
+  }
+
+  @Post
+  public DebateResponse create(DebateRequest request) {
+    var taskId = componentClient
+      .forAutonomousAgent(DebateModerator.class, UUID.randomUUID().toString())
+      .runSingleTask(DebateTasks.DEBATE.instructions(request.topic()));
+    return new DebateResponse(taskId);
+  }
+
+  @Get("/{taskId}")
+  public DebateResult get(String taskId) {
+    return componentClient.forTask(taskId).get(DebateTasks.DEBATE).result();
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/debate/application/Advocate.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/debate/application/Advocate.java
@@ -1,0 +1,14 @@
+package demo.debate.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.annotations.Component;
+
+@Component(id = "advocate", description = "Argues in favor of a position in debates")
+public class Advocate extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define().goal("Present compelling arguments in favor of the assigned position.");
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/debate/application/Critic.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/debate/application/Critic.java
@@ -1,0 +1,17 @@
+package demo.debate.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.annotations.Component;
+
+@Component(id = "critic", description = "Argues against a position in debates")
+public class Critic extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+      .goal(
+        "Present compelling counterarguments and identify weaknesses in the opposing position."
+      );
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/debate/application/DebateModerator.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/debate/application/DebateModerator.java
@@ -1,0 +1,24 @@
+package demo.debate.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.agent.autonomous.capability.Moderation;
+import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
+import akka.javasdk.annotations.Component;
+
+@Component(
+  id = "debate-moderator",
+  description = "Moderates structured debates and synthesizes balanced conclusions"
+)
+public class DebateModerator extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+      .goal(
+        "Moderate structured debates between participants and synthesize balanced conclusions."
+      )
+      .capability(TaskAcceptance.of(DebateTasks.DEBATE))
+      .capability(Moderation.of(Advocate.class, Critic.class).maxRounds(5));
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/debate/application/DebateTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/debate/application/DebateTasks.java
@@ -1,0 +1,15 @@
+package demo.debate.application;
+
+import akka.javasdk.agent.task.Task;
+import java.util.List;
+
+public class DebateTasks {
+
+  public record DebateResult(String topic, String synthesis, List<String> keyArguments) {}
+
+  // prettier-ignore
+  public static final Task<DebateResult> DEBATE = Task
+    .define("Debate")
+    .description("Moderate a structured debate between advocates and critics, then synthesize a balanced conclusion.")
+    .resultConformsTo(DebateResult.class);
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/devteam/application/ProjectLead.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/devteam/application/ProjectLead.java
@@ -17,7 +17,7 @@ public class ProjectLead extends AutonomousAgent {
   public AgentDefinition definition() {
     return define()
       .goal("Deliver completed software projects with all features implemented and tested.")
-      .capability(TaskAcceptance.of(ProjectTasks.PLAN).maxIterationsPerTask(40))
+      .capability(TaskAcceptance.of(ProjectTasks.PLAN))
       .capability(TeamLeadership.of(TeamMember.of(Developer.class).maxInstances(3)));
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/negotiation/api/NegotiationEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/negotiation/api/NegotiationEndpoint.java
@@ -1,0 +1,39 @@
+package demo.negotiation.api;
+
+import akka.javasdk.annotations.Acl;
+import akka.javasdk.annotations.http.Get;
+import akka.javasdk.annotations.http.HttpEndpoint;
+import akka.javasdk.annotations.http.Post;
+import akka.javasdk.client.ComponentClient;
+import demo.negotiation.application.Facilitator;
+import demo.negotiation.application.NegotiationTasks;
+import demo.negotiation.application.NegotiationTasks.NegotiationResult;
+import java.util.UUID;
+
+@Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET))
+@HttpEndpoint("/negotiation")
+public class NegotiationEndpoint {
+
+  public record NegotiationRequest(String topic) {}
+
+  public record NegotiationResponse(String taskId) {}
+
+  private final ComponentClient componentClient;
+
+  public NegotiationEndpoint(ComponentClient componentClient) {
+    this.componentClient = componentClient;
+  }
+
+  @Post
+  public NegotiationResponse create(NegotiationRequest request) {
+    var taskId = componentClient
+      .forAutonomousAgent(Facilitator.class, UUID.randomUUID().toString())
+      .runSingleTask(NegotiationTasks.NEGOTIATE.instructions(request.topic()));
+    return new NegotiationResponse(taskId);
+  }
+
+  @Get("/{taskId}")
+  public NegotiationResult get(String taskId) {
+    return componentClient.forTask(taskId).get(NegotiationTasks.NEGOTIATE).result();
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Buyer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Buyer.java
@@ -1,0 +1,14 @@
+package demo.negotiation.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.annotations.Component;
+
+@Component(id = "buyer", description = "Negotiates from the buyer's perspective")
+public class Buyer extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define().goal("Negotiate the best possible deal from the buyer's perspective.");
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Facilitator.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Facilitator.java
@@ -1,0 +1,24 @@
+package demo.negotiation.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.agent.autonomous.capability.Moderation;
+import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
+import akka.javasdk.annotations.Component;
+
+@Component(id = "facilitator", description = "Facilitates negotiations between parties")
+public class Facilitator extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+      .goal(
+        """
+        Facilitate negotiations by directing each psarty through structured rounds \
+        of offers and counteroffers to reach agreement.
+        """
+      )
+      .capability(TaskAcceptance.of(NegotiationTasks.NEGOTIATE))
+      .capability(Moderation.of(Buyer.class, Seller.class).maxRounds(10));
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/NegotiationTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/NegotiationTasks.java
@@ -1,0 +1,12 @@
+package demo.negotiation.application;
+
+import akka.javasdk.agent.task.Task;
+
+public class NegotiationTasks {
+
+  public record NegotiationResult(String topic, String outcome, String finalOffer) {}
+
+  public static final Task<NegotiationResult> NEGOTIATE = Task.define("Negotiate")
+    .description("Facilitate a negotiation between buyer and seller.")
+    .resultConformsTo(NegotiationResult.class);
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Seller.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Seller.java
@@ -1,0 +1,14 @@
+package demo.negotiation.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.annotations.Component;
+
+@Component(id = "seller", description = "Negotiates from the seller's perspective")
+public class Seller extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define().goal("Negotiate the best possible deal from the seller's perspective.");
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/api/PeerReviewEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/api/PeerReviewEndpoint.java
@@ -1,0 +1,39 @@
+package demo.peerreview.api;
+
+import akka.javasdk.annotations.Acl;
+import akka.javasdk.annotations.http.Get;
+import akka.javasdk.annotations.http.HttpEndpoint;
+import akka.javasdk.annotations.http.Post;
+import akka.javasdk.client.ComponentClient;
+import demo.peerreview.application.ReviewModerator;
+import demo.peerreview.application.ReviewTasks;
+import demo.peerreview.application.ReviewTasks.ReviewResult;
+import java.util.UUID;
+
+@Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET))
+@HttpEndpoint("/peerreview")
+public class PeerReviewEndpoint {
+
+  public record ReviewRequest(String document) {}
+
+  public record ReviewResponse(String taskId) {}
+
+  private final ComponentClient componentClient;
+
+  public PeerReviewEndpoint(ComponentClient componentClient) {
+    this.componentClient = componentClient;
+  }
+
+  @Post
+  public ReviewResponse create(ReviewRequest request) {
+    var taskId = componentClient
+      .forAutonomousAgent(ReviewModerator.class, UUID.randomUUID().toString())
+      .runSingleTask(ReviewTasks.REVIEW.instructions(request.document()));
+    return new ReviewResponse(taskId);
+  }
+
+  @Get("/{taskId}")
+  public ReviewResult get(String taskId) {
+    return componentClient.forTask(taskId).get(ReviewTasks.REVIEW).result();
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ComplianceReviewer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ComplianceReviewer.java
@@ -1,0 +1,14 @@
+package demo.peerreview.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.annotations.Component;
+
+@Component(id = "compliance-reviewer", description = "Reviews documents for compliance")
+public class ComplianceReviewer extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define().goal("Review documents for regulatory compliance and policy adherence.");
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ReviewModerator.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ReviewModerator.java
@@ -1,0 +1,24 @@
+package demo.peerreview.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.agent.autonomous.capability.Moderation;
+import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
+import akka.javasdk.annotations.Component;
+
+@Component(
+  id = "review-moderator",
+  description = "Coordinates peer review of documents through specialist reviewers"
+)
+public class ReviewModerator extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+      .goal("Coordinate document peer review and synthesize reviewer findings.")
+      .capability(TaskAcceptance.of(ReviewTasks.REVIEW))
+      .capability(
+        Moderation.of(TechnicalReviewer.class, StyleReviewer.class, ComplianceReviewer.class)
+      );
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ReviewTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ReviewTasks.java
@@ -1,0 +1,19 @@
+package demo.peerreview.application;
+
+import akka.javasdk.agent.task.Task;
+import java.util.List;
+
+public class ReviewTasks {
+
+  public record ReviewResult(
+    String document,
+    String assessment,
+    List<String> reviewerFindings
+  ) {}
+
+  public static final Task<ReviewResult> REVIEW = Task.define("Review")
+    .description(
+      "Coordinate peer review of a document by technical, style, and compliance reviewers."
+    )
+    .resultConformsTo(ReviewResult.class);
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/StyleReviewer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/StyleReviewer.java
@@ -1,0 +1,14 @@
+package demo.peerreview.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.annotations.Component;
+
+@Component(id = "style-reviewer", description = "Reviews documents for clarity and style")
+public class StyleReviewer extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define().goal("Review documents for clarity, readability, and consistent style.");
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/TechnicalReviewer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/TechnicalReviewer.java
@@ -1,0 +1,18 @@
+package demo.peerreview.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.annotations.Component;
+
+@Component(
+  id = "technical-reviewer",
+  description = "Reviews documents for technical accuracy"
+)
+public class TechnicalReviewer extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+      .goal("Review documents for technical accuracy, correctness, and completeness.");
+  }
+}

--- a/samples/autonomous-agent-playground/src/test/java/demo/debate/DebateIntegrationTest.java
+++ b/samples/autonomous-agent-playground/src/test/java/demo/debate/DebateIntegrationTest.java
@@ -1,0 +1,164 @@
+package demo.debate;
+
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.SUBMIT_TURN;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.completeTask;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.providePrompt;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.startScriptedConversation;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.submitTurn;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import akka.javasdk.testkit.TestKit;
+import akka.javasdk.testkit.TestKitSupport;
+import akka.javasdk.testkit.TestModelProvider;
+import akka.javasdk.testkit.TestModelProvider.AiResponse;
+import akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.ParticipantRef;
+import akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.ScriptStep;
+import demo.debate.api.DebateEndpoint;
+import demo.debate.application.Advocate;
+import demo.debate.application.Critic;
+import demo.debate.application.DebateModerator;
+import demo.debate.application.DebateTasks;
+import demo.debate.application.DebateTasks.DebateResult;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+public class DebateIntegrationTest extends TestKitSupport {
+
+  private final TestModelProvider moderatorModel = new TestModelProvider()
+    .withMessageSelector(DebateIntegrationTest::preferUserMessage);
+  private final TestModelProvider advocateModel = new TestModelProvider()
+    .withMessageSelector(DebateIntegrationTest::preferToolResult);
+  private final TestModelProvider criticModel = new TestModelProvider()
+    .withMessageSelector(DebateIntegrationTest::preferToolResult);
+
+  /** Select the last tool result if present, otherwise the last message. */
+  private static TestModelProvider.InputMessage preferToolResult(
+    List<TestModelProvider.InputMessage> messages
+  ) {
+    return messages
+      .stream()
+      .filter(m -> m instanceof TestModelProvider.ToolResult)
+      .reduce((a, b) -> b)
+      .orElse(messages.getLast());
+  }
+
+  /** Select the last user message if present, otherwise the last message. */
+  private static TestModelProvider.InputMessage preferUserMessage(
+    List<TestModelProvider.InputMessage> messages
+  ) {
+    return messages
+      .stream()
+      .filter(m -> m instanceof TestModelProvider.UserMessage)
+      .reduce((a, b) -> b)
+      .orElse(messages.getLast());
+  }
+
+  @Override
+  protected TestKit.Settings testKitSettings() {
+    return TestKit.Settings.DEFAULT.withAdditionalConfig(
+      "akka.javasdk.agent.openai.api-key = n/a"
+    )
+      .withModelProvider(DebateModerator.class, moderatorModel)
+      .withModelProvider(Advocate.class, advocateModel)
+      .withModelProvider(Critic.class, criticModel);
+  }
+
+  @Test
+  public void shouldRunScriptedDebate() {
+    // Moderator: respond to user messages based on content.
+    // Uses preferUserMessage so scripted step instructions drive the flow.
+    moderatorModel.fixedResponse(msg -> {
+      if (msg instanceof TestModelProvider.UserMessage um) {
+        var text = um.text();
+        if (text.startsWith("Task:")) {
+          return new AiResponse(
+            startScriptedConversation(
+              "AI in education",
+              List.of(new ParticipantRef("advocate"), new ParticipantRef("critic")),
+              List.of(
+                new ScriptStep("advocate", "Argue in favor of AI in education"),
+                new ScriptStep("critic", "Argue against AI in education"),
+                new ScriptStep("moderator", "Synthesize both perspectives")
+              )
+            )
+          );
+        }
+        if (text.contains("provide_prompt")) {
+          return new AiResponse(
+            providePrompt("Please present your perspective on AI in education.")
+          );
+        }
+        if (text.contains("submit_turn")) {
+          return new AiResponse(
+            submitTurn("Both sides raise valid points about AI in education.")
+          );
+        }
+        if (text.contains("Moderation capability")) {
+          // Conversation completed — moderator sees available participants again
+          return new AiResponse(
+            completeTask(
+              new DebateResult(
+                "AI in education",
+                "Both sides presented valid points about AI in education.",
+                List.of(
+                  "AI enhances personalized learning",
+                  "AI risks reducing critical thinking"
+                )
+              )
+            )
+          );
+        }
+        return new AiResponse("Acknowledged.");
+      }
+      return new AiResponse("Acknowledged.");
+    });
+
+    // Participants: submit turn whenever given the floor
+    advocateModel.fixedResponse(msg -> {
+      if (
+        msg instanceof TestModelProvider.ToolResult toolResult &&
+        toolResult.name().equals(SUBMIT_TURN)
+      ) {
+        return new AiResponse("Turn submitted.");
+      }
+      return new AiResponse(
+        submitTurn("AI enhances personalized learning for every student.")
+      );
+    });
+
+    criticModel.fixedResponse(msg -> {
+      if (
+        msg instanceof TestModelProvider.ToolResult toolResult &&
+        toolResult.name().equals(SUBMIT_TURN)
+      ) {
+        return new AiResponse("Turn submitted.");
+      }
+      return new AiResponse(
+        submitTurn("Over-reliance on AI risks reducing critical thinking skills.")
+      );
+    });
+
+    var response = httpClient
+      .POST("/debate")
+      .withRequestBody(new DebateEndpoint.DebateRequest("Should AI be used in education?"))
+      .responseBodyAs(DebateEndpoint.DebateResponse.class)
+      .invoke()
+      .body();
+
+    var taskId = response.taskId();
+    assertThat(taskId).isNotBlank();
+
+    Awaitility.await()
+      .ignoreExceptions()
+      .atMost(30, TimeUnit.SECONDS)
+      .untilAsserted(() -> {
+        var snapshot = componentClient.forTask(taskId).get(DebateTasks.DEBATE);
+        assertThat(snapshot.result()).isNotNull();
+        assertThat(snapshot.result().topic()).isEqualTo("AI in education");
+        assertThat(snapshot.result().synthesis()).contains("Both sides");
+        assertThat(snapshot.result().keyArguments()).hasSize(2);
+      });
+  }
+}

--- a/samples/autonomous-agent-playground/src/test/java/demo/negotiation/NegotiationIntegrationTest.java
+++ b/samples/autonomous-agent-playground/src/test/java/demo/negotiation/NegotiationIntegrationTest.java
@@ -1,0 +1,141 @@
+package demo.negotiation;
+
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.COMPLETE_TASK;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.DIRECT;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.END_CONVERSATION;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.START_CONVERSATION;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.SUBMIT_TURN;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.completeTask;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.direct;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.endConversation;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.startDirectedConversation;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.submitTurn;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import akka.javasdk.testkit.TestKit;
+import akka.javasdk.testkit.TestKitSupport;
+import akka.javasdk.testkit.TestModelProvider;
+import akka.javasdk.testkit.TestModelProvider.AiResponse;
+import akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.ParticipantRef;
+import demo.negotiation.api.NegotiationEndpoint;
+import demo.negotiation.application.Buyer;
+import demo.negotiation.application.Facilitator;
+import demo.negotiation.application.NegotiationTasks;
+import demo.negotiation.application.NegotiationTasks.NegotiationResult;
+import demo.negotiation.application.Seller;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+public class NegotiationIntegrationTest extends TestKitSupport {
+
+  private final TestModelProvider facilitatorModel = new TestModelProvider()
+    .withMessageSelector(NegotiationIntegrationTest::preferToolResult);
+  private final TestModelProvider buyerModel = new TestModelProvider()
+    .withMessageSelector(NegotiationIntegrationTest::preferToolResult);
+  private final TestModelProvider sellerModel = new TestModelProvider()
+    .withMessageSelector(NegotiationIntegrationTest::preferToolResult);
+
+  private static TestModelProvider.InputMessage preferToolResult(
+    List<TestModelProvider.InputMessage> messages
+  ) {
+    return messages
+      .stream()
+      .filter(m -> m instanceof TestModelProvider.ToolResult)
+      .reduce((a, b) -> b)
+      .orElse(messages.getLast());
+  }
+
+  @Override
+  protected TestKit.Settings testKitSettings() {
+    return TestKit.Settings.DEFAULT.withAdditionalConfig(
+      "akka.javasdk.agent.openai.api-key = n/a"
+    )
+      .withModelProvider(Facilitator.class, facilitatorModel)
+      .withModelProvider(Buyer.class, buyerModel)
+      .withModelProvider(Seller.class, sellerModel);
+  }
+
+  @Test
+  public void shouldRunDirectedNegotiation() {
+    // Facilitator: drive negotiation through directed tool calls.
+    // Uses preferToolResult — each tool result triggers the next action.
+    facilitatorModel.fixedResponse(msg -> {
+      if (msg instanceof TestModelProvider.UserMessage) {
+        // Task assigned — start directed conversation
+        return new AiResponse(
+          startDirectedConversation(
+            "Software licensing deal",
+            5,
+            List.of(new ParticipantRef("buyer"), new ParticipantRef("seller"))
+          )
+        );
+      }
+      if (msg instanceof TestModelProvider.ToolResult toolResult) {
+        return switch (toolResult.name()) {
+          case START_CONVERSATION -> new AiResponse(
+            direct("buyer", "Make your opening offer for the license.")
+          );
+          case DIRECT -> {
+            if (toolResult.content().contains("[buyer]")) {
+              yield new AiResponse(direct("seller", "Respond to the buyer's offer."));
+            }
+            // Seller responded — end negotiation
+            yield new AiResponse(endConversation());
+          }
+          case END_CONVERSATION -> new AiResponse(
+            completeTask(
+              new NegotiationResult(
+                "Software licensing deal",
+                "Agreement reached on licensing terms.",
+                "$50,000 annual license"
+              )
+            )
+          );
+          case COMPLETE_TASK -> new AiResponse("Done.");
+          default -> new AiResponse("Acknowledged.");
+        };
+      }
+      return new AiResponse("Acknowledged.");
+    });
+
+    // Participants: submit turn whenever given the floor
+    buyerModel.fixedResponse(msg -> {
+      if (msg instanceof TestModelProvider.ToolResult tr && tr.name().equals(SUBMIT_TURN)) {
+        return new AiResponse("Turn submitted.");
+      }
+      return new AiResponse(submitTurn("We offer $50,000 for an annual license."));
+    });
+
+    sellerModel.fixedResponse(msg -> {
+      if (msg instanceof TestModelProvider.ToolResult tr && tr.name().equals(SUBMIT_TURN)) {
+        return new AiResponse("Turn submitted.");
+      }
+      return new AiResponse(submitTurn("We accept $50,000 for the annual license."));
+    });
+
+    var response = httpClient
+      .POST("/negotiation")
+      .withRequestBody(
+        new NegotiationEndpoint.NegotiationRequest("Negotiate software licensing terms")
+      )
+      .responseBodyAs(NegotiationEndpoint.NegotiationResponse.class)
+      .invoke()
+      .body();
+
+    var taskId = response.taskId();
+    assertThat(taskId).isNotBlank();
+
+    Awaitility.await()
+      .ignoreExceptions()
+      .atMost(30, TimeUnit.SECONDS)
+      .untilAsserted(() -> {
+        var snapshot = componentClient.forTask(taskId).get(NegotiationTasks.NEGOTIATE);
+        assertThat(snapshot.result()).isNotNull();
+        assertThat(snapshot.result().topic()).isEqualTo("Software licensing deal");
+        assertThat(snapshot.result().outcome()).contains("Agreement reached");
+        assertThat(snapshot.result().finalOffer()).isEqualTo("$50,000 annual license");
+      });
+  }
+}

--- a/samples/autonomous-agent-playground/src/test/java/demo/peerreview/PeerReviewIntegrationTest.java
+++ b/samples/autonomous-agent-playground/src/test/java/demo/peerreview/PeerReviewIntegrationTest.java
@@ -1,0 +1,173 @@
+package demo.peerreview;
+
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.SUBMIT_TURN;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.completeTask;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.providePrompt;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.startScriptedConversation;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.submitTurn;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import akka.javasdk.testkit.TestKit;
+import akka.javasdk.testkit.TestKitSupport;
+import akka.javasdk.testkit.TestModelProvider;
+import akka.javasdk.testkit.TestModelProvider.AiResponse;
+import akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.ParticipantRef;
+import akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.ScriptStep;
+import demo.peerreview.api.PeerReviewEndpoint;
+import demo.peerreview.application.ComplianceReviewer;
+import demo.peerreview.application.ReviewModerator;
+import demo.peerreview.application.ReviewTasks;
+import demo.peerreview.application.ReviewTasks.ReviewResult;
+import demo.peerreview.application.StyleReviewer;
+import demo.peerreview.application.TechnicalReviewer;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+public class PeerReviewIntegrationTest extends TestKitSupport {
+
+  private final TestModelProvider moderatorModel = new TestModelProvider()
+    .withMessageSelector(PeerReviewIntegrationTest::preferUserMessage);
+  private final TestModelProvider technicalModel = new TestModelProvider()
+    .withMessageSelector(PeerReviewIntegrationTest::preferToolResult);
+  private final TestModelProvider styleModel = new TestModelProvider()
+    .withMessageSelector(PeerReviewIntegrationTest::preferToolResult);
+  private final TestModelProvider complianceModel = new TestModelProvider()
+    .withMessageSelector(PeerReviewIntegrationTest::preferToolResult);
+
+  private static TestModelProvider.InputMessage preferToolResult(
+    List<TestModelProvider.InputMessage> messages
+  ) {
+    return messages
+      .stream()
+      .filter(m -> m instanceof TestModelProvider.ToolResult)
+      .reduce((a, b) -> b)
+      .orElse(messages.getLast());
+  }
+
+  private static TestModelProvider.InputMessage preferUserMessage(
+    List<TestModelProvider.InputMessage> messages
+  ) {
+    return messages
+      .stream()
+      .filter(m -> m instanceof TestModelProvider.UserMessage)
+      .reduce((a, b) -> b)
+      .orElse(messages.getLast());
+  }
+
+  @Override
+  protected TestKit.Settings testKitSettings() {
+    return TestKit.Settings.DEFAULT.withAdditionalConfig(
+      "akka.javasdk.agent.openai.api-key = n/a"
+    )
+      .withModelProvider(ReviewModerator.class, moderatorModel)
+      .withModelProvider(TechnicalReviewer.class, technicalModel)
+      .withModelProvider(StyleReviewer.class, styleModel)
+      .withModelProvider(ComplianceReviewer.class, complianceModel);
+  }
+
+  @Test
+  public void shouldRunScriptedPeerReview() {
+    // Moderator: respond to user messages based on content.
+    // Uses preferUserMessage so scripted step instructions drive the flow.
+    moderatorModel.fixedResponse(msg -> {
+      if (msg instanceof TestModelProvider.UserMessage um) {
+        var text = um.text();
+        if (text.startsWith("Task:")) {
+          return new AiResponse(
+            startScriptedConversation(
+              "API design document review",
+              List.of(
+                new ParticipantRef("technical-reviewer"),
+                new ParticipantRef("style-reviewer"),
+                new ParticipantRef("compliance-reviewer")
+              ),
+              List.of(
+                new ScriptStep("technical-reviewer", "Review for technical accuracy"),
+                new ScriptStep("style-reviewer", "Review for clarity and style"),
+                new ScriptStep("compliance-reviewer", "Review for compliance"),
+                new ScriptStep("moderator", "Synthesize all reviews")
+              )
+            )
+          );
+        }
+        if (text.contains("provide_prompt")) {
+          return new AiResponse(
+            providePrompt("Please review this document from your area of expertise.")
+          );
+        }
+        if (text.contains("submit_turn")) {
+          return new AiResponse(
+            submitTurn(
+              "Based on all reviews, the document is approved with minor revisions needed."
+            )
+          );
+        }
+        if (text.contains("Moderation capability")) {
+          // Conversation completed — moderator sees available participants again
+          return new AiResponse(
+            completeTask(
+              new ReviewResult(
+                "API design document",
+                "Approved with minor revisions.",
+                List.of(
+                  "Technical: API contracts are well-defined",
+                  "Style: Clear and readable",
+                  "Compliance: Meets data handling requirements"
+                )
+              )
+            )
+          );
+        }
+        return new AiResponse("Acknowledged.");
+      }
+      return new AiResponse("Acknowledged.");
+    });
+
+    // Participants: submit turn whenever given the floor
+    technicalModel.fixedResponse(msg -> {
+      if (msg instanceof TestModelProvider.ToolResult tr && tr.name().equals(SUBMIT_TURN)) {
+        return new AiResponse("Turn submitted.");
+      }
+      return new AiResponse(submitTurn("API contracts are well-defined and consistent."));
+    });
+
+    styleModel.fixedResponse(msg -> {
+      if (msg instanceof TestModelProvider.ToolResult tr && tr.name().equals(SUBMIT_TURN)) {
+        return new AiResponse("Turn submitted.");
+      }
+      return new AiResponse(
+        submitTurn("Document is clear and readable with good structure.")
+      );
+    });
+
+    complianceModel.fixedResponse(msg -> {
+      if (msg instanceof TestModelProvider.ToolResult tr && tr.name().equals(SUBMIT_TURN)) {
+        return new AiResponse("Turn submitted.");
+      }
+      return new AiResponse(submitTurn("Meets data handling and privacy requirements."));
+    });
+
+    var response = httpClient
+      .POST("/peerreview")
+      .withRequestBody(new PeerReviewEndpoint.ReviewRequest("Review the API design document"))
+      .responseBodyAs(PeerReviewEndpoint.ReviewResponse.class)
+      .invoke()
+      .body();
+
+    var taskId = response.taskId();
+    assertThat(taskId).isNotBlank();
+
+    Awaitility.await()
+      .ignoreExceptions()
+      .atMost(30, TimeUnit.SECONDS)
+      .untilAsserted(() -> {
+        var snapshot = componentClient.forTask(taskId).get(ReviewTasks.REVIEW);
+        assertThat(snapshot.result()).isNotNull();
+        assertThat(snapshot.result().document()).isEqualTo("API design document");
+        assertThat(snapshot.result().assessment()).contains("Approved");
+        assertThat(snapshot.result().reviewerFindings()).hasSize(3);
+      });
+  }
+}


### PR DESCRIPTION
Runtime changes:

- https://github.com/lightbend/akka-runtime/pull/5032

Some example runs of the 3 demo samples, at the session history level, with combined sessions across the agents:

- [debate-history.txt](https://github.com/user-attachments/files/26623668/debate-history.txt)
- [peer-review-history.txt](https://github.com/user-attachments/files/26623671/peer-review-history.txt)
- [negotiation-history.txt](https://github.com/user-attachments/files/26623672/negotiation-history.txt)
