### PR TITLE
fix: Unwrap delegated command payloads

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/CommandSerialization.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/CommandSerialization.scala
@@ -11,6 +11,7 @@ import java.util
 import scala.util.control.NonFatal
 
 import akka.annotation.InternalApi
+import akka.javasdk.impl.serialization.JsonSerializer
 import akka.javasdk.impl.serialization.Serializer
 import akka.runtime.sdk.spi.BytesPayload
 
@@ -19,6 +20,9 @@ import akka.runtime.sdk.spi.BytesPayload
  */
 @InternalApi
 object CommandSerialization {
+
+  // Content type used by autonomous agent delegation for tool call arguments
+  private val UntypedJsonObjectContentType = JsonSerializer.JsonContentTypePrefix + "object"
 
   def deserializeComponentClientCommand(
       method: Method,
@@ -37,7 +41,14 @@ object CommandSerialization {
       try {
         parameterTypes.head match {
           case paramClass: Class[_] =>
-            Some(serializer.fromBytes(paramClass, command).asInstanceOf[AnyRef])
+            // When the payload is an untyped JSON object (e.g. from autonomous agent delegation where
+            // the LLM produces tool call arguments as a JSON object wrapping the method parameter),
+            // unwrap the single property value to match the expected parameter type.
+            if (command.contentType == UntypedJsonObjectContentType) {
+              Some(unwrapSingleParameter(method, command, paramClass, serializer))
+            } else {
+              Some(serializer.fromBytes(paramClass, command).asInstanceOf[AnyRef])
+            }
           case parameterizedType: ParameterizedType =>
             if (classOf[java.util.Collection[_]]
                 .isAssignableFrom(parameterizedType.getRawType.asInstanceOf[Class[_]])) {
@@ -64,5 +75,27 @@ object CommandSerialization {
             ex)
       }
     }
+  }
+
+  /**
+   * Unwraps a single property from a JSON object payload, matching the ToolExecutor pattern. The JSON from LLM tool
+   * calls is always an object like {"paramName": value}, where paramName matches the method parameter name.
+   */
+  private def unwrapSingleParameter(
+      method: Method,
+      command: BytesPayload,
+      paramClass: Class[_],
+      serializer: Serializer): AnyRef = {
+    val mapper = serializer.objectMapper
+    val jsonNode = mapper.readTree(command.bytes.toArrayUnsafe())
+    val paramName = method.getParameters.head.getName
+    val valueNode = jsonNode.get(paramName)
+    if (valueNode == null) {
+      throw new IllegalArgumentException(
+        s"JSON object does not contain expected property [$paramName] " +
+        s"for method [${method.getDeclaringClass.getName}.${method.getName}]")
+    }
+    val javaType = mapper.getTypeFactory.constructType(paramClass)
+    mapper.treeToValue(valueNode, javaType).asInstanceOf[AnyRef]
   }
 }

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/CommandSerializationSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/CommandSerializationSpec.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl
+
+import akka.javasdk.JsonSupport
+import akka.javasdk.impl.serialization.JsonSerializer
+import akka.javasdk.impl.serialization.Serializer
+import akka.util.ByteString
+import akka.runtime.sdk.spi.BytesPayload
+import org.scalatest.TestSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+object CommandSerializationSpec {
+  // test classes need to be defined outside the test class for reflection to work
+  class StringParamHandler {
+    def handle(message: String): String = message
+  }
+
+  class IntParamHandler {
+    def handle(count: java.lang.Integer): java.lang.Integer = count
+  }
+
+  case class MyRecord(name: String, value: Int)
+
+  class RecordParamHandler {
+    def handle(request: MyRecord): MyRecord = request
+  }
+
+  class NoParamHandler {
+    def handle(): String = "ok"
+  }
+}
+
+class CommandSerializationSpec extends AnyWordSpecLike with TestSuite with Matchers {
+  import CommandSerializationSpec._
+
+  private val serializer = new Serializer(JsonSupport.getObjectMapper)
+  private val untypedObjectContentType = JsonSerializer.JsonContentTypePrefix + "object"
+
+  private def method(cls: Class[_]) =
+    cls.getMethods.find(_.getName == "handle").get
+
+  private def untypedJsonPayload(json: String): BytesPayload =
+    new BytesPayload(ByteString.fromString(json), untypedObjectContentType)
+
+  private def typedJsonPayload(json: String, typeName: String): BytesPayload =
+    new BytesPayload(ByteString.fromString(json), JsonSerializer.JsonContentTypePrefix + typeName)
+
+  "CommandSerialization" should {
+
+    "unwrap String parameter from untyped JSON object" in {
+      val m = method(classOf[StringParamHandler])
+      val payload = untypedJsonPayload("""{"message":"hello world"}""")
+
+      val result = CommandSerialization.deserializeComponentClientCommand(m, payload, serializer)
+
+      result shouldBe Some("hello world")
+    }
+
+    "unwrap Integer parameter from untyped JSON object" in {
+      val m = method(classOf[IntParamHandler])
+      val payload = untypedJsonPayload("""{"count":42}""")
+
+      val result = CommandSerialization.deserializeComponentClientCommand(m, payload, serializer)
+
+      result shouldBe Some(42)
+    }
+
+    "fail with clear error when expected property is missing from untyped JSON object" in {
+      val m = method(classOf[StringParamHandler])
+      val payload = untypedJsonPayload("""{"wrongName":"hello"}""")
+
+      val ex = intercept[IllegalArgumentException] {
+        CommandSerialization.deserializeComponentClientCommand(m, payload, serializer)
+      }
+      ex.getMessage should include("message")
+    }
+
+    "unwrap record parameter from untyped JSON object" in {
+      // LLM wraps the record under the parameter name: {"request": {"name": "test", "value": 123}}
+      val m = method(classOf[RecordParamHandler])
+      val payload = untypedJsonPayload("""{"request":{"name":"test","value":123}}""")
+
+      val result = CommandSerialization.deserializeComponentClientCommand(m, payload, serializer)
+
+      result shouldBe Some(MyRecord("test", 123))
+    }
+
+    "deserialize String parameter from typed JSON payload (normal component client path)" in {
+      // Typed content type (from normal componentClient calls) should use existing path
+      val m = method(classOf[StringParamHandler])
+      val payload = typedJsonPayload("\"hello world\"", classOf[String].getName)
+
+      val result = CommandSerialization.deserializeComponentClientCommand(m, payload, serializer)
+
+      result shouldBe Some("hello world")
+    }
+
+    "return None for no-param handler" in {
+      val m = method(classOf[NoParamHandler])
+      val payload = BytesPayload.empty
+
+      val result = CommandSerialization.deserializeComponentClientCommand(m, payload, serializer)
+
+      result shouldBe None
+    }
+  }
+}


### PR DESCRIPTION
Before fix, delegation from autonomous to request based agent would fail with errors.

Like this for String input:
```
11:49:27.505 ERROR c.example.application.WeatherAgent - Agent [weather-agent], command handler error [24710210-aa58-4d13-8cdc-48f97a85e112]: akka.javasdk.impl.agent.AgentException: Unexpected failure: java.lang.IllegalArgumentException: Could not deserialize message of type [json.akka.io/object] to type [java.lang.String] as expected by method [com.example.application.WeatherAgent.query]
akka.javasdk.impl.agent.AgentException: Unexpected failure: java.lang.IllegalArgumentException: Could not deserialize message of type [json.akka.io/object] to type [java.lang.String] as expected by method [com.example.application.WeatherAgent.query]
	at akka.javasdk.impl.agent.AgentImpl.$anonfun$handleCommand$1(AgentImpl.scala:602)
	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:691)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:500)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:48)
	at java.base/java.util.concurrent.ThreadPerTaskExecutor$TaskRunner.run(ThreadPerTaskExecutor.java:291)
	at java.base/java.lang.VirtualThread.run(VirtualThread.java:456)
Caused by: java.lang.IllegalArgumentException: Could not deserialize message of type [json.akka.io/object] to type [java.lang.String] as expected by method [com.example.application.WeatherAgent.query]
	at akka.javasdk.impl.CommandSerialization$.deserializeComponentClientCommand(CommandSerialization.scala:64)
	at akka.javasdk.impl.agent.ReflectiveAgentRouter.handleCommand(ReflectiveAgentRouter.scala:55)
	at akka.javasdk.impl.agent.AgentImpl.$anonfun$handleCommand$1(AgentImpl.scala:490)
	... 5 common frames omitted
```

and like this for class input:
```
11:52:29.390 WARN  akka.runtime.ComponentClientsImpl - Component client error [bde05110-a03c-41db-8bd1-7e4582b01b3d]
java.lang.IllegalArgumentException: text cannot be null or blank
	at dev.langchain4j.internal.Exceptions.illegalArgument(Exceptions.java:23)
	at dev.langchain4j.internal.ValidationUtils.ensureNotBlank(ValidationUtils.java:169)
	at dev.langchain4j.internal.ValidationUtils.ensureNotBlank(ValidationUtils.java:156)
	at dev.langchain4j.data.message.TextContent.<init>(TextContent.java:21)
	at dev.langchain4j.data.message.TextContent.from(TextContent.java:63)
	at kalix.runtime.agent.AgentUtilities$.$anonfun$requestToOriginalMessages$1(AgentUtilities.scala:111)
	at scala.concurrent.Future$.$anonfun$traverse$1(Future.scala:887)
	at scala.collection.IterableOnceOps.foldLeft(IterableOnce.scala:738)
	at scala.collection.IterableOnceOps.foldLeft$(IterableOnce.scala:732)
	at scala.collection.AbstractIterator.foldLeft(Iterator.scala:1313)
	at scala.concurrent.Future$.traverse(Future.scala:887)
	at kalix.runtime.agent.AgentUtilities$.requestToOriginalMessages(AgentUtilities.scala:109)
	at kalix.runtime.agent.Agent.origMessagesFut$1(Agent.scala:285)
	at kalix.runtime.agent.Agent.$anonfun$requestModel$3(Agent.scala:302)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:503)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:48)
	at java.base/java.util.concurrent.ThreadPerTaskExecutor$TaskRunner.run(ThreadPerTaskExecutor.java:291)
	at java.base/java.lang.VirtualThread.run(VirtualThread.java:456)
```

With this fix it works for both kinds of command handler input

