### PR TITLE
feat: task rules for result validation

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/agent/task/TaskEntityTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/agent/task/TaskEntityTest.java
@@ -34,7 +34,7 @@ public class TaskEntityTest {
 
   private TaskEntity.CreateRequest createRequest(String name) {
     return new TaskEntity.CreateRequest(
-        name, "description", "instructions", "String", List.of(), List.of());
+        name, "description", "instructions", "String", List.of(), List.of(), List.of());
   }
 
   @Test

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TaskRuleIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TaskRuleIntegrationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akkajavasdk.components.agent.autonomous;
+
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.completeTask;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import akka.javasdk.agent.task.TaskStatus;
+import akka.javasdk.testkit.TestKit;
+import akka.javasdk.testkit.TestKitSupport;
+import akka.javasdk.testkit.TestModelProvider;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class TaskRuleIntegrationTest extends TestKitSupport {
+
+  private final TestModelProvider agentModel = new TestModelProvider();
+
+  @Override
+  protected TestKit.Settings testKitSettings() {
+    return TestKit.Settings.DEFAULT
+        .withAdditionalConfig("akka.javasdk.agent.openai.api-key = n/a")
+        .withModelProvider(ValidatedTaskAgent.class, agentModel)
+        .withModelProvider(TestAutonomousAgent.class, new TestModelProvider());
+  }
+
+  @AfterEach
+  public void afterEach() {
+    agentModel.reset();
+  }
+
+  @Test
+  public void shouldCompleteTaskWhenRuleAccepts() {
+    agentModel.fixedResponse(completeTask(new TestTasks.TestResult("good result", 50)));
+
+    var taskId =
+        componentClient
+            .forAutonomousAgent(ValidatedTaskAgent.class, UUID.randomUUID().toString())
+            .runSingleTask(TestTasks.VALIDATED_TASK.instructions("Do something well."));
+
+    Awaitility.await()
+        .ignoreExceptions()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var snapshot = componentClient.forTask(taskId).get(TestTasks.VALIDATED_TASK);
+              assertThat(snapshot.status()).isEqualTo(TaskStatus.COMPLETED);
+              assertThat(snapshot.result()).isNotNull();
+              assertThat(snapshot.result().value()).isEqualTo("good result");
+              assertThat(snapshot.result().score()).isEqualTo(50);
+            });
+  }
+
+  @Test
+  public void shouldFailTaskWhenRuleRejects() {
+    agentModel.fixedResponse(completeTask(new TestTasks.TestResult("low quality", 3)));
+
+    var taskId =
+        componentClient
+            .forAutonomousAgent(ValidatedTaskAgent.class, UUID.randomUUID().toString())
+            .runSingleTask(TestTasks.VALIDATED_TASK.instructions("Do something poorly."));
+
+    Awaitility.await()
+        .ignoreExceptions()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var snapshot = componentClient.forTask(taskId).get(TestTasks.VALIDATED_TASK);
+              assertThat(snapshot.status()).isEqualTo(TaskStatus.FAILED);
+              assertThat(snapshot.failureReason()).contains("score must be >= 10");
+            });
+  }
+}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestResultRule.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestResultRule.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akkajavasdk.components.agent.autonomous;
+
+import akka.javasdk.agent.task.TaskRule;
+
+public class TestResultRule implements TaskRule<TestTasks.TestResult> {
+
+  @Override
+  public Result onComplete(TestTasks.TestResult result) {
+    if (result.value() == null || result.value().isEmpty()) {
+      return new Result.Rejected("value must not be empty");
+    }
+    if (result.score() < 10) {
+      return new Result.Rejected("score must be >= 10, was " + result.score());
+    }
+    return new Result.Accepted();
+  }
+}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestTasks.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestTasks.java
@@ -69,4 +69,10 @@ public class TestTasks {
       Task.define("Moderate")
           .description("Moderate a conversation")
           .resultConformsTo(ModerationResult.class);
+
+  public static final Task<TestResult> VALIDATED_TASK =
+      Task.define("Validated task")
+          .description("A task with rule validation")
+          .resultConformsTo(TestResult.class)
+          .rules(TestResultRule.class);
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/ValidatedTaskAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/ValidatedTaskAgent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akkajavasdk.components.agent.autonomous;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
+import akka.javasdk.annotations.Component;
+
+@Component(id = "validated-task-agent")
+public class ValidatedTaskAgent extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+        .goal("Complete tasks with rule validation")
+        .capability(TaskAcceptance.of(TestTasks.VALIDATED_TASK));
+  }
+}

--- a/akka-javasdk-tests/src/test/resources/META-INF/akka-javasdk-components_akka-javasdk-tests.conf
+++ b/akka-javasdk-tests/src/test/resources/META-INF/akka-javasdk-components_akka-javasdk-tests.conf
@@ -35,7 +35,8 @@ akka.javasdk {
       "akkajavasdk.components.agent.autonomous.TestModerator",
       "akkajavasdk.components.agent.autonomous.DirectedModerator",
       "akkajavasdk.components.agent.autonomous.DebaterA",
-      "akkajavasdk.components.agent.autonomous.DebaterB"
+      "akkajavasdk.components.agent.autonomous.DebaterB",
+      "akkajavasdk.components.agent.autonomous.ValidatedTaskAgent"
     ],
     http-endpoint = [
       "akkajavasdk.components.jwt.HelloJwtEndpoint",

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/task/Task.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/task/Task.java
@@ -172,9 +172,11 @@ public final class Task<R> implements TaskDefinition<R> {
    * completed. If any rule rejects the result, the task is failed instead of completed.
    */
   @SafeVarargs
-  public final Task<R> rules(Class<? extends TaskRule<R>>... ruleClasses) {
+  public final Task<R> rules(
+      Class<? extends TaskRule<R>> firstRule, Class<? extends TaskRule<R>>... moreRules) {
     var updated = new ArrayList<>(this.ruleClasses);
-    updated.addAll(List.of(ruleClasses));
+    updated.add(firstRule);
+    updated.addAll(List.of(moreRules));
     return new Task<>(
         this.name,
         this.description,

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/task/Task.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/task/Task.java
@@ -29,6 +29,7 @@ public final class Task<R> implements TaskDefinition<R> {
   private final String instructions;
   private final List<MessageContent> attachments;
   private final List<String> dependencyTaskIds;
+  private final List<Class<? extends TaskRule<R>>> ruleClasses;
 
   Task(
       String name,
@@ -36,13 +37,15 @@ public final class Task<R> implements TaskDefinition<R> {
       Class<R> resultType,
       String instructions,
       List<MessageContent> attachments,
-      List<String> dependencyTaskIds) {
+      List<String> dependencyTaskIds,
+      List<Class<? extends TaskRule<R>>> ruleClasses) {
     this.name = name;
     this.description = description;
     this.resultType = resultType;
     this.instructions = instructions;
     this.attachments = attachments;
     this.dependencyTaskIds = dependencyTaskIds;
+    this.ruleClasses = ruleClasses;
   }
 
   /**
@@ -52,7 +55,7 @@ public final class Task<R> implements TaskDefinition<R> {
    * @param name a stable identifier for this task type
    */
   public static Task<String> define(String name) {
-    return new Task<>(name, "", String.class, "", List.of(), List.of());
+    return new Task<>(name, "", String.class, "", List.of(), List.of(), List.of());
   }
 
   @Override
@@ -73,7 +76,8 @@ public final class Task<R> implements TaskDefinition<R> {
         this.resultType,
         this.instructions,
         this.attachments,
-        this.dependencyTaskIds);
+        this.dependencyTaskIds,
+        this.ruleClasses);
   }
 
   @Override
@@ -97,7 +101,8 @@ public final class Task<R> implements TaskDefinition<R> {
         this.resultType,
         instructions,
         this.attachments,
-        this.dependencyTaskIds);
+        this.dependencyTaskIds,
+        this.ruleClasses);
   }
 
   /** Content attached to this task (images, PDFs), or an empty list. */
@@ -115,7 +120,8 @@ public final class Task<R> implements TaskDefinition<R> {
         this.resultType,
         this.instructions,
         List.copyOf(updated),
-        this.dependencyTaskIds);
+        this.dependencyTaskIds,
+        this.ruleClasses);
   }
 
   /**
@@ -130,7 +136,8 @@ public final class Task<R> implements TaskDefinition<R> {
         type,
         this.instructions,
         this.attachments,
-        this.dependencyTaskIds);
+        this.dependencyTaskIds,
+        List.of());
   }
 
   /** Task IDs that must complete before this task can start, or an empty list. */
@@ -151,6 +158,30 @@ public final class Task<R> implements TaskDefinition<R> {
         this.resultType,
         this.instructions,
         this.attachments,
+        List.copyOf(updated),
+        this.ruleClasses);
+  }
+
+  /** Rule classes that validate the result before accepting completion, or an empty list. */
+  public List<Class<? extends TaskRule<R>>> ruleClasses() {
+    return ruleClasses;
+  }
+
+  /**
+   * Return a new task with the given rules. Rules are evaluated in order when the task is
+   * completed. If any rule rejects the result, the task is failed instead of completed.
+   */
+  @SafeVarargs
+  public final Task<R> rules(Class<? extends TaskRule<R>>... ruleClasses) {
+    var updated = new ArrayList<>(this.ruleClasses);
+    updated.addAll(List.of(ruleClasses));
+    return new Task<>(
+        this.name,
+        this.description,
+        this.resultType,
+        this.instructions,
+        this.attachments,
+        this.dependencyTaskIds,
         List.copyOf(updated));
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskEntity.java
@@ -32,7 +32,8 @@ public final class TaskEntity extends EventSourcedEntity<TaskState, TaskEvent> {
       String instructions,
       String resultTypeName,
       List<String> dependencyTaskIds,
-      List<TaskAttachment> attachments) {}
+      List<TaskAttachment> attachments,
+      List<String> ruleClassNames) {}
 
   public record ReassignRequest(String newAssignee, String context) {}
 
@@ -48,6 +49,7 @@ public final class TaskEntity extends EventSourcedEntity<TaskState, TaskEvent> {
     var deps =
         request.dependencyTaskIds() != null ? request.dependencyTaskIds() : List.<String>of();
     var atts = request.attachments() != null ? request.attachments() : List.<TaskAttachment>of();
+    var rules = request.ruleClassNames() != null ? request.ruleClassNames() : List.<String>of();
     return effects()
         .persist(
             new TaskEvent.TaskCreated(
@@ -57,7 +59,8 @@ public final class TaskEntity extends EventSourcedEntity<TaskState, TaskEvent> {
                 request.instructions(),
                 request.resultTypeName(),
                 deps,
-                atts))
+                atts,
+                rules))
         .thenReply(__ -> done());
   }
 
@@ -180,7 +183,8 @@ public final class TaskEntity extends EventSourcedEntity<TaskState, TaskEvent> {
               e.dependencyTaskIds() != null ? e.dependencyTaskIds() : List.of(),
               null,
               e.attachments() != null ? e.attachments() : List.of(),
-              List.of());
+              List.of(),
+              e.ruleClassNames() != null ? e.ruleClassNames() : List.of());
       case TaskEvent.TaskAssigned e -> currentState().withAssignee(e.assignee());
       case TaskEvent.TaskStarted e -> currentState().withStatus(TaskStatus.IN_PROGRESS);
       case TaskEvent.TaskCompleted e -> currentState().withResult(e.result());

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskEvent.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskEvent.java
@@ -17,7 +17,8 @@ public sealed interface TaskEvent {
       String instructions,
       String resultTypeName,
       List<String> dependencyTaskIds,
-      List<TaskAttachment> attachments)
+      List<TaskAttachment> attachments,
+      List<String> ruleClassNames)
       implements TaskEvent {}
 
   @TypeName("akka-task-assigned")

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskRule.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskRule.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.agent.task;
+
+/**
+ * A rule that validates the result of a task before accepting its completion.
+ *
+ * <p>Add rules to a {@link Task} definition with {@link Task#rules}. When the task is completed,
+ * each rule's {@link #onComplete} method is called with the deserialized result. If any rule
+ * returns {@link Result.Rejected}, the task is failed instead of completed.
+ *
+ * <p>Implementations must have a public no-arg constructor.
+ *
+ * @param <R> The result type of the task.
+ */
+public interface TaskRule<R> {
+
+  /**
+   * Evaluate the task result before accepting completion.
+   *
+   * @param result the deserialized task result
+   * @return {@link Result.Accepted} to allow completion, or {@link Result.Rejected} to reject it
+   */
+  Result onComplete(R result);
+
+  sealed interface Result {
+    record Accepted() implements Result {}
+
+    record Rejected(String reason) implements Result {}
+  }
+}

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskState.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskState.java
@@ -20,7 +20,8 @@ public record TaskState(
     List<String> dependencyTaskIds,
     String assignee,
     List<TaskAttachment> attachments,
-    List<String> reassignmentContext) {
+    List<String> reassignmentContext,
+    List<String> ruleClassNames) {
 
   public static TaskState empty() {
     return new TaskState(
@@ -34,6 +35,7 @@ public record TaskState(
         null,
         List.of(),
         null,
+        List.of(),
         List.of(),
         List.of());
   }
@@ -51,7 +53,8 @@ public record TaskState(
         dependencyTaskIds,
         assignee,
         attachments,
-        reassignmentContext);
+        reassignmentContext,
+        ruleClassNames);
   }
 
   public TaskState withAssignee(String assignee) {
@@ -67,7 +70,8 @@ public record TaskState(
         dependencyTaskIds,
         assignee,
         attachments,
-        reassignmentContext);
+        reassignmentContext,
+        ruleClassNames);
   }
 
   public TaskState withResult(String result) {
@@ -83,7 +87,8 @@ public record TaskState(
         dependencyTaskIds,
         assignee,
         attachments,
-        reassignmentContext);
+        reassignmentContext,
+        ruleClassNames);
   }
 
   public TaskState withFailure(String reason) {
@@ -99,7 +104,8 @@ public record TaskState(
         dependencyTaskIds,
         assignee,
         attachments,
-        reassignmentContext);
+        reassignmentContext,
+        ruleClassNames);
   }
 
   public TaskState withCancellation(String reason) {
@@ -115,7 +121,8 @@ public record TaskState(
         dependencyTaskIds,
         assignee,
         attachments,
-        reassignmentContext);
+        reassignmentContext,
+        ruleClassNames);
   }
 
   public TaskState withReassignment(String newAssignee, String context) {
@@ -133,6 +140,7 @@ public record TaskState(
         dependencyTaskIds,
         newAssignee,
         attachments,
-        List.copyOf(updated));
+        List.copyOf(updated),
+        ruleClassNames);
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskTemplate.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskTemplate.java
@@ -31,12 +31,19 @@ public final class TaskTemplate<R> implements TaskDefinition<R> {
   private final String description;
   private final Class<R> resultType;
   private final String instructionTemplate;
+  private final List<Class<? extends TaskRule<R>>> ruleClasses;
 
-  TaskTemplate(String name, String description, Class<R> resultType, String instructionTemplate) {
+  TaskTemplate(
+      String name,
+      String description,
+      Class<R> resultType,
+      String instructionTemplate,
+      List<Class<? extends TaskRule<R>>> ruleClasses) {
     this.name = name;
     this.description = description;
     this.resultType = resultType;
     this.instructionTemplate = instructionTemplate;
+    this.ruleClasses = ruleClasses;
   }
 
   /**
@@ -47,7 +54,7 @@ public final class TaskTemplate<R> implements TaskDefinition<R> {
    * @param name a stable identifier for this task type
    */
   public static TaskTemplate<String> define(String name) {
-    return new TaskTemplate<>(name, "", String.class, "");
+    return new TaskTemplate<>(name, "", String.class, "", List.of());
   }
 
   @Override
@@ -62,7 +69,8 @@ public final class TaskTemplate<R> implements TaskDefinition<R> {
 
   /** Set the description of this task — what kind of work it represents. */
   public TaskTemplate<R> description(String description) {
-    return new TaskTemplate<>(this.name, description, this.resultType, this.instructionTemplate);
+    return new TaskTemplate<>(
+        this.name, description, this.resultType, this.instructionTemplate, this.ruleClasses);
   }
 
   @Override
@@ -76,12 +84,14 @@ public final class TaskTemplate<R> implements TaskDefinition<R> {
    * @param <S> The new result type
    */
   public <S> TaskTemplate<S> resultConformsTo(Class<S> type) {
-    return new TaskTemplate<>(this.name, this.description, type, this.instructionTemplate);
+    return new TaskTemplate<>(
+        this.name, this.description, type, this.instructionTemplate, List.of());
   }
 
   /** Set the instruction template with {@code {paramName}} placeholders. */
   public TaskTemplate<R> instructionTemplate(String template) {
-    return new TaskTemplate<>(this.name, this.description, this.resultType, template);
+    return new TaskTemplate<>(
+        this.name, this.description, this.resultType, template, this.ruleClasses);
   }
 
   /** The instruction template string with {@code {paramName}} placeholders. */
@@ -97,6 +107,27 @@ public final class TaskTemplate<R> implements TaskDefinition<R> {
       names.add(matcher.group(1));
     }
     return names;
+  }
+
+  /** Rule classes that validate the result before accepting completion, or an empty list. */
+  public List<Class<? extends TaskRule<R>>> ruleClasses() {
+    return ruleClasses;
+  }
+
+  /**
+   * Return a new task template with the given rules. Rules carry through to any {@link Task}
+   * produced by {@link #params} or {@link #instructions}.
+   */
+  @SafeVarargs
+  public final TaskTemplate<R> rules(Class<? extends TaskRule<R>>... ruleClasses) {
+    var updated = new ArrayList<>(this.ruleClasses);
+    updated.addAll(List.of(ruleClasses));
+    return new TaskTemplate<>(
+        this.name,
+        this.description,
+        this.resultType,
+        this.instructionTemplate,
+        List.copyOf(updated));
   }
 
   /**
@@ -117,11 +148,12 @@ public final class TaskTemplate<R> implements TaskDefinition<R> {
       }
       resolved = resolved.replace("{" + paramName + "}", value);
     }
-    return new Task<>(name, description, resultType, resolved, List.of(), List.of());
+    return new Task<>(name, description, resultType, resolved, List.of(), List.of(), ruleClasses);
   }
 
   /** Override the template with free-form instructions, returning a submittable {@link Task}. */
   public Task<R> instructions(String instructions) {
-    return new Task<>(name, description, resultType, instructions, List.of(), List.of());
+    return new Task<>(
+        name, description, resultType, instructions, List.of(), List.of(), ruleClasses);
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskTemplate.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskTemplate.java
@@ -119,9 +119,11 @@ public final class TaskTemplate<R> implements TaskDefinition<R> {
    * produced by {@link #params} or {@link #instructions}.
    */
   @SafeVarargs
-  public final TaskTemplate<R> rules(Class<? extends TaskRule<R>>... ruleClasses) {
+  public final TaskTemplate<R> rules(
+      Class<? extends TaskRule<R>> firstRule, Class<? extends TaskRule<R>>... moreRules) {
     var updated = new ArrayList<>(this.ruleClasses);
-    updated.addAll(List.of(ruleClasses));
+    updated.add(firstRule);
+    updated.addAll(List.of(moreRules));
     return new TaskTemplate<>(
         this.name,
         this.description,

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AutonomousAgentImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AutonomousAgentImpl.scala
@@ -30,6 +30,7 @@ import akka.javasdk.agent.task.BacklogEntity
 import akka.javasdk.agent.task.BacklogState
 import akka.javasdk.agent.task.TaskAttachment
 import akka.javasdk.agent.task.TaskEntity
+import akka.javasdk.agent.task.TaskState
 import akka.javasdk.agent.task.TaskStatus
 import akka.javasdk.client.ComponentClient
 import akka.javasdk.impl.JsonSchema
@@ -113,6 +114,8 @@ private[impl] final class AutonomousAgentImpl(
     new ToolExecutor(agentInvokers ++ definitionToolInvokers, serializer)
   }
 
+  private val taskRuleRunner = new TaskRuleRunner(system.classicSystem, serializer)
+
   // Pre-resolve TaskEntity methods for calling via EntityClientImpl
   private val taskCreateMethod = classOf[TaskEntity].getMethod("create", classOf[TaskEntity.CreateRequest])
   private val taskGetStateMethod = classOf[TaskEntity].getMethod("getState")
@@ -152,7 +155,8 @@ private[impl] final class AutonomousAgentImpl(
         request.instructions.orNull,
         request.resultTypeName.orNull,
         request.dependencyTaskIds.asJava,
-        attachments)
+        attachments,
+        Seq.empty[String].asJava)
       taskEntityClient(taskId)
         .methodRefOneArg[TaskEntity.CreateRequest, Done](taskCreateMethod)
         .withMetadata(MetadataImpl.of(context))
@@ -163,7 +167,7 @@ private[impl] final class AutonomousAgentImpl(
 
     override def getTaskState(taskId: String, context: Option[TelemetryContext]): Future[SpiTask.SpiTaskState] =
       taskEntityClient(taskId)
-        .methodRefNoArg[akka.javasdk.agent.task.TaskState](taskGetStateMethod)
+        .methodRefNoArg[TaskState](taskGetStateMethod)
         .withMetadata(MetadataImpl.of(context))
         .invokeAsync()
         .asScala
@@ -187,11 +191,34 @@ private[impl] final class AutonomousAgentImpl(
 
     override def completeTask(taskId: String, resultJson: String, context: Option[TelemetryContext]): Future[Done] =
       taskEntityClient(taskId)
-        .methodRefOneArg[String, Done](taskCompleteMethod)
+        .methodRefNoArg[TaskState](taskGetStateMethod)
         .withMetadata(MetadataImpl.of(context))
-        .invokeAsync(resultJson)
+        .invokeAsync()
         .asScala
-        .map(_ => Done)(sdkExecutionContext)
+        .flatMap { taskState =>
+          taskRuleRunner.evaluate(taskState, resultJson) match {
+            case TaskRuleRunner.RuleOutcome.Accepted =>
+              taskEntityClient(taskId)
+                .methodRefOneArg[String, Done](taskCompleteMethod)
+                .withMetadata(MetadataImpl.of(context))
+                .invokeAsync(resultJson)
+                .asScala
+                .map(_ => Done)(sdkExecutionContext)
+            case TaskRuleRunner.RuleOutcome.Rejected(ruleClassName, reason) =>
+              log.warn(
+                "Task [{}] [{}] completion rejected by rule [{}]: {}",
+                taskState.name(),
+                taskId,
+                ruleClassName,
+                reason)
+              taskEntityClient(taskId)
+                .methodRefOneArg[String, Done](taskFailMethod)
+                .withMetadata(MetadataImpl.of(context))
+                .invokeAsync("Task rule rejected: " + reason)
+                .asScala
+                .map(_ => Done)(sdkExecutionContext)
+          }
+        }(sdkExecutionContext)
 
     override def failTask(taskId: String, reason: String, context: Option[TelemetryContext]): Future[Done] =
       taskEntityClient(taskId)

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/TaskRuleRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/TaskRuleRunner.scala
@@ -60,20 +60,21 @@ private[javasdk] class TaskRuleRunner(system: ActorSystem, serializer: Serialize
 
   private def runRules(ruleClassNames: Seq[String], result: Any): RuleOutcome = {
     ruleClassNames.iterator
-      .map { className =>
+      .flatMap { className =>
         dynamicAccess.createInstanceFor[TaskRule[Any]](className, Nil) match {
           case Success(rule) =>
-            val ruleResult = rule.onComplete(result)
-            (className, Some(ruleResult))
+            rule.onComplete(result) match {
+              case rejected: TaskRule.Result.Rejected =>
+                log.debug("Task rule [{}] rejected: {}", className, rejected.reason())
+                Some(RuleOutcome.Rejected(className, rejected.reason()))
+              case _ => None
+            }
           case Failure(ex) =>
             log.error("Failed to instantiate task rule [{}]: {}", className, ex.getMessage)
-            return RuleOutcome.Rejected(className, s"Failed to instantiate task rule: ${ex.getMessage}")
+            Some(RuleOutcome.Rejected(className, s"Failed to instantiate task rule: ${ex.getMessage}"))
         }
       }
-      .collectFirst { case (className, Some(rejected: TaskRule.Result.Rejected)) =>
-        log.debug("Task rule [{}] rejected: {}", className, rejected.reason())
-        RuleOutcome.Rejected(className, rejected.reason())
-      }
+      .nextOption()
       .getOrElse(RuleOutcome.Accepted)
   }
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/TaskRuleRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/TaskRuleRunner.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl.agent
+
+import scala.jdk.CollectionConverters._
+import scala.util.Failure
+import scala.util.Success
+
+import akka.actor.ActorSystem
+import akka.actor.ExtendedActorSystem
+import akka.annotation.InternalApi
+import akka.javasdk.agent.task.TaskRule
+import akka.javasdk.agent.task.TaskState
+import akka.javasdk.impl.serialization.Serializer
+import org.slf4j.LoggerFactory
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[javasdk] object TaskRuleRunner {
+  sealed trait RuleOutcome
+  object RuleOutcome {
+    case object Accepted extends RuleOutcome
+    final case class Rejected(ruleClassName: String, reason: String) extends RuleOutcome
+  }
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[javasdk] class TaskRuleRunner(system: ActorSystem, serializer: Serializer) {
+  import TaskRuleRunner._
+
+  private val dynamicAccess = system.asInstanceOf[ExtendedActorSystem].dynamicAccess
+
+  private val log = LoggerFactory.getLogger(classOf[TaskRuleRunner])
+
+  def evaluate(taskState: TaskState, resultJson: String): RuleOutcome = {
+    val ruleClassNames = taskState.ruleClassNames().asScala.toSeq
+    if (ruleClassNames.isEmpty) {
+      RuleOutcome.Accepted
+    } else {
+      val resultTypeName = Option(taskState.resultTypeName()).getOrElse(classOf[String].getName)
+      val result = deserializeResult(resultJson, resultTypeName)
+      runRules(ruleClassNames, result)
+    }
+  }
+
+  private def deserializeResult(resultJson: String, resultTypeName: String): Any = {
+    if (resultTypeName == classOf[String].getName) {
+      resultJson
+    } else {
+      serializer.json.fromJsonString(resultJson, Class.forName(resultTypeName))
+    }
+  }
+
+  private def runRules(ruleClassNames: Seq[String], result: Any): RuleOutcome = {
+    ruleClassNames.iterator
+      .map { className =>
+        dynamicAccess.createInstanceFor[TaskRule[Any]](className, Nil) match {
+          case Success(rule) =>
+            val ruleResult = rule.onComplete(result)
+            (className, Some(ruleResult))
+          case Failure(ex) =>
+            log.error("Failed to instantiate task rule [{}]: {}", className, ex.getMessage)
+            return RuleOutcome.Rejected(className, s"Failed to instantiate task rule: ${ex.getMessage}")
+        }
+      }
+      .collectFirst { case (className, Some(rejected: TaskRule.Result.Rejected)) =>
+        log.debug("Task rule [{}] rejected: {}", className, rejected.reason())
+        RuleOutcome.Rejected(className, rejected.reason())
+      }
+      .getOrElse(RuleOutcome.Accepted)
+  }
+}

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/TaskClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/TaskClientImpl.scala
@@ -26,6 +26,7 @@ import akka.javasdk.agent.task.TaskState
 import akka.javasdk.agent.task.TaskStatus
 import akka.javasdk.client.TaskClient
 import akka.javasdk.impl.MetadataImpl
+import akka.javasdk.impl.agent.TaskRuleRunner
 import akka.javasdk.impl.serialization.Serializer
 import akka.runtime.sdk.spi.BytesPayload
 import akka.runtime.sdk.spi.EntityRequest
@@ -33,7 +34,6 @@ import akka.runtime.sdk.spi.SpiMetadata
 import akka.runtime.sdk.spi.{ ComponentClients => RuntimeComponentClients }
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
-import akka.util.ByteString
 import org.slf4j.LoggerFactory
 
 /**
@@ -52,6 +52,8 @@ private[javasdk] final class TaskClientImpl(
 
   private val TaskEntityComponentId = "akka-task"
 
+  private val taskRuleRunner = new TaskRuleRunner(materializer.system, serializer)
+
   private def spiMetadata: SpiMetadata = callMetadata.fold(SpiMetadata.empty)(MetadataImpl.toSpi)
 
   override def createAsync[R](task: Task[R]): CompletionStage[String] = {
@@ -61,13 +63,15 @@ private[javasdk] final class TaskClientImpl(
       task.description(),
       task.resultType().getName)
     val attachments = task.attachments().asScala.map(TaskAttachment.fromMessageContent(_)).asJava
+    val ruleClassNames = task.ruleClasses().asScala.map(_.getName).asJava
     val createRequest = new TaskEntity.CreateRequest(
       task.name(),
       task.description(),
       task.instructions(),
       task.resultType().getName,
       task.dependencyTaskIds(),
-      attachments)
+      attachments,
+      ruleClassNames)
     val createPayload = serializer.toBytes(createRequest)
     log.debug("createTask: sending Create to entity [{}], payload contentType=[{}]", taskId, createPayload.contentType)
     runtimeComponentClients.eventSourcedEntityClient
@@ -183,7 +187,29 @@ private[javasdk] final class TaskClientImpl(
       case s: String => s
       case other     => serializer.json.toJsonString(other)
     }
-    sendCommand("Complete", serializer.toBytes(resultJson))
+    runtimeComponentClients.eventSourcedEntityClient
+      .send(new EntityRequest(TaskEntityComponentId, taskId, "GetState", BytesPayload.empty, spiMetadata))
+      .flatMap { reply =>
+        reply.exceptionPayload match {
+          case Some(exBytes) =>
+            throw serializer.json.exceptionFromBytes(exBytes)
+          case None =>
+            val taskState = serializer.fromBytes[TaskState](classOf[TaskState], reply.payload)
+            taskRuleRunner.evaluate(taskState, resultJson) match {
+              case TaskRuleRunner.RuleOutcome.Accepted =>
+                sendCommand("Complete", serializer.toBytes(resultJson)).asScala
+              case TaskRuleRunner.RuleOutcome.Rejected(ruleClassName, reason) =>
+                log.warn(
+                  "Task [{}] [{}] completion rejected by rule [{}]: {}",
+                  taskState.name(),
+                  taskId,
+                  ruleClassName,
+                  reason)
+                sendCommand("Fail", serializer.toBytes("Task rule rejected: " + reason)).asScala
+            }
+        }
+      }
+      .asJava
   }
 
   override def failAsync(reason: String): CompletionStage[Done] = {
@@ -229,9 +255,7 @@ private[javasdk] final class TaskClientImpl(
         // String results are stored as raw text by the runtime (not JSON-encoded)
         resultString.asInstanceOf[R]
       } else {
-        // Typed results are stored as JSON — deserialize via the serializer
-        val resultBytes = new BytesPayload(ByteString.fromString(resultString), "application/json")
-        serializer.fromBytes[R](resultType.asInstanceOf[java.lang.reflect.Type], resultBytes)
+        serializer.json.fromJsonString(resultString, resultType)
       }
     }
   }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/serialization/JsonSerializer.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/serialization/JsonSerializer.scala
@@ -160,6 +160,9 @@ final class JsonSerializer(val objectMapper: ObjectMapper) {
     objectMapper.writerFor(value.getClass).writeValueAsString(value)
   }
 
+  def fromJsonString[T](jsonString: String, expectedType: Class[T]): T =
+    parseBytes(expectedType, ByteString.fromString(jsonString))
+
   def fromBytes[T](expectedType: Type, bytesPayload: BytesPayload): T = {
     val clazz = expectedType match {
       case parameterizedType: ParameterizedType =>

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/client/TaskClientImplSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/client/TaskClientImplSpec.scala
@@ -9,16 +9,20 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 import scala.jdk.FutureConverters._
 
 import akka.NotUsed
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.javasdk.agent.task.Task
+import akka.javasdk.agent.task.TaskAttachment
 import akka.javasdk.agent.task.TaskEntity
 import akka.javasdk.agent.task.TaskException
 import akka.javasdk.agent.task.TaskNotification
+import akka.javasdk.agent.task.TaskRule
 import akka.javasdk.agent.task.TaskState
 import akka.javasdk.agent.task.TaskStatus
+import akka.javasdk.agent.task.TaskTemplate
 import akka.javasdk.impl.serialization.Serializer
 import akka.runtime.sdk.spi._
 import akka.stream.scaladsl.Source
@@ -33,6 +37,24 @@ object TaskClientImplSpec {
   case class RecordedCommand(methodName: String, payload: BytesPayload) {
     def payloadAs[T](implicit ct: reflect.ClassTag[T], serializer: Serializer): T =
       serializer.fromBytes(ct.runtimeClass.asInstanceOf[Class[T]], payload)
+  }
+
+  class TestResultRule extends TaskRule[TestResult] {
+    override def onComplete(result: TestResult): TaskRule.Result =
+      if (result.value == null || result.value.isEmpty)
+        new TaskRule.Result.Rejected("value must not be empty")
+      else if (result.score < 10)
+        new TaskRule.Result.Rejected("score must be >= 10, was " + result.score)
+      else
+        new TaskRule.Result.Accepted()
+  }
+
+  class NoBannedContentRule extends TaskRule[TestResult] {
+    override def onComplete(result: TestResult): TaskRule.Result =
+      if (result.value != null && result.value.contains("banned"))
+        new TaskRule.Result.Rejected("value must not contain banned content")
+      else
+        new TaskRule.Result.Accepted()
   }
 }
 
@@ -61,7 +83,11 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
     .define("String task")
     .description("A string task")
 
-  private def taskState(status: TaskStatus, result: String = null, failureReason: String = null): TaskState =
+  private def taskState(
+      status: TaskStatus,
+      result: String = null,
+      failureReason: String = null,
+      ruleClassNames: java.util.List[String] = Seq.empty[String].asJava): TaskState =
     new TaskState(
       "test-task",
       "Test task",
@@ -71,10 +97,11 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
       classOf[TestResult].getName,
       result,
       failureReason,
-      java.util.List.of(),
+      Seq.empty[String].asJava,
       null,
-      java.util.List.of(),
-      java.util.List.of())
+      Seq.empty[TaskAttachment].asJava,
+      Seq.empty[String].asJava,
+      ruleClassNames)
 
   private def entityReplyFor(state: TaskState): EntityReply =
     new EntityReply(serializer.toBytes(state), SpiMetadata.empty, None)
@@ -380,6 +407,126 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
       ex shouldBe a[TaskException.TypeMismatch]
       ex.getMessage should include("Other task")
       ex.getMessage should include("Test task")
+    }
+  }
+
+  "TaskClientImpl completeAsync with rules" should {
+
+    val ruleNames = Seq(classOf[TestResultRule].getName).asJava
+
+    "complete when rule accepts" in {
+      val mock = mockEntityClient(taskState(TaskStatus.IN_PROGRESS, ruleClassNames = ruleNames))
+      val client = createClient(mock)
+
+      client.completeAsync(TEST_TASK, new TestResult("good", 50)).asScala.futureValue
+
+      mock.commands.map(_.methodName) should contain("Complete")
+      mock.commands.map(_.methodName) should not contain "Fail"
+    }
+
+    "fail when value is empty" in {
+      val mock = mockEntityClient(taskState(TaskStatus.IN_PROGRESS, ruleClassNames = ruleNames))
+      val client = createClient(mock)
+
+      client.completeAsync(TEST_TASK, new TestResult("", 50)).asScala.futureValue
+
+      mock.commands.map(_.methodName) should contain("Fail")
+      mock.commands.map(_.methodName) should not contain "Complete"
+      val reason = mock.commands.find(_.methodName == "Fail").get.payloadAs[String]
+      reason shouldBe "Task rule rejected: value must not be empty"
+    }
+
+    "fail when score is below threshold" in {
+      val mock = mockEntityClient(taskState(TaskStatus.IN_PROGRESS, ruleClassNames = ruleNames))
+      val client = createClient(mock)
+
+      client.completeAsync(TEST_TASK, new TestResult("ok", 5)).asScala.futureValue
+
+      mock.commands.map(_.methodName) should contain("Fail")
+      mock.commands.map(_.methodName) should not contain "Complete"
+      val reason = mock.commands.find(_.methodName == "Fail").get.payloadAs[String]
+      reason shouldBe "Task rule rejected: score must be >= 10, was 5"
+    }
+
+    "proceed normally when no rules are defined" in {
+      val mock = mockEntityClient(taskState(TaskStatus.IN_PROGRESS))
+      val client = createClient(mock)
+
+      client.completeAsync(TEST_TASK, new TestResult("done", 42)).asScala.futureValue
+
+      mock.commands.map(_.methodName) should contain("Complete")
+    }
+
+    val bothRules =
+      Seq(classOf[TestResultRule].getName, classOf[NoBannedContentRule].getName).asJava
+
+    "complete when all rules accept" in {
+      val mock = mockEntityClient(taskState(TaskStatus.IN_PROGRESS, ruleClassNames = bothRules))
+      val client = createClient(mock)
+
+      client.completeAsync(TEST_TASK, new TestResult("good", 50)).asScala.futureValue
+
+      mock.commands.map(_.methodName) should contain("Complete")
+      mock.commands.map(_.methodName) should not contain "Fail"
+    }
+
+    "fail when first rule rejects" in {
+      val mock = mockEntityClient(taskState(TaskStatus.IN_PROGRESS, ruleClassNames = bothRules))
+      val client = createClient(mock)
+
+      client.completeAsync(TEST_TASK, new TestResult("ok", 5)).asScala.futureValue
+
+      mock.commands.map(_.methodName) should contain("Fail")
+      val reason = mock.commands.find(_.methodName == "Fail").get.payloadAs[String]
+      reason shouldBe "Task rule rejected: score must be >= 10, was 5"
+    }
+
+    "fail when second rule rejects" in {
+      val mock = mockEntityClient(taskState(TaskStatus.IN_PROGRESS, ruleClassNames = bothRules))
+      val client = createClient(mock)
+
+      client.completeAsync(TEST_TASK, new TestResult("banned stuff", 50)).asScala.futureValue
+
+      mock.commands.map(_.methodName) should contain("Fail")
+      val reason = mock.commands.find(_.methodName == "Fail").get.payloadAs[String]
+      reason shouldBe "Task rule rejected: value must not contain banned content"
+    }
+  }
+
+  "TaskTemplate with rules" should {
+
+    "carry rules through to resolved task" in {
+      val template = TaskTemplate
+        .define("Templated task")
+        .description("A templated task")
+        .resultConformsTo(classOf[TestResult])
+        .instructionTemplate("Process {item}")
+        .rules(classOf[TestResultRule])
+
+      val task = template.params(java.util.Map.of("item", "something"))
+
+      task.ruleClasses().asScala should have size 1
+      task.ruleClasses().asScala.head shouldBe classOf[TestResultRule]
+    }
+
+    "enforce rules on completion of template-resolved task" in {
+      val template = TaskTemplate
+        .define("Test task")
+        .description("A test task")
+        .resultConformsTo(classOf[TestResult])
+        .instructionTemplate("Process {item}")
+        .rules(classOf[TestResultRule])
+
+      val task = template.params(java.util.Map.of("item", "something"))
+      val ruleNames = task.ruleClasses().asScala.map(_.getName).asJava
+      val mock = mockEntityClient(taskState(TaskStatus.IN_PROGRESS, ruleClassNames = ruleNames))
+      val client = createClient(mock)
+
+      client.completeAsync(task, new TestResult("ok", 5)).asScala.futureValue
+
+      mock.commands.map(_.methodName) should contain("Fail")
+      val reason = mock.commands.find(_.methodName == "Fail").get.payloadAs[String]
+      reason shouldBe "Task rule rejected: score must be >= 10, was 5"
     }
   }
 }


### PR DESCRIPTION
Introduce task rules, which implement the task policies idea in the old prototype. While HITL is done with task dependencies.

Task rules are just for validating the task result on completion. The task rule class name is stored in the task on creation, from the definition. And then the task rules are run on the client side or the task operations side for agents. Currently, it just creates the task rule instances as needed.

We can also update the task SPI so that the runtime is aware of these rules. But at the moment, this is all on the SDK side. 