### PR TITLE
chore: remove deprecated Context commandId

### DIFF
--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/TestKitEventSourcedEntityCommandContext.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/TestKitEventSourcedEntityCommandContext.scala
@@ -12,7 +12,6 @@ import akka.javasdk.impl.InternalContext
 /** INTERNAL API Used by the generated testkit */
 final class TestKitEventSourcedEntityCommandContext(
     override val entityId: String = "stubEntityId",
-    override val commandId: Long = 0L,
     override val commandName: String = "stubCommandName",
     override val sequenceNumber: Long = 0L,
     override val isDeleted: Boolean = false,

--- a/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/TestKitKeyValueEntityCommandContext.scala
+++ b/akka-javasdk-testkit/src/main/scala/akka/javasdk/testkit/impl/TestKitKeyValueEntityCommandContext.scala
@@ -16,7 +16,6 @@ import akka.javasdk.testkit.MockRegistry
 final class TestKitKeyValueEntityCommandContext(
     override val entityId: String,
     override val commandName: String = "stubCommandName",
-    override val commandId: Long = 0L,
     override val metadata: Metadata = Metadata.EMPTY,
     mockRegistry: MockRegistry = MockRegistry.EMPTY)
     extends AbstractTestKitContext(mockRegistry)

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/counter/CounterEntity.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/eventsourcedentities/counter/CounterEntity.java
@@ -168,8 +168,7 @@ public class CounterEntity extends EventSourcedEntity<Counter, CounterEvent> {
 
   public Effect<Integer> times(int value) {
     logger.info(
-        "Multiplying counter with commandId={} commandName={} seqNr={} current={} by value={}",
-        commandContext().commandId(),
+        "Multiplying counter with commandName={} seqNr={} current={} by value={}",
         commandContext().commandName(),
         commandContext().sequenceNumber(),
         currentState(),
@@ -180,8 +179,7 @@ public class CounterEntity extends EventSourcedEntity<Counter, CounterEvent> {
 
   public Effect<Integer> restart() { // force entity restart, useful for testing
     logger.info(
-        "Restarting counter with commandId={} commandName={} seqNr={} current={}",
-        commandContext().commandId(),
+        "Restarting counter with commandName={} seqNr={} current={}",
         commandContext().commandName(),
         commandContext().sequenceNumber(),
         currentState());

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/user/UserEntity.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/keyvalueentities/user/UserEntity.java
@@ -83,8 +83,7 @@ public class UserEntity extends KeyValueEntity<User> {
 
   public Effect<Ok> deleteUser(Delete cmd) {
     logger.info(
-        "Deleting user with commandId={} commandName={} current={}",
-        commandContext().commandId(),
+        "Deleting user with commandName={} current={}",
         commandContext().commandName(),
         currentState());
     return effects().deleteEntity().thenReply(Ok.instance);
@@ -96,8 +95,7 @@ public class UserEntity extends KeyValueEntity<User> {
 
   public Effect<Integer> restart(Restart cmd) { // force entity restart, useful for testing
     logger.info(
-        "Restarting counter with commandId={} commandName={} current={}",
-        commandContext().commandId(),
+        "Restarting counter with commandName={} current={}",
         commandContext().commandName(),
         currentState());
 

--- a/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/CommandContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/eventsourcedentity/CommandContext.java
@@ -33,15 +33,6 @@ public interface CommandContext extends MetadataContext {
   String commandName();
 
   /**
-   * Returns the command id for the current command.
-   *
-   * @return the command id
-   * @deprecated This method is no longer used and will be removed in a future version
-   */
-  @Deprecated
-  long commandId();
-
-  /**
    * Returns the unique identifier of the entity instance that this command is being executed on.
    * This is the same id used when calling the entity through a component client.
    *

--- a/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/CommandContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/keyvalueentity/CommandContext.java
@@ -25,15 +25,6 @@ public interface CommandContext extends MetadataContext {
   String commandName();
 
   /**
-   * Returns the command id for the current command.
-   *
-   * @return the command id
-   * @deprecated This method is no longer used and will be removed in a future version
-   */
-  @Deprecated
-  long commandId();
-
-  /**
    * Returns the unique identifier of the entity instance that this command is being executed on.
    * This is the same id used when calling the entity through a component client.
    *

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/eventsourcedentity/EventSourcedEntityImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/eventsourcedentity/EventSourcedEntityImpl.scala
@@ -61,8 +61,6 @@ private[impl] object EventSourcedEntityImpl {
       extends AbstractContext
       with CommandContext {
     override def tracing(): Tracing = new SpanTracingImpl(telemetryContext, tracerFactory)
-
-    override def commandId(): Long = 0
   }
 
   private class EventSourcedEntityContextImpl(override final val entityId: String, override val selfRegion: String)

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/keyvalueentity/KeyValueEntityImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/keyvalueentity/KeyValueEntityImpl.scala
@@ -56,8 +56,6 @@ private[impl] object KeyValueEntityImpl {
       extends AbstractContext
       with CommandContext {
     override def tracing(): Tracing = new SpanTracingImpl(telemetryContext, tracerFactory)
-
-    override def commandId(): Long = 0
   }
 
   private class KeyValueEntityContextImpl(override final val entityId: String, override val selfRegion: String)


### PR DESCRIPTION
Remove deprecated Context.commandId

To be merged before next major release.
       