### PR TITLE
chore: add 'since' to all deprecated methods

### DIFF
--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventingTestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/EventingTestKit.java
@@ -44,7 +44,7 @@ public interface EventingTestKit {
      * @param message raw protobuf bytestring to be published
      * @deprecated Use publish with byte array parameter
      */
-    @Deprecated
+    @Deprecated(since = "3.1.0")
     void publish(ByteString message);
 
     /**
@@ -54,7 +54,7 @@ public interface EventingTestKit {
      * @param metadata associated with the message
      * @deprecated Use publish with byte array parameter
      */
-    @Deprecated
+    @Deprecated(since = "3.1.0")
     void publish(ByteString message, Metadata metadata);
 
     /**

--- a/akka-javasdk/src/main/java/akka/javasdk/JsonSupport.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/JsonSupport.java
@@ -70,7 +70,7 @@ public final class JsonSupport {
    * @see {{encodeJson(T, String}}
    * @deprecated Protobuf Any with JSON is not supported
    */
-  @Deprecated
+  @Deprecated(since = "3.1.0")
   public static <T> Any encodeJson(T value) {
     return encodeJson(value, value.getClass().getName());
   }
@@ -87,7 +87,7 @@ public final class JsonSupport {
    * @throws IllegalArgumentException if the given value cannot be turned into JSON
    * @deprecated Protobuf Any with JSON is not supported
    */
-  @Deprecated
+  @Deprecated(since = "3.1.0")
   public static <T> Any encodeJson(T value, String jsonType) {
     try {
       ByteString bytes = encodeToBytes(value);
@@ -105,7 +105,7 @@ public final class JsonSupport {
   /**
    * @deprecated Use encodeToAkkaByteString
    */
-  @Deprecated
+  @Deprecated(since = "3.1.0")
   public static <T> ByteString encodeToBytes(T value) throws JsonProcessingException {
     return UnsafeByteOperations.unsafeWrap(
         objectMapper.writerFor(value.getClass()).writeValueAsBytes(value));
@@ -147,7 +147,7 @@ public final class JsonSupport {
   /**
    * @deprecated was only intended for internal use
    */
-  @Deprecated
+  @Deprecated(since = "3.1.0")
   public static akka.util.ByteString encodeDynamicToAkkaByteString(String key, String value) {
     try {
       ObjectNode dynamicJson = objectMapper.createObjectNode().put(key, value);
@@ -160,7 +160,7 @@ public final class JsonSupport {
   /**
    * @deprecated was only intended for internal use
    */
-  @Deprecated
+  @Deprecated(since = "3.1.0")
   public static akka.util.ByteString encodeDynamicCollectionToAkkaByteString(
       String key, Collection<?> values) {
     try {
@@ -213,7 +213,7 @@ public final class JsonSupport {
    * @throws IllegalArgumentException if the given value cannot be decoded to a T
    * @deprecated Protobuf Any with JSON is not supported
    */
-  @Deprecated
+  @Deprecated(since = "3.1.0")
   public static <T> T decodeJson(Class<T> valueClass, Any any) {
     if (!AnySupport.isJsonTypeUrl(any.getTypeUrl())) {
       throw new IllegalArgumentException(
@@ -266,7 +266,7 @@ public final class JsonSupport {
   /**
    * @deprecated Use decodeJson
    */
-  @Deprecated
+  @Deprecated(since = "3.1.0")
   public static <T> T parseBytes(byte[] bytes, Class<T> valueClass) throws IOException {
     return objectMapper.readValue(bytes, valueClass);
   }
@@ -315,7 +315,7 @@ public final class JsonSupport {
   /**
    * @deprecated Protobuf Any with JSON is not supported
    */
-  @Deprecated
+  @Deprecated(since = "3.1.0")
   public static <T, C extends Collection<T>> C decodeJsonCollection(
       Class<T> valueClass, Class<C> collectionType, Any any) {
     if (!AnySupport.isJsonTypeUrl(any.getTypeUrl())) {
@@ -342,7 +342,7 @@ public final class JsonSupport {
   /**
    * @deprecated was only intended for internal use
    */
-  @Deprecated
+  @Deprecated(since = "3.2.2")
   public static <T, C extends Collection<T>> C decodeJsonCollection(
       Class<T> valueClass, Class<C> collectionType, akka.util.ByteString bytes) {
     return jsonSerializer.fromBytes(
@@ -354,7 +354,7 @@ public final class JsonSupport {
   /**
    * @deprecated was only intended for internal use
    */
-  @Deprecated
+  @Deprecated(since = "3.2.2")
   public static <T, C extends Collection<T>> C decodeJsonCollection(
       Class<T> valueClass, Class<C> collectionType, byte[] bytes) {
     return decodeJsonCollection(
@@ -370,7 +370,7 @@ public final class JsonSupport {
    * @throws IllegalArgumentException if the suffix matches but the Any cannot be parsed into a T
    * @deprecated Protobuf Any with JSON is not supported
    */
-  @Deprecated
+  @Deprecated(since = "3.1.0")
   public static <T> Optional<T> decodeJson(Class<T> valueClass, String jsonType, Any any) {
     if (any.getTypeUrl().endsWith(jsonType)) {
       return Optional.of(decodeJson(valueClass, any));
@@ -383,7 +383,7 @@ public final class JsonSupport {
 /**
  * @deprecated Not indented for public use and no longer used internally
  */
-@Deprecated
+@Deprecated(since = "3.2.2")
 class DoneSerializer extends JsonSerializer<Done> {
 
   @Override
@@ -408,7 +408,7 @@ class DoneSerializer extends JsonSerializer<Done> {
 /**
  * @deprecated Not indented for public use and no longer used internally
  */
-@Deprecated
+@Deprecated(since = "3.2.2")
 class DoneDeserializer extends JsonDeserializer<Done> {
 
   @Override

--- a/akka-javasdk/src/main/java/akka/javasdk/Metadata.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/Metadata.java
@@ -69,7 +69,7 @@ public interface Metadata extends Iterable<Metadata.MetadataEntry> {
    * @return The value, if found.
    * @deprecated binary not supported, always returns empty. Use {@link #get(String)}.
    */
-  @Deprecated
+  @Deprecated(since = "3.6.0-M2")
   Optional<ByteBuffer> getBinary(String key);
 
   /**
@@ -81,7 +81,7 @@ public interface Metadata extends Iterable<Metadata.MetadataEntry> {
    * @return A list of all the binary values for the given key.
    * @deprecated binary not supported, always returns empty. Use {@link #getAll(String)}.
    */
-  @Deprecated
+  @Deprecated(since = "3.6.0-M2")
   List<ByteBuffer> getBinaryAll(String key);
 
   /**

--- a/akka-javasdk/src/main/java/akka/javasdk/Metadata.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/Metadata.java
@@ -69,7 +69,7 @@ public interface Metadata extends Iterable<Metadata.MetadataEntry> {
    * @return The value, if found.
    * @deprecated binary not supported, always returns empty. Use {@link #get(String)}.
    */
-  @Deprecated(since = "3.6.0-M2")
+  @Deprecated(since = "3.6.0")
   Optional<ByteBuffer> getBinary(String key);
 
   /**
@@ -81,7 +81,7 @@ public interface Metadata extends Iterable<Metadata.MetadataEntry> {
    * @return A list of all the binary values for the given key.
    * @deprecated binary not supported, always returns empty. Use {@link #getAll(String)}.
    */
-  @Deprecated(since = "3.6.0-M2")
+  @Deprecated(since = "3.6.0")
   List<ByteBuffer> getBinaryAll(String key);
 
   /**

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/Agent.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/Agent.java
@@ -258,7 +258,7 @@ public abstract class Agent implements AgentDelegationWorker {
        * @see ImageLoader
        * @deprecated use contentLoader
        */
-      @Deprecated
+      @Deprecated(since = "3.5.15")
       @SuppressWarnings("removal")
       Builder imageLoader(ImageLoader imageLoader);
 
@@ -629,7 +629,7 @@ public abstract class Agent implements AgentDelegationWorker {
        * @return this builder for method chaining
        * @deprecated use contentLoader
        */
-      @Deprecated
+      @Deprecated(since = "3.5.18")
       @SuppressWarnings("removal")
       Builder imageLoader(ImageLoader imageLoader);
 

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/ImageLoader.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/ImageLoader.java
@@ -54,7 +54,7 @@ import java.util.Optional;
  * @see Agent.Effect.Builder#imageLoader(ImageLoader)
  * @deprecated use {@link ContentLoader}
  */
-@Deprecated(forRemoval = true)
+@Deprecated(since = "3.5.15", forRemoval = true)
 public interface ImageLoader extends ContentLoader {
 
   /**

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/ModelProvider.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/ModelProvider.java
@@ -375,7 +375,7 @@ public sealed interface ModelProvider {
      * @deprecated Use constructor with baseUrl parameter, or the static factory method and {@code
      *     with} methods.
      */
-    @Deprecated
+    @Deprecated(since = "3.5.11")
     public GoogleAIGemini(
         String apiKey,
         String modelName,


### PR DESCRIPTION
Asked claude to generate a report of all deprecated methods and include the `since` field. This will help us in removing. 

