### PR TITLE
feat: Notifications from BacklogEntity

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/agent/task/BacklogEntityTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/agent/task/BacklogEntityTest.java
@@ -8,18 +8,31 @@ import static akka.Done.done;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import akka.Done;
+import akka.javasdk.NotificationPublisher;
 import akka.javasdk.agent.task.BacklogEntity;
 import akka.javasdk.agent.task.BacklogEvent;
+import akka.javasdk.agent.task.BacklogNotification;
 import akka.javasdk.agent.task.BacklogState;
 import akka.javasdk.testkit.EventSourcedResult;
 import akka.javasdk.testkit.EventSourcedTestKit;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import org.junit.jupiter.api.Test;
 
 public class BacklogEntityTest {
 
+  private final ConcurrentLinkedQueue<BacklogNotification> publishedNotifications =
+      new ConcurrentLinkedQueue<>();
+
+  private final NotificationPublisher<BacklogNotification> testPublisher =
+      publishedNotifications::add;
+
+  private EventSourcedTestKit<BacklogState, BacklogEvent, BacklogEntity> createTestKit() {
+    return EventSourcedTestKit.of(ctx -> new BacklogEntity(ctx, testPublisher));
+  }
+
   @Test
   public void shouldCreate() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     EventSourcedResult<Done> result = testKit.method(BacklogEntity::create).invoke("development");
     assertThat(result.getReply()).isEqualTo(done());
     result.getNextEventOfType(BacklogEvent.BacklogCreated.class);
@@ -29,7 +42,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldCreateIdempotently() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::create).invoke("development");
     EventSourcedResult<Done> result = testKit.method(BacklogEntity::create).invoke("development");
     assertThat(result.getReply()).isEqualTo(done());
@@ -38,7 +51,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldAddTask() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     EventSourcedResult<Done> result = testKit.method(BacklogEntity::addTask).invoke("task-1");
     assertThat(result.getReply()).isEqualTo(done());
     result.getNextEventOfType(BacklogEvent.TaskAdded.class);
@@ -48,7 +61,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldAddTaskIdempotently() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::addTask).invoke("task-1");
     EventSourcedResult<Done> result = testKit.method(BacklogEntity::addTask).invoke("task-1");
     assertThat(result.getReply()).isEqualTo(done());
@@ -57,7 +70,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldClaimTask() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::addTask).invoke("task-1");
 
     EventSourcedResult<Done> result =
@@ -73,7 +86,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldRejectClaimForNonExistentTask() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     EventSourcedResult<Done> result =
         testKit
             .method(BacklogEntity::claim)
@@ -83,7 +96,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldRejectClaimForAlreadyClaimedTask() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::addTask).invoke("task-1");
     testKit
         .method(BacklogEntity::claim)
@@ -98,7 +111,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldReleaseClaimedTask() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::addTask).invoke("task-1");
     testKit
         .method(BacklogEntity::claim)
@@ -112,7 +125,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldReleaseUnclaimedTaskIdempotently() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::addTask).invoke("task-1");
 
     EventSourcedResult<Done> result = testKit.method(BacklogEntity::release).invoke("task-1");
@@ -122,7 +135,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldTransferTask() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::addTask).invoke("task-1");
     testKit
         .method(BacklogEntity::claim)
@@ -140,7 +153,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldCancelUnclaimed() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::addTask).invoke("task-1");
     testKit.method(BacklogEntity::addTask).invoke("task-2");
     testKit.method(BacklogEntity::addTask).invoke("task-3");
@@ -159,7 +172,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldCancelUnclaimedIdempotently() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     EventSourcedResult<Done> result = testKit.method(BacklogEntity::cancelUnclaimed).invoke();
     assertThat(result.getReply()).isEqualTo(done());
     assertThat(result.getAllEvents()).isEmpty();
@@ -167,7 +180,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldClose() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::create).invoke("development");
 
     EventSourcedResult<Done> result = testKit.method(BacklogEntity::close).invoke();
@@ -178,7 +191,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldCloseIdempotently() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::close).invoke();
 
     EventSourcedResult<Done> result = testKit.method(BacklogEntity::close).invoke();
@@ -188,7 +201,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldRejectCreateWhenClosed() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::close).invoke();
 
     EventSourcedResult<Done> result = testKit.method(BacklogEntity::create).invoke("development");
@@ -197,7 +210,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldRejectAddTaskWhenClosed() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::close).invoke();
 
     EventSourcedResult<Done> result = testKit.method(BacklogEntity::addTask).invoke("task-1");
@@ -206,7 +219,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldRejectClaimWhenClosed() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::addTask).invoke("task-1");
     testKit.method(BacklogEntity::close).invoke();
 
@@ -219,7 +232,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldRejectReleaseWhenClosed() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::addTask).invoke("task-1");
     testKit
         .method(BacklogEntity::claim)
@@ -232,7 +245,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldRejectTransferWhenClosed() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::addTask).invoke("task-1");
     testKit
         .method(BacklogEntity::claim)
@@ -248,7 +261,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldRejectCancelUnclaimedWhenClosed() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::addTask).invoke("task-1");
     testKit.method(BacklogEntity::close).invoke();
 
@@ -258,7 +271,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldAllowGetStateWhenClosed() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::addTask).invoke("task-1");
     testKit.method(BacklogEntity::close).invoke();
 
@@ -269,7 +282,7 @@ public class BacklogEntityTest {
 
   @Test
   public void shouldGetState() {
-    var testKit = EventSourcedTestKit.of(BacklogEntity::new);
+    var testKit = createTestKit();
     testKit.method(BacklogEntity::addTask).invoke("task-1");
     testKit.method(BacklogEntity::addTask).invoke("task-2");
     testKit
@@ -281,5 +294,117 @@ public class BacklogEntityTest {
     assertThat(state.entries()).hasSize(2);
     assertThat(state.claimedTaskIds()).hasSize(1);
     assertThat(state.unclaimedTaskIds()).hasSize(1);
+  }
+
+  @Test
+  public void shouldPublishNotificationOnCreate() {
+    var testKit = createTestKit();
+    publishedNotifications.clear();
+
+    testKit.method(BacklogEntity::create).invoke("development");
+
+    var created = (BacklogNotification.BacklogCreated) publishedNotifications.poll();
+    assertThat(created.name()).isEqualTo("development");
+    assertThat(publishedNotifications).isEmpty();
+  }
+
+  @Test
+  public void shouldPublishNotificationOnAddTask() {
+    var testKit = createTestKit();
+    testKit.method(BacklogEntity::create).invoke("development");
+    publishedNotifications.clear();
+
+    testKit.method(BacklogEntity::addTask).invoke("task-1");
+
+    var added = (BacklogNotification.TaskAdded) publishedNotifications.poll();
+    assertThat(added.taskId()).isEqualTo("task-1");
+    assertThat(publishedNotifications).isEmpty();
+  }
+
+  @Test
+  public void shouldPublishNotificationOnClaim() {
+    var testKit = createTestKit();
+    testKit.method(BacklogEntity::addTask).invoke("task-1");
+    publishedNotifications.clear();
+
+    testKit
+        .method(BacklogEntity::claim)
+        .invoke(new BacklogEntity.ClaimRequest("task-1", "agent-1"));
+
+    var claimed = (BacklogNotification.TaskClaimed) publishedNotifications.poll();
+    assertThat(claimed.taskId()).isEqualTo("task-1");
+    assertThat(claimed.claimedBy()).isEqualTo("agent-1");
+    assertThat(publishedNotifications).isEmpty();
+  }
+
+  @Test
+  public void shouldPublishNotificationOnRelease() {
+    var testKit = createTestKit();
+    testKit.method(BacklogEntity::addTask).invoke("task-1");
+    testKit
+        .method(BacklogEntity::claim)
+        .invoke(new BacklogEntity.ClaimRequest("task-1", "agent-1"));
+    publishedNotifications.clear();
+
+    testKit.method(BacklogEntity::release).invoke("task-1");
+
+    var released = (BacklogNotification.TaskReleased) publishedNotifications.poll();
+    assertThat(released.taskId()).isEqualTo("task-1");
+    assertThat(publishedNotifications).isEmpty();
+  }
+
+  @Test
+  public void shouldPublishNotificationOnTransfer() {
+    var testKit = createTestKit();
+    testKit.method(BacklogEntity::addTask).invoke("task-1");
+    testKit
+        .method(BacklogEntity::claim)
+        .invoke(new BacklogEntity.ClaimRequest("task-1", "agent-1"));
+    publishedNotifications.clear();
+
+    testKit
+        .method(BacklogEntity::transfer)
+        .invoke(new BacklogEntity.TransferRequest("task-1", "agent-2"));
+
+    var transferred = (BacklogNotification.TaskTransferred) publishedNotifications.poll();
+    assertThat(transferred.taskId()).isEqualTo("task-1");
+    assertThat(transferred.transferredTo()).isEqualTo("agent-2");
+    assertThat(publishedNotifications).isEmpty();
+  }
+
+  @Test
+  public void shouldPublishNotificationOnCancelUnclaimed() {
+    var testKit = createTestKit();
+    testKit.method(BacklogEntity::addTask).invoke("task-1");
+    publishedNotifications.clear();
+
+    testKit.method(BacklogEntity::cancelUnclaimed).invoke();
+
+    assertThat(publishedNotifications.poll())
+        .isInstanceOf(BacklogNotification.UnclaimedCancelled.class);
+    assertThat(publishedNotifications).isEmpty();
+  }
+
+  @Test
+  public void shouldPublishNotificationOnClose() {
+    var testKit = createTestKit();
+    testKit.method(BacklogEntity::create).invoke("development");
+    publishedNotifications.clear();
+
+    testKit.method(BacklogEntity::close).invoke();
+
+    assertThat(publishedNotifications.poll()).isInstanceOf(BacklogNotification.BacklogClosed.class);
+    assertThat(publishedNotifications).isEmpty();
+  }
+
+  @Test
+  public void shouldNotPublishNotificationOnIdempotentClose() {
+    var testKit = createTestKit();
+    testKit.method(BacklogEntity::close).invoke();
+    publishedNotifications.clear();
+
+    testKit.method(BacklogEntity::close).invoke();
+
+    assertThat(publishedNotifications).isEmpty();
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/agent/task/TaskEntityTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/agent/task/TaskEntityTest.java
@@ -213,6 +213,7 @@ public class TaskEntityTest {
     testKit.method(TaskEntity::complete).invoke("{\"summary\":\"done\"}");
 
     var completed = (TaskNotification.Completed) publishedNotifications.poll();
+    assertThat(completed.taskName()).isEqualTo("research");
     assertThat(completed.result()).isEqualTo("{\"summary\":\"done\"}");
     assertThat(publishedNotifications).isEmpty();
   }
@@ -228,6 +229,7 @@ public class TaskEntityTest {
     testKit.method(TaskEntity::fail).invoke("something broke");
 
     var failed = (TaskNotification.Failed) publishedNotifications.poll();
+    assertThat(failed.taskName()).isEqualTo("research");
     assertThat(failed.reason()).isEqualTo("something broke");
     assertThat(publishedNotifications).isEmpty();
   }
@@ -241,6 +243,7 @@ public class TaskEntityTest {
     testKit.method(TaskEntity::cancel).invoke("no longer needed");
 
     var cancelled = (TaskNotification.Cancelled) publishedNotifications.poll();
+    assertThat(cancelled.taskName()).isEqualTo("research");
     assertThat(cancelled.reason()).isEqualTo("no longer needed");
     assertThat(publishedNotifications).isEmpty();
   }
@@ -315,6 +318,7 @@ public class TaskEntityTest {
     assertThat(testKit.getState().failureReason()).isEqualTo("result too short");
 
     var rejected = (TaskNotification.ResultRejected) publishedNotifications.poll();
+    assertThat(rejected.taskName()).isEqualTo("research");
     assertThat(rejected.ruleClassName()).isEqualTo("com.example.MyRule");
     assertThat(rejected.reason()).isEqualTo("result too short");
     assertThat(publishedNotifications).isEmpty();

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/task/BacklogEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/task/BacklogEntity.java
@@ -7,6 +7,7 @@ package akka.javasdk.agent.task;
 import static akka.Done.done;
 
 import akka.Done;
+import akka.javasdk.NotificationPublisher;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.eventsourcedentity.EventSourcedEntity;
 import akka.javasdk.eventsourcedentity.EventSourcedEntityContext;
@@ -22,7 +23,13 @@ public final class BacklogEntity extends EventSourcedEntity<BacklogState, Backlo
 
   public record TransferRequest(String taskId, String transferredTo) {}
 
-  public BacklogEntity(EventSourcedEntityContext context) {}
+  private final NotificationPublisher<BacklogNotification> notificationPublisher;
+
+  public BacklogEntity(
+      EventSourcedEntityContext context,
+      NotificationPublisher<BacklogNotification> notificationPublisher) {
+    this.notificationPublisher = notificationPublisher;
+  }
 
   @Override
   public BacklogState emptyState() {
@@ -37,7 +44,13 @@ public final class BacklogEntity extends EventSourcedEntity<BacklogState, Backlo
     if (currentState().isCreated()) {
       return effects().reply(done()); // idempotent
     }
-    return effects().persist(new BacklogEvent.BacklogCreated(name)).thenReply(__ -> done());
+    return effects()
+        .persist(new BacklogEvent.BacklogCreated(name))
+        .thenReply(
+            __ -> {
+              notificationPublisher.publish(new BacklogNotification.BacklogCreated(name));
+              return done();
+            });
   }
 
   /** Add a task reference to this backlog. The task must already exist in TaskEntity. */
@@ -48,7 +61,13 @@ public final class BacklogEntity extends EventSourcedEntity<BacklogState, Backlo
     if (currentState().containsTask(taskId)) {
       return effects().reply(done()); // idempotent
     }
-    return effects().persist(new BacklogEvent.TaskAdded(taskId)).thenReply(__ -> done());
+    return effects()
+        .persist(new BacklogEvent.TaskAdded(taskId))
+        .thenReply(
+            __ -> {
+              notificationPublisher.publish(new BacklogNotification.TaskAdded(taskId));
+              return done();
+            });
   }
 
   /** Atomic first-come-first-served claim. */
@@ -66,7 +85,12 @@ public final class BacklogEntity extends EventSourcedEntity<BacklogState, Backlo
     }
     return effects()
         .persist(new BacklogEvent.TaskClaimed(request.taskId(), request.claimedBy()))
-        .thenReply(__ -> done());
+        .thenReply(
+            __ -> {
+              notificationPublisher.publish(
+                  new BacklogNotification.TaskClaimed(request.taskId(), request.claimedBy()));
+              return done();
+            });
   }
 
   /** Release a claimed task back to unclaimed. */
@@ -80,7 +104,13 @@ public final class BacklogEntity extends EventSourcedEntity<BacklogState, Backlo
     if (!currentState().isClaimed(taskId)) {
       return effects().reply(done()); // already unclaimed, idempotent
     }
-    return effects().persist(new BacklogEvent.TaskReleased(taskId)).thenReply(__ -> done());
+    return effects()
+        .persist(new BacklogEvent.TaskReleased(taskId))
+        .thenReply(
+            __ -> {
+              notificationPublisher.publish(new BacklogNotification.TaskReleased(taskId));
+              return done();
+            });
   }
 
   /** Transfer a claimed task directly to a different agent. */
@@ -93,7 +123,13 @@ public final class BacklogEntity extends EventSourcedEntity<BacklogState, Backlo
     }
     return effects()
         .persist(new BacklogEvent.TaskTransferred(request.taskId(), request.transferredTo()))
-        .thenReply(__ -> done());
+        .thenReply(
+            __ -> {
+              notificationPublisher.publish(
+                  new BacklogNotification.TaskTransferred(
+                      request.taskId(), request.transferredTo()));
+              return done();
+            });
   }
 
   /** Remove all unclaimed tasks from the backlog. */
@@ -104,7 +140,13 @@ public final class BacklogEntity extends EventSourcedEntity<BacklogState, Backlo
     if (currentState().unclaimedTaskIds().isEmpty()) {
       return effects().reply(done()); // nothing to cancel
     }
-    return effects().persist(new BacklogEvent.UnclaimedCancelled()).thenReply(__ -> done());
+    return effects()
+        .persist(new BacklogEvent.UnclaimedCancelled())
+        .thenReply(
+            __ -> {
+              notificationPublisher.publish(new BacklogNotification.UnclaimedCancelled());
+              return done();
+            });
   }
 
   /** Close the backlog — no further modifications allowed. */
@@ -112,12 +154,22 @@ public final class BacklogEntity extends EventSourcedEntity<BacklogState, Backlo
     if (currentState().closed()) {
       return effects().reply(done()); // idempotent
     }
-    return effects().persist(new BacklogEvent.BacklogClosed()).thenReply(__ -> done());
+    return effects()
+        .persist(new BacklogEvent.BacklogClosed())
+        .thenReply(
+            __ -> {
+              notificationPublisher.publish(new BacklogNotification.BacklogClosed());
+              return done();
+            });
   }
 
   /** Get the current state of the backlog. */
   public ReadOnlyEffect<BacklogState> getState() {
     return effects().reply(currentState());
+  }
+
+  public NotificationPublisher.NotificationStream<BacklogNotification> notifications() {
+    return notificationPublisher.stream();
   }
 
   private Effect<Done> closedError() {

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/task/BacklogNotification.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/task/BacklogNotification.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.agent.task;
+
+import akka.javasdk.annotations.TypeName;
+
+/** Notifications published by a BacklogEntity when its state changes. */
+public sealed interface BacklogNotification {
+
+  @TypeName("akka-backlog-notification-created")
+  record BacklogCreated(String name) implements BacklogNotification {}
+
+  @TypeName("akka-backlog-notification-task-added")
+  record TaskAdded(String taskId) implements BacklogNotification {}
+
+  @TypeName("akka-backlog-notification-task-claimed")
+  record TaskClaimed(String taskId, String claimedBy) implements BacklogNotification {}
+
+  @TypeName("akka-backlog-notification-task-released")
+  record TaskReleased(String taskId) implements BacklogNotification {}
+
+  @TypeName("akka-backlog-notification-task-transferred")
+  record TaskTransferred(String taskId, String transferredTo) implements BacklogNotification {}
+
+  @TypeName("akka-backlog-notification-unclaimed-cancelled")
+  record UnclaimedCancelled() implements BacklogNotification {}
+
+  @TypeName("akka-backlog-notification-closed")
+  record BacklogClosed() implements BacklogNotification {}
+}

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskEntity.java
@@ -103,7 +103,8 @@ public final class TaskEntity extends EventSourcedEntity<TaskState, TaskEvent> {
         .persist(new TaskEvent.TaskCompleted(taskId, result))
         .thenReply(
             __ -> {
-              notificationPublisher.publish(new TaskNotification.Completed(taskId, result));
+              notificationPublisher.publish(
+                  new TaskNotification.Completed(taskId, currentState().name(), result));
               return done();
             });
   }
@@ -125,7 +126,7 @@ public final class TaskEntity extends EventSourcedEntity<TaskState, TaskEvent> {
             __ -> {
               notificationPublisher.publish(
                   new TaskNotification.ResultRejected(
-                      taskId, request.ruleClassName(), request.reason()));
+                      taskId, currentState().name(), request.ruleClassName(), request.reason()));
               return done();
             });
   }
@@ -144,7 +145,8 @@ public final class TaskEntity extends EventSourcedEntity<TaskState, TaskEvent> {
         .persist(new TaskEvent.TaskFailed(taskId, reason))
         .thenReply(
             __ -> {
-              notificationPublisher.publish(new TaskNotification.Failed(taskId, reason));
+              notificationPublisher.publish(
+                  new TaskNotification.Failed(taskId, currentState().name(), reason));
               return done();
             });
   }
@@ -161,7 +163,8 @@ public final class TaskEntity extends EventSourcedEntity<TaskState, TaskEvent> {
         .persist(new TaskEvent.TaskCancelled(taskId, reason))
         .thenReply(
             __ -> {
-              notificationPublisher.publish(new TaskNotification.Cancelled(taskId, reason));
+              notificationPublisher.publish(
+                  new TaskNotification.Cancelled(taskId, currentState().name(), reason));
               return done();
             });
   }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskNotification.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/task/TaskNotification.java
@@ -11,16 +11,18 @@ public sealed interface TaskNotification {
 
   String taskId();
 
+  String taskName();
+
   @TypeName("akka-task-notification-completed")
-  record Completed(String taskId, String result) implements TaskNotification {}
+  record Completed(String taskId, String taskName, String result) implements TaskNotification {}
 
   @TypeName("akka-task-notification-result-rejected")
-  record ResultRejected(String taskId, String ruleClassName, String reason)
+  record ResultRejected(String taskId, String taskName, String ruleClassName, String reason)
       implements TaskNotification {}
 
   @TypeName("akka-task-notification-failed")
-  record Failed(String taskId, String reason) implements TaskNotification {}
+  record Failed(String taskId, String taskName, String reason) implements TaskNotification {}
 
   @TypeName("akka-task-notification-cancelled")
-  record Cancelled(String taskId, String reason) implements TaskNotification {}
+  record Cancelled(String taskId, String taskName, String reason) implements TaskNotification {}
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AutonomousAgentImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AutonomousAgentImpl.scala
@@ -27,9 +27,11 @@ import akka.javasdk.agent.SessionMessage.ToolCallResponse
 import akka.javasdk.agent.SessionMessage.UserMessage
 import akka.javasdk.agent._
 import akka.javasdk.agent.task.BacklogEntity
+import akka.javasdk.agent.task.BacklogNotification
 import akka.javasdk.agent.task.BacklogState
 import akka.javasdk.agent.task.TaskAttachment
 import akka.javasdk.agent.task.TaskEntity
+import akka.javasdk.agent.task.TaskNotification
 import akka.javasdk.agent.task.TaskState
 import akka.javasdk.agent.task.TaskStatus
 import akka.javasdk.client.ComponentClient
@@ -39,6 +41,7 @@ import akka.javasdk.impl.agent.autonomous.AgentDefinitionImpl
 import akka.javasdk.impl.client.EntityClientImpl
 import akka.javasdk.impl.reflection.Reflect
 import akka.javasdk.impl.serialization.Serializer
+import akka.runtime.sdk.spi.BytesPayload
 import akka.runtime.sdk.spi.RegionInfo
 import akka.runtime.sdk.spi.SpiAgent
 import akka.runtime.sdk.spi.SpiAutonomousAgent
@@ -246,6 +249,11 @@ private[impl] final class AutonomousAgentImpl(
         .invokeAsync(reassignReq)
         .asScala
     }
+
+    override val taskEntityType: String = Reflect.readComponentId(classOf[TaskEntity])
+
+    override def decodeNotification(payload: BytesPayload): SpiTask.SpiTaskNotification =
+      toSpiTaskNotification(serializer.fromBytes(payload).asInstanceOf[TaskNotification])
   }
 
   override val backlogOperations: SpiBacklogOperations = new SpiBacklogOperations {
@@ -298,6 +306,11 @@ private[impl] final class AutonomousAgentImpl(
         .invokeAsync()
         .asScala
         .map(toSpiBacklogState)(sdkExecutionContext)
+
+    override val backlogEntityType: String = Reflect.readComponentId(classOf[BacklogEntity])
+
+    override def decodeNotification(payload: BytesPayload): SpiBacklog.SpiBacklogNotification =
+      toSpiBacklogNotification(serializer.fromBytes(payload).asInstanceOf[BacklogNotification])
   }
 
   override def getSessionHistory(
@@ -398,6 +411,48 @@ private[impl] final class AutonomousAgentImpl(
       attachments = attachments,
       reassignmentContext = Option(state.reassignmentContext()).map(_.asScala.toSeq).getOrElse(Seq.empty))
   }
+
+  private def toSpiTaskNotification(notification: TaskNotification): SpiTask.SpiTaskNotification =
+    notification match {
+      case c: TaskNotification.Completed =>
+        new SpiTask.SpiTaskNotification.StatusChanged(c.taskId(), c.taskName(), SpiTask.SpiTaskStatus.Completed, "")
+      case r: TaskNotification.ResultRejected =>
+        new SpiTask.SpiTaskNotification.StatusChanged(
+          r.taskId(),
+          r.taskName(),
+          SpiTask.SpiTaskStatus.ResultRejected,
+          r.reason())
+      case f: TaskNotification.Failed =>
+        new SpiTask.SpiTaskNotification.StatusChanged(
+          f.taskId(),
+          f.taskName(),
+          SpiTask.SpiTaskStatus.Failed,
+          f.reason())
+      case c: TaskNotification.Cancelled =>
+        new SpiTask.SpiTaskNotification.StatusChanged(
+          c.taskId(),
+          c.taskName(),
+          SpiTask.SpiTaskStatus.Cancelled,
+          c.reason())
+    }
+
+  private def toSpiBacklogNotification(notification: BacklogNotification): SpiBacklog.SpiBacklogNotification =
+    notification match {
+      case c: BacklogNotification.BacklogCreated =>
+        new SpiBacklog.SpiBacklogNotification.BacklogCreated(c.name())
+      case a: BacklogNotification.TaskAdded =>
+        new SpiBacklog.SpiBacklogNotification.TaskAdded(a.taskId())
+      case c: BacklogNotification.TaskClaimed =>
+        new SpiBacklog.SpiBacklogNotification.TaskClaimed(c.taskId(), c.claimedBy())
+      case r: BacklogNotification.TaskReleased =>
+        new SpiBacklog.SpiBacklogNotification.TaskReleased(r.taskId())
+      case t: BacklogNotification.TaskTransferred =>
+        new SpiBacklog.SpiBacklogNotification.TaskTransferred(t.taskId(), t.transferredTo())
+      case _: BacklogNotification.UnclaimedCancelled =>
+        SpiBacklog.SpiBacklogNotification.UnclaimedCancelled
+      case _: BacklogNotification.BacklogClosed =>
+        SpiBacklog.SpiBacklogNotification.BacklogClosed
+    }
 
   private def toSpiBacklogState(state: BacklogState): SpiBacklog.SpiBacklogState = {
     import scala.jdk.CollectionConverters._

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/client/TaskClientImplSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/client/TaskClientImplSpec.scala
@@ -338,7 +338,8 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
       future.isCompleted shouldBe false
 
       notificationPromise.success(
-        entityReplyFor(new TaskNotification.Completed("test-task", """{"value":"via notification","score":7}""")))
+        entityReplyFor(
+          new TaskNotification.Completed("test-task", "test-task", """{"value":"via notification","score":7}""")))
 
       val result = future.futureValue
       result.value shouldBe "via notification"
@@ -348,7 +349,8 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
     "throw TaskException.Failed via notification when task fails after subscription" in {
       val (notificationPromise, future) = inProgressClientWithNotification()
 
-      notificationPromise.success(entityReplyFor(new TaskNotification.Failed("test-task", "failed via notification")))
+      notificationPromise.success(
+        entityReplyFor(new TaskNotification.Failed("test-task", "test-task", "failed via notification")))
 
       val ex = failedWith[TaskException.Failed](future)
       ex.reason() shouldBe "failed via notification"
@@ -358,7 +360,7 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
       val (notificationPromise, future) = inProgressClientWithNotification()
 
       notificationPromise.success(
-        entityReplyFor(new TaskNotification.Cancelled("test-task", "cancelled via notification")))
+        entityReplyFor(new TaskNotification.Cancelled("test-task", "test-task", "cancelled via notification")))
 
       val ex = failedWith[TaskException.Cancelled](future)
       ex.reason() shouldBe "cancelled via notification"

--- a/docs/src/modules/sdk/pages/autonomous-agents.html.md
+++ b/docs/src/modules/sdk/pages/autonomous-agents.html.md
@@ -337,9 +337,32 @@ Dependencies are specified by task ID, which means tasks must be created (via `c
 
 ### Task notifications
 
-<!-- TODO: Task notification stream API is defined in design notes but not yet implemented. The following describes the planned design. -->
+`TaskEntity` publishes a `TaskNotification` on each terminal transition so the runtime (and `TaskClient.resultAsync`) can observe completion without polling. Every variant carries `taskId` and `taskName`:
 
-Tasks publish a live notification stream for async observation. Notification types include `TaskCreated`, `TaskAssigned`, `TaskStarted`, `TaskCompleted`, `TaskFailed`, `TaskHandedOff`, `DecisionRequested`, and `InputProvided`.
+| Notification | Additional fields |
+| --- | --- |
+| `TaskNotification.Completed` | `result` (JSON string) |
+| `TaskNotification.ResultRejected` | `ruleClassName`, `reason` |
+| `TaskNotification.Failed` | `reason` |
+| `TaskNotification.Cancelled` | `reason` |
+
+Non-terminal transitions (`TaskCreated`, `TaskAssigned`, `TaskStarted`, `TaskReassigned`) do not publish notifications — they are only observable via event-sourced history or by reading state.
+
+### Backlog notifications
+
+`BacklogEntity` publishes a `BacklogNotification` on every state change so backlog-aware agents can react to claims, releases, and transfers without polling:
+
+| Notification | Fields |
+| --- | --- |
+| `BacklogNotification.BacklogCreated` | `name` |
+| `BacklogNotification.TaskAdded` | `taskId` |
+| `BacklogNotification.TaskClaimed` | `taskId`, `claimedBy` |
+| `BacklogNotification.TaskReleased` | `taskId` |
+| `BacklogNotification.TaskTransferred` | `taskId`, `transferredTo` |
+| `BacklogNotification.UnclaimedCancelled` | — |
+| `BacklogNotification.BacklogClosed` | — |
+
+Idempotent no-ops (e.g. re-creating an existing backlog, releasing an already-unclaimed task, closing twice) do not publish a notification.
 
 ## <a href="about:blank#_client_api"></a> Client API
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val ProtocolVersionMajor = 1
     val ProtocolVersionMinor = 1
   }
-  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.0-M1-64-215accf9-SNAPSHOT")
+  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.0-M1-68-123c070a-SNAPSHOT")
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned
   // for prod code, they are marked as Provided, but testkit still requires the alignment


### PR DESCRIPTION
* Needed for the notification updates that is used by the runtime when watching backlog and task dependencies
* Also public API
* SPI translation
* task name in task notifications

Runtime https://github.com/lightbend/akka-runtime/pull/5083 and https://github.com/lightbend/akka-runtime/pull/5072
