### PR TITLE
test: completeTask with json vs string vs object task types

### DIFF
--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestModelProvider.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestModelProvider.java
@@ -525,17 +525,43 @@ public final class TestModelProvider implements ModelProvider.Custom {
 
     /**
      * Creates a {@link ToolInvocationRequest} for the {@code complete_task} tool, with the given
-     * result JSON. The JSON must conform to the task's result type schema.
+     * raw result JSON string. The JSON must conform to the task's result type schema. Use {@link
+     * #completeTask(Object)} for type-safe serialization of result objects.
      */
-    public static ToolInvocationRequest completeTask(String resultJson) {
+    public static ToolInvocationRequest completeTaskJson(String resultJson) {
+      if (resultJson == null
+          || !resultJson.trim().startsWith("{")
+          || !resultJson.trim().endsWith("}")) {
+        throw new IllegalArgumentException(
+            "resultJson must be a JSON object (starting with '{' and ending with '}'). "
+                + "For type-safe serialization, use completeTask(Object) instead.");
+      }
       return new ToolInvocationRequest(COMPLETE_TASK, resultJson);
     }
 
     /**
      * Creates a {@link ToolInvocationRequest} for the {@code complete_task} tool, serializing the
-     * given result object to JSON.
+     * given result object to JSON. For non-object result types (String, Integer, Number, Boolean,
+     * and collections/arrays), wraps the value in a {@code {"result": ...}} JSON object matching
+     * the runtime's expected format. For object types (records, POJOs), the object's own properties
+     * become the tool arguments directly (passthrough).
      */
     public static ToolInvocationRequest completeTask(Object result) {
+      if (result instanceof String s) {
+        return new ToolInvocationRequest(COMPLETE_TASK, "{\"result\":" + toJsonString(s) + "}");
+      }
+      if (result instanceof Number || result instanceof Boolean) {
+        return new ToolInvocationRequest(COMPLETE_TASK, "{\"result\":" + result + "}");
+      }
+      if (result instanceof java.util.Collection || result.getClass().isArray()) {
+        try {
+          return new ToolInvocationRequest(
+              COMPLETE_TASK,
+              "{\"result\":" + JsonSupport.getObjectMapper().writeValueAsString(result) + "}");
+        } catch (JsonProcessingException e) {
+          throw new IllegalArgumentException("Failed to serialize task result to JSON", e);
+        }
+      }
       try {
         return new ToolInvocationRequest(
             COMPLETE_TASK, JsonSupport.getObjectMapper().writeValueAsString(result));

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/AgentLifecycleIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/AgentLifecycleIntegrationTest.java
@@ -42,7 +42,7 @@ public class AgentLifecycleIntegrationTest extends TestKitSupport {
 
   @Test
   public void shouldGetAgentState() {
-    testAgentModel.fixedResponse(completeTask("{\"value\":\"done\",\"score\":1}"));
+    testAgentModel.fixedResponse(completeTask(new TestTasks.TestResult("done", 1)));
 
     var agentId = UUID.randomUUID().toString();
     var agentClient = componentClient.forAutonomousAgent(TestAutonomousAgent.class, agentId);
@@ -69,7 +69,7 @@ public class AgentLifecycleIntegrationTest extends TestKitSupport {
 
   @Test
   public void shouldPauseAndResumeAgent() {
-    testAgentModel.fixedResponse(completeTask("{\"value\":\"done after resume\",\"score\":1}"));
+    testAgentModel.fixedResponse(completeTask(new TestTasks.TestResult("done after resume", 1)));
 
     var agentId = UUID.randomUUID().toString();
     var agentClient = componentClient.forAutonomousAgent(TestAutonomousAgent.class, agentId);
@@ -154,7 +154,7 @@ public class AgentLifecycleIntegrationTest extends TestKitSupport {
     testAgentModel.fixedResponse(
         new AiResponse(
             "",
-            List.of(completeTask("{\"value\":\"done\",\"score\":1}")),
+            List.of(completeTask(new TestTasks.TestResult("done", 1))),
             Optional.of(new Agent.TokenUsage(150, 42))));
 
     var agentId = UUID.randomUUID().toString();

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/AutonomousAgentIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/AutonomousAgentIntegrationTest.java
@@ -64,15 +64,15 @@ public class AutonomousAgentIntegrationTest extends TestKitSupport {
 
     workerModel.fixedResponse(
         completeTask(
-            "{\"topic\":\"Quantum Computing\",\"findings\":\"Qubits enable parallel"
-                + " computation.\"}"));
+            new TestTasks.FindingsResult(
+                "Quantum Computing", "Qubits enable parallel computation.")));
 
     coordinatorModel
         .whenMessage(msg -> msg.contains("Continue working"))
         .reply(
             completeTask(
-                "{\"title\":\"Quantum Computing Summary\",\"summary\":\"Qubits enable parallel"
-                    + " computation.\"}"));
+                new TestTasks.ResearchResult(
+                    "Quantum Computing Summary", "Qubits enable parallel computation.")));
 
     var taskId =
         componentClient
@@ -97,8 +97,7 @@ public class AutonomousAgentIntegrationTest extends TestKitSupport {
         handoffTo(SpecialistTestAgent.class, "Customer has a billing dispute."));
 
     specialistModel.fixedResponse(
-        completeTask(
-            "{\"category\":\"billing\",\"resolution\":\"Refund issued.\",\"resolved\":true}"));
+        completeTask(new TestTasks.SupportResolution("billing", "Refund issued.", true)));
 
     var taskId =
         componentClient
@@ -127,7 +126,7 @@ public class AutonomousAgentIntegrationTest extends TestKitSupport {
 
     requestDelegatingModel
         .whenMessage(msg -> msg.contains("Continue working"))
-        .reply(completeTask("{\"value\":\"Claim verified.\",\"score\":90}"));
+        .reply(completeTask(new TestTasks.TestResult("Claim verified.", 90)));
 
     var taskId =
         componentClient

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/DirectedModerationIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/DirectedModerationIntegrationTest.java
@@ -103,7 +103,7 @@ public class DirectedModerationIntegrationTest extends TestKitSupport {
               case END_CONVERSATION ->
                   new AiResponse(
                       completeTask(
-                          "{\"topic\":\"Directed debate\",\"conclusion\":\"Agreement reached.\"}"));
+                          new TestTasks.ModerationResult("Directed debate", "Agreement reached.")));
               case COMPLETE_TASK -> new AiResponse("Done.");
               default -> new AiResponse("Acknowledged.");
             };

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/ScriptedModerationIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/ScriptedModerationIntegrationTest.java
@@ -103,8 +103,8 @@ public class ScriptedModerationIntegrationTest extends TestKitSupport {
               // Conversation completed
               return new AiResponse(
                   completeTask(
-                      "{\"topic\":\"Test topic\",\"conclusion\":\"Balanced conclusion"
-                          + " reached.\"}"));
+                      new TestTasks.ModerationResult(
+                          "Test topic", "Balanced conclusion reached.")));
             }
             return new AiResponse("Acknowledged.");
           }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TaskIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TaskIntegrationTest.java
@@ -5,6 +5,7 @@
 package akkajavasdk.components.agent.autonomous;
 
 import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.completeTask;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.completeTaskJson;
 import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.delegateTo;
 import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.failTask;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,7 +63,7 @@ public class TaskIntegrationTest extends TestKitSupport {
 
   @Test
   public void shouldCompleteTaskWithTypedResult() {
-    testAgentModel.fixedResponse(completeTask("{\"value\":\"42 is the answer.\",\"score\":95}"));
+    testAgentModel.fixedResponse(completeTask(new TestTasks.TestResult("42 is the answer.", 95)));
 
     var taskId =
         componentClient
@@ -85,7 +86,7 @@ public class TaskIntegrationTest extends TestKitSupport {
 
   @Test
   public void shouldCompleteTaskWithStringResult() {
-    testAgentModel.fixedResponse(completeTask("{\"result\":\"The capital of France is Paris.\"}"));
+    testAgentModel.fixedResponse(completeTask("The capital of France is Paris."));
 
     var taskId =
         componentClient
@@ -99,6 +100,64 @@ public class TaskIntegrationTest extends TestKitSupport {
             () -> {
               var snapshot = componentClient.forTask(taskId).get(TestTasks.STRING_TASK);
               assertThat(snapshot.result()).isEqualTo("The capital of France is Paris.");
+            });
+  }
+
+  @Test
+  public void shouldCompleteTaskWithJsonStringResult() {
+    testAgentModel.fixedResponse(
+        completeTaskJson("{\"result\":\"The capital of France is Paris.\"}"));
+
+    var taskId =
+        componentClient
+            .forAutonomousAgent(TestAutonomousAgent.class, UUID.randomUUID().toString())
+            .runSingleTask(TestTasks.STRING_TASK.instructions("What is the capital of France?"));
+
+    Awaitility.await()
+        .ignoreExceptions()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var snapshot = componentClient.forTask(taskId).get(TestTasks.STRING_TASK);
+              assertThat(snapshot.result()).isEqualTo("The capital of France is Paris.");
+            });
+  }
+
+  @Test
+  public void shouldCompleteTaskWithIntegerResult() {
+    testAgentModel.fixedResponse(completeTask(42));
+
+    var taskId =
+        componentClient
+            .forAutonomousAgent(TestAutonomousAgent.class, UUID.randomUUID().toString())
+            .runSingleTask(TestTasks.INTEGER_TASK.instructions("What is the answer?"));
+
+    Awaitility.await()
+        .ignoreExceptions()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var snapshot = componentClient.forTask(taskId).get(TestTasks.INTEGER_TASK);
+              assertThat(snapshot.result()).isEqualTo(42);
+            });
+  }
+
+  @Test
+  public void shouldCompleteTaskWithBooleanResult() {
+    testAgentModel.fixedResponse(completeTask(true));
+
+    var taskId =
+        componentClient
+            .forAutonomousAgent(TestAutonomousAgent.class, UUID.randomUUID().toString())
+            .runSingleTask(TestTasks.BOOLEAN_TASK.instructions("Is the sky blue?"));
+
+    Awaitility.await()
+        .ignoreExceptions()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var snapshot = componentClient.forTask(taskId).get(TestTasks.BOOLEAN_TASK);
+              assertThat(snapshot.result()).isTrue();
             });
   }
 
@@ -132,7 +191,8 @@ public class TaskIntegrationTest extends TestKitSupport {
         .whenToolResult(result -> result.content().equals("2025-01-15"))
         .thenReply(
             result ->
-                new AiResponse(completeTask("{\"value\":\"Today is 2025-01-15.\",\"score\":100}")));
+                new AiResponse(
+                    completeTask(new TestTasks.TestResult("Today is 2025-01-15.", 100))));
 
     var taskId =
         componentClient
@@ -171,7 +231,8 @@ public class TaskIntegrationTest extends TestKitSupport {
     requestDelegatingModel
         .whenToolResult(result -> result.content().contains("sky is indeed blue"))
         .thenReply(
-            result -> new AiResponse(completeTask("{\"value\":\"Claim verified.\",\"score\":90}")));
+            result ->
+                new AiResponse(completeTask(new TestTasks.TestResult("Claim verified.", 90))));
 
     var taskId =
         componentClient
@@ -213,7 +274,8 @@ public class TaskIntegrationTest extends TestKitSupport {
     requestDelegatingModel
         .whenToolResult(result -> result.content().contains("Confirmed"))
         .thenReply(
-            result -> new AiResponse(completeTask("{\"value\":\"Fact confirmed.\",\"score\":95}")));
+            result ->
+                new AiResponse(completeTask(new TestTasks.TestResult("Fact confirmed.", 95))));
 
     var taskId =
         componentClient
@@ -245,14 +307,14 @@ public class TaskIntegrationTest extends TestKitSupport {
 
     // Worker completes the delegated work item
     teamWorkerModel.fixedResponse(
-        completeTask("{\"item\":\"Login page\",\"output\":\"Implemented OAuth login flow.\"}"));
+        completeTask(new TestTasks.WorkItemResult("Login page", "Implemented OAuth login flow.")));
 
     // Coordinator synthesizes worker result into research result
     templateDelegatingModel
         .whenMessage(msg -> msg.contains("Continue working"))
         .reply(
             completeTask(
-                "{\"title\":\"Login Feature\",\"summary\":\"OAuth login flow implemented.\"}"));
+                new TestTasks.ResearchResult("Login Feature", "OAuth login flow implemented.")));
 
     var taskId =
         componentClient

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TeamBacklogIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TeamBacklogIntegrationTest.java
@@ -100,8 +100,7 @@ public class TeamBacklogIntegrationTest extends TestKitSupport {
               case GET_TEAM_STATUS -> new AiResponse(disbandTeam());
               case DISBAND_TEAM ->
                   new AiResponse(
-                      completeTask(
-                          "{\"summary\":\"Team created and disbanded.\",\"tasksCompleted\":0}"));
+                      completeTask(new TestTasks.PlanResult("Team created and disbanded.", 0)));
               default -> new AiResponse("Continuing work.");
             };
           }
@@ -146,8 +145,7 @@ public class TeamBacklogIntegrationTest extends TestKitSupport {
               case GET_MANAGED_BACKLOG_STATUS -> new AiResponse(cancelUnclaimedTasksFromBacklog());
               case CANCEL_UNCLAIMED_TASKS_FROM_BACKLOG -> new AiResponse(disbandTeam());
               case DISBAND_TEAM ->
-                  new AiResponse(
-                      completeTask("{\"summary\":\"Backlog managed.\",\"tasksCompleted\":0}"));
+                  new AiResponse(completeTask(new TestTasks.PlanResult("Backlog managed.", 0)));
               default -> new AiResponse("Continuing work.");
             };
           }
@@ -193,8 +191,7 @@ public class TeamBacklogIntegrationTest extends TestKitSupport {
               case GET_MANAGED_BACKLOG_STATUS -> new AiResponse(disbandTeam());
               case DISBAND_TEAM ->
                   new AiResponse(
-                      completeTask(
-                          "{\"summary\":\"Template task created.\",\"tasksCompleted\":0}"));
+                      completeTask(new TestTasks.PlanResult("Template task created.", 0)));
               default -> new AiResponse("Continuing work.");
             };
           }
@@ -244,8 +241,7 @@ public class TeamBacklogIntegrationTest extends TestKitSupport {
                 yield new AiResponse(getManagedBacklogStatus());
               }
               case DISBAND_TEAM ->
-                  new AiResponse(
-                      completeTask("{\"summary\":\"Work completed.\",\"tasksCompleted\":1}"));
+                  new AiResponse(completeTask(new TestTasks.PlanResult("Work completed.", 1)));
               default -> new AiResponse("Continuing work.");
             };
           }
@@ -266,7 +262,7 @@ public class TeamBacklogIntegrationTest extends TestKitSupport {
               }
               case CLAIM_TASK ->
                   new AiResponse(
-                      completeTask("{\"item\":\"Feature X\",\"output\":\"Implemented.\"}"));
+                      completeTask(new TestTasks.WorkItemResult("Feature X", "Implemented.")));
               case COMPLETE_TASK -> new AiResponse(getBacklogStatus());
               default -> new AiResponse(getBacklogStatus());
             };
@@ -315,8 +311,7 @@ public class TeamBacklogIntegrationTest extends TestKitSupport {
                 yield new AiResponse(getManagedBacklogStatus());
               }
               case DISBAND_TEAM ->
-                  new AiResponse(
-                      completeTask("{\"summary\":\"Release tested.\",\"tasksCompleted\":1}"));
+                  new AiResponse(completeTask(new TestTasks.PlanResult("Release tested.", 1)));
               default -> new AiResponse("Continuing work.");
             };
           }
@@ -346,7 +341,7 @@ public class TeamBacklogIntegrationTest extends TestKitSupport {
                 // Second claim: complete it
                 yield new AiResponse(
                     completeTask(
-                        "{\"item\":\"Releasable task\",\"output\":\"Done after release.\"}"));
+                        new TestTasks.WorkItemResult("Releasable task", "Done after release.")));
               }
               case RELEASE_TASK -> new AiResponse(getBacklogStatus());
               case COMPLETE_TASK -> new AiResponse(getBacklogStatus());
@@ -396,8 +391,7 @@ public class TeamBacklogIntegrationTest extends TestKitSupport {
                 yield new AiResponse(getManagedBacklogStatus());
               }
               case DISBAND_TEAM ->
-                  new AiResponse(
-                      completeTask("{\"summary\":\"Transfer tested.\",\"tasksCompleted\":1}"));
+                  new AiResponse(completeTask(new TestTasks.PlanResult("Transfer tested.", 1)));
               default -> new AiResponse("Continuing work.");
             };
           }
@@ -424,14 +418,14 @@ public class TeamBacklogIntegrationTest extends TestKitSupport {
                 }
                 yield new AiResponse(
                     completeTask(
-                        "{\"item\":\"Transferable task\",\"output\":\"Completed after"
-                            + " transfer.\"}"));
+                        new TestTasks.WorkItemResult(
+                            "Transferable task", "Completed after transfer.")));
               }
               case TRANSFER_TASK ->
                   new AiResponse(
                       completeTask(
-                          "{\"item\":\"Transferable task\",\"output\":\"Completed after"
-                              + " transfer.\"}"));
+                          new TestTasks.WorkItemResult(
+                              "Transferable task", "Completed after transfer.")));
               case COMPLETE_TASK -> new AiResponse(getBacklogStatus());
               default -> new AiResponse(getBacklogStatus());
             };

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestAutonomousAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestAutonomousAgent.java
@@ -27,6 +27,11 @@ public class TestAutonomousAgent extends AutonomousAgent {
   public AgentDefinition definition() {
     return define()
         .goal("Test agent")
-        .capability(TaskAcceptance.of(TestTasks.TEST_TASK, TestTasks.STRING_TASK));
+        .capability(
+            TaskAcceptance.of(
+                TestTasks.TEST_TASK,
+                TestTasks.STRING_TASK,
+                TestTasks.INTEGER_TASK,
+                TestTasks.BOOLEAN_TASK));
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestTasks.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestTasks.java
@@ -29,6 +29,16 @@ public class TestTasks {
   public static final Task<String> STRING_TASK =
       Task.define("String task").description("A task with string result");
 
+  public static final Task<Integer> INTEGER_TASK =
+      Task.define("Integer task")
+          .description("A task with integer result")
+          .resultConformsTo(Integer.class);
+
+  public static final Task<Boolean> BOOLEAN_TASK =
+      Task.define("Boolean task")
+          .description("A task with boolean result")
+          .resultConformsTo(Boolean.class);
+
   public static final Task<ResearchResult> RESEARCH =
       Task.define("Research")
           .description("Produce a research summary")

--- a/docs/src/modules/sdk/pages/autonomous-agents.html.md
+++ b/docs/src/modules/sdk/pages/autonomous-agents.html.md
@@ -953,7 +953,7 @@ public class QuestionAnswererIntegrationTest extends TestKitSupport {
   public void shouldAnswerQuestionWithTypedResult() {
     // Mock the LLM to call the built-in complete_task tool
     model.fixedResponse(
-      completeTask("{\"answer\":\"2 plus 2 equals 4.\",\"confidence\":100}")
+      completeTask(new QuestionTasks.Answer("2 plus 2 equals 4.", 100))
     );
 
     // Create and run a task
@@ -991,8 +991,11 @@ The `TestModelProvider.AutonomousAgentTools` class provides factory methods for 
 ```java
 import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.*;
 
-// Complete a task — result JSON must match the task's result type schema
-completeTask("{\"title\":\"Report\",\"summary\":\"Done.\"}");
+// Complete a task — pass a result object matching the task's result type
+completeTask(new ReportTasks.Report("Report", "Done."));
+
+// Complete a task with raw JSON (must be a valid JSON object)
+completeTaskJson("{\"title\":\"Report\",\"summary\":\"Done.\"}");
 
 // Fail a task with a reason
 failTask("Not enough information to proceed.");
@@ -1044,12 +1047,12 @@ public class ResearchCoordinatorIntegrationTest extends TestKitSupport {
 
     // Researcher completes with findings
     researcherModel.fixedResponse(
-      completeTask("{\"topic\":\"Quantum Computing\",\"findings\":\"Qubits enable parallel computation.\"}"));
+      completeTask(new ResearchTasks.Findings("Quantum Computing", "Qubits enable parallel computation.")));
 
     // After receiving the delegation result, coordinator completes the brief
     coordinatorModel
       .whenMessage(msg -> msg.contains("Continue working"))
-      .reply(completeTask("{\"title\":\"Quantum Computing\",\"summary\":\"Qubits enable parallel computation.\"}"));
+      .reply(completeTask(new ResearchTasks.Brief("Quantum Computing", "Qubits enable parallel computation.")));
 
     var taskId = componentClient
       .forAutonomousAgent(ResearchCoordinator.class, UUID.randomUUID().toString())
@@ -1076,7 +1079,7 @@ triageModel
   .reply(handoffTo(BillingSpecialist.class, "Customer has a billing question"));
 
 // Specialist completes the task
-specialistModel.fixedResponse(completeTask("{\"resolved\":true,\"response\":\"Refund issued.\"}"));
+specialistModel.fixedResponse(completeTask(new SupportTasks.Resolution(true, "Refund issued.")));
 ```
 
 **Testing tool use before completion:**
@@ -1091,7 +1094,7 @@ model
 model
   .whenToolResult(result -> result.content().equals("2025-01-15"))
   .thenReply(result -> new AiResponse(
-      completeTask("{\"value\":\"Today is 2025-01-15.\",\"score\":100}")));
+      completeTask(new TestTasks.TestResult("Today is 2025-01-15.", 100))));
 ```
 
 Call `model.reset()` in `@AfterEach` to clear all configured responses between tests.


### PR DESCRIPTION
* need separate completeTaskJson to disambiguate betwen json string and string
* update tests to use task result objects
* also test completeTask with Boolean and Integer types

Follow up to https://github.com/akka/akka-sdk/pull/1512