### PR TITLE
chore: autonomous agent goal -> purpose

### DIFF
--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/invalid/AutonomousAgentWithCommandHandler.java
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/invalid/AutonomousAgentWithCommandHandler.java
@@ -10,7 +10,7 @@ public class AutonomousAgentWithCommandHandler extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Test goal");
+    return define().purpose("Test purpose");
   }
 
   // This should be rejected — AutonomousAgent must not have command handlers

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/valid/ValidAutonomousAgent.java
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/valid/ValidAutonomousAgent.java
@@ -9,6 +9,6 @@ public class ValidAutonomousAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Test goal");
+    return define().purpose("Test purpose");
   }
 }

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/valid/ValidAutonomousAgentWithFunctionTool.java
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/valid/ValidAutonomousAgentWithFunctionTool.java
@@ -10,7 +10,7 @@ public class ValidAutonomousAgentWithFunctionTool extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Test goal");
+    return define().purpose("Test purpose");
   }
 
   @FunctionTool(description = "A helper tool")

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/CoordinatorAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/CoordinatorAgent.java
@@ -16,7 +16,7 @@ public class CoordinatorAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Coordinate research by delegating to workers and synthesising results.")
+        .purpose("Coordinate research by delegating to workers and synthesising results.")
         .capability(TaskAcceptance.of(TestTasks.RESEARCH).maxIterationsPerTask(5))
         .capability(Delegation.to(WorkerAgent.class).maxParallelWorkers(2));
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/DebaterA.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/DebaterA.java
@@ -13,6 +13,6 @@ public class DebaterA extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Argue in favor of the assigned position.");
+    return define().purpose("Argue in favor of the assigned position.");
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/DebaterB.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/DebaterB.java
@@ -13,6 +13,6 @@ public class DebaterB extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Argue against the assigned position.");
+    return define().purpose("Argue against the assigned position.");
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/DirectedModerator.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/DirectedModerator.java
@@ -16,7 +16,7 @@ public class DirectedModerator extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Moderate directed conversations between participants.")
+        .purpose("Moderate directed conversations between participants.")
         .capability(TaskAcceptance.of(TestTasks.MODERATE))
         .capability(Moderation.of(DebaterA.class, DebaterB.class).maxRounds(5));
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/RequestDelegatingAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/RequestDelegatingAgent.java
@@ -18,7 +18,7 @@ public class RequestDelegatingAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Coordinate work by delegating fact-checking to a request-based agent.")
+        .purpose("Coordinate work by delegating fact-checking to a request-based agent.")
         .capability(TaskAcceptance.of(TestTasks.TEST_TASK).maxIterationsPerTask(5))
         .capability(Delegation.to(SomeAgent.class, FactCheckAgent.class));
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/SpecialistTestAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/SpecialistTestAgent.java
@@ -15,7 +15,7 @@ public class SpecialistTestAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Resolve billing support requests.")
+        .purpose("Resolve billing support requests.")
         .capability(TaskAcceptance.of(TestTasks.RESOLVE).maxIterationsPerTask(3));
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TeamLeadAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TeamLeadAgent.java
@@ -17,7 +17,7 @@ public class TeamLeadAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Plan and coordinate work by leading a team.")
+        .purpose("Plan and coordinate work by leading a team.")
         .capability(TaskAcceptance.of(TestTasks.PLAN))
         .capability(TeamLeadership.of(TeamMember.of(TeamWorkerAgent.class).maxInstances(2)));
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TeamWorkerAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TeamWorkerAgent.java
@@ -15,7 +15,7 @@ public class TeamWorkerAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Implement work items.")
+        .purpose("Implement work items.")
         .capability(TaskAcceptance.of(TestTasks.WORK_ITEM));
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TemplateDelegatingAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TemplateDelegatingAgent.java
@@ -16,7 +16,7 @@ public class TemplateDelegatingAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Coordinate research by delegating work items using task templates.")
+        .purpose("Coordinate research by delegating work items using task templates.")
         .capability(TaskAcceptance.of(TestTasks.RESEARCH).maxIterationsPerTask(5))
         .capability(Delegation.to(TeamWorkerAgent.class));
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestAutonomousAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestAutonomousAgent.java
@@ -26,7 +26,7 @@ public class TestAutonomousAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Test agent")
+        .purpose("Test agent")
         .capability(
             TaskAcceptance.of(
                 TestTasks.TEST_TASK,

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestModerator.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestModerator.java
@@ -16,7 +16,7 @@ public class TestModerator extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Moderate structured conversations between participants.")
+        .purpose("Moderate structured conversations between participants.")
         .capability(TaskAcceptance.of(TestTasks.MODERATE))
         .capability(Moderation.of(DebaterA.class, DebaterB.class).maxRounds(3));
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/ToolUsingAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/ToolUsingAgent.java
@@ -16,7 +16,7 @@ public class ToolUsingAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Answer questions using available tools.")
+        .purpose("Answer questions using available tools.")
         .capability(TaskAcceptance.of(TestTasks.TEST_TASK).maxIterationsPerTask(5))
         .tools(new DateService());
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TriageTestAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TriageTestAgent.java
@@ -15,7 +15,7 @@ public class TriageTestAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Classify support requests and hand off to the appropriate specialist.")
+        .purpose("Classify support requests and hand off to the appropriate specialist.")
         .capability(
             TaskAcceptance.of(TestTasks.RESOLVE)
                 .maxIterationsPerTask(3)

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/ValidatedTaskAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/ValidatedTaskAgent.java
@@ -15,7 +15,7 @@ public class ValidatedTaskAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Complete tasks with rule validation")
+        .purpose("Complete tasks with rule validation")
         .capability(TaskAcceptance.of(TestTasks.VALIDATED_TASK));
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/WorkerAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/WorkerAgent.java
@@ -15,7 +15,7 @@ public class WorkerAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Research a topic and produce factual findings.")
+        .purpose("Research a topic and produce factual findings.")
         .capability(TaskAcceptance.of(TestTasks.FINDINGS).maxIterationsPerTask(3));
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/AgentDefinition.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/AgentDefinition.java
@@ -10,8 +10,8 @@ import akka.javasdk.agent.RemoteMcpTools;
 import akka.javasdk.agent.autonomous.capability.AgentCapability;
 
 /**
- * Defines an autonomous agent's configuration: goal, tools, model provider, guardrails, and
- * capabilities. Built via {@link AutonomousAgent#define()} and returned from {@link
+ * Defines an autonomous agent's configuration: purpose, guidance, tools, model provider,
+ * guardrails, and capabilities. Built via {@link AutonomousAgent#define()} and returned from {@link
  * AutonomousAgent#definition()}.
  *
  * <p>Each fluent method returns a new immutable instance.
@@ -19,11 +19,18 @@ import akka.javasdk.agent.autonomous.capability.AgentCapability;
 public interface AgentDefinition {
 
   /**
-   * The agent's high-level purpose. Goal text should describe what the agent achieves, not how it
-   * coordinates. The runtime combines the goal with capability-specific context and tool
+   * The agent's high-level purpose. Describes what the agent is for — not how it operates. The
+   * runtime combines the purpose with optional guidance, capability-specific context, and tool
    * descriptions to build the system message.
    */
-  AgentDefinition goal(String goal);
+  AgentDefinition purpose(String purpose);
+
+  /**
+   * Optional guidance on how the agent should operate — style, conventions, behavioral preferences.
+   * Distinct from {@link #purpose}, which describes what the agent is for, and from task-level
+   * instructions, which apply only to a specific task.
+   */
+  AgentDefinition guidance(String guidance);
 
   /** Add a capability to this agent: task acceptance, delegation, etc. */
   AgentDefinition capability(AgentCapability capability);

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/AgentSetup.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/AgentSetup.java
@@ -9,8 +9,8 @@ import akka.javasdk.impl.agent.autonomous.AgentSetupImpl;
 
 /**
  * Per-instance configuration applied on top of an agent's static {@link AgentDefinition}. Use this
- * to dynamically configure an agent instance at runtime — the goal overrides the static goal, and
- * capabilities extend the static capabilities.
+ * to dynamically configure an agent instance at runtime — purpose and guidance override their
+ * static counterparts, and capabilities extend the static capabilities.
  *
  * <p>Each fluent method returns a new immutable instance.
  *
@@ -24,10 +24,16 @@ public interface AgentSetup {
   }
 
   /**
-   * Override the agent's goal for this instance. If not set, the static goal from {@link
+   * Override the agent's purpose for this instance. If not set, the static purpose from {@link
    * AgentDefinition} is used.
    */
-  AgentSetup goal(String goal);
+  AgentSetup purpose(String purpose);
+
+  /**
+   * Override the agent's guidance for this instance. If not set, the static guidance from {@link
+   * AgentDefinition} is used.
+   */
+  AgentSetup guidance(String guidance);
 
   /** Add a capability for this instance, extending the static capabilities. */
   AgentSetup capability(AgentCapability capability);

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/AgentState.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/AgentState.java
@@ -19,7 +19,7 @@ public final class AgentState {
 
   private final String phase;
   private final boolean paused;
-  private final String goal;
+  private final String purpose;
   private final AutonomousAgent.TokenUsage totalTokenUsage;
   private final Optional<TaskKey> currentTask;
   private final List<String> pendingTaskIds;
@@ -27,13 +27,13 @@ public final class AgentState {
   public AgentState(
       String phase,
       boolean paused,
-      String goal,
+      String purpose,
       AutonomousAgent.TokenUsage totalTokenUsage,
       Optional<TaskKey> currentTask,
       List<String> pendingTaskIds) {
     this.phase = phase;
     this.paused = paused;
-    this.goal = goal;
+    this.purpose = purpose;
     this.totalTokenUsage = totalTokenUsage;
     this.currentTask = currentTask;
     this.pendingTaskIds = pendingTaskIds;
@@ -49,9 +49,11 @@ public final class AgentState {
     return paused;
   }
 
-  /** The agent's current goal. */
-  public String goal() {
-    return goal;
+  // FIXME: Currently the returned string contains the purpose and guidance combined as a single
+  // system prompt. SPI update will split these into separate accessors.
+  /** The agent's current purpose. */
+  public String purpose() {
+    return purpose;
   }
 
   /** Total token usage for this agent instance. */

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -812,9 +812,9 @@ private final class Sdk(
           }
           tempAgent.definition() match {
             case impl: AgentDefinitionImpl =>
-              if (impl.goal.isEmpty)
+              if (impl.purpose.isEmpty)
                 logger.warn(
-                  "AutonomousAgent [{}] has no goal configured. Set a goal via define().goal(...)",
+                  "AutonomousAgent [{}] has no purpose configured. Set a purpose via define().purpose(...)",
                   clz.getName)
               impl
             case other =>
@@ -870,7 +870,8 @@ private final class Sdk(
             applicationConfig,
             system,
             agentDefinition,
-            goal = agentDefinition.goal,
+            // TODO: replace SPI goal with purpose and guidance
+            goal = AgentDefinitionImpl.composeSystemPrompt(agentDefinition.purpose, agentDefinition.guidance),
             modelProvider = spiModelProvider,
             toolDescriptors = spiToolDescriptors,
             mcpClientDescriptors = spiMcpDescriptors,

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/autonomous/AgentDefinitionImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/autonomous/AgentDefinitionImpl.scala
@@ -18,7 +18,8 @@ import akka.javasdk.agent.autonomous.capability.AgentCapability
  */
 @InternalApi
 final case class AgentDefinitionImpl(
-    goal: String,
+    purpose: String,
+    guidance: Option[String],
     modelProvider: ModelProvider,
     toolInstancesOrClasses: util.List[AnyRef],
     mcpTools: util.List[RemoteMcpTools],
@@ -27,8 +28,11 @@ final case class AgentDefinitionImpl(
     capabilities: util.List[AgentCapability])
     extends AgentDefinition {
 
-  override def goal(goal: String): AgentDefinition =
-    copy(goal = goal)
+  override def purpose(purpose: String): AgentDefinition =
+    copy(purpose = purpose)
+
+  override def guidance(guidance: String): AgentDefinition =
+    copy(guidance = Some(guidance))
 
   override def capability(capability: AgentCapability): AgentDefinition =
     copy(capabilities = concat(this.capabilities, Seq(capability)))
@@ -62,11 +66,19 @@ final case class AgentDefinitionImpl(
 object AgentDefinitionImpl {
   def empty(): AgentDefinitionImpl =
     AgentDefinitionImpl(
-      goal = "",
+      purpose = "",
+      guidance = None,
       modelProvider = null,
       toolInstancesOrClasses = util.List.of(),
       mcpTools = util.List.of(),
       requestGuardrailClassNames = util.List.of(),
       responseGuardrailClassNames = util.List.of(),
       capabilities = util.List.of())
+
+  /**
+   * Combine purpose and optional guidance into a single system prompt string. Used internally until the runtime SPI has
+   * separate fields for purpose and guidance.
+   */
+  def composeSystemPrompt(purpose: String, guidance: Option[String]): String =
+    guidance.filter(_.nonEmpty).fold(purpose)(g => s"$purpose\n\n$g")
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/autonomous/AgentSetupImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/autonomous/AgentSetupImpl.scala
@@ -14,10 +14,17 @@ import akka.javasdk.agent.autonomous.capability.AgentCapability
  * INTERNAL API
  */
 @InternalApi
-final case class AgentSetupImpl(goal: Option[String], capabilities: util.List[AgentCapability]) extends AgentSetup {
+final case class AgentSetupImpl(
+    purpose: Option[String],
+    guidance: Option[String],
+    capabilities: util.List[AgentCapability])
+    extends AgentSetup {
 
-  override def goal(goal: String): AgentSetup =
-    copy(goal = Some(goal))
+  override def purpose(purpose: String): AgentSetup =
+    copy(purpose = Some(purpose))
+
+  override def guidance(guidance: String): AgentSetup =
+    copy(guidance = Some(guidance))
 
   override def capability(capability: AgentCapability): AgentSetup = {
     val result = new util.ArrayList[AgentCapability](this.capabilities)
@@ -32,5 +39,5 @@ final case class AgentSetupImpl(goal: Option[String], capabilities: util.List[Ag
 @InternalApi
 object AgentSetupImpl {
   def empty(): AgentSetupImpl =
-    AgentSetupImpl(goal = None, capabilities = util.List.of())
+    AgentSetupImpl(purpose = None, guidance = None, capabilities = util.List.of())
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AutonomousAgentClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AutonomousAgentClientImpl.scala
@@ -115,8 +115,14 @@ private[javasdk] final class AutonomousAgentClientImpl(
       throw new IllegalStateException("Agent capability converter not available in this context"))
 
     val spiCapabilities = converter.toSpiCapabilities(setupImpl.capabilities)
+    val composedGoal: Option[String] = (setupImpl.purpose, setupImpl.guidance) match {
+      case (None, None)       => None
+      case (Some(p), None)    => Some(p)
+      case (None, Some(g))    => Some(g)
+      case (Some(p), Some(g)) => Some(s"$p\n\n$g")
+    }
     runtimeComponentClients.autonomousAgentClient
-      .applySetup(agentComponentId, agentInstanceId, setupImpl.goal, spiCapabilities)
+      .applySetup(agentComponentId, agentInstanceId, composedGoal, spiCapabilities)
       .asJava
   }
 

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/AgentSetupSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/AgentSetupSpec.scala
@@ -25,20 +25,34 @@ class AgentSetupSpec extends AnyWordSpec with Matchers with AutonomousAgentImplS
     "start empty" in {
       val setup = AgentSetup.create().impl
 
-      setup.goal shouldBe None
+      setup.purpose shouldBe None
+      setup.guidance shouldBe None
       setup.capabilities.asScala shouldBe empty
     }
 
-    "set goal" in {
-      val setup = AgentSetup.create().goal("Do something").impl
+    "set purpose" in {
+      val setup = AgentSetup.create().purpose("Do something").impl
 
-      setup.goal shouldBe Some("Do something")
+      setup.purpose shouldBe Some("Do something")
     }
 
-    "override goal" in {
-      val setup = AgentSetup.create().goal("First goal").goal("Second goal").impl
+    "override purpose" in {
+      val setup = AgentSetup.create().purpose("First purpose").purpose("Second purpose").impl
 
-      setup.goal shouldBe Some("Second goal")
+      setup.purpose shouldBe Some("Second purpose")
+    }
+
+    "set guidance" in {
+      val setup = AgentSetup.create().guidance("Be precise").impl
+
+      setup.guidance shouldBe Some("Be precise")
+    }
+
+    "set purpose and guidance together" in {
+      val setup = AgentSetup.create().purpose("Do something").guidance("Be precise").impl
+
+      setup.purpose shouldBe Some("Do something")
+      setup.guidance shouldBe Some("Be precise")
     }
 
     "set capabilities" in {
@@ -60,30 +74,30 @@ class AgentSetupSpec extends AnyWordSpec with Matchers with AutonomousAgentImplS
       setup.capabilities.asScala(1).asDelegation
     }
 
-    "set goal and capabilities together" in {
+    "set purpose and capabilities together" in {
       val setup = AgentSetup
         .create()
-        .goal("Analyse data")
+        .purpose("Analyse data")
         .capability(TaskAcceptance.of(testTask).maxIterationsPerTask(5))
         .capability(DelegationImpl.create(Array()).maxParallelWorkers(2))
         .impl
 
-      setup.goal shouldBe Some("Analyse data")
+      setup.purpose shouldBe Some("Analyse data")
       setup.capabilities.asScala should have size 2
     }
 
     "be immutable — each method returns a new instance" in {
       val setup1 = AgentSetup.create()
-      val setup2 = setup1.goal("A goal")
+      val setup2 = setup1.purpose("A purpose")
       val setup3 = setup2.capability(TaskAcceptance.of(testTask))
 
-      setup1.impl.goal shouldBe None
+      setup1.impl.purpose shouldBe None
       setup1.impl.capabilities.asScala shouldBe empty
 
-      setup2.impl.goal shouldBe Some("A goal")
+      setup2.impl.purpose shouldBe Some("A purpose")
       setup2.impl.capabilities.asScala shouldBe empty
 
-      setup3.impl.goal shouldBe Some("A goal")
+      setup3.impl.purpose shouldBe Some("A purpose")
       setup3.impl.capabilities.asScala should have size 1
     }
   }

--- a/docs/src/modules/sdk/pages/autonomous-agents.html.md
+++ b/docs/src/modules/sdk/pages/autonomous-agents.html.md
@@ -59,7 +59,8 @@ public class QuestionAnswerer extends AutonomousAgent { // <1>
   @Override
   public AgentDefinition definition() { // <3>
     return define()
-      .goal("Answer questions clearly and concisely, showing reasoning step by step.")
+      .purpose("Answer questions.")
+      .guidance("Be clear and concise. Show reasoning step by step.")
       .capability(TaskAcceptance.of(QuestionTasks.ANSWER).maxIterationsPerTask(3));
   }
 }
@@ -75,13 +76,21 @@ There are no command handlers. The agent is a process — it runs, works on assi
 
 The `definition()` method returns an `AgentDefinition` built with a fluent builder API. `define()` starts the builder.
 
-### Goal
+### Purpose and guidance
 
-The goal is the agent's high-level purpose — what it achieves, not how it coordinates. The runtime combines the goal with capability-specific context and tool descriptions to build the system message sent to the LLM.
+The **purpose** is the agent's high-level reason for existing — what it is for, not how it operates. The runtime combines the purpose with optional guidance, capability-specific context, and tool descriptions to build the system message sent to the LLM.
 
 ```java
 define()
-  .goal("Answer questions clearly and concisely, showing reasoning step by step.")
+  .purpose("Answer questions.")
+```
+
+Optional **guidance** describes how the agent should operate — style, conventions, behavioral preferences. This is distinct from the purpose (what the agent is for) and from task-level instructions (which apply only to a specific task).
+
+```java
+define()
+  .purpose("Answer questions.")
+  .guidance("Be clear and concise. Show reasoning step by step.")
 ```
 
 ### Accepted task types
@@ -137,7 +146,7 @@ public class ReportAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("Process report phases: collect data, analyze findings, produce comprehensive reports.")
+      .purpose("Process report phases: collect data, analyze findings, produce comprehensive reports.")
       .capability(
         TaskAcceptance.of(PipelineTasks.COLLECT, PipelineTasks.ANALYZE, PipelineTasks.REPORT)
           .maxIterationsPerTask(5));
@@ -212,7 +221,7 @@ public class ConsultingCoordinator extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("""
+      .purpose("""
         Deliver actionable consulting recommendations. Assess each client \
         problem, determine its complexity, and ensure it reaches the right \
         level of expertise for resolution. \
@@ -441,7 +450,7 @@ var state = componentClient
 
 state.phase();           // execution phase, e.g. "PHASE_RUNNING", "PHASE_STOPPED"
 state.paused();          // whether the agent is paused
-state.goal();            // the agent's current goal
+state.purpose();         // the agent's current purpose
 state.totalTokenUsage(); // cumulative token usage (inputTokens, outputTokens)
 state.currentTask();     // Optional<TaskKey> — the task currently being worked on
 state.pendingTaskIds();  // List<String> — IDs of tasks queued but not yet started
@@ -718,7 +727,7 @@ public class ResearchCoordinator extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("""
+      .purpose("""
         Produce comprehensive research briefs by synthesising findings \
         from multiple specialist perspectives. \
         """)
@@ -738,7 +747,7 @@ public class Researcher extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("""
+      .purpose("""
         You are a thorough researcher. When given a topic, find key facts, \
         important details, and relevant context. \
         """)
@@ -755,7 +764,7 @@ public class Analyst extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("""
+      .purpose("""
         You are an insightful analyst. When given a topic, analyse its implications, \
         identify trends and patterns, and produce actionable insights. \
         """)
@@ -793,7 +802,7 @@ public class TriageAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("""
+      .purpose("""
         Classify customer support requests and ensure they are resolved \
         by the appropriate specialist. \
         """)
@@ -815,7 +824,7 @@ public class BillingSpecialist extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("Resolve billing and payment issues for customers.")
+      .purpose("Resolve billing and payment issues for customers.")
       .capability(TaskAcceptance.of(SupportTasks.RESOLVE).maxIterationsPerTask(5));
   }
 }
@@ -829,7 +838,7 @@ public class TechnicalSpecialist extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("Diagnose and resolve technical issues for customers.")
+      .purpose("Diagnose and resolve technical issues for customers.")
       .capability(TaskAcceptance.of(SupportTasks.RESOLVE).maxIterationsPerTask(5));
   }
 }
@@ -866,7 +875,7 @@ define()
 
 ### Moderation
 
-A moderator agent orchestrates turn-taking conversations between participant agents. The moderator declares which agent types can participate, and the framework manages conversation setup, turn-taking, and transcript collection. Participant agents are simple — they define a goal and the framework handles the conversation mechanics automatically.
+A moderator agent orchestrates turn-taking conversations between participant agents. The moderator declares which agent types can participate, and the framework manages conversation setup, turn-taking, and transcript collection. Participant agents are simple — they define a purpose and the framework handles the conversation mechanics automatically.
 
 ```java
 import akka.javasdk.agent.autonomous.capability.Moderation;
@@ -905,7 +914,7 @@ public class ReviewModerator extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("Coordinate document peer review and synthesize reviewer findings.")
+      .purpose("Coordinate document peer review and synthesize reviewer findings.")
       .capability(TaskAcceptance.of(ReviewTasks.REVIEW))
       .capability(
         Moderation.of(TechnicalReviewer.class, StyleReviewer.class, ComplianceReviewer.class));
@@ -913,7 +922,7 @@ public class ReviewModerator extends AutonomousAgent {
 }
 ```
 
-Participant agents need only a goal — the framework provides the conversation tools:
+Participant agents need only a purpose — the framework provides the conversation tools:
 
 ```java
 @Component(id = "technical-reviewer", description = "Reviews documents for technical accuracy")
@@ -921,7 +930,7 @@ public class TechnicalReviewer extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Review documents for technical accuracy, correctness, and completeness.");
+    return define().purpose("Review documents for technical accuracy, correctness, and completeness.");
   }
 }
 ```
@@ -941,7 +950,7 @@ public class Facilitator extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("Facilitate negotiations and help parties reach agreement.")
+      .purpose("Facilitate negotiations and help parties reach agreement.")
       .capability(TaskAcceptance.of(NegotiationTasks.NEGOTIATE))
       .capability(Moderation.of(Buyer.class, Seller.class).maxRounds(5));
   }
@@ -958,7 +967,7 @@ public class Critic extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Provide critical analysis from the assigned perspective.");
+    return define().purpose("Provide critical analysis from the assigned perspective.");
   }
 }
 ```
@@ -991,7 +1000,7 @@ public class ConsultingCoordinator extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("""
+      .purpose("""
         Deliver actionable consulting recommendations. Assess each client \
         problem, determine its complexity, and ensure it reaches the right \
         level of expertise for resolution. \

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val ProtocolVersionMajor = 1
     val ProtocolVersionMinor = 1
   }
-  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.0-M2-17-6d765e5c-SNAPSHOT")
+  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.0-M2-4-6223445d-SNAPSHOT")
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned
   // for prod code, they are marked as Provided, but testkit still requires the alignment

--- a/samples/autonomous-agent-playground/README.md
+++ b/samples/autonomous-agent-playground/README.md
@@ -15,7 +15,7 @@ A browser UI is bundled with the service. Boot the service (`mvn compile exec:ja
 | **helloworld** | None | Simplest usage — single agent, single task, no coordination |
 | **pipeline** | None (task dependencies) | 3-phase dependency chain: collect, analyze, report |
 | **docreview** | None (attachments) | Document review with text content attachments |
-| **dynamic** | None (runtime configuration) | One generic agent class configured per request with different goals and capabilities |
+| **dynamic** | None (runtime configuration) | One generic agent class configured per request with different purposes and capabilities |
 | **research** | Delegation | Coordinator delegates to researcher and analyst, synthesises findings |
 | **consulting** | Delegation + handoff | Delegate to specialists, hand off complex cases |
 | **support** | Handoff | Triage classifies request, hands off to billing or technical specialist |
@@ -78,17 +78,17 @@ A single agent reviews a document for compliance, receiving the document content
 
 ## dynamic
 
-A single generic agent class is configured per request with different goals and task capabilities. The same `DynamicAgent` code runs both the summarize and translate flows.
+A single generic agent class is configured per request with different purposes and task capabilities. The same `DynamicAgent` code runs both the summarize and translate flows.
 
-**Agents:** DynamicAgent — declared with no static goal or capabilities; configured at runtime via `AgentSetup` before each task is assigned
+**Agents:** DynamicAgent — declared with no static purpose or capabilities; configured at runtime via `AgentSetup` before each task is assigned
 
 **Tasks:**
 - SUMMARIZE → `String` — produces a concise summary of the input content
 - TRANSLATE → `String` — translates the input content to French
 
-**Flow:** Two HTTP routes (`POST /dynamic/summarize`, `POST /dynamic/translate`) each create a fresh DynamicAgent instance, configure its goal and accepted capability dynamically, then assign a single task. The summarize route sets a summarization goal and accepts only the SUMMARIZE task; the translate route sets a translation goal and accepts only the TRANSLATE task — same agent class, two different runtime specialisations.
+**Flow:** Two HTTP routes (`POST /dynamic/summarize`, `POST /dynamic/translate`) each create a fresh DynamicAgent instance, configure its purpose and accepted capability dynamically, then assign a single task. The summarize route sets a summarization purpose and accepts only the SUMMARIZE task; the translate route sets a translation purpose and accepts only the TRANSLATE task — same agent class, two different runtime specialisations.
 
-**Demonstrates:** Runtime agent configuration. The same `AutonomousAgent` subclass with no static goal or capabilities can be specialised per request via `AgentSetup`. Useful when many task variants share the same execution shape and the differences are best expressed as data rather than as separate agent classes.
+**Demonstrates:** Runtime agent configuration. The same `AutonomousAgent` subclass with no static purpose or capabilities can be specialised per request via `AgentSetup`. Useful when many task variants share the same execution shape and the differences are best expressed as data rather than as separate agent classes.
 
 ---
 

--- a/samples/autonomous-agent-playground/pom.xml
+++ b/samples/autonomous-agent-playground/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.akka</groupId>
     <artifactId>akka-javasdk-parent</artifactId>
-    <version>3.6.0-M2-23-5d40a409-SNAPSHOT</version>
+    <version>3.6.0-M2-3-c26144d2-dev-SNAPSHOT</version>
   </parent>
 
   <groupId>demo</groupId>

--- a/samples/autonomous-agent-playground/src/main/java/demo/consulting/api/ConsultingEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/consulting/api/ConsultingEndpoint.java
@@ -28,7 +28,9 @@ public class ConsultingEndpoint extends AbstractHttpEndpoint {
 
   @Post
   public ConsultingResponse create(ConsultingRequest request) {
-    var agentInstanceId = requestContext().queryParams().getString("runId")
+    var agentInstanceId = requestContext()
+      .queryParams()
+      .getString("runId")
       .filter(s -> !s.isBlank())
       .orElseGet(() -> UUID.randomUUID().toString());
     var taskId = componentClient

--- a/samples/autonomous-agent-playground/src/main/java/demo/consulting/application/ConsultingCoordinator.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/consulting/application/ConsultingCoordinator.java
@@ -18,7 +18,7 @@ public class ConsultingCoordinator extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose(
         """
         Deliver actionable consulting recommendations. Assess each client \
         problem, determine its complexity, and ensure it reaches the right \

--- a/samples/autonomous-agent-playground/src/main/java/demo/consulting/application/ConsultingResearcher.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/consulting/application/ConsultingResearcher.java
@@ -14,7 +14,7 @@ public class ConsultingResearcher extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose(
         """
         Research the given topic thoroughly and produce a clear, \
         factual summary of your findings. \

--- a/samples/autonomous-agent-playground/src/main/java/demo/consulting/application/SeniorConsultant.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/consulting/application/SeniorConsultant.java
@@ -15,7 +15,7 @@ public class SeniorConsultant extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose(
         """
         Resolve complex, high-stakes consulting problems — regulatory issues, \
         M&A integration, enterprise transformation. Deliver a comprehensive \

--- a/samples/autonomous-agent-playground/src/main/java/demo/debate/api/DebateEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/debate/api/DebateEndpoint.java
@@ -27,7 +27,9 @@ public class DebateEndpoint extends AbstractHttpEndpoint {
 
   @Post
   public DebateResponse create(DebateRequest request) {
-    var agentInstanceId = requestContext().queryParams().getString("runId")
+    var agentInstanceId = requestContext()
+      .queryParams()
+      .getString("runId")
       .filter(s -> !s.isBlank())
       .orElseGet(() -> UUID.randomUUID().toString());
     var taskId = componentClient

--- a/samples/autonomous-agent-playground/src/main/java/demo/debate/application/Advocate.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/debate/application/Advocate.java
@@ -9,6 +9,7 @@ public class Advocate extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Present compelling arguments in favor of the assigned position.");
+    return define()
+      .purpose("Present compelling arguments in favor of the assigned position.");
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/debate/application/Critic.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/debate/application/Critic.java
@@ -10,7 +10,7 @@ public class Critic extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose(
         "Present compelling counterarguments and identify weaknesses in the opposing position."
       );
   }

--- a/samples/autonomous-agent-playground/src/main/java/demo/debate/application/DebateModerator.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/debate/application/DebateModerator.java
@@ -15,7 +15,7 @@ public class DebateModerator extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose(
         "Moderate structured debates between participants and synthesize balanced conclusions."
       )
       .capability(TaskAcceptance.of(DebateTasks.DEBATE))

--- a/samples/autonomous-agent-playground/src/main/java/demo/devteam/api/DevTeamEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/devteam/api/DevTeamEndpoint.java
@@ -27,7 +27,9 @@ public class DevTeamEndpoint extends AbstractHttpEndpoint {
 
   @Post
   public ProjectResponse create(ProjectRequest request) {
-    var agentInstanceId = requestContext().queryParams().getString("runId")
+    var agentInstanceId = requestContext()
+      .queryParams()
+      .getString("runId")
       .filter(s -> !s.isBlank())
       .orElseGet(() -> UUID.randomUUID().toString());
     var taskId = componentClient

--- a/samples/autonomous-agent-playground/src/main/java/demo/devteam/application/Developer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/devteam/application/Developer.java
@@ -11,9 +11,9 @@ public class Developer extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose("Implement features with clean, tested code.")
+      .guidance(
         """
-        Implement features with clean, tested code. \
         Coordinate with teammates when your work depends on or affects \
         their tasks — agree on shared contracts before implementing. \
         """

--- a/samples/autonomous-agent-playground/src/main/java/demo/devteam/application/ProjectLead.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/devteam/application/ProjectLead.java
@@ -16,9 +16,11 @@ public class ProjectLead extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose(
+        "Deliver completed software projects with all features implemented and tested."
+      )
+      .guidance(
         """
-        Deliver completed software projects with all features implemented and tested. \
         Message team members directly when their tasks have dependencies or \
         shared interfaces that require coordination before implementation. \
         """

--- a/samples/autonomous-agent-playground/src/main/java/demo/docreview/api/DocReviewEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/docreview/api/DocReviewEndpoint.java
@@ -37,7 +37,9 @@ public class DocReviewEndpoint extends AbstractHttpEndpoint {
       .instructions(request.reviewInstructions())
       .attach(TextMessageContent.from(request.document()));
 
-    var agentInstanceId = requestContext().queryParams().getString("runId")
+    var agentInstanceId = requestContext()
+      .queryParams()
+      .getString("runId")
       .filter(s -> !s.isBlank())
       .orElseGet(() -> UUID.randomUUID().toString());
     var taskId = componentClient

--- a/samples/autonomous-agent-playground/src/main/java/demo/docreview/application/DocumentReviewer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/docreview/application/DocumentReviewer.java
@@ -15,7 +15,7 @@ public class DocumentReviewer extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose(
         """
         Review documents for regulatory and compliance standards, \
         providing structured assessments with specific findings. \

--- a/samples/autonomous-agent-playground/src/main/java/demo/dynamic/api/DynamicEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/dynamic/api/DynamicEndpoint.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 /**
  * Demonstrates dynamic agent setup — the same generic agent class is configured with different
- * goals and capabilities per request.
+ * purposes and capabilities per request.
  */
 @Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET))
 @HttpEndpoint("/dynamic")
@@ -31,14 +31,16 @@ public class DynamicEndpoint extends AbstractHttpEndpoint {
 
   @Post("/summarize")
   public TaskResponse summarize(TaskRequest request) {
-    var agentId = requestContext().queryParams().getString("runId")
+    var agentId = requestContext()
+      .queryParams()
+      .getString("runId")
       .filter(s -> !s.isBlank())
       .orElseGet(() -> UUID.randomUUID().toString());
     var agent = componentClient.forAutonomousAgent(DynamicAgent.class, agentId);
 
     agent.setup(
       AgentSetup.create()
-        .goal("Produce a concise summary of the given content, highlighting key points.")
+        .purpose("Produce a concise summary of the given content, highlighting key points.")
         .capability(TaskAcceptance.of(DynamicTasks.SUMMARIZE))
     );
 
@@ -48,14 +50,16 @@ public class DynamicEndpoint extends AbstractHttpEndpoint {
 
   @Post("/translate")
   public TaskResponse translate(TaskRequest request) {
-    var agentId = requestContext().queryParams().getString("runId")
+    var agentId = requestContext()
+      .queryParams()
+      .getString("runId")
       .filter(s -> !s.isBlank())
       .orElseGet(() -> UUID.randomUUID().toString());
     var agent = componentClient.forAutonomousAgent(DynamicAgent.class, agentId);
 
     agent.setup(
       AgentSetup.create()
-        .goal("Translate the given content to French, preserving tone and meaning.")
+        .purpose("Translate the given content to French, preserving tone and meaning.")
         .capability(TaskAcceptance.of(DynamicTasks.TRANSLATE))
     );
 

--- a/samples/autonomous-agent-playground/src/main/java/demo/dynamic/application/DynamicAgent.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/dynamic/application/DynamicAgent.java
@@ -5,7 +5,7 @@ import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.annotations.Component;
 
 /**
- * A generic agent with no static goal or capabilities. Configured dynamically at runtime via
+ * A generic agent with no static purpose or capabilities. Configured dynamically at runtime via
  * AgentSetup before assigning tasks.
  */
 @Component(id = "dynamic-agent")

--- a/samples/autonomous-agent-playground/src/main/java/demo/helloworld/api/QuestionEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/helloworld/api/QuestionEndpoint.java
@@ -27,7 +27,9 @@ public class QuestionEndpoint extends AbstractHttpEndpoint {
 
   @Post
   public QuestionResponse ask(AskQuestion request) {
-    var agentInstanceId = requestContext().queryParams().getString("runId")
+    var agentInstanceId = requestContext()
+      .queryParams()
+      .getString("runId")
       .filter(s -> !s.isBlank())
       .orElseGet(() -> UUID.randomUUID().toString());
     var taskId = componentClient

--- a/samples/autonomous-agent-playground/src/main/java/demo/helloworld/application/QuestionAnswerer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/helloworld/application/QuestionAnswerer.java
@@ -11,7 +11,8 @@ public class QuestionAnswerer extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("Answer questions clearly and concisely, showing reasoning step by step.")
+      .purpose("Answer questions.")
+      .guidance("Be clear and concise. Show reasoning step by step.")
       .capability(TaskAcceptance.of(QuestionTasks.ANSWER).maxIterationsPerTask(3));
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/negotiation/api/NegotiationEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/negotiation/api/NegotiationEndpoint.java
@@ -27,7 +27,9 @@ public class NegotiationEndpoint extends AbstractHttpEndpoint {
 
   @Post
   public NegotiationResponse create(NegotiationRequest request) {
-    var agentInstanceId = requestContext().queryParams().getString("runId")
+    var agentInstanceId = requestContext()
+      .queryParams()
+      .getString("runId")
       .filter(s -> !s.isBlank())
       .orElseGet(() -> UUID.randomUUID().toString());
     var taskId = componentClient

--- a/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Buyer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Buyer.java
@@ -9,6 +9,6 @@ public class Buyer extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Negotiate the best possible deal from the buyer's perspective.");
+    return define().purpose("Negotiate the best possible deal from the buyer's perspective.");
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Facilitator.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Facilitator.java
@@ -12,7 +12,7 @@ public class Facilitator extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose(
         """
         Facilitate negotiations by directing each psarty through structured rounds \
         of offers and counteroffers to reach agreement.

--- a/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Seller.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Seller.java
@@ -9,6 +9,7 @@ public class Seller extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Negotiate the best possible deal from the seller's perspective.");
+    return define()
+      .purpose("Negotiate the best possible deal from the seller's perspective.");
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/api/PeerReviewEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/api/PeerReviewEndpoint.java
@@ -27,7 +27,9 @@ public class PeerReviewEndpoint extends AbstractHttpEndpoint {
 
   @Post
   public ReviewResponse create(ReviewRequest request) {
-    var agentInstanceId = requestContext().queryParams().getString("runId")
+    var agentInstanceId = requestContext()
+      .queryParams()
+      .getString("runId")
       .filter(s -> !s.isBlank())
       .orElseGet(() -> UUID.randomUUID().toString());
     var taskId = componentClient

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ComplianceReviewer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ComplianceReviewer.java
@@ -9,6 +9,7 @@ public class ComplianceReviewer extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Review documents for regulatory compliance and policy adherence.");
+    return define()
+      .purpose("Review documents for regulatory compliance and policy adherence.");
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ReviewModerator.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ReviewModerator.java
@@ -15,7 +15,7 @@ public class ReviewModerator extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("Coordinate document peer review and synthesize reviewer findings.")
+      .purpose("Coordinate document peer review and synthesize reviewer findings.")
       .capability(TaskAcceptance.of(ReviewTasks.REVIEW))
       .capability(
         Moderation.of(TechnicalReviewer.class, StyleReviewer.class, ComplianceReviewer.class)

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/StyleReviewer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/StyleReviewer.java
@@ -9,6 +9,7 @@ public class StyleReviewer extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Review documents for clarity, readability, and consistent style.");
+    return define()
+      .purpose("Review documents for clarity, readability, and consistent style.");
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/TechnicalReviewer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/TechnicalReviewer.java
@@ -13,6 +13,6 @@ public class TechnicalReviewer extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("Review documents for technical accuracy, correctness, and completeness.");
+      .purpose("Review documents for technical accuracy, correctness, and completeness.");
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/pipeline/api/PipelineEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/pipeline/api/PipelineEndpoint.java
@@ -65,7 +65,9 @@ public class PipelineEndpoint extends AbstractHttpEndpoint {
 
     // Assign all tasks to a single agent instance — accept an optional pre-generated runId so the
     // UI can subscribe to the notification stream before the agent activates.
-    var agentInstanceId = requestContext().queryParams().getString("runId")
+    var agentInstanceId = requestContext()
+      .queryParams()
+      .getString("runId")
       .filter(s -> !s.isBlank())
       .orElseGet(() -> UUID.randomUUID().toString());
     componentClient

--- a/samples/autonomous-agent-playground/src/main/java/demo/pipeline/application/ReportAgent.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/pipeline/application/ReportAgent.java
@@ -16,7 +16,7 @@ public class ReportAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose(
         "Process report phases: collect data, analyze findings, produce comprehensive reports."
       )
       .capability(

--- a/samples/autonomous-agent-playground/src/main/java/demo/publishing/api/PublishingEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/publishing/api/PublishingEndpoint.java
@@ -51,7 +51,9 @@ public class PublishingEndpoint extends AbstractHttpEndpoint {
   public PublishingPipeline request(PublishRequest request) {
     // 1. Create draft task and assign to content agent. Accept an optional pre-generated runId
     //    so the UI can subscribe to the notification stream before the agent activates.
-    var contentAgentId = requestContext().queryParams().getString("runId")
+    var contentAgentId = requestContext()
+      .queryParams()
+      .getString("runId")
       .filter(s -> !s.isBlank())
       .orElseGet(() -> UUID.randomUUID().toString());
     var draftTaskId = componentClient

--- a/samples/autonomous-agent-playground/src/main/java/demo/publishing/application/ContentAgent.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/publishing/application/ContentAgent.java
@@ -11,7 +11,8 @@ public class ContentAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("Draft blog posts. Write clear, engaging content on the given topic.")
+      .purpose("Draft blog posts.")
+      .guidance("Write clear, engaging content on the given topic.")
       .capability(TaskAcceptance.of(PublishingTasks.DRAFT).maxIterationsPerTask(3));
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/publishing/application/PublishingAgent.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/publishing/application/PublishingAgent.java
@@ -11,7 +11,7 @@ public class PublishingAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose(
         "Publish approved blog posts. Generate a URL and timestamp for the published post."
       )
       .capability(TaskAcceptance.of(PublishingTasks.PUBLISH).maxIterationsPerTask(3));

--- a/samples/autonomous-agent-playground/src/main/java/demo/research/api/ResearchEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/research/api/ResearchEndpoint.java
@@ -29,7 +29,9 @@ public class ResearchEndpoint extends AbstractHttpEndpoint {
 
   @Post
   public ResearchResponse create(ResearchRequest request) {
-    var agentInstanceId = requestContext().queryParams().getString("runId")
+    var agentInstanceId = requestContext()
+      .queryParams()
+      .getString("runId")
       .filter(s -> !s.isBlank())
       .orElseGet(() -> UUID.randomUUID().toString());
     var taskId = componentClient

--- a/samples/autonomous-agent-playground/src/main/java/demo/research/application/Analyst.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/research/application/Analyst.java
@@ -14,7 +14,7 @@ public class Analyst extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose(
         """
         You are an insightful analyst. When given a topic, analyse its implications, \
         identify trends and patterns, and produce actionable insights. \

--- a/samples/autonomous-agent-playground/src/main/java/demo/research/application/ResearchCoordinator.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/research/application/ResearchCoordinator.java
@@ -12,7 +12,7 @@ public class ResearchCoordinator extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose(
         """
         Produce comprehensive research briefs by synthesising findings \
         from multiple specialist perspectives. \

--- a/samples/autonomous-agent-playground/src/main/java/demo/research/application/Researcher.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/research/application/Researcher.java
@@ -14,7 +14,7 @@ public class Researcher extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose(
         """
         You are a thorough researcher. When given a topic, find key facts, \
         important details, and relevant context. \

--- a/samples/autonomous-agent-playground/src/main/java/demo/support/api/SupportEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/support/api/SupportEndpoint.java
@@ -28,7 +28,9 @@ public class SupportEndpoint extends AbstractHttpEndpoint {
 
   @Post
   public SupportResponse create(SupportRequest request) {
-    var agentInstanceId = requestContext().queryParams().getString("runId")
+    var agentInstanceId = requestContext()
+      .queryParams()
+      .getString("runId")
       .filter(s -> !s.isBlank())
       .orElseGet(() -> UUID.randomUUID().toString());
     var taskId = componentClient

--- a/samples/autonomous-agent-playground/src/main/java/demo/support/application/BillingSpecialist.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/support/application/BillingSpecialist.java
@@ -14,7 +14,7 @@ public class BillingSpecialist extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("Resolve billing and payment issues for customers.")
+      .purpose("Resolve billing and payment issues for customers.")
       .capability(TaskAcceptance.of(SupportTasks.RESOLVE).maxIterationsPerTask(5));
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/support/application/TechnicalSpecialist.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/support/application/TechnicalSpecialist.java
@@ -14,7 +14,7 @@ public class TechnicalSpecialist extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("Diagnose and resolve technical issues for customers.")
+      .purpose("Diagnose and resolve technical issues for customers.")
       .capability(TaskAcceptance.of(SupportTasks.RESOLVE).maxIterationsPerTask(5));
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/support/application/TriageAgent.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/support/application/TriageAgent.java
@@ -11,7 +11,7 @@ public class TriageAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .purpose(
         """
         Classify customer support requests and ensure they are resolved \
         by the appropriate specialist. \

--- a/samples/autonomous-agent-playground/src/main/java/demo/ui/api/RunControlEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/ui/api/RunControlEndpoint.java
@@ -10,7 +10,6 @@ import akka.javasdk.annotations.http.Post;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.http.AbstractHttpEndpoint;
 import akka.javasdk.http.HttpException;
-import java.time.Instant;
 import demo.consulting.application.ConsultingTasks;
 import demo.debate.application.DebateTasks;
 import demo.devteam.application.ProjectTasks;
@@ -21,6 +20,7 @@ import demo.pipeline.application.PipelineTasks;
 import demo.publishing.application.PublishingTasks;
 import demo.research.application.ResearchTasks;
 import demo.support.application.SupportTasks;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -63,7 +63,8 @@ public class RunControlEndpoint extends AbstractHttpEndpoint {
 
   @Get("/samples")
   public SampleList samples() {
-    var entries = SampleRegistry.samples().stream()
+    var entries = SampleRegistry.samples()
+      .stream()
       .map(e -> new SampleSummary(e.id(), e.displayName(), e.agentComponentId()))
       .toList();
     return new SampleList(entries);
@@ -136,7 +137,10 @@ public class RunControlEndpoint extends AbstractHttpEndpoint {
       case "negotiation" -> NegotiationTasks.NEGOTIATE;
       case "peerreview" -> demo.peerreview.application.ReviewTasks.REVIEW;
       case "devteam" -> ProjectTasks.PLAN;
-      default -> throw HttpException.error(StatusCodes.NOT_FOUND, "Unknown sample id: " + sampleId);
+      default -> throw HttpException.error(
+        StatusCodes.NOT_FOUND,
+        "Unknown sample id: " + sampleId
+      );
     };
   }
 

--- a/samples/autonomous-agent-playground/src/main/java/demo/ui/api/RunNotificationEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/ui/api/RunNotificationEndpoint.java
@@ -65,12 +65,15 @@ public class RunNotificationEndpoint extends AbstractHttpEndpoint {
 
   @Get("/runs/{runId}/events")
   public HttpResponse events(String runId) {
-    var component = requestContext().queryParams().getString("component")
-      .orElseThrow(() ->
-        akka.javasdk.http.HttpException.error(
-          akka.http.javadsl.model.StatusCodes.BAD_REQUEST,
-          "Missing required query parameter: component"
-        )
+    var component = requestContext()
+      .queryParams()
+      .getString("component")
+      .orElseThrow(
+        () ->
+          akka.javasdk.http.HttpException.error(
+            akka.http.javadsl.model.StatusCodes.BAD_REQUEST,
+            "Missing required query parameter: component"
+          )
       );
 
     var agentClass = SampleRegistry.classFor(component);
@@ -83,20 +86,23 @@ public class RunNotificationEndpoint extends AbstractHttpEndpoint {
     // outgoing stream. Each notification is tagged with the emitter's (componentId, instanceId)
     // so the UI can attribute it correctly. The expansion is recursive — children's own spawn
     // events also expand — so multi-level nesting is supported.
-    Source<TaggedNotification, NotUsed> mergedSource = taggedStream(rootAgent, agentClass)
-      .flatMapMerge(MERGE_PARALLELISM, this::expand);
+    Source<TaggedNotification, NotUsed> mergedSource = taggedStream(
+      rootAgent,
+      agentClass
+    ).flatMapMerge(MERGE_PARALLELISM, this::expand);
 
-    Source<EventEnvelope, NotUsed> envelopes = mergedSource.map(t ->
-      new EventEnvelope(
-        counter.incrementAndGet(),
-        Instant.now(),
-        tierFor(t.notification()),
-        categoryFor(t.notification()),
-        t.notification().getClass().getSimpleName(),
-        t.notification(),
-        t.emitter().componentId(),
-        t.emitter().instanceId()
-      )
+    Source<EventEnvelope, NotUsed> envelopes = mergedSource.map(
+      t ->
+        new EventEnvelope(
+          counter.incrementAndGet(),
+          Instant.now(),
+          tierFor(t.notification()),
+          categoryFor(t.notification()),
+          t.notification().getClass().getSimpleName(),
+          t.notification(),
+          t.emitter().componentId(),
+          t.emitter().instanceId()
+        )
     );
 
     return HttpResponses.serverSentEvents(envelopes, env -> String.valueOf(env.eventId()));
@@ -129,8 +135,7 @@ public class RunNotificationEndpoint extends AbstractHttpEndpoint {
       .filter(c -> SampleRegistry.classForOrNull(c.componentId()) != null)
       .flatMapMerge(MERGE_PARALLELISM, c -> {
         var clazz = SampleRegistry.classForOrNull(c.componentId());
-        return taggedStream(c, clazz)
-          .flatMapMerge(MERGE_PARALLELISM, this::expand); // recurse for grandchildren
+        return taggedStream(c, clazz).flatMapMerge(MERGE_PARALLELISM, this::expand); // recurse for grandchildren
       });
 
     return Source.single(tagged).concat(childMerged);

--- a/samples/autonomous-agent-playground/src/main/java/demo/ui/api/SampleRegistry.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/ui/api/SampleRegistry.java
@@ -61,10 +61,25 @@ public final class SampleRegistry {
   private static final List<SampleEntry> ENTRIES = List.of(
     new SampleEntry("helloworld", "Hello world", "question-answerer", QuestionAnswerer.class),
     new SampleEntry("pipeline", "Pipeline", "report-agent", ReportAgent.class),
-    new SampleEntry("docreview", "Document review", "document-reviewer", DocumentReviewer.class),
+    new SampleEntry(
+      "docreview",
+      "Document review",
+      "document-reviewer",
+      DocumentReviewer.class
+    ),
     new SampleEntry("dynamic", "Dynamic", "dynamic-agent", DynamicAgent.class),
-    new SampleEntry("research", "Research", "research-coordinator", ResearchCoordinator.class),
-    new SampleEntry("consulting", "Consulting", "consulting-coordinator", ConsultingCoordinator.class),
+    new SampleEntry(
+      "research",
+      "Research",
+      "research-coordinator",
+      ResearchCoordinator.class
+    ),
+    new SampleEntry(
+      "consulting",
+      "Consulting",
+      "consulting-coordinator",
+      ConsultingCoordinator.class
+    ),
     new SampleEntry("support", "Support", "triage-agent", TriageAgent.class),
     new SampleEntry("publishing", "Publishing", "content-agent", ContentAgent.class),
     new SampleEntry("debate", "Debate", "debate-moderator", DebateModerator.class),
@@ -85,23 +100,23 @@ public final class SampleRegistry {
     // Owning agents — every entry in ENTRIES contributes here.
     for (var e : ENTRIES) map.put(e.agentComponentId(), e.agentClass());
     // Child agents reached via delegation / handoff / team / moderation.
-    map.put("researcher", Researcher.class);                    // research → delegation
+    map.put("researcher", Researcher.class); // research → delegation
     map.put("analyst", Analyst.class);
     map.put("consulting-researcher", ConsultingResearcher.class); // consulting → delegation
-    map.put("senior-consultant", SeniorConsultant.class);         // consulting → handoff
+    map.put("senior-consultant", SeniorConsultant.class); // consulting → handoff
     // FactCheckAgent is intentionally omitted — it's a request-based Agent (not AutonomousAgent)
     // and therefore doesn't have a notificationStream() to subscribe to.
-    map.put("billing-specialist", BillingSpecialist.class);      // support → handoff
+    map.put("billing-specialist", BillingSpecialist.class); // support → handoff
     map.put("technical-specialist", TechnicalSpecialist.class);
-    map.put("publishing-agent", PublishingAgent.class);          // publishing → publish task
-    map.put("advocate", Advocate.class);                          // debate → moderation
+    map.put("publishing-agent", PublishingAgent.class); // publishing → publish task
+    map.put("advocate", Advocate.class); // debate → moderation
     map.put("critic", Critic.class);
-    map.put("buyer", Buyer.class);                                // negotiation → moderation
+    map.put("buyer", Buyer.class); // negotiation → moderation
     map.put("seller", Seller.class);
-    map.put("technical-reviewer", TechnicalReviewer.class);      // peerreview → moderation
+    map.put("technical-reviewer", TechnicalReviewer.class); // peerreview → moderation
     map.put("style-reviewer", StyleReviewer.class);
     map.put("compliance-reviewer", ComplianceReviewer.class);
-    map.put("developer", Developer.class);                        // devteam → team
+    map.put("developer", Developer.class); // devteam → team
     ALL_AGENTS = Map.copyOf(map);
   }
 

--- a/samples/autonomous-agent-playground/src/main/resources/static-resources/samples/dynamic.js
+++ b/samples/autonomous-agent-playground/src/main/resources/static-resources/samples/dynamic.js
@@ -4,10 +4,10 @@ export const dynamic = {
   id: 'dynamic',
   displayName: 'Dynamic',
   description: {
-    overview: 'A single generic agent class is configured per request with different goals and task capabilities. The same DynamicAgent code runs both the summarize and translate flows.',
-    agents: ['DynamicAgent — declared with no static goal or capabilities; configured at runtime via AgentSetup'],
+    overview: 'A single generic agent class is configured per request with different purposes and task capabilities. The same DynamicAgent code runs both the summarize and translate flows.',
+    agents: ['DynamicAgent — declared with no static purpose or capabilities; configured at runtime via AgentSetup'],
     tasks: ['SUMMARIZE → String', 'TRANSLATE → String'],
-    flow: 'Two HTTP routes (/dynamic/summarize, /dynamic/translate) each create a fresh DynamicAgent instance, configure its goal and accepted capability dynamically, then assign a single task. Same agent class, two different runtime specialisations.',
+    flow: 'Two HTTP routes (/dynamic/summarize, /dynamic/translate) each create a fresh DynamicAgent instance, configure its purpose and accepted capability dynamically, then assign a single task. Same agent class, two different runtime specialisations.',
     demonstrates: 'Runtime agent configuration via AgentSetup. Useful when many task variants share the same execution shape and the differences are best expressed as data.',
   },
   agentComponentId: 'dynamic-agent',

--- a/samples/autonomous-agent-playground/src/test/java/demo/ui/PlaygroundUiEndpointIntegrationTest.java
+++ b/samples/autonomous-agent-playground/src/test/java/demo/ui/PlaygroundUiEndpointIntegrationTest.java
@@ -13,8 +13,9 @@ public class PlaygroundUiEndpointIntegrationTest extends TestKitSupport {
     var response = httpClient.GET("/").invoke();
 
     assertThat(response.status()).isEqualTo(StatusCodes.FOUND);
-    assertThat(response.httpResponse().getHeader("Location"))
-      .hasValueSatisfying(h -> assertThat(h.value()).isEqualTo("/playground"));
+    assertThat(response.httpResponse().getHeader("Location")).hasValueSatisfying(
+      h -> assertThat(h.value()).isEqualTo("/playground")
+    );
   }
 
   @Test
@@ -49,7 +50,9 @@ public class PlaygroundUiEndpointIntegrationTest extends TestKitSupport {
     var response = httpClient.GET("/playground/research").invoke();
 
     assertThat(response.status()).isEqualTo(StatusCodes.OK);
-    assertThat(response.body().utf8String()).contains("<title>Autonomous Agent Playground</title>");
+    assertThat(response.body().utf8String()).contains(
+      "<title>Autonomous Agent Playground</title>"
+    );
   }
 
   @Test
@@ -57,6 +60,8 @@ public class PlaygroundUiEndpointIntegrationTest extends TestKitSupport {
     var response = httpClient.GET("/playground/research/run/abc-123").invoke();
 
     assertThat(response.status()).isEqualTo(StatusCodes.OK);
-    assertThat(response.body().utf8String()).contains("<title>Autonomous Agent Playground</title>");
+    assertThat(response.body().utf8String()).contains(
+      "<title>Autonomous Agent Playground</title>"
+    );
   }
 }

--- a/samples/autonomous-agent-playground/src/test/java/demo/ui/RunControlEndpointSamplesTest.java
+++ b/samples/autonomous-agent-playground/src/test/java/demo/ui/RunControlEndpointSamplesTest.java
@@ -6,7 +6,6 @@ import akka.javasdk.testkit.TestKitSupport;
 import demo.ui.api.RunControlEndpoint;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Test;
 
 public class RunControlEndpointSamplesTest extends TestKitSupport {
@@ -37,9 +36,10 @@ public class RunControlEndpointSamplesTest extends TestKitSupport {
       )
     );
 
-    var byId = response.samples().stream().collect(
-      Collectors.toMap(RunControlEndpoint.SampleSummary::id, e -> e)
-    );
+    var byId = response
+      .samples()
+      .stream()
+      .collect(Collectors.toMap(RunControlEndpoint.SampleSummary::id, e -> e));
     assertThat(byId.get("helloworld").agentComponentId()).isEqualTo("question-answerer");
     assertThat(byId.get("debate").agentComponentId()).isEqualTo("debate-moderator");
     assertThat(byId.get("publishing").agentComponentId()).isEqualTo("content-agent");

--- a/samples/autonomous-agent-playground/src/test/java/demo/ui/RunControlEndpointStopTest.java
+++ b/samples/autonomous-agent-playground/src/test/java/demo/ui/RunControlEndpointStopTest.java
@@ -26,9 +26,7 @@ public class RunControlEndpointStopTest extends TestKitSupport {
   @Test
   public void stopReturns404ForUnknownComponent() {
     var response = httpClient
-      .POST(
-        "/playground/api/runs/" + UUID.randomUUID() + "/stop?component=does-not-exist"
-      )
+      .POST("/playground/api/runs/" + UUID.randomUUID() + "/stop?component=does-not-exist")
       .invoke();
     assertThat(response.status()).isEqualTo(StatusCodes.NOT_FOUND);
   }
@@ -80,7 +78,8 @@ public class RunControlEndpointStopTest extends TestKitSupport {
       .invoke()
       .body();
 
-    var url = "/playground/api/runs/" + post.runId() + "/stop?component=" + post.agentComponentId();
+    var url =
+      "/playground/api/runs/" + post.runId() + "/stop?component=" + post.agentComponentId();
     var first = httpClient.POST(url).invoke();
     var second = httpClient.POST(url).invoke();
 

--- a/samples/autonomous-agent-playground/src/test/java/demo/ui/RunNotificationEndpointIntegrationTest.java
+++ b/samples/autonomous-agent-playground/src/test/java/demo/ui/RunNotificationEndpointIntegrationTest.java
@@ -12,9 +12,7 @@ public class RunNotificationEndpointIntegrationTest extends TestKitSupport {
   @Test
   public void returns404ForUnknownComponent() {
     var response = httpClient
-      .GET(
-        "/playground/api/runs/" + UUID.randomUUID() + "/events?component=does-not-exist"
-      )
+      .GET("/playground/api/runs/" + UUID.randomUUID() + "/events?component=does-not-exist")
       .invoke();
     assertThat(response.status()).isEqualTo(StatusCodes.NOT_FOUND);
   }
@@ -26,7 +24,6 @@ public class RunNotificationEndpointIntegrationTest extends TestKitSupport {
       .invoke();
     assertThat(response.status()).isEqualTo(StatusCodes.BAD_REQUEST);
   }
-
   // Note: a content-type smoke test for the live SSE stream is intentionally omitted —
   // httpClient.invoke() materialises the body strictly and would hang on a long-lived stream.
   // The wire shape is unit-tested in TierClassifierTest; live behaviour is covered manually

--- a/samples/autonomous-agent-playground/src/test/java/demo/ui/TierClassifierTest.java
+++ b/samples/autonomous-agent-playground/src/test/java/demo/ui/TierClassifierTest.java
@@ -15,29 +15,46 @@ public class TierClassifierTest {
 
   @Test
   public void healthyEvents() {
-    assertThat(RunNotificationEndpoint.tierFor(new Notification.Activated())).isEqualTo("healthy");
-    assertThat(RunNotificationEndpoint.tierFor(new Notification.Deactivated())).isEqualTo("healthy");
-    assertThat(RunNotificationEndpoint.tierFor(new Notification.IterationStarted())).isEqualTo("healthy");
-    assertThat(RunNotificationEndpoint.tierFor(new Notification.TaskAssigned("t1")))
-      .isEqualTo("healthy");
-    assertThat(RunNotificationEndpoint.tierFor(new Notification.TaskStarted("t1", "name")))
-      .isEqualTo("healthy");
-    assertThat(RunNotificationEndpoint.tierFor(new Notification.TaskCompleted("t1", "name")))
-      .isEqualTo("healthy");
+    assertThat(RunNotificationEndpoint.tierFor(new Notification.Activated())).isEqualTo(
+      "healthy"
+    );
+    assertThat(RunNotificationEndpoint.tierFor(new Notification.Deactivated())).isEqualTo(
+      "healthy"
+    );
+    assertThat(
+      RunNotificationEndpoint.tierFor(new Notification.IterationStarted())
+    ).isEqualTo("healthy");
+    assertThat(
+      RunNotificationEndpoint.tierFor(new Notification.TaskAssigned("t1"))
+    ).isEqualTo("healthy");
+    assertThat(
+      RunNotificationEndpoint.tierFor(new Notification.TaskStarted("t1", "name"))
+    ).isEqualTo("healthy");
+    assertThat(
+      RunNotificationEndpoint.tierFor(new Notification.TaskCompleted("t1", "name"))
+    ).isEqualTo("healthy");
   }
 
   @Test
   public void struggleEvents() {
     assertThat(
       RunNotificationEndpoint.tierFor(
-        new Notification.IterationFailed("llm timeout", java.util.Optional.empty(), java.util.Optional.empty())
+        new Notification.IterationFailed(
+          "llm timeout",
+          java.util.Optional.empty(),
+          java.util.Optional.empty()
+        )
       )
     ).isEqualTo("struggle");
     assertThat(
-      RunNotificationEndpoint.tierFor(new Notification.TaskResultRejected("t1", "name", "rule-x"))
+      RunNotificationEndpoint.tierFor(
+        new Notification.TaskResultRejected("t1", "name", "rule-x")
+      )
     ).isEqualTo("struggle");
     assertThat(
-      RunNotificationEndpoint.tierFor(new Notification.TaskDependencyWait("t1", java.util.List.of("dep1")))
+      RunNotificationEndpoint.tierFor(
+        new Notification.TaskDependencyWait("t1", java.util.List.of("dep1"))
+      )
     ).isEqualTo("struggle");
   }
 
@@ -47,15 +64,19 @@ public class TierClassifierTest {
       RunNotificationEndpoint.tierFor(new Notification.TaskFailed("t1", "name", "boom"))
     ).isEqualTo("terminal_failure");
     assertThat(
-      RunNotificationEndpoint.tierFor(new Notification.TaskCancelled("t1", "name", "max iterations"))
+      RunNotificationEndpoint.tierFor(
+        new Notification.TaskCancelled("t1", "name", "max iterations")
+      )
     ).isEqualTo("terminal_failure");
-    assertThat(RunNotificationEndpoint.tierFor(new Notification.Stopped("operator")))
-      .isEqualTo("terminal_failure");
+    assertThat(
+      RunNotificationEndpoint.tierFor(new Notification.Stopped("operator"))
+    ).isEqualTo("terminal_failure");
   }
 
   @Test
   public void autoStoppedIsHealthy() {
-    assertThat(RunNotificationEndpoint.tierFor(new Notification.Stopped("auto-stopped")))
-      .isEqualTo("healthy");
+    assertThat(
+      RunNotificationEndpoint.tierFor(new Notification.Stopped("auto-stopped"))
+    ).isEqualTo("healthy");
   }
 }


### PR DESCRIPTION
Try out a rename from goal to purpose for autonomous agent definitions. And also include a new optional guidance definition parameter for additional instructions for the agent. SPI has not been updated, so these are currently just concatenated together for the current SPI goal. But if we go ahead with this change, then we'll also update the SPI. . 