### PR TITLE
build: Release process simplifications

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,9 @@
 # Releasing Akka SDK
 
-Create a release issue (using the [GitHub CLI](https://cli.github.com/))
+Create a release issue:
 
 ```shell
-gh issue create --title 'Release Akka SDK' --label akka-javasdk --body-file docs/release-issue-template.md -w
+bin/create-release-issue.sh 3.1.0
 ````
 
 and follow the instructions.

--- a/bin/create-release-issue.sh
+++ b/bin/create-release-issue.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+VERSION=$1
+if [ -z $VERSION ]
+then
+  echo specify the version name to be released, eg. 3.1.0
+else
+  sed -e 's/\$VERSION\$/'$VERSION'/g' docs/release-issue-template.md > /tmp/release-$VERSION.md
+  echo Created $(gh issue create --title "Release $VERSION" --body-file /tmp/release-$VERSION.md --web)
+fi

--- a/bin/update-license-and-pr.sh
+++ b/bin/update-license-and-pr.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+VERSION=$1
+if [ -z "$VERSION" ]; then
+  echo "Usage: bin/update-license-and-pr.sh <version>"
+  echo "Example: bin/update-license-and-pr.sh 3.2.0"
+  exit 1
+fi
+
+CURRENT_YEAR=$(date +%Y)
+CHANGE_DATE=$(date -v+3y +%Y-%m-%d)
+BRANCH="release-license-$VERSION"
+
+git checkout -b "$BRANCH" main
+
+sed -i '' \
+  -e "s/Licensed Work:        Akka SDK for Java v .*/Licensed Work:        Akka SDK for Java v $VERSION/" \
+  -e "s/The Licensed Work is (c) [0-9]* Lightbend Inc./The Licensed Work is (c) $CURRENT_YEAR Lightbend Inc./" \
+  -e "s/Change Date:          .*/Change Date:          $CHANGE_DATE/" \
+  LICENSE
+
+git add LICENSE
+git commit -m "chore: License change date for $VERSION"
+git push -u origin "$BRANCH"
+gh pr create --base main --title "chore: License change date for $VERSION" --body ""

--- a/docs/release-issue-template.md
+++ b/docs/release-issue-template.md
@@ -15,8 +15,8 @@ You can see the Akka Runtime version on prod [on grafana](https://app.groundcove
     bin/update-license-and-pr.sh $VERSION$
     ```
 - [ ] [Draft](https://github.com/akka/akka-sdk/releases/new?tag=v$VERSION$) a new release with the tag version `v$VERSION$`. Use the **Generate release notes** button and finally press **Publish release**.
-    - CI will automatically publish to the repository based on the tag
-    - CI will update the docs/kalix-current branch
+    - [CI](https://github.com/akka/akka-sdk/actions/workflows/publish.yml) will automatically publish to the repository based on the tag
+
 
 ### Update to the latest version
  
@@ -24,7 +24,7 @@ You can see the Akka Runtime version on prod [on grafana](https://app.groundcove
     - SDK `version` in the `samples/*/pom.xml` files
 
 ### Publish latest docs
-- [ ] Add a summary of relevant changes into `docs/src/modules/reference/pages/release-notes.adoc`
+- [ ] Add a summary of relevant changes into [`release-notes.adoc`](https://github.com/akka/akka-sdk/edit/main/docs/src/modules/reference/pages/release-notes.adoc)
 - [ ] Create a PR and merge (do not squash) `main` into `docs-current`.
     Note that the PR will be pretty big normally, not only involving documentation files.
     ```

--- a/docs/release-issue-template.md
+++ b/docs/release-issue-template.md
@@ -1,4 +1,4 @@
-# Release Akka SDK 
+# Release Akka SDK $VERSION$
 
 ### Prepare
 
@@ -10,9 +10,11 @@ You can see the Akka Runtime version on prod [on grafana](https://app.groundcove
 
 ### Cutting the release 
 
-- [ ] Update the "Change date" on [the license](../blob/main/LICENSE#L9) to release date plus three years
-- [ ] Use the "Generate release notes" button to create [a new release](https://github.com/akka/akka-sdk/releases/new) with the appropriate tag.
-    - Review the generated notes and "Publish release"
+- [ ] Update the license version and change date, merge the PR created by:
+    ```
+    bin/update-license-and-pr.sh $VERSION$
+    ```
+- [ ] [Draft](https://github.com/akka/akka-sdk/releases/new?tag=v$VERSION$) a new release with the tag version `v$VERSION$`. Use the **Generate release notes** button and finally press **Publish release**.
     - CI will automatically publish to the repository based on the tag
     - CI will update the docs/kalix-current branch
 
@@ -23,11 +25,14 @@ You can see the Akka Runtime version on prod [on grafana](https://app.groundcove
 
 ### Publish latest docs
 - [ ] Add a summary of relevant changes into `docs/src/modules/reference/pages/release-notes.adoc`
-- [ ] Create a PR and merge `main` into `docs-current` (do not squash)
-    - Note that the PR will be pretty big normally, not only involving documentation files.
+- [ ] Create a PR and merge (do not squash) `main` into `docs-current`.
+    Note that the PR will be pretty big normally, not only involving documentation files.
+    ```
+    gh pr create --base docs-current --head main --title "Publish docs for $VERSION$" --body "MERGE, DON'T SQUASH"
+    ```
 
 ### Update samples
-- [ ] Run https://github.com/akka/akka-sdk/actions/workflows/pr-akka-samples.yml from the release tag 
+- [ ] Run https://github.com/akka/akka-sdk/actions/workflows/pr-akka-samples.yml from the release tag `v$VERSION$`
 - [ ] Merge auto-PRs in akka-samples https://github.com/orgs/akka-samples/repositories?q=sort%3Aname-asc
   - Easiest is to use `.github/akka-sample-sdk-bump-prs.sh` script to collect all PR links or do it manually from "Open PR with changes" in https://github.com/akka/akka-sdk/actions/workflows/pr-akka-samples.yml
 - [ ] Bump runtime SDK projects 


### PR DESCRIPTION
We could go further, but this is a start at least

 * Script that takes version number and provides prefilled version related links etc
 * Script for license change date PR
 * link to edit release notes in browser
 * Copy-pasteable docs publish cmdline

