### PR TITLE
feat: testkit support for testing service to service producer

### DIFF
--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventingTestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventingTestKit.java
@@ -4,11 +4,8 @@
 
 package akka.javasdk.testkit;
 
-import akka.actor.typed.ActorSystem;
-import akka.annotation.InternalApi;
 import akka.javasdk.Metadata;
 import akka.javasdk.impl.serialization.Serializer;
-import akka.javasdk.testkit.impl.EventingTestKitImpl;
 import akka.javasdk.testkit.impl.OutgoingMessagesImpl;
 import akka.javasdk.testkit.impl.TestKitMessageImpl;
 import com.google.protobuf.ByteString;
@@ -16,13 +13,6 @@ import java.time.Duration;
 import java.util.List;
 
 public interface EventingTestKit {
-
-  /** INTERNAL API */
-  @InternalApi
-  static EventingTestKit start(
-      ActorSystem<?> system, String host, int port, Serializer serializer) {
-    return EventingTestKitImpl.start(system, host, port, serializer);
-  }
 
   OutgoingMessages getTopicOutgoingMessages(String topic);
 

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventingTestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventingTestKit.java
@@ -36,6 +36,8 @@ public interface EventingTestKit {
 
   IncomingMessages getStreamIncomingMessages(String service, String streamId);
 
+  OutgoingMessages getStreamOutgoingMessages(String service, String streamId);
+
   /** Allows to simulate publishing messages for the purposes of testing incoming message flow. */
   interface IncomingMessages {
     /**

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -1363,6 +1363,15 @@ public class TestKit {
    * transformation path is exercised. The {@code service} must match the service name used by
    * consumers in their {@code @Consume.FromServiceStream} annotation.
    *
+   * <p>Note: the {@code service} value is used by the testkit as a lookup key (and must match what
+   * was registered via {@link Settings#withStreamOutgoingMessages(String, String)}); the underlying
+   * subscription itself is resolved against the service-under-test by {@code streamId}.
+   *
+   * <p>Each call returns a handle whose subscription replays events from the beginning of the
+   * stream. In a suite that shares a single {@code TestKit} across multiple tests, call {@link
+   * EventingTestKit.OutgoingMessages#clear()} at the start of each test to drop events produced by
+   * prior tests.
+   *
    * @param service service name
    * @param streamId service stream id
    */

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -1357,7 +1357,7 @@ public class TestKit {
   }
 
   /**
-   * Get outgoing messages produced by a {@code @Produce.ServiceStream} publisher in the service
+   * Get outgoing messages produced by a {@code @Produce.ServiceStream} producer in the service
    * under test. The {@code service} must match the service name used by consumers in their
    * {@code @Consume.FromServiceStream} annotation.
    *

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -547,7 +547,9 @@ public class TestKit {
           additionalConfig,
           disabledComponents,
           overrideDisabledComponents,
-          modelProvidersByAgentId);
+          modelProvidersByAgentId,
+          httpMocks,
+          grpcMocks);
     }
 
     public Settings withEventingSupport(EventingSupport eventingSupport) {

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -535,8 +535,7 @@ public class TestKit {
 
     /**
      * Capture the outgoing messages produced by a {@code @Produce.ServiceStream} for test
-     * assertions. No runtime mocking is involved — the testkit subscribes to the running producer
-     * stream over gRPC, so the real transformation code path is exercised.
+     * assertions.
      */
     public Settings withStreamOutgoingMessages(String service, String streamId) {
       return new Settings(
@@ -1359,9 +1358,8 @@ public class TestKit {
 
   /**
    * Get outgoing messages produced by a {@code @Produce.ServiceStream} publisher in the service
-   * under test. The testkit subscribes to the running producer stream over gRPC so the real
-   * transformation path is exercised. The {@code service} must match the service name used by
-   * consumers in their {@code @Consume.FromServiceStream} annotation.
+   * under test. The {@code service} must match the service name used by consumers in their
+   * {@code @Consume.FromServiceStream} annotation.
    *
    * <p>Note: the {@code service} value is used by the testkit as a lookup key (and must match what
    * was registered via {@link Settings#withStreamOutgoingMessages(String, String)}); the underlying

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -142,6 +142,12 @@ public class TestKit {
       return new MockedEventing(new HashMap<>(mockedIncomingEvents), copy);
     }
 
+    public MockedEventing withStreamOutgoingMessages(String service, String streamId) {
+      Map<String, Set<String>> copy = new HashMap<>(mockedOutgoingEvents);
+      copy.compute(STREAM, updateValues(service + "/" + streamId));
+      return new MockedEventing(new HashMap<>(mockedIncomingEvents), copy);
+    }
+
     @NotNull
     private BiFunction<String, Set<String>, Set<String>> updateValues(String componentId) {
       return (key, currentValues) -> {
@@ -220,6 +226,11 @@ public class TestKit {
     boolean hasTopicDestination(String topic) {
       Set<String> values = mockedOutgoingEvents.get(TOPIC);
       return values != null && values.contains(topic);
+    }
+
+    boolean hasStreamDestination(String service, String streamId) {
+      Set<String> values = mockedOutgoingEvents.get(STREAM);
+      return values != null && values.contains(service + "/" + streamId);
     }
 
     private boolean checkExistence(String type, String name) {
@@ -522,6 +533,24 @@ public class TestKit {
           grpcMocks);
     }
 
+    /**
+     * Capture the outgoing messages produced by a {@code @Produce.ServiceStream} for test
+     * assertions. No runtime mocking is involved — the testkit subscribes to the running producer
+     * stream over gRPC, so the real transformation code path is exercised.
+     */
+    public Settings withStreamOutgoingMessages(String service, String streamId) {
+      return new Settings(
+          serviceName,
+          aclEnabled,
+          eventingSupport,
+          mockedEventing.withStreamOutgoingMessages(service, streamId),
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          overrideDisabledComponents,
+          modelProvidersByAgentId);
+    }
+
     public Settings withEventingSupport(EventingSupport eventingSupport) {
       return new Settings(
           serviceName,
@@ -820,8 +849,15 @@ public class TestKit {
       // actual message codec instance not available until runtime/sdk started, thus this is called
       // after discovery happens
       eventingTestKit =
-          EventingTestKit.start(
-              runtimeActorSystem, "0.0.0.0", eventingTestKitPort, new Serializer());
+          akka.javasdk.testkit.impl.EventingTestKitImpl.start(
+              runtimeActorSystem,
+              "0.0.0.0",
+              eventingTestKitPort,
+              scala.Option.apply(runtimeHost),
+              scala.Option.apply((Integer) runtimePort),
+              scala.Option.apply("impersonate-service"),
+              scala.Option.apply("testkit"),
+              new Serializer());
     }
   }
 
@@ -1319,6 +1355,23 @@ public class TestKit {
       throwMissingConfigurationException("Topic " + topic);
     }
     return eventingTestKit.getTopicOutgoingMessages(topic);
+  }
+
+  /**
+   * Get outgoing messages produced by a {@code @Produce.ServiceStream} publisher in the service
+   * under test. The testkit subscribes to the running producer stream over gRPC so the real
+   * transformation path is exercised. The {@code service} must match the service name used by
+   * consumers in their {@code @Consume.FromServiceStream} annotation.
+   *
+   * @param service service name
+   * @param streamId service stream id
+   */
+  public EventingTestKit.OutgoingMessages getStreamOutgoingMessages(
+      String service, String streamId) {
+    if (!settings.mockedEventing.hasStreamDestination(service, streamId)) {
+      throwMissingConfigurationException("Stream " + service + "/" + streamId);
+    }
+    return eventingTestKit.getStreamOutgoingMessages(service, streamId);
   }
 
   private void throwMissingConfigurationException(String hint) {

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/EventingTestKitImpl.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/EventingTestKitImpl.scala
@@ -79,10 +79,30 @@ object EventingTestKitImpl {
    * The returned testkit can be used to expect and emit events to the proxy as if they came from an actual pub/sub
    * event backend.
    */
-  def start(system: ActorSystem[_], host: String, port: Int, serializer: Serializer): EventingTestKit = {
+  def start(system: ActorSystem[_], host: String, port: Int, serializer: Serializer): EventingTestKit =
+    start(system, host, port, None, None, None, None, serializer)
+
+  def start(
+      system: ActorSystem[_],
+      host: String,
+      port: Int,
+      runtimeHost: Option[String],
+      runtimePort: Option[Int],
+      serviceIdentityHeader: Option[String],
+      serviceIdentityToken: Option[String],
+      serializer: Serializer): EventingTestKit = {
 
     // Create service handlers
-    val service = new EventingTestServiceImpl(system, host, port, serializer)
+    val service =
+      new EventingTestServiceImpl(
+        system,
+        host,
+        port,
+        runtimeHost,
+        runtimePort,
+        serviceIdentityHeader,
+        serviceIdentityToken,
+        serializer)
     val handler: HttpRequest => Future[HttpResponse] =
       EventingTestKitServiceHandler(new service.ServiceImpl)(system)
 
@@ -161,14 +181,26 @@ object EventingTestKitImpl {
  * Implements the EventingTestKit protocol originally defined in proxy
  * protocols/testkit/src/main/protobuf/eventing_test_backend.proto
  */
-final class EventingTestServiceImpl(system: ActorSystem[_], val host: String, var port: Int, serializer: Serializer)
+final class EventingTestServiceImpl(
+    system: ActorSystem[_],
+    val host: String,
+    var port: Int,
+    runtimeHost: Option[String],
+    runtimePort: Option[Int],
+    serviceIdentityHeader: Option[String],
+    serviceIdentityToken: Option[String],
+    serializer: Serializer)
     extends EventingTestKit {
+
+  def this(system: ActorSystem[_], host: String, port: Int, serializer: Serializer) =
+    this(system, host, port, None, None, None, None, serializer)
 
   private val log = LoggerFactory.getLogger(classOf[EventingTestServiceImpl])
   private implicit val sys: akka.actor.ActorSystem = system.classicSystem
   private implicit val ec: ExecutionContextExecutor = system.executionContext
 
   private val topicDestinations = new ConcurrentHashMap[String, OutgoingMessagesImpl]()
+  private val streamDestinations = new ConcurrentHashMap[String, OutgoingMessagesImpl]()
 
   private val veSubscriptions = new ConcurrentHashMap[String, VeIncomingMessagesImpl]()
   private val esSubscriptions = new ConcurrentHashMap[String, IncomingMessagesImpl]()
@@ -220,6 +252,29 @@ final class EventingTestServiceImpl(system: ActorSystem[_], val host: String, va
       service + "/" + streamId,
       _ =>
         new IncomingMessagesImpl(sys.actorOf(Props[SourcesHolder](), s"stream-holder-$service-$streamId"), serializer))
+
+  override def getStreamOutgoingMessages(service: String, streamId: String): OutgoingMessages = {
+    val host = runtimeHost.getOrElse(
+      throw new IllegalStateException(
+        "getStreamOutgoingMessages requires the testkit to know the service runtime host/port; " +
+        "this EventingTestKit was started without them."))
+    val port = runtimePort.getOrElse(
+      throw new IllegalStateException(
+        "getStreamOutgoingMessages requires the testkit to know the service runtime host/port; " +
+        "this EventingTestKit was started without them."))
+
+    streamDestinations.computeIfAbsent(
+      service + "/" + streamId,
+      _ =>
+        StreamOutgoingMessagesImpl(
+          system,
+          host,
+          port,
+          serviceIdentityHeader,
+          serviceIdentityToken,
+          streamId,
+          serializer))
+  }
 
   final class ServiceImpl extends EventingTestKitService {
     override def emitSingle(in: EmitSingleCommand): Future[EmitSingleResult] = {

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/EventingTestKitImpl.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/EventingTestKitImpl.scala
@@ -79,9 +79,6 @@ object EventingTestKitImpl {
    * The returned testkit can be used to expect and emit events to the proxy as if they came from an actual pub/sub
    * event backend.
    */
-  def start(system: ActorSystem[_], host: String, port: Int, serializer: Serializer): EventingTestKit =
-    start(system, host, port, None, None, None, None, serializer)
-
   def start(
       system: ActorSystem[_],
       host: String,
@@ -192,9 +189,6 @@ final class EventingTestServiceImpl(
     serializer: Serializer)
     extends EventingTestKit {
 
-  def this(system: ActorSystem[_], host: String, port: Int, serializer: Serializer) =
-    this(system, host, port, None, None, None, None, serializer)
-
   private val log = LoggerFactory.getLogger(classOf[EventingTestServiceImpl])
   private implicit val sys: akka.actor.ActorSystem = system.classicSystem
   private implicit val ec: ExecutionContextExecutor = system.executionContext
@@ -272,6 +266,7 @@ final class EventingTestServiceImpl(
           port,
           serviceIdentityHeader,
           serviceIdentityToken,
+          service,
           streamId,
           serializer))
   }

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/StreamOutgoingMessagesImpl.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/StreamOutgoingMessagesImpl.scala
@@ -4,6 +4,11 @@
 
 package akka.javasdk.testkit.impl
 
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.util.Failure
+import scala.util.Success
+
 import akka.Done
 import akka.actor.CoordinatedShutdown
 import akka.actor.typed.ActorSystem
@@ -30,10 +35,6 @@ import kalix.protocol.component.MetadataEntry
 import kalix.testkit.protocol.eventing_test_backend.EmitSingleCommand
 import kalix.testkit.protocol.eventing_test_backend.{ Message => TestkitMessage }
 import org.slf4j.LoggerFactory
-
-import java.util.concurrent.atomic.AtomicBoolean
-import scala.util.Failure
-import scala.util.Success
 
 /**
  * Captures events produced by a `@Produce.ServiceStream` publisher by subscribing to the running service's producer

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/StreamOutgoingMessagesImpl.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/StreamOutgoingMessagesImpl.scala
@@ -37,8 +37,8 @@ import kalix.testkit.protocol.eventing_test_backend.{ Message => TestkitMessage 
 import org.slf4j.LoggerFactory
 
 /**
- * Captures events emitted by a `@Produce.ServiceStream` producer by consuming the running service's producer
- * stream via Akka Projection gRPC. No runtime mocking is involved — the real transformation path runs.
+ * Captures events emitted by a `@Produce.ServiceStream` producer by consuming the running service's producer stream via
+ * Akka Projection gRPC. No runtime mocking is involved — the real transformation path runs.
  *
  * INTERNAL API
  */

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/StreamOutgoingMessagesImpl.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/StreamOutgoingMessagesImpl.scala
@@ -7,8 +7,10 @@ package akka.javasdk.testkit.impl
 import akka.Done
 import akka.actor.CoordinatedShutdown
 import akka.actor.typed.ActorSystem
+import akka.annotation.InternalApi
 import akka.grpc.GrpcClientSettings
 import akka.grpc.scaladsl.MetadataBuilder
+import akka.javasdk.impl.AnySupport
 import akka.javasdk.impl.serialization.Serializer
 import akka.persistence.Persistence
 import akka.persistence.query.Offset
@@ -36,14 +38,16 @@ import scala.util.Success
 /**
  * Captures events produced by a `@Produce.ServiceStream` publisher by subscribing to the running service's producer
  * stream via Akka Projection gRPC. No runtime mocking is involved — the real transformation path runs.
+ *
+ * INTERNAL API
  */
+@InternalApi
 private[testkit] object StreamOutgoingMessagesImpl {
 
   private val log = LoggerFactory.getLogger("akka.javasdk.testkit.impl.StreamOutgoingMessagesImpl")
 
-  private val GoogleTypeUrlPrefix = "type.googleapis.com/"
-  private val JsonTypeUrlPrefix = "json.akka.io/"
-  private val ProtoAnyTypeUrl = "type.googleapis.com/google.protobuf.Any"
+  private val GoogleTypeUrlPrefix = AnySupport.DefaultTypeUrlPrefix + "/"
+  private val ProtoAnyTypeUrl = GoogleTypeUrlPrefix + com.google.protobuf.Any.getDescriptor.getFullName
 
   def apply(
       system: ActorSystem[_],
@@ -128,19 +132,16 @@ private[testkit] object StreamOutgoingMessagesImpl {
           val tu = any.typeUrl
           val isProto = tu.startsWith(GoogleTypeUrlPrefix)
           val (ceType, contentType) =
-            if (tu.startsWith(JsonTypeUrlPrefix)) (tu.substring(JsonTypeUrlPrefix.length), "application/json")
+            if (tu.startsWith(AnySupport.JsonTypeUrlPrefix))
+              (tu.substring(AnySupport.JsonTypeUrlPrefix.length), "application/json")
             else if (isProto) (tu.substring(GoogleTypeUrlPrefix.length), "application/protobuf")
             else (tu, "application/octet-stream")
 
-          // Non-protobuf payloads are length-delim wrapped as field 1 by the runtime's ProtobufUtils;
-          // unwrap to get the raw (JSON) bytes.
+          // Non-protobuf payloads (e.g. JSON) are length-delim wrapped by the runtime as a primitive-bytes
+          // field when packed into ScalaPbAny; unwrap them via the SDK's primitive-bytes decoder.
           val payloadBytes: ByteString =
             if (isProto || any.value.isEmpty) any.value
-            else {
-              val in = any.value.newCodedInput()
-              in.readTag()
-              in.readBytes()
-            }
+            else AnySupport.decodePrimitiveBytes(any.value)
 
           val metadata = Metadata(entries = Seq(
             MetadataEntry("ce-type", MetadataEntry.Value.StringValue(ceType)),

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/StreamOutgoingMessagesImpl.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/StreamOutgoingMessagesImpl.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.testkit.impl
+
+import akka.actor.typed.ActorSystem
+import akka.grpc.GrpcClientSettings
+import akka.grpc.scaladsl.MetadataBuilder
+import akka.javasdk.impl.serialization.Serializer
+import akka.persistence.query.Offset
+import akka.persistence.query.typed.EventEnvelope
+import akka.projection.grpc.consumer.GrpcQuerySettings
+import akka.projection.grpc.consumer.scaladsl.GrpcReadJournal
+import akka.stream.Materializer
+import akka.stream.SystemMaterializer
+import akka.stream.scaladsl.Sink
+import akka.testkit.TestProbe
+import com.google.protobuf.ByteString
+import com.google.protobuf.any.{ Any => ScalaPbAny }
+import kalix.protocol.component.Metadata
+import kalix.protocol.component.MetadataEntry
+import kalix.testkit.protocol.eventing_test_backend.EmitSingleCommand
+import kalix.testkit.protocol.eventing_test_backend.{ Message => TestkitMessage }
+import org.slf4j.LoggerFactory
+
+/**
+ * Captures events produced by a `@Produce.ServiceStream` publisher by subscribing to the running service's producer
+ * stream via Akka Projection gRPC. No runtime mocking is involved — the real transformation path runs.
+ */
+private[testkit] object StreamOutgoingMessagesImpl {
+
+  private val log = LoggerFactory.getLogger(classOf[OutgoingMessagesImpl])
+
+  private val GoogleTypeUrlPrefix = "type.googleapis.com/"
+  private val JsonTypeUrlPrefix = "json.akka.io/"
+  private val ProtoAnyTypeUrl = "type.googleapis.com/google.protobuf.Any"
+
+  def apply(
+      system: ActorSystem[_],
+      runtimeHost: String,
+      runtimePort: Int,
+      serviceIdentityHeader: Option[String],
+      serviceIdentityToken: Option[String],
+      streamId: String,
+      serializer: Serializer): OutgoingMessagesImpl = {
+
+    val classic = system.classicSystem
+    val materializer: Materializer = SystemMaterializer(system).materializer
+    val probe = TestProbe()(classic)
+
+    val clientSettings = GrpcClientSettings
+      .connectToServiceAt(runtimeHost, runtimePort)(classic)
+      .withTls(false)
+
+    val querySettings = {
+      val base = GrpcQuerySettings(streamId)
+      (serviceIdentityHeader, serviceIdentityToken) match {
+        case (Some(header), Some(token)) =>
+          base.withAdditionalRequestMetadata(new MetadataBuilder().addText(header, token).build())
+        case _ => base
+      }
+    }
+
+    val journal = GrpcReadJournal(querySettings, clientSettings, Seq.empty)(classic)
+
+    val done = journal
+      .eventsBySlices[AnyRef](streamId, 0, 1023, Offset.noOffset)
+      .runWith(Sink.foreach { (env: EventEnvelope[AnyRef]) =>
+        toEmitSingleCommand(env, streamId).foreach(cmd => probe.ref ! cmd)
+      })(materializer)
+
+    done.failed.foreach(ex => log.debug("Stream outgoing subscription terminated: {}", ex.toString))(
+      system.executionContext)
+
+    new OutgoingMessagesImpl(probe, serializer)
+  }
+
+  private def toEmitSingleCommand(env: EventEnvelope[AnyRef], streamId: String): Option[EmitSingleCommand] = {
+    if (env.filtered || env.eventOption.isEmpty) None
+    else {
+      env.event match {
+        case outer: ScalaPbAny =>
+          // The runtime wraps produced events as ScalaPbAny(typeUrl=google.protobuf.Any, value=innerScalaPbAny)
+          // for passthrough — unwrap one level when we see that.
+          val any =
+            if (outer.typeUrl == ProtoAnyTypeUrl) ScalaPbAny.parseFrom(outer.value.newCodedInput())
+            else outer
+          log.debug("Stream [{}] received event typeUrl=[{}]", streamId, any.typeUrl)
+          val tu = any.typeUrl
+          val isProto = tu.startsWith(GoogleTypeUrlPrefix)
+          val (ceType, contentType) =
+            if (tu.startsWith(JsonTypeUrlPrefix)) (tu.substring(JsonTypeUrlPrefix.length), "application/json")
+            else if (isProto) (tu.substring(GoogleTypeUrlPrefix.length), "application/protobuf")
+            else (tu, "application/octet-stream")
+
+          // Non-protobuf payloads are length-delim wrapped as field 1 by the runtime's ProtobufUtils;
+          // unwrap to get the raw (JSON) bytes.
+          val payloadBytes: ByteString =
+            if (isProto || any.value.isEmpty) any.value
+            else {
+              val in = any.value.newCodedInput()
+              in.readTag()
+              in.readBytes()
+            }
+
+          val metadata = Metadata(entries = Seq(
+            MetadataEntry("ce-type", MetadataEntry.Value.StringValue(ceType)),
+            MetadataEntry("Content-Type", MetadataEntry.Value.StringValue(contentType))))
+
+          Some(
+            EmitSingleCommand(
+              destination = None,
+              message = Some(TestkitMessage(payload = payloadBytes, metadata = Some(metadata)))))
+
+        case other =>
+          log.warn(
+            "Stream [{}] produced an event of unexpected type [{}]; only ScalaPbAny pass-through is supported in the testkit.",
+            streamId,
+            other.getClass.getName)
+          None
+      }
+    }
+  }
+}

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/StreamOutgoingMessagesImpl.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/StreamOutgoingMessagesImpl.scala
@@ -4,16 +4,21 @@
 
 package akka.javasdk.testkit.impl
 
+import akka.Done
+import akka.actor.CoordinatedShutdown
 import akka.actor.typed.ActorSystem
 import akka.grpc.GrpcClientSettings
 import akka.grpc.scaladsl.MetadataBuilder
 import akka.javasdk.impl.serialization.Serializer
+import akka.persistence.Persistence
 import akka.persistence.query.Offset
 import akka.persistence.query.typed.EventEnvelope
 import akka.projection.grpc.consumer.GrpcQuerySettings
 import akka.projection.grpc.consumer.scaladsl.GrpcReadJournal
+import akka.stream.KillSwitches
 import akka.stream.Materializer
 import akka.stream.SystemMaterializer
+import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
 import akka.testkit.TestProbe
 import com.google.protobuf.ByteString
@@ -24,13 +29,17 @@ import kalix.testkit.protocol.eventing_test_backend.EmitSingleCommand
 import kalix.testkit.protocol.eventing_test_backend.{ Message => TestkitMessage }
 import org.slf4j.LoggerFactory
 
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.util.Failure
+import scala.util.Success
+
 /**
  * Captures events produced by a `@Produce.ServiceStream` publisher by subscribing to the running service's producer
  * stream via Akka Projection gRPC. No runtime mocking is involved — the real transformation path runs.
  */
 private[testkit] object StreamOutgoingMessagesImpl {
 
-  private val log = LoggerFactory.getLogger(classOf[OutgoingMessagesImpl])
+  private val log = LoggerFactory.getLogger("akka.javasdk.testkit.impl.StreamOutgoingMessagesImpl")
 
   private val GoogleTypeUrlPrefix = "type.googleapis.com/"
   private val JsonTypeUrlPrefix = "json.akka.io/"
@@ -42,11 +51,13 @@ private[testkit] object StreamOutgoingMessagesImpl {
       runtimePort: Int,
       serviceIdentityHeader: Option[String],
       serviceIdentityToken: Option[String],
+      service: String,
       streamId: String,
       serializer: Serializer): OutgoingMessagesImpl = {
 
     val classic = system.classicSystem
     val materializer: Materializer = SystemMaterializer(system).materializer
+    implicit val ec = system.executionContext
     val probe = TestProbe()(classic)
 
     val clientSettings = GrpcClientSettings
@@ -64,14 +75,41 @@ private[testkit] object StreamOutgoingMessagesImpl {
 
     val journal = GrpcReadJournal(querySettings, clientSettings, Seq.empty)(classic)
 
-    val done = journal
-      .eventsBySlices[AnyRef](streamId, 0, 1023, Offset.noOffset)
-      .runWith(Sink.foreach { (env: EventEnvelope[AnyRef]) =>
-        toEmitSingleCommand(env, streamId).foreach(cmd => probe.ref ! cmd)
-      })(materializer)
+    // all slices — testkit runs a single instance covering the full range
+    val sliceRange = Persistence(classic).sliceRanges(1).head
 
-    done.failed.foreach(ex => log.debug("Stream outgoing subscription terminated: {}", ex.toString))(
-      system.executionContext)
+    val shuttingDown = new AtomicBoolean(false)
+
+    val (killSwitch, done) = journal
+      .eventsBySlices[AnyRef](streamId, sliceRange.min, sliceRange.max, Offset.noOffset)
+      .viaMat(KillSwitches.single)(Keep.right)
+      .toMat(Sink.foreach { (env: EventEnvelope[AnyRef]) =>
+        toEmitSingleCommand(env, streamId).foreach(cmd => probe.ref ! cmd)
+      })(Keep.both)
+      .run()(materializer)
+
+    done.onComplete {
+      case Success(_) =>
+        log.debug("Stream [{}] outgoing subscription completed", streamId)
+      case Failure(_) if shuttingDown.get() =>
+        log.debug("Stream [{}] outgoing subscription terminated during shutdown", streamId)
+      case Failure(ex) =>
+        log.warn(
+          "Stream [{}] outgoing subscription failed — expectations on this stream will time out: {}",
+          streamId,
+          ex.toString,
+          ex)
+    }
+
+    CoordinatedShutdown(classic).addTask(
+      CoordinatedShutdown.PhaseBeforeActorSystemTerminate,
+      s"stream-outgoing-testkit-shutdown-$service-$streamId") { () =>
+      shuttingDown.set(true)
+      killSwitch.shutdown()
+      // wait for the stream to fully drain so the actor system doesn't proceed to terminate
+      // mid-teardown, which is what produces abrupt shutdown noise.
+      done.recover { case _ => Done }
+    }
 
     new OutgoingMessagesImpl(probe, serializer)
   }

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/StreamOutgoingMessagesImpl.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/StreamOutgoingMessagesImpl.scala
@@ -37,7 +37,7 @@ import kalix.testkit.protocol.eventing_test_backend.{ Message => TestkitMessage 
 import org.slf4j.LoggerFactory
 
 /**
- * Captures events produced by a `@Produce.ServiceStream` publisher by subscribing to the running service's producer
+ * Captures events emitted by a `@Produce.ServiceStream` producer by consuming the running service's producer
  * stream via Akka Projection gRPC. No runtime mocking is involved — the real transformation path runs.
  *
  * INTERNAL API

--- a/akka-javasdk-testkit/src/test/scala/akka/javasdk/testkit/impl/TestKitSpec.scala
+++ b/akka-javasdk-testkit/src/test/scala/akka/javasdk/testkit/impl/TestKitSpec.scala
@@ -23,9 +23,11 @@ class TestKitSpec extends AnyWordSpec with Matchers {
         .withTopicIncomingMessages("h")
         .withTopicOutgoingMessages("aa")
         .withTopicOutgoingMessages("bb")
+        .withStreamOutgoingMessages("s3", "cc")
+        .withStreamOutgoingMessages("s4", "dd")
 
       config.toIncomingFlowConfig shouldBe "event-sourced-entity,c;event-sourced-entity,d;key-value-entity,a;key-value-entity,b;stream,s1/e;stream,s2/f;topic,g;topic,h"
-      config.toOutgoingFlowConfig shouldBe "topic,aa;topic,bb"
+      config.toOutgoingFlowConfig shouldBe "stream,s3/cc;stream,s4/dd;topic,aa;topic,bb"
     }
 
     "create immutable config" in {

--- a/docs/src/modules/sdk/pages/consuming-producing.adoc
+++ b/docs/src/modules/sdk/pages/consuming-producing.adoc
@@ -349,11 +349,11 @@ include::example$event-sourced-counter-brokers/src/test/java/counter/application
 
 === Service-to-Service Streams
 
-The TestKit also supports xref:#s2s-eventing[] in both directions — mocking the upstream stream a subscribing service consumes from, and capturing the public events a producing service emits for downstream subscribers.
+The TestKit also supports xref:#s2s-eventing[] in both directions — mocking the upstream stream a consuming service reads from, and capturing the public events a producing service emits for downstream consumers.
 
-==== Testing a Subscriber
+==== Testing a Consumer
 
-In a service that consumes another service's stream via `@Consume.FromServiceStream`, the TestKit can stand in for the upstream producer. Messages published to the mocked stream flow through the subscriber's real consumer or view logic.
+In a service that consumes another service's stream via `@Consume.FromServiceStream`, the TestKit can stand in for the upstream producer. Messages published to the mocked stream flow through the consumer's or view's real logic.
 
 The https://github.com/akka/akka-sdk/tree/main/samples/event-sourced-customer-registry-subscriber[`event-sourced-customer-registry-subscriber`, window="new"] sample consumes the `customer_events` stream produced by `customer-registry` (see xref:#s2s-eventing[]). Its integration test mocks that upstream stream:
 
@@ -362,7 +362,7 @@ The https://github.com/akka/akka-sdk/tree/main/samples/event-sourced-customer-re
 ----
 include::example$event-sourced-customer-registry-subscriber/src/test/java/customer/api/CustomersByNameViewIntegrationTest.java[tags=eventing-config]
 ----
-<1> Mock the upstream stream by service and stream id — matches the values in the subscriber's `@Consume.FromServiceStream` annotation.
+<1> Mock the upstream stream by service and stream id — matches the values in the consumer's `@Consume.FromServiceStream` annotation.
 
 [source,java,indent=0]
 .{sample-base-url}/event-sourced-customer-registry-subscriber/src/test/java/customer/api/CustomersByNameViewIntegrationTest.java[CustomersByNameViewIntegrationTest.java]
@@ -375,16 +375,16 @@ include::example$event-sourced-customer-registry-subscriber/src/test/java/custom
 
 ==== Testing a Producer
 
-For a service that publishes a stream via `@Produce.ServiceStream` — typically with a transformation from internal events to a narrower public event type — the TestKit can capture what is emitted so the transformation can be asserted. Unlike the subscriber case, nothing is mocked: the real transformation path runs and the TestKit observes the emitted public events.
+For a service that produces a stream via `@Produce.ServiceStream` — typically with a transformation from internal events to a narrower public event type — the TestKit can capture what is emitted so the transformation can be asserted. Unlike the consumer case, nothing is mocked: the real transformation path runs and the TestKit observes the emitted public events.
 
-The https://github.com/akka/akka-sdk/tree/main/samples/event-sourced-customer-registry[`event-sourced-customer-registry`, window="new"] sample has a `CustomerEvents` consumer that transforms internal `CustomerEvent` values into `CustomerPublicEvent` values for downstream services. Its integration test verifies that transformation:
+The https://github.com/akka/akka-sdk/tree/main/samples/event-sourced-customer-registry[`event-sourced-customer-registry`, window="new"] sample has a `CustomerEvents` producer that transforms internal `CustomerEvent` values into `CustomerPublicEvent` values for downstream services. Its integration test verifies that transformation:
 
 [source,java,indent=0]
 .{sample-base-url}/event-sourced-customer-registry/src/test/java/customer/api/CustomerEventsOutgoingIntegrationTest.java[CustomerEventsOutgoingIntegrationTest.java]
 ----
 include::example$event-sourced-customer-registry/src/test/java/customer/api/CustomerEventsOutgoingIntegrationTest.java[tags=eventing-config]
 ----
-<1> Register the outgoing stream to capture. The values must match the producer's `@Produce.ServiceStream` id and the service name that downstream subscribers use.
+<1> Register the outgoing stream to capture. The values must match the producer's `@Produce.ServiceStream` id and the service name that downstream consumers use.
 
 [source,java,indent=0]
 .{sample-base-url}/event-sourced-customer-registry/src/test/java/customer/api/CustomerEventsOutgoingIntegrationTest.java[CustomerEventsOutgoingIntegrationTest.java]

--- a/docs/src/modules/sdk/pages/consuming-producing.adoc
+++ b/docs/src/modules/sdk/pages/consuming-producing.adoc
@@ -347,6 +347,57 @@ To run an integration test against a real instance of Google PubSub (or its Emul
 include::example$event-sourced-counter-brokers/src/test/java/counter/application/CounterWithRealKafkaIntegrationTest.java[tags=kafka]
 ----
 
+=== Service-to-Service Streams
+
+The TestKit also supports xref:#s2s-eventing[] in both directions — mocking the upstream stream a subscribing service consumes from, and capturing the public events a producing service emits for downstream subscribers.
+
+==== Testing a Subscriber
+
+In a service that consumes another service's stream via `@Consume.FromServiceStream`, the TestKit can stand in for the upstream producer. Messages published to the mocked stream flow through the subscriber's real consumer or view logic.
+
+The https://github.com/akka/akka-sdk/tree/main/samples/event-sourced-customer-registry-subscriber[`event-sourced-customer-registry-subscriber`, window="new"] sample consumes the `customer_events` stream produced by `customer-registry` (see xref:#s2s-eventing[]). Its integration test mocks that upstream stream:
+
+[source,java,indent=0]
+.{sample-base-url}/event-sourced-customer-registry-subscriber/src/test/java/customer/api/CustomersByNameViewIntegrationTest.java[CustomersByNameViewIntegrationTest.java]
+----
+include::example$event-sourced-customer-registry-subscriber/src/test/java/customer/api/CustomersByNameViewIntegrationTest.java[tags=eventing-config]
+----
+<1> Mock the upstream stream by service and stream id — matches the values in the subscriber's `@Consume.FromServiceStream` annotation.
+
+[source,java,indent=0]
+.{sample-base-url}/event-sourced-customer-registry-subscriber/src/test/java/customer/api/CustomersByNameViewIntegrationTest.java[CustomersByNameViewIntegrationTest.java]
+----
+include::example$event-sourced-customer-registry-subscriber/src/test/java/customer/api/CustomersByNameViewIntegrationTest.java[tags=class]
+----
+<1> Register the mocked stream in the `TestKit` settings.
+<2> Retrieve an `IncomingMessages` handle for that stream.
+<3> Publish messages of the public event type the producing service would emit. The second argument is the subject id (for example, an entity id).
+
+==== Testing a Producer
+
+For a service that publishes a stream via `@Produce.ServiceStream` — typically with a transformation from internal events to a narrower public event type — the TestKit can capture what is emitted so the transformation can be asserted. Unlike the subscriber case, nothing is mocked: the real transformation path runs and the TestKit observes the emitted public events.
+
+The https://github.com/akka/akka-sdk/tree/main/samples/event-sourced-customer-registry[`event-sourced-customer-registry`, window="new"] sample has a `CustomerEvents` consumer that transforms internal `CustomerEvent` values into `CustomerPublicEvent` values for downstream services. Its integration test verifies that transformation:
+
+[source,java,indent=0]
+.{sample-base-url}/event-sourced-customer-registry/src/test/java/customer/api/CustomerEventsOutgoingIntegrationTest.java[CustomerEventsOutgoingIntegrationTest.java]
+----
+include::example$event-sourced-customer-registry/src/test/java/customer/api/CustomerEventsOutgoingIntegrationTest.java[tags=eventing-config]
+----
+<1> Register the outgoing stream to capture. The values must match the producer's `@Produce.ServiceStream` id and the service name that downstream subscribers use.
+
+[source,java,indent=0]
+.{sample-base-url}/event-sourced-customer-registry/src/test/java/customer/api/CustomerEventsOutgoingIntegrationTest.java[CustomerEventsOutgoingIntegrationTest.java]
+----
+include::example$event-sourced-customer-registry/src/test/java/customer/api/CustomerEventsOutgoingIntegrationTest.java[tags=class]
+----
+<1> Register the outgoing stream in the `TestKit` settings.
+<2> Retrieve an `OutgoingMessages` handle for the stream.
+<3> Drive the service as usual — invoking the entity here triggers the internal event that the producer transforms.
+<4> Assert against the transformed public event type.
+
+`OutgoingMessages` exposes the same assertions used for topic outgoing messages, such as `expectN(...)` to read several messages or `expectNone(...)` to verify that a given internal event produces no public event (for example, when the transformation uses `effects().ignore()`).
+
 == Multi-region replication
 
 Consumers are not replicated directly in the same way as for example xref:event-sourced-entities.adoc#_replication[Event Sourced Entity replication]. A Consumer receives events from entities in the same service, or another service, in the same region. The entities will replicate all events across regions and identical processing can occur in the consumers of each region.

--- a/samples/event-sourced-customer-registry-subscriber/src/test/java/customer/api/CustomersByNameViewIntegrationTest.java
+++ b/samples/event-sourced-customer-registry-subscriber/src/test/java/customer/api/CustomersByNameViewIntegrationTest.java
@@ -12,17 +12,21 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
+// tag::class[]
 public class CustomersByNameViewIntegrationTest extends CustomerRegistryIntegrationTest {
 
+  // tag::eventing-config[]
   @Override
   protected TestKit.Settings testKitSettings() {
     return super.testKitSettings()
-      .withStreamIncomingMessages("customer-registry", "customer_events");
+      .withStreamIncomingMessages("customer-registry", "customer_events"); // <1>
   }
+
+  // end::eventing-config[]
 
   @Test
   public void shouldReturnCustomersFromViews() {
-    IncomingMessages customerEvents = testKit.getStreamIncomingMessages(
+    IncomingMessages customerEvents = testKit.getStreamIncomingMessages( // <2>
       "customer-registry",
       "customer_events"
     );
@@ -31,7 +35,7 @@ public class CustomersByNameViewIntegrationTest extends CustomerRegistryIntegrat
     Created created1 = new Created("bob@gmail.com", bob);
     Created created2 = new Created("alice@gmail.com", "alice");
 
-    customerEvents.publish(created1, "b");
+    customerEvents.publish(created1, "b"); // <3>
     customerEvents.publish(created2, "a");
 
     Awaitility.await()
@@ -67,3 +71,4 @@ public class CustomersByNameViewIntegrationTest extends CustomerRegistryIntegrat
       });
   }
 }
+// end::class[]

--- a/samples/event-sourced-customer-registry/src/test/java/customer/api/CustomerEventsOutgoingIntegrationTest.java
+++ b/samples/event-sourced-customer-registry/src/test/java/customer/api/CustomerEventsOutgoingIntegrationTest.java
@@ -1,0 +1,102 @@
+package customer.api;
+
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import akka.javasdk.testkit.EventingTestKit.OutgoingMessages;
+import akka.javasdk.testkit.TestKit;
+import akka.javasdk.testkit.TestKitSupport;
+import customer.application.CustomerEntity;
+import customer.domain.Address;
+import customer.domain.Customer;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+// tag::class[]
+public class CustomerEventsOutgoingIntegrationTest extends TestKitSupport {
+
+  // tag::eventing-config[]
+  @Override
+  protected TestKit.Settings testKitSettings() {
+    return super.testKitSettings()
+      .withStreamOutgoingMessages("customer-registry", "customer_events"); // <1>
+  }
+
+  // end::eventing-config[]
+
+  @Test
+  public void shouldCaptureCreatedEvent() {
+    OutgoingMessages outgoing = testKit.getStreamOutgoingMessages( // <2>
+      "customer-registry",
+      "customer_events"
+    );
+
+    String id = UUID.randomUUID().toString();
+    componentClient // <3>
+      .forEventSourcedEntity(id)
+      .method(CustomerEntity::create)
+      .invoke(
+        new Customer("foo@example.com", "Johanna", new Address("Regent Street", "London"))
+      );
+
+    var msg = outgoing.expectOneTyped(CustomerPublicEvent.Created.class, ofSeconds(20)); // <4>
+    assertThat(msg.getPayload().email()).isEqualTo("foo@example.com");
+    assertThat(msg.getPayload().name()).isEqualTo("Johanna");
+  }
+
+  // end::class[]
+
+  @Test
+  public void shouldCaptureMultiplePublicEvents() {
+    OutgoingMessages outgoing = testKit.getStreamOutgoingMessages(
+      "customer-registry",
+      "customer_events"
+    );
+    // drain anything produced by prior tests in the same suite
+    outgoing.clear();
+
+    String id = UUID.randomUUID().toString();
+    componentClient
+      .forEventSourcedEntity(id)
+      .method(CustomerEntity::create)
+      .invoke(
+        new Customer("alice@example.com", "Alice", new Address("Baker Street", "London"))
+      );
+    componentClient
+      .forEventSourcedEntity(id)
+      .method(CustomerEntity::changeName)
+      .invoke("Alicia");
+
+    var created = outgoing.expectOneTyped(CustomerPublicEvent.Created.class, ofSeconds(20));
+    assertThat(created.getPayload().name()).isEqualTo("Alice");
+
+    var renamed = outgoing.expectOneTyped(CustomerPublicEvent.NameChanged.class, ofSeconds(20));
+    assertThat(renamed.getPayload().newName()).isEqualTo("Alicia");
+  }
+
+  @Test
+  public void shouldNotEmitForIgnoredInternalEvents() {
+    OutgoingMessages outgoing = testKit.getStreamOutgoingMessages(
+      "customer-registry",
+      "customer_events"
+    );
+    outgoing.clear();
+
+    String id = UUID.randomUUID().toString();
+    componentClient
+      .forEventSourcedEntity(id)
+      .method(CustomerEntity::create)
+      .invoke(
+        new Customer("bob@example.com", "Bob", new Address("Oxford Street", "London"))
+      );
+    outgoing.expectOneTyped(CustomerPublicEvent.Created.class, ofSeconds(20));
+
+    // AddressChanged is filtered by the producer (effects().ignore()) — no public event should be emitted
+    componentClient
+      .forEventSourcedEntity(id)
+      .method(CustomerEntity::changeAddress)
+      .invoke(new Address("Elm st. 5", "New Orleans"));
+
+    outgoing.expectNone(ofSeconds(3));
+  }
+}

--- a/samples/event-sourced-customer-registry/src/test/java/customer/api/CustomerEventsOutgoingIntegrationTest.java
+++ b/samples/event-sourced-customer-registry/src/test/java/customer/api/CustomerEventsOutgoingIntegrationTest.java
@@ -70,7 +70,10 @@ public class CustomerEventsOutgoingIntegrationTest extends TestKitSupport {
     var created = outgoing.expectOneTyped(CustomerPublicEvent.Created.class, ofSeconds(20));
     assertThat(created.getPayload().name()).isEqualTo("Alice");
 
-    var renamed = outgoing.expectOneTyped(CustomerPublicEvent.NameChanged.class, ofSeconds(20));
+    var renamed = outgoing.expectOneTyped(
+      CustomerPublicEvent.NameChanged.class,
+      ofSeconds(20)
+    );
     assertThat(renamed.getPayload().newName()).isEqualTo("Alicia");
   }
 
@@ -86,9 +89,7 @@ public class CustomerEventsOutgoingIntegrationTest extends TestKitSupport {
     componentClient
       .forEventSourcedEntity(id)
       .method(CustomerEntity::create)
-      .invoke(
-        new Customer("bob@example.com", "Bob", new Address("Oxford Street", "London"))
-      );
+      .invoke(new Customer("bob@example.com", "Bob", new Address("Oxford Street", "London")));
     outgoing.expectOneTyped(CustomerPublicEvent.Created.class, ofSeconds(20));
 
     // AddressChanged is filtered by the producer (effects().ignore()) — no public event should be emitted


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/akka/akka-sdk/issues/1299

Implemented by using actual akka-projection-grpc client

Also contains reference docs section on the pre-existing service to service consumer testkit support (mocking the incoming stream of events) 
