### PR TITLE
feat: validate task definition on get and result

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskException.java
@@ -42,4 +42,36 @@ public abstract sealed class TaskException extends RuntimeException {
       super(taskId, reason);
     }
   }
+
+  /** Thrown when a task result is retrieved with a mismatched task definition. */
+  public static final class TypeMismatch extends TaskException {
+    private TypeMismatch(String taskId, String reason) {
+      super(taskId, reason);
+    }
+
+    public static TypeMismatch forName(String taskId, String actualName, String requestedName) {
+      return new TypeMismatch(
+          taskId,
+          "Task ["
+              + taskId
+              + "] was created with task definition ["
+              + actualName
+              + "] but was requested with ["
+              + requestedName
+              + "]");
+    }
+
+    public static TypeMismatch forResultType(
+        String taskId, String actualType, String requestedType) {
+      return new TypeMismatch(
+          taskId,
+          "Task ["
+              + taskId
+              + "] has result type ["
+              + actualType
+              + "] but was requested as ["
+              + requestedType
+              + "]");
+    }
+  }
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/TaskClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/TaskClientImpl.scala
@@ -204,7 +204,20 @@ private[javasdk] final class TaskClientImpl(
   }
 
   private def deserializeResult[R](taskState: TaskState, taskDefinition: TaskDefinition[R]): R = {
+    validateTaskDefinition(taskState, taskDefinition)
     deserializeResultFromString(taskState.result(), taskDefinition)
+  }
+
+  private def validateTaskDefinition[R](taskState: TaskState, taskDefinition: TaskDefinition[R]): Unit = {
+    if (taskState.name() != taskDefinition.name()) {
+      throw TaskException.TypeMismatch.forName(taskId, taskState.name(), taskDefinition.name())
+    }
+    if (taskState.resultTypeName() != taskDefinition.resultType().getName) {
+      throw TaskException.TypeMismatch.forResultType(
+        taskId,
+        taskState.resultTypeName(),
+        taskDefinition.resultType().getName)
+    }
   }
 
   private def deserializeResultFromString[R](resultString: String, taskDefinition: TaskDefinition[R]): R = {

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/CommandSerializationSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/CommandSerializationSpec.scala
@@ -7,8 +7,8 @@ package akka.javasdk.impl
 import akka.javasdk.JsonSupport
 import akka.javasdk.impl.serialization.JsonSerializer
 import akka.javasdk.impl.serialization.Serializer
-import akka.util.ByteString
 import akka.runtime.sdk.spi.BytesPayload
+import akka.util.ByteString
 import org.scalatest.TestSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/client/TaskClientImplSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/client/TaskClientImplSpec.scala
@@ -28,6 +28,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 object TaskClientImplSpec {
   case class TestResult(value: String, score: Int)
+  case class OtherResult(title: String, summary: String)
 
   case class RecordedCommand(methodName: String, payload: BytesPayload) {
     def payloadAs[T](implicit ct: reflect.ClassTag[T], serializer: Serializer): T =
@@ -241,6 +242,38 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
       snapshot.status() shouldBe TaskStatus.FAILED
       snapshot.failureReason() shouldBe "something broke"
     }
+
+    "throw TypeMismatch when task definition name does not match" in {
+      val otherTask: Task[TestResult] = Task
+        .define("Other task")
+        .description("A different task")
+        .resultConformsTo(classOf[TestResult])
+
+      val mock =
+        mockEntityClient(taskState(TaskStatus.COMPLETED, result = """{"value":"done","score":42}"""))
+      val client = createClient(mock)
+
+      val ex = client.getAsync(otherTask).asScala.failed.futureValue
+      ex shouldBe a[TaskException.TypeMismatch]
+      ex.getMessage should include("Other task")
+      ex.getMessage should include("Test task")
+    }
+
+    "throw TypeMismatch when result type does not match" in {
+      val otherTask: Task[OtherResult] = Task
+        .define("Test task") // same name, different result type
+        .description("A different task")
+        .resultConformsTo(classOf[OtherResult])
+
+      val mock =
+        mockEntityClient(taskState(TaskStatus.COMPLETED, result = """{"value":"done","score":42}"""))
+      val client = createClient(mock)
+
+      val ex = client.getAsync(otherTask).asScala.failed.futureValue
+      ex shouldBe a[TaskException.TypeMismatch]
+      ex.getMessage should include(classOf[OtherResult].getName)
+      ex.getMessage should include(classOf[TestResult].getName)
+    }
   }
 
   "TaskClientImpl resultAsync" should {
@@ -301,6 +334,52 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
 
       val ex = failedWith[TaskException.Cancelled](future)
       ex.reason() shouldBe "cancelled via notification"
+    }
+
+    "throw TypeMismatch when task definition name does not match for already completed task" in {
+      val otherTask: Task[TestResult] = Task
+        .define("Other task")
+        .description("A different task")
+        .resultConformsTo(classOf[TestResult])
+
+      val client =
+        createClient(mockEntityClient(taskState(TaskStatus.COMPLETED, result = """{"value":"done","score":42}""")))
+
+      val ex = client.resultAsync(otherTask).asScala.failed.futureValue
+      ex shouldBe a[TaskException.TypeMismatch]
+      ex.getMessage should include("Other task")
+      ex.getMessage should include("Test task")
+    }
+
+    "throw TypeMismatch when result type does not match for already completed task" in {
+      val otherTask: Task[OtherResult] = Task
+        .define("Test task")
+        .description("A different task")
+        .resultConformsTo(classOf[OtherResult])
+
+      val client =
+        createClient(mockEntityClient(taskState(TaskStatus.COMPLETED, result = """{"value":"done","score":42}""")))
+
+      val ex = client.resultAsync(otherTask).asScala.failed.futureValue
+      ex shouldBe a[TaskException.TypeMismatch]
+      ex.getMessage should include(classOf[OtherResult].getName)
+      ex.getMessage should include(classOf[TestResult].getName)
+    }
+
+    "throw TypeMismatch when task definition name does not match for in-progress task" in {
+      val otherTask: Task[TestResult] = Task
+        .define("Other task")
+        .description("A different task")
+        .resultConformsTo(classOf[TestResult])
+
+      val notificationPromise = Promise[EntityReply]()
+      val client =
+        createClient(mockEntityClient(taskState(TaskStatus.IN_PROGRESS), Source.future(notificationPromise.future)))
+
+      val ex = client.resultAsync(otherTask).asScala.failed.futureValue
+      ex shouldBe a[TaskException.TypeMismatch]
+      ex.getMessage should include("Other task")
+      ex.getMessage should include("Test task")
     }
   }
 }


### PR DESCRIPTION
Refs:

- https://github.com/lightbend/akka-runtime/issues/5038

Validate both the name and the result type name, against a provided task definition when we're doing task client get. And this applies on the result methods as well. 