### PR TITLE
feat: MCP endpoint structured tool output

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/McpEndpointTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/McpEndpointTest.java
@@ -22,7 +22,7 @@ public class McpEndpointTest extends TestKitSupport {
   // MCP endpoint defined in akkajavasdk.components.mcp.TestMcpEndpoint
 
   @Test
-  public void listTools() {
+  public void listTools() throws Exception {
     var listingResult =
         httpClient
             .POST("/mcp")
@@ -35,10 +35,73 @@ public class McpEndpointTest extends TestKitSupport {
             .invoke();
 
     assertThat(listingResult.status()).isEqualTo(StatusCodes.OK);
-    assertThat(listingResult.body().utf8String())
+    var tools =
+        JsonSerializer.internalObjectMapper()
+            .readValue(listingResult.body().utf8String(), JsonNode.class)
+            .get("result")
+            .get("tools");
+    assertThat(tools).hasSize(3);
+    var byName = new java.util.HashMap<String, JsonNode>();
+    tools.forEach(t -> byName.put(t.get("name").asText(), t));
+    // String return: no outputSchema
+    assertThat(byName.get("echo").has("outputSchema")).isFalse();
+    // int return: toString fallback, no outputSchema
+    assertThat(byName.get("answer").has("outputSchema")).isFalse();
+    // Record return: outputSchema advertised with properties from the record fields
+    var weatherOutput = byName.get("weather").get("outputSchema");
+    assertThat(weatherOutput.get("type").asText()).isEqualTo("object");
+    assertThat(weatherOutput.get("properties").get("city").get("type").asText())
+        .isEqualTo("string");
+    assertThat(weatherOutput.get("properties").get("tempC").get("type").asText())
+        .isEqualTo("integer");
+  }
+
+  @Test
+  public void callStructuredTool() throws Exception {
+    var result =
+        httpClient
+            .POST("/mcp")
+            .withRequestBody(
+                ContentTypes.APPLICATION_JSON,
+"""
+{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"weather","arguments":{"city":"Leuven"}}}
+"""
+                    .getBytes(StandardCharsets.UTF_8))
+            .invoke();
+
+    assertThat(result.status()).isEqualTo(StatusCodes.OK);
+    var resultNode =
+        JsonSerializer.internalObjectMapper()
+            .readValue(result.body().utf8String(), JsonNode.class)
+            .get("result");
+    var structured = resultNode.get("structuredContent");
+    assertThat(structured.get("city").asText()).isEqualTo("Leuven");
+    assertThat(structured.get("tempC").asInt()).isEqualTo(20);
+    // Spec back-compat: fallback text content with the JSON serialization is included
+    var content = resultNode.get("content");
+    assertThat(content).hasSize(1);
+    assertThat(content.get(0).get("type").asText()).isEqualTo("text");
+    assertThat(content.get(0).get("text").asText()).contains("\"city\":\"Leuven\"");
+  }
+
+  @Test
+  public void callPrimitiveReturningTool() {
+    var result =
+        httpClient
+            .POST("/mcp")
+            .withRequestBody(
+                ContentTypes.APPLICATION_JSON,
+"""
+{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"answer","arguments":{}}}
+"""
+                    .getBytes(StandardCharsets.UTF_8))
+            .invoke();
+
+    assertThat(result.status()).isEqualTo(StatusCodes.OK);
+    assertThat(result.body().utf8String())
         .isEqualTo(
 """
-{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"echo","description":"A method that returns what is fed to it","inputSchema":{"type":"object","properties":{"echo":{"type":"string","description":"the string to echo"}},"required":["echo"]}}]}}
+{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"42"}],"isError":false}}
 """
                 .trim());
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/mcp/TestMcpEndpoint.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/mcp/TestMcpEndpoint.java
@@ -19,6 +19,18 @@ public class TestMcpEndpoint extends AbstractMcpEndpoint {
     return echo;
   }
 
+  public record Weather(String city, int tempC) {}
+
+  @McpTool(description = "Structured weather tool")
+  public Weather weather(@Description("the city") String city) {
+    return new Weather(city, 20);
+  }
+
+  @McpTool(description = "A tool returning a primitive")
+  public int answer() {
+    return 42;
+  }
+
   @McpResource(
       name = "example text",
       uri = "file:///example.txt",

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/McpEndpointDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/McpEndpointDescriptorFactory.scala
@@ -45,6 +45,7 @@ import akka.runtime.sdk.spi.McpEndpointDescriptor.Resource
 import akka.runtime.sdk.spi.McpEndpointDescriptor.ResourceMethodDescriptor
 import akka.runtime.sdk.spi.McpEndpointDescriptor.ResourceTemplateMethodDescriptor
 import akka.runtime.sdk.spi.McpEndpointDescriptor.ResponseContent
+import akka.runtime.sdk.spi.McpEndpointDescriptor.StructuredToolCallResult
 import akka.runtime.sdk.spi.McpEndpointDescriptor.TextContent
 import akka.runtime.sdk.spi.McpEndpointDescriptor.TextResourceContents
 import akka.runtime.sdk.spi.McpEndpointDescriptor.ToolDescription
@@ -117,9 +118,18 @@ object McpEndpointDescriptorFactory {
     val toolMethods = methodsWithAnnotation[McpTool](mcpEndpointClass)
     val tools = toolMethods
       .map { case (annotation, method) =>
-        if (method.getReturnType != classOf[String])
-          throw new IllegalArgumentException(
-            s"MCP tool method must return String, but [${mcpEndpointClass.getName}.${method.getName}] returns [${method.getReturnType}]")
+        val returnType = method.getReturnType
+        val isStringReturn = returnType == classOf[String]
+        // Non-String, non-primitive object return types are surfaced as MCP 2025-06-18 structured tool output.
+        // Non-object return types (primitives, dates, arrays, collections) are rendered as toString text.
+        val structuredOutputSchema: Option[JsonSchemaObject] =
+          if (isStringReturn) None
+          else
+            JsonSchema.jsonSchemaFor(returnType) match {
+              case obj: JsonSchemaObject => Some(obj)
+              case _                     => None
+            }
+        val isStructuredReturn = structuredOutputSchema.isDefined
 
         val inputSchema: JsonSchemaObject =
           if (annotation.inputSchema().isBlank) {
@@ -135,49 +145,76 @@ object McpEndpointDescriptorFactory {
           else annotation.name()
 
         val toolAnnotations = toolAnnotationsFor(mcpEndpointClass, method.getName, annotation.annotations().toVector)
-        val toolDescription = new ToolDescription(toolName, annotation.description(), inputSchema, toolAnnotations)
+        val toolDescription =
+          new ToolDescription(toolName, annotation.description(), inputSchema, toolAnnotations, structuredOutputSchema)
 
         val requiredParameterNames = inputSchema.required.toSet
-        val callback = (context: McpEndpointConstructionContext, params: Map[String, Any]) =>
-          Future[ResponseContent] {
-            val endpointInstance = instanceFactory.apply(context)
-            val returnValue =
-              try {
-                if (method.getParameterCount == 0) {
-                  method.invoke(endpointInstance)
-                } else {
-                  val parsedParams = method.getParameters.map { param =>
-                    val required = requiredParameterNames(param.getName)
-                    params.get(param.getName) match {
-                      case Some(unparsedValue) =>
-                        val paramValue = objectMapper.convertValue(unparsedValue, param.getType)
-                        if (required) paramValue
-                        else Optional.ofNullable(paramValue)
-                      case None =>
-                        if (required)
-                          throw new IllegalArgumentException(
-                            s"Missing required tool parameter [${param.getName}] for tool [$toolName]")
-                        else Optional.empty()
-                    }
-                  }
-                  method.invoke(endpointInstance, parsedParams: _*)
+        def invoke(context: McpEndpointConstructionContext, params: Map[String, Any]): AnyRef = {
+          val endpointInstance = instanceFactory.apply(context)
+          try {
+            if (method.getParameterCount == 0) {
+              method.invoke(endpointInstance)
+            } else {
+              val parsedParams = method.getParameters.map { param =>
+                val required = requiredParameterNames(param.getName)
+                params.get(param.getName) match {
+                  case Some(unparsedValue) =>
+                    val paramValue = objectMapper.convertValue(unparsedValue, param.getType)
+                    if (required) paramValue
+                    else Optional.ofNullable(paramValue)
+                  case None =>
+                    if (required)
+                      throw new IllegalArgumentException(
+                        s"Missing required tool parameter [${param.getName}] for tool [$toolName]")
+                    else Optional.empty()
                 }
-              } catch unwrapInvocationTargetExceptionCatcher
-
-            returnValue match {
-              case text: String => new TextContent(text)
-              case unknown      =>
-                // FIXME handle/allow audio and image content types, supported by protocol, but how do we fit it in SDK API?
-                throw new RuntimeException(
-                  s"Unsupported tool return value for tool [$toolName] defined in [${mcpEndpointClass.getName}.${method.getName}] (${if (unknown == null) "null"
-                  else unknown.getClass.toString}")
+              }
+              method.invoke(endpointInstance, parsedParams: _*)
             }
-          }
+          } catch unwrapInvocationTargetExceptionCatcher
+        }
 
-        new ToolMethodDescriptor(
-          toolDescription = toolDescription,
-          method = callback,
-          methodOptions = new MethodOptions(None, None))
+        if (!isStructuredReturn) {
+          // FIXME handle/allow audio and image content types, supported by protocol, but how do we fit it in SDK API?
+          val callback = (context: McpEndpointConstructionContext, params: Map[String, Any]) =>
+            Future[ResponseContent] {
+              invoke(context, params) match {
+                case text: String => new TextContent(text)
+                case null         => new TextContent("")
+                case other        => new TextContent(other.toString)
+              }
+            }
+          new ToolMethodDescriptor(
+            toolDescription = toolDescription,
+            method = callback,
+            methodOptions = new MethodOptions(None, None))
+        } else {
+          // Structured output: serialize the returned object into a Map[String, Any] for structuredContent.
+          val mapTypeRef = new com.fasterxml.jackson.core.`type`.TypeReference[java.util.Map[String, AnyRef]] {}
+          val legacyCallback = (context: McpEndpointConstructionContext, params: Map[String, Any]) =>
+            Future.failed[ResponseContent](new IllegalStateException(
+              s"Tool [$toolName] is a structured tool, structuredMethod should have been used instead"))
+          val structuredCallback = (context: McpEndpointConstructionContext, params: Map[String, Any]) =>
+            Future[StructuredToolCallResult] {
+              val returnValue = invoke(context, params)
+              val asJavaMap =
+                try objectMapper.convertValue(returnValue, mapTypeRef)
+                catch {
+                  case NonFatal(ex) =>
+                    throw new RuntimeException(
+                      s"Failed to serialize structured return value of tool [$toolName] defined in [${mcpEndpointClass.getName}.${method.getName}] to a JSON object",
+                      ex)
+                }
+              import scala.jdk.CollectionConverters._
+              val asScalaMap: Map[String, Any] = asJavaMap.asScala.toMap
+              new StructuredToolCallResult(content = Seq.empty, structuredContent = asScalaMap, isError = false)
+            }
+          new ToolMethodDescriptor(
+            toolDescription = toolDescription,
+            method = legacyCallback,
+            methodOptions = new MethodOptions(None, None),
+            structuredMethod = Some(structuredCallback))
+        }
       }
       .sortBy(_.toolDescription.name)
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/McpEndpointDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/McpEndpointDescriptorFactory.scala
@@ -44,6 +44,7 @@ import akka.runtime.sdk.spi.McpEndpointDescriptor.Resource
 import akka.runtime.sdk.spi.McpEndpointDescriptor.ResourceMethodDescriptor
 import akka.runtime.sdk.spi.McpEndpointDescriptor.ResourceTemplateMethodDescriptor
 import akka.runtime.sdk.spi.McpEndpointDescriptor.ResponseContent
+import akka.runtime.sdk.spi.McpEndpointDescriptor.StructuredToolCallResult
 import akka.runtime.sdk.spi.McpEndpointDescriptor.TextContent
 import akka.runtime.sdk.spi.McpEndpointDescriptor.TextResourceContents
 import akka.runtime.sdk.spi.McpEndpointDescriptor.ToolDescription
@@ -107,9 +108,18 @@ object McpEndpointDescriptorFactory {
     val toolMethods = methodsWithAnnotation[McpTool](mcpEndpointClass)
     val tools = toolMethods
       .map { case (annotation, method) =>
-        if (method.getReturnType != classOf[String])
-          throw new IllegalArgumentException(
-            s"MCP tool method must return String, but [${mcpEndpointClass.getName}.${method.getName}] returns [${method.getReturnType}]")
+        val returnType = method.getReturnType
+        val isStringReturn = returnType == classOf[String]
+        // Non-String, non-primitive object return types are surfaced as MCP 2025-06-18 structured tool output.
+        // Non-object return types (primitives, dates, arrays, collections) are rendered as toString text.
+        val structuredOutputSchema: Option[JsonSchemaObject] =
+          if (isStringReturn) None
+          else
+            JsonSchema.jsonSchemaFor(returnType) match {
+              case obj: JsonSchemaObject => Some(obj)
+              case _                     => None
+            }
+        val isStructuredReturn = structuredOutputSchema.isDefined
 
         val inputSchema: JsonSchemaObject =
           if (annotation.inputSchema().isBlank) {
@@ -125,49 +135,76 @@ object McpEndpointDescriptorFactory {
           else annotation.name()
 
         val toolAnnotations = toolAnnotationsFor(mcpEndpointClass, method.getName, annotation.annotations().toVector)
-        val toolDescription = new ToolDescription(toolName, annotation.description(), inputSchema, toolAnnotations)
+        val toolDescription =
+          new ToolDescription(toolName, annotation.description(), inputSchema, toolAnnotations, structuredOutputSchema)
 
         val requiredParameterNames = inputSchema.required.toSet
-        val callback = (context: McpEndpointConstructionContext, params: Map[String, Any]) =>
-          Future[ResponseContent] {
-            val endpointInstance = instanceFactory.apply(context)
-            val returnValue =
-              try {
-                if (method.getParameterCount == 0) {
-                  method.invoke(endpointInstance)
-                } else {
-                  val parsedParams = method.getParameters.map { param =>
-                    val required = requiredParameterNames(param.getName)
-                    params.get(param.getName) match {
-                      case Some(unparsedValue) =>
-                        val paramValue = objectMapper.convertValue(unparsedValue, param.getType)
-                        if (required) paramValue
-                        else Optional.ofNullable(paramValue)
-                      case None =>
-                        if (required)
-                          throw new IllegalArgumentException(
-                            s"Missing required tool parameter [${param.getName}] for tool [$toolName]")
-                        else Optional.empty()
-                    }
-                  }
-                  method.invoke(endpointInstance, parsedParams: _*)
+        def invoke(context: McpEndpointConstructionContext, params: Map[String, Any]): AnyRef = {
+          val endpointInstance = instanceFactory.apply(context)
+          try {
+            if (method.getParameterCount == 0) {
+              method.invoke(endpointInstance)
+            } else {
+              val parsedParams = method.getParameters.map { param =>
+                val required = requiredParameterNames(param.getName)
+                params.get(param.getName) match {
+                  case Some(unparsedValue) =>
+                    val paramValue = objectMapper.convertValue(unparsedValue, param.getType)
+                    if (required) paramValue
+                    else Optional.ofNullable(paramValue)
+                  case None =>
+                    if (required)
+                      throw new IllegalArgumentException(
+                        s"Missing required tool parameter [${param.getName}] for tool [$toolName]")
+                    else Optional.empty()
                 }
-              } catch unwrapInvocationTargetExceptionCatcher
-
-            returnValue match {
-              case text: String => new TextContent(text)
-              case unknown      =>
-                // FIXME handle/allow audio and image content types, supported by protocol, but how do we fit it in SDK API?
-                throw new RuntimeException(
-                  s"Unsupported tool return value for tool [$toolName] defined in [${mcpEndpointClass.getName}.${method.getName}] (${if (unknown == null) "null"
-                  else unknown.getClass.toString}")
+              }
+              method.invoke(endpointInstance, parsedParams: _*)
             }
-          }
+          } catch unwrapInvocationTargetExceptionCatcher
+        }
 
-        new ToolMethodDescriptor(
-          toolDescription = toolDescription,
-          method = callback,
-          methodOptions = new MethodOptions(None, None))
+        if (!isStructuredReturn) {
+          // FIXME handle/allow audio and image content types, supported by protocol, but how do we fit it in SDK API?
+          val callback = (context: McpEndpointConstructionContext, params: Map[String, Any]) =>
+            Future[ResponseContent] {
+              invoke(context, params) match {
+                case text: String => new TextContent(text)
+                case null         => new TextContent("")
+                case other        => new TextContent(other.toString)
+              }
+            }
+          new ToolMethodDescriptor(
+            toolDescription = toolDescription,
+            method = callback,
+            methodOptions = new MethodOptions(None, None))
+        } else {
+          // Structured output: serialize the returned object into a Map[String, Any] for structuredContent.
+          val mapTypeRef = new com.fasterxml.jackson.core.`type`.TypeReference[java.util.Map[String, AnyRef]] {}
+          val legacyCallback = (context: McpEndpointConstructionContext, params: Map[String, Any]) =>
+            Future.failed[ResponseContent](new IllegalStateException(
+              s"Tool [$toolName] is a structured tool, structuredMethod should have been used instead"))
+          val structuredCallback = (context: McpEndpointConstructionContext, params: Map[String, Any]) =>
+            Future[StructuredToolCallResult] {
+              val returnValue = invoke(context, params)
+              val asJavaMap =
+                try objectMapper.convertValue(returnValue, mapTypeRef)
+                catch {
+                  case NonFatal(ex) =>
+                    throw new RuntimeException(
+                      s"Failed to serialize structured return value of tool [$toolName] defined in [${mcpEndpointClass.getName}.${method.getName}] to a JSON object",
+                      ex)
+                }
+              import scala.jdk.CollectionConverters._
+              val asScalaMap: Map[String, Any] = asJavaMap.asScala.toMap
+              new StructuredToolCallResult(content = Seq.empty, structuredContent = asScalaMap, isError = false)
+            }
+          new ToolMethodDescriptor(
+            toolDescription = toolDescription,
+            method = legacyCallback,
+            methodOptions = new MethodOptions(None, None),
+            structuredMethod = Some(structuredCallback))
+        }
       }
       .sortBy(_.toolDescription.name)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,12 +8,13 @@ object Dependencies {
     val ProtocolVersionMinor = 1
   }
 
-  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.10")
+  // FIXME pinned to locally published snapshot of akka-runtime wip-mcp-endpoint-structured-tool-output, restore to release version once runtime PR is merged
+  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.10-11-1fcafba0-SNAPSHOT")
 
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned
   // for prod code, they are marked as Provided, but testkit still requires the alignment
-  val AkkaVersion = "2.10.18"
+  val AkkaVersion = "2.10.20"
   val AkkaHttpVersion = "10.7.4" // Note: should at least the Akka HTTP version required by Akka gRPC
   val AkkaGrpcVersion = akka.grpc.gen.BuildInfo.version
   val GoogleProtobufVersion = akka.grpc.gen.BuildInfo.googleProtobufVersion


### PR DESCRIPTION
Allows arbitrary class return values from MCP endpoint tools, turned into JSON schema and json output payloads.

Depends on upstream https://github.com/lightbend/akka-runtime/pull/5082