### PR TITLE
chore: Improved delegation in testkit and test coverage

### DIFF
--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestModelProvider.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestModelProvider.java
@@ -586,12 +586,11 @@ public final class TestModelProvider implements ModelProvider.Custom {
     }
 
     /**
-     * Returns the tool name for a {@code send_<Method>_to_<agent>} tool, derived from the method
-     * name and target agent's component ID.
+     * Returns the tool name for a {@code delegate_to_<agent>} tool for request-based agent
+     * delegation, derived from the target agent's component ID.
      */
     public static String sendToToolName(Class<?> agentClass, String methodName) {
-      var capitalizedMethod = Character.toUpperCase(methodName.charAt(0)) + methodName.substring(1);
-      return "send_" + sanitize(capitalizedMethod) + "_to_" + sanitize(componentId(agentClass));
+      return "delegate_to_" + sanitize(componentId(agentClass));
     }
 
     /**
@@ -628,20 +627,19 @@ public final class TestModelProvider implements ModelProvider.Custom {
     }
 
     /**
-     * Creates a {@link ToolInvocationRequest} for a {@code send_<Method>_to_<agent>} tool, used
-     * when an autonomous agent delegates to a request-based agent. The method name has its first
-     * letter capitalized to match the runtime naming convention.
+     * Creates a {@link ToolInvocationRequest} for a {@code delegate_to_<agent>} tool, used when an
+     * autonomous agent delegates to a request-based agent. The method name is not part of the tool
+     * name — the runtime resolves it from the agent's definition.
      *
      * @param agentClass the request-based agent class (must carry {@code @Component} or
      *     {@code @ComponentId})
-     * @param methodName the exact name of the agent method to invoke
+     * @param methodName the exact name of the agent method to invoke (kept for API compatibility
+     *     but not used in the tool name)
      * @param argsJson the JSON arguments to pass (must match the method's parameter type)
      */
     public static ToolInvocationRequest sendTo(
         Class<?> agentClass, String methodName, String argsJson) {
-      var capitalizedMethod = Character.toUpperCase(methodName.charAt(0)) + methodName.substring(1);
-      var toolName =
-          "send_" + sanitize(capitalizedMethod) + "_to_" + sanitize(componentId(agentClass));
+      var toolName = "delegate_to_" + sanitize(componentId(agentClass));
       return new ToolInvocationRequest(toolName, argsJson);
     }
 

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestModelProvider.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestModelProvider.java
@@ -7,8 +7,10 @@ package akka.javasdk.testkit;
 import akka.japi.Pair;
 import akka.javasdk.JsonSupport;
 import akka.javasdk.agent.Agent;
+import akka.javasdk.agent.AgentDelegationWorker;
 import akka.javasdk.agent.MessageContent;
 import akka.javasdk.agent.ModelProvider;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.agent.task.Task;
 import akka.javasdk.agent.task.TaskDefinition;
 import akka.javasdk.agent.task.TaskTemplate;
@@ -558,7 +560,7 @@ public final class TestModelProvider implements ModelProvider.Custom {
      * Returns the tool name for a {@code handoff_to_<agent>} tool, derived from the target agent's
      * component ID.
      */
-    public static String handoffToToolName(Class<?> agentClass) {
+    public static String handoffToToolName(Class<? extends AutonomousAgent> agentClass) {
       return "handoff_to_" + sanitize(componentId(agentClass));
     }
 
@@ -566,11 +568,12 @@ public final class TestModelProvider implements ModelProvider.Custom {
      * Creates a {@link ToolInvocationRequest} for a {@code handoff_to_<agent>} tool, deriving the
      * tool name from the target agent's component ID.
      *
-     * @param agentClass the agent class to hand off to (must carry {@code @Component} or
+     * @param agentClass the autonomous agent class to hand off to (must carry {@code @Component} or
      *     {@code @ComponentId})
      * @param context context passed to the receiving agent
      */
-    public static ToolInvocationRequest handoffTo(Class<?> agentClass, String context) {
+    public static ToolInvocationRequest handoffTo(
+        Class<? extends AutonomousAgent> agentClass, String context) {
       var toolName = "handoff_to_" + sanitize(componentId(agentClass));
       return new ToolInvocationRequest(toolName, "{\"context\":" + toJsonString(context) + "}");
     }
@@ -581,7 +584,8 @@ public final class TestModelProvider implements ModelProvider.Custom {
      * Returns the tool name for a {@code delegate_<task>_to_<agent>} tool, derived from the task
      * definition and target agent's component ID.
      */
-    public static String delegateToToolName(TaskDefinition<?> task, Class<?> agentClass) {
+    public static String delegateToToolName(
+        TaskDefinition<?> task, Class<? extends AgentDelegationWorker> agentClass) {
       return "delegate_" + sanitize(task.name()) + "_to_" + sanitize(componentId(agentClass));
     }
 
@@ -589,7 +593,7 @@ public final class TestModelProvider implements ModelProvider.Custom {
      * Returns the tool name for a {@code delegate_to_<agent>} tool for request-based agent
      * delegation, derived from the target agent's component ID.
      */
-    public static String sendToToolName(Class<?> agentClass, String methodName) {
+    public static String delegateToToolName(Class<? extends AgentDelegationWorker> agentClass) {
       return "delegate_to_" + sanitize(componentId(agentClass));
     }
 
@@ -603,7 +607,7 @@ public final class TestModelProvider implements ModelProvider.Custom {
      * @param instructions instructions passed to the delegated agent
      */
     public static ToolInvocationRequest delegateTo(
-        Task<?> task, Class<?> agentClass, String instructions) {
+        Task<?> task, Class<? extends AgentDelegationWorker> agentClass, String instructions) {
       var toolName =
           "delegate_" + sanitize(task.name()) + "_to_" + sanitize(componentId(agentClass));
       return new ToolInvocationRequest(
@@ -620,7 +624,9 @@ public final class TestModelProvider implements ModelProvider.Custom {
      * @param templateParams values for the template parameters
      */
     public static ToolInvocationRequest delegateTo(
-        TaskTemplate<?> task, Class<?> agentClass, Map<String, String> templateParams) {
+        TaskTemplate<?> task,
+        Class<? extends AgentDelegationWorker> agentClass,
+        Map<String, String> templateParams) {
       var toolName =
           "delegate_" + sanitize(task.name()) + "_to_" + sanitize(componentId(agentClass));
       return new ToolInvocationRequest(toolName, templateParamsToJson(templateParams));
@@ -628,17 +634,15 @@ public final class TestModelProvider implements ModelProvider.Custom {
 
     /**
      * Creates a {@link ToolInvocationRequest} for a {@code delegate_to_<agent>} tool, used when an
-     * autonomous agent delegates to a request-based agent. The method name is not part of the tool
-     * name — the runtime resolves it from the agent's definition.
+     * autonomous agent delegates to a request-based agent. The runtime resolves the target method
+     * from the agent's definition (request-based agents have a single effect method).
      *
      * @param agentClass the request-based agent class (must carry {@code @Component} or
      *     {@code @ComponentId})
-     * @param methodName the exact name of the agent method to invoke (kept for API compatibility
-     *     but not used in the tool name)
      * @param argsJson the JSON arguments to pass (must match the method's parameter type)
      */
-    public static ToolInvocationRequest sendTo(
-        Class<?> agentClass, String methodName, String argsJson) {
+    public static ToolInvocationRequest delegateTo(
+        Class<? extends AgentDelegationWorker> agentClass, String argsJson) {
       var toolName = "delegate_to_" + sanitize(componentId(agentClass));
       return new ToolInvocationRequest(toolName, argsJson);
     }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/FactCheckAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/FactCheckAgent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akkajavasdk.components.agent;
+
+import akka.javasdk.agent.Agent;
+import akka.javasdk.annotations.Component;
+
+@Component(id = "fact-check-agent")
+public class FactCheckAgent extends Agent {
+
+  public record FactCheckRequest(String claim, int confidence) {}
+
+  public record FactCheckResponse(String verdict, boolean verified) {}
+
+  public Effect<FactCheckResponse> checkFact(FactCheckRequest request) {
+    return effects()
+        .systemMessage("You are a fact checker.")
+        .userMessage(
+            "Check claim '" + request.claim() + "' with confidence " + request.confidence())
+        .map(raw -> new FactCheckResponse(raw, true))
+        .thenReply();
+  }
+}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/AutonomousAgentIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/AutonomousAgentIntegrationTest.java
@@ -17,6 +17,7 @@ import akka.javasdk.testkit.TestKit;
 import akka.javasdk.testkit.TestKitSupport;
 import akka.javasdk.testkit.TestModelProvider;
 import akka.javasdk.testkit.TestModelProvider.AiResponse;
+import akkajavasdk.components.agent.FactCheckAgent;
 import akkajavasdk.components.agent.SomeAgent;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +38,7 @@ public class AutonomousAgentIntegrationTest extends TestKitSupport {
   private final TestModelProvider specialistModel = new TestModelProvider();
   private final TestModelProvider requestDelegatingModel = new TestModelProvider();
   private final TestModelProvider someAgentModel = new TestModelProvider();
+  private final TestModelProvider factCheckAgentModel = new TestModelProvider();
 
   @Override
   protected TestKit.Settings testKitSettings() {
@@ -49,7 +51,8 @@ public class AutonomousAgentIntegrationTest extends TestKitSupport {
         .withModelProvider(TriageTestAgent.class, triageModel)
         .withModelProvider(SpecialistTestAgent.class, specialistModel)
         .withModelProvider(RequestDelegatingAgent.class, requestDelegatingModel)
-        .withModelProvider(SomeAgent.class, someAgentModel);
+        .withModelProvider(SomeAgent.class, someAgentModel)
+        .withModelProvider(FactCheckAgent.class, factCheckAgentModel);
   }
 
   @AfterEach
@@ -62,6 +65,7 @@ public class AutonomousAgentIntegrationTest extends TestKitSupport {
     specialistModel.reset();
     requestDelegatingModel.reset();
     someAgentModel.reset();
+    factCheckAgentModel.reset();
   }
 
   @Test
@@ -444,6 +448,103 @@ public class AutonomousAgentIntegrationTest extends TestKitSupport {
                       .orElseThrow();
               assertThat(taskFailed.taskId()).isEqualTo(taskId);
               assertThat(taskFailed.reason()).isNotBlank();
+            });
+  }
+
+  @Test
+  public void shouldUnwrapDelegatedCommandPayload() {
+    // Prefer ToolResult messages so we can match on the delegation response content
+    requestDelegatingModel.withMessageSelector(
+        messages ->
+            messages.stream()
+                .filter(m -> m instanceof TestModelProvider.ToolResult)
+                .findFirst()
+                .orElse(messages.getLast()));
+
+    // LLM tool call args wrap the String parameter under its name: {"question": "..."}
+    // The CommandSerialization unwrap fix extracts the value matching the method parameter name
+    requestDelegatingModel
+        .whenMessage(msg -> msg.contains("verify"))
+        .reply(sendTo(SomeAgent.class, "mapLlmResponse", "{\"question\":\"The sky is blue.\"}"));
+
+    // SomeAgent passes the unwrapped question as user message to the model,
+    // verify it arrived correctly
+    someAgentModel
+        .whenMessage(msg -> msg.contains("The sky is blue."))
+        .reply("Verified: the sky is indeed blue.");
+
+    // After successful delegation, the tool result contains SomeAgent's response.
+    // Match on that content so a failed delegation ("Delegation failed: ...") won't match.
+    requestDelegatingModel
+        .whenToolResult(result -> result.content().contains("sky is indeed blue"))
+        .thenReply(
+            result -> new AiResponse(completeTask("{\"value\":\"Claim verified.\",\"score\":90}")));
+
+    var taskId =
+        componentClient
+            .forAutonomousAgent(RequestDelegatingAgent.class, UUID.randomUUID().toString())
+            .runSingleTask(TestTasks.TEST_TASK.instructions("Please verify: the sky is blue."));
+
+    Awaitility.await()
+        .ignoreExceptions()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var snapshot = componentClient.forTask(taskId).get(TestTasks.TEST_TASK);
+              assertThat(snapshot.result()).isNotNull();
+              assertThat(snapshot.result().value()).isEqualTo("Claim verified.");
+              assertThat(snapshot.result().score()).isEqualTo(90);
+            });
+  }
+
+  @Test
+  public void shouldUnwrapTypedParameterWhenDelegatingToRequestBasedAgent() {
+    // Prefer ToolResult messages so we can match on the delegation response content
+    requestDelegatingModel.withMessageSelector(
+        messages ->
+            messages.stream()
+                .filter(m -> m instanceof TestModelProvider.ToolResult)
+                .findFirst()
+                .orElse(messages.getLast()));
+
+    // LLM tool call args wrap the record parameter under its name:
+    // {"request": {"claim": "...", "confidence": 95}}
+    // The unwrap fix extracts the inner object and deserializes it as FactCheckRequest
+    requestDelegatingModel
+        .whenMessage(msg -> msg.contains("round"))
+        .reply(
+            sendTo(
+                FactCheckAgent.class,
+                "checkFact",
+                "{\"request\":{\"claim\":\"The earth is round.\",\"confidence\":95}}"));
+
+    // FactCheckAgent builds its user message from the record fields,
+    // verify both fields arrived correctly
+    factCheckAgentModel
+        .whenMessage(msg -> msg.contains("The earth is round.") && msg.contains("95"))
+        .reply("Confirmed: the earth is round.");
+
+    // Match on the successful delegation result — "Confirmed" only appears
+    // in FactCheckAgent's model response, not in the initial task instructions
+    requestDelegatingModel
+        .whenToolResult(result -> result.content().contains("Confirmed"))
+        .thenReply(
+            result -> new AiResponse(completeTask("{\"value\":\"Fact confirmed.\",\"score\":95}")));
+
+    var taskId =
+        componentClient
+            .forAutonomousAgent(RequestDelegatingAgent.class, UUID.randomUUID().toString())
+            .runSingleTask(TestTasks.TEST_TASK.instructions("Check: the earth is round."));
+
+    Awaitility.await()
+        .ignoreExceptions()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var snapshot = componentClient.forTask(taskId).get(TestTasks.TEST_TASK);
+              assertThat(snapshot.result()).isNotNull();
+              assertThat(snapshot.result().value()).isEqualTo("Fact confirmed.");
+              assertThat(snapshot.result().score()).isEqualTo(95);
             });
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/AutonomousAgentIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/AutonomousAgentIntegrationTest.java
@@ -8,7 +8,6 @@ import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.comple
 import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.delegateTo;
 import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.failTask;
 import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.handoffTo;
-import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.sendTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import akka.javasdk.agent.Agent;
@@ -234,7 +233,7 @@ public class AutonomousAgentIntegrationTest extends TestKitSupport {
     // Autonomous agent delegates to request-based SomeAgent
     requestDelegatingModel
         .whenMessage(msg -> msg.contains("verify"))
-        .reply(sendTo(SomeAgent.class, "mapLlmResponse", "{\"claim\":\"The sky is blue.\"}"));
+        .reply(delegateTo(SomeAgent.class, "{\"claim\":\"The sky is blue.\"}"));
 
     // SomeAgent responds
     someAgentModel.fixedResponse("{\"response\":\"Verified: the sky is indeed blue.\"}");
@@ -465,7 +464,7 @@ public class AutonomousAgentIntegrationTest extends TestKitSupport {
     // The CommandSerialization unwrap fix extracts the value matching the method parameter name
     requestDelegatingModel
         .whenMessage(msg -> msg.contains("verify"))
-        .reply(sendTo(SomeAgent.class, "mapLlmResponse", "{\"question\":\"The sky is blue.\"}"));
+        .reply(delegateTo(SomeAgent.class, "{\"question\":\"The sky is blue.\"}"));
 
     // SomeAgent passes the unwrapped question as user message to the model,
     // verify it arrived correctly
@@ -513,9 +512,8 @@ public class AutonomousAgentIntegrationTest extends TestKitSupport {
     requestDelegatingModel
         .whenMessage(msg -> msg.contains("round"))
         .reply(
-            sendTo(
+            delegateTo(
                 FactCheckAgent.class,
-                "checkFact",
                 "{\"request\":{\"claim\":\"The earth is round.\",\"confidence\":95}}"));
 
     // FactCheckAgent builds its user message from the record fields,

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/RequestDelegatingAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/RequestDelegatingAgent.java
@@ -9,6 +9,7 @@ import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.agent.autonomous.capability.Delegation;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
+import akkajavasdk.components.agent.FactCheckAgent;
 import akkajavasdk.components.agent.SomeAgent;
 
 @Component(id = "request-delegating-agent")
@@ -19,6 +20,6 @@ public class RequestDelegatingAgent extends AutonomousAgent {
     return define()
         .goal("Coordinate work by delegating fact-checking to a request-based agent.")
         .capability(TaskAcceptance.of(TestTasks.TEST_TASK).maxIterationsPerTask(5))
-        .capability(Delegation.to(SomeAgent.class));
+        .capability(Delegation.to(SomeAgent.class, FactCheckAgent.class));
   }
 }

--- a/akka-javasdk-tests/src/test/resources/META-INF/akka-javasdk-components_akka-javasdk-tests.conf
+++ b/akka-javasdk-tests/src/test/resources/META-INF/akka-javasdk-components_akka-javasdk-tests.conf
@@ -1,6 +1,7 @@
 akka.javasdk {
   components {
     agent = [
+      "akkajavasdk.components.agent.FactCheckAgent",
       "akkajavasdk.components.agent.SomeAgent",
       "akkajavasdk.components.agent.SomeMultiModalUserMessageAgent",
       "akkajavasdk.components.agent.SomeAgentAcceptingInt",

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/CommandSerializationSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/CommandSerializationSpec.scala
@@ -7,8 +7,8 @@ package akka.javasdk.impl
 import akka.javasdk.JsonSupport
 import akka.javasdk.impl.serialization.JsonSerializer
 import akka.javasdk.impl.serialization.Serializer
-import akka.util.ByteString
 import akka.runtime.sdk.spi.BytesPayload
+import akka.util.ByteString
 import org.scalatest.TestSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike

--- a/docs/src/modules/sdk/pages/autonomous-agents.html.md
+++ b/docs/src/modules/sdk/pages/autonomous-agents.html.md
@@ -1007,8 +1007,8 @@ handoffTo(BillingSpecialist.class, "Customer has billing dispute");
 // Delegate a subtask to a worker agent
 delegateTo(ResearchTasks.FINDINGS, Researcher.class, "Research quantum computing");
 
-// Invoke a method on a request-based agent
-sendTo(SomeAgent.class, "processData", "{\"input\":\"value\"}");
+// Delegate to a request-based agent
+delegateTo(SomeAgent.class, "{\"input\":\"value\"}");
 ```
 
 **Testing a delegation flow:**


### PR DESCRIPTION
Looks like the testkit was mimic:ing the runtime incorrectly for delegation. Fix for that and added integration test coverage for delegate agent inputs.