### PR TITLE
docs: Extend local/dev mode broker docs, add page for arbitrary Kafka in prod

### DIFF
--- a/docs/src/modules/ROOT/pages/llms.txt
+++ b/docs/src/modules/ROOT/pages/llms.txt
@@ -128,6 +128,7 @@ Personas: Builders (Application Developers, AI/ML Engineers, Product Managers), 
 ## Optional
 
 - [Run a service locally](https://doc.akka.io/sdk/running-locally.html.md): Steps to run and test Akka services in a local development environment
+- [Running locally with a message broker](https://doc.akka.io/sdk/running-with-broker.html.md): Running an Akka service locally against a real Kafka broker or the Google Pub/Sub emulator
 - [AI coding assistant](https://doc.akka.io/sdk/ai-coding-assistant.html.md): How to set up AI coding assistant tools with Akka
 - [Access Control List concepts](https://doc.akka.io/concepts/acls.html.md): Core concepts behind Access Control Lists and how they secure Akka services
 - [Developing Access Control Lists (ACLs)](https://doc.akka.io/sdk/access-control.html.md): Implementing ACLs to control access to your Akka service endpoints
@@ -145,6 +146,7 @@ Personas: Builders (Application Developers, AI/ML Engineers, Product Managers), 
 - [Using Aiven for Apache Kafka](https://doc.akka.io/operations/projects/broker-aiven.html.md): Integrating Aiven-hosted Kafka with Akka services
 - [Using Confluent Cloud as Kafka service](https://doc.akka.io/operations/projects/broker-confluent.html.md): Setting up Confluent Cloud Kafka for use with Akka services
 - [Using AWS MSK as Kafka service](https://doc.akka.io/operations/projects/broker-aws-msk.html.md): Configuring AWS Managed Streaming for Kafka with Akka services
+- [Using a self-hosted or arbitrary Kafka cluster](https://doc.akka.io/operations/projects/broker-kafka.html.md): Connecting Akka to any Kafka cluster that meets the supported authentication and TLS requirements
 - [Using Google Cloud Pub/Sub as message broker](https://doc.akka.io/operations/projects/broker-google-pubsub.html.md): Integrating Google Cloud Pub/Sub with Akka services
 - [Projects](https://doc.akka.io/operations/projects/index.html.md): Managing projects in the Akka Platform
 - [Create a new project](https://doc.akka.io/operations/projects/create-project.html.md): Steps to create and configure a new project in the Akka Platform

--- a/docs/src/modules/operations/nav.adoc
+++ b/docs/src/modules/operations/nav.adoc
@@ -19,6 +19,7 @@
 ****** xref:operations:projects/broker-confluent.adoc[Confluent Cloud]
 ****** xref:operations:projects/broker-aws-msk.adoc[AWS MSK Kafka]
 ****** xref:operations:projects/broker-aiven.adoc[Aiven for Kafka]
+****** xref:operations:projects/broker-kafka.adoc[Self-hosted Kafka]
 ****** xref:operations:projects/broker-azure-eventhubs.adoc[Azure Event Hubs]
 ***** xref:operations:projects/secrets.adoc[]
 ***** xref:operations:projects/external-secrets.adoc[]

--- a/docs/src/modules/operations/pages/projects/broker-kafka.adoc
+++ b/docs/src/modules/operations/pages/projects/broker-kafka.adoc
@@ -109,7 +109,7 @@ akka projects config get broker
 
 Create the topics used by your service ahead of time, using the Kafka tooling that ships with your cluster (for example `kafka-topics.sh`, the Strimzi `KafkaTopic` custom resource, or the management UI of your provider). Akka does not create topics automatically.
 
-When partitioning, follow the guidance in <<_delivery_characteristics>> below: use the cloud event `ce-subject` (typically the entity id) as the partition key, so messages for the same subject are processed in order.
+When partitioning, follow the guidance in <<_delivery_characteristics,Delivery characteristics>> below: use the cloud event `ce-subject` (typically the entity id) as the partition key, so messages for the same subject are processed in order.
 
 include::partial$broker-kafka-setup-common.adoc[]
 

--- a/docs/src/modules/operations/pages/projects/broker-kafka.adoc
+++ b/docs/src/modules/operations/pages/projects/broker-kafka.adoc
@@ -1,0 +1,120 @@
+= Using a self-hosted or arbitrary Kafka cluster
+include::ROOT:partial$include.adoc[]
+
+In addition to the managed Kafka services with dedicated guides (xref:operations:projects/broker-confluent.adoc[Confluent Cloud], xref:operations:projects/broker-aws-msk.adoc[Amazon MSK], xref:operations:projects/broker-aiven.adoc[Aiven for Apache Kafka]), Akka can connect to any Kafka cluster that is reachable from the Akka platform and offers a supported authentication mechanism — including self-hosted Kafka, Strimzi/Kafka on Kubernetes, Redpanda, or another managed provider.
+
+This page describes the general configuration steps and lists the connectivity and authentication requirements your cluster must meet.
+
+[#_requirements]
+== Requirements
+
+The Kafka cluster must satisfy the following:
+
+* *Network reachability* — The cluster's bootstrap servers must be reachable from Akka. For clusters running in a private network, this typically means exposing public endpoints with a firewall allow-list, or arranging a peering/VPN solution.
+* *Broker port* — Akka restricts outbound traffic to a fixed allow-list of ports. The standard Kafka port `9092` is open by default, as are the ports used by the managed providers covered by the dedicated guides (for example `9093` for Azure Event Hubs, `9096` and `9196` for AWS MSK, `12976` for Aiven). If your cluster listens on a port that is not on this list, contact mailto:support@akka.io[] to have it added before configuring the broker.
+* *TLS* — All authenticated connections from Akka use TLS. The broker must present a certificate trusted by either a public CA or a CA certificate that you provide as an Akka secret.
+* *SASL authentication* — Akka authenticates using one of the supported SASL mechanisms (see <<_supported_authentication>>). Anonymous/plaintext access is not supported for production brokers.
+
+[#_supported_authentication]
+== Supported authentication
+
+Akka supports the following Kafka authentication mechanisms when configured via `akka projects config set broker`:
+
+[cols="1,3", options="header"]
+|===
+| Mechanism | Notes
+
+| `plain`
+| SASL/PLAIN over TLS. Username and password are sent in plaintext inside the TLS-protected channel.
+
+| `scram-sha-256`
+| SASL/SCRAM with SHA-256. Username and password are negotiated through a challenge–response handshake.
+
+| `scram-sha-512`
+| SASL/SCRAM with SHA-512. Same as above with a stronger hash.
+|===
+
+The following mechanisms are *not* supported:
+
+* mTLS / SSL client-certificate authentication
+* Kerberos (GSSAPI)
+* OAUTHBEARER (token-based SASL)
+* Plaintext connections without TLS (except in xref:sdk:running-with-broker.adoc#_kafka[local development])
+
+If your cluster only supports an unsupported mechanism, enable SASL/SCRAM or SASL/PLAIN for the Akka service user before continuing.
+
+[#_steps]
+== Steps to connect
+
+. Prepare the broker
++
+On your Kafka cluster, create a user dedicated to your Akka service and grant it the ACLs required for the topics your service consumes from and produces to. Make sure the broker listener used by Akka is configured for `SASL_SSL` with the chosen mechanism.
+
+. Ensure you are on the correct Akka project
++
+[source, command window]
+----
+akka config get-project
+----
+
+. (Optional) Create an Akka TLS CA secret
++
+If the broker's TLS certificate is *not* signed by a public CA already trusted by the Akka platform, store the CA certificate as a secret.
++
+[source, command window]
+----
+akka secret create tls-ca kafka-ca-cert --cert ./ca.pem
+----
++
+Skip this step if the broker certificate is signed by a public CA.
+
+. Store the user's password in an Akka secret
++
+[source, command window]
+----
+akka secret create generic kafka-secret --literal pwd=<the password>
+----
+
+. Configure the broker for the project
++
+[source, command window]
+----
+akka projects config set broker \
+  --broker-service kafka \
+  --broker-auth scram-sha-512 \
+  --broker-user <username> \
+  --broker-password-secret kafka-secret/pwd \
+  --broker-bootstrap-servers <host1:port1,host2:port2> \
+  --broker-ca-cert-secret kafka-ca-cert
+----
++
+Use the auth mechanism matching your broker setup: `plain`, `scram-sha-256` or `scram-sha-512`. Omit `--broker-ca-cert-secret` if the broker uses a publicly trusted CA. Multiple bootstrap servers can be provided as a comma-separated list.
++
+The `--broker-password-secret` and `--broker-ca-cert-secret` flags refer to the *names* of the Akka secrets created earlier rather than the actual secret values.
++
+An optional description can be added with the parameter `--description` to provide additional notes about the broker.
+
+. Open the network path
++
+If the broker port is not in the Akka outbound allow-list (see <<_requirements>>), contact mailto:support@akka.io[] to have it added. Clusters that are not reachable on a public, generally-routable endpoint also need a peering or VPN solution arranged with support.
+
+The broker config can be inspected using:
+
+[source, command window]
+----
+akka projects config get broker
+----
+
+== Create topics
+
+Create the topics used by your service ahead of time, using the Kafka tooling that ships with your cluster (for example `kafka-topics.sh`, the Strimzi `KafkaTopic` custom resource, or the management UI of your provider). Akka does not create topics automatically.
+
+When partitioning, follow the guidance in <<_delivery_characteristics>> below: use the cloud event `ce-subject` (typically the entity id) as the partition key, so messages for the same subject are processed in order.
+
+include::partial$broker-kafka-setup-common.adoc[]
+
+== See also
+
+* xref:operations:projects/message-brokers.adoc[Configure message brokers]
+* xref:sdk:running-with-broker.adoc[Running locally with a message broker]
+* xref:reference:cli/akka-cli/akka_projects_config.adoc#_see_also[`akka projects config` commands]

--- a/docs/src/modules/operations/pages/projects/index.adoc
+++ b/docs/src/modules/operations/pages/projects/index.adoc
@@ -22,5 +22,6 @@ Akka services are deployed to _Projects_ within an xref:operations:organizations
 **** xref:operations:projects/broker-aws-msk.adoc[AWS MSK Kafka]
 **** xref:operations:projects/broker-confluent.adoc[Confluent Cloud]
 **** xref:operations:projects/broker-google-pubsub.adoc[Google Pub/Sub]
+**** xref:operations:projects/broker-kafka.adoc[Self-hosted Kafka]
 **** xref:operations:projects/broker-azure-eventhubs.adoc[Azure Event Hubs]
 *** xref:operations:projects/secrets.adoc[]

--- a/docs/src/modules/operations/pages/projects/message-brokers.adoc
+++ b/docs/src/modules/operations/pages/projects/message-brokers.adoc
@@ -13,6 +13,7 @@ Follow the detailed steps to configure the desired message broker service for us
 - xref:operations:projects/broker-confluent.adoc[Confluent Cloud]
 - xref:operations:projects/broker-aws-msk.adoc[Amazon MSK]
 - xref:operations:projects/broker-aiven.adoc[Aiven for Apache Kafka]
+- xref:operations:projects/broker-kafka.adoc[Self-hosted Kafka or another provider]
 - xref:operations:projects/broker-azure-eventhubs.adoc[Azure Event Hubs]
 
 We continuously evaluate additional integrations for potential built-in support in Akka. If you have specific requirements, please contact us at mailto:support@akka.io[].

--- a/docs/src/modules/operations/partials/broker-kafka-setup-common.adoc
+++ b/docs/src/modules/operations/partials/broker-kafka-setup-common.adoc
@@ -6,7 +6,12 @@ Kafka partitions are consumed independently. When passing messages to a certain 
 
 WARNING: Correct partitioning is especially important for topics that stream directly into views and transform the updates: when messages for the same subject id are spread over different transactions, they may read stale data and lose updates.
 
-To achieve at-least-once delivery, messages that are not acknowledged will be redelivered. This means redeliveries of 'older' messages may arrive behind fresh deliveries of 'newer' messages. The _first_ delivery of each message is always in-order, though.
+At-least-once delivery means a message may be delivered more than once. Within a single partition, redeliveries preserve the original order — there is no scenario where a newer message lands at the consumer before an older message's redelivery completes. Two cases lead to redelivery:
+
+* A message whose handler failed is replayed from the last committed offset, followed by the messages after it.
+* A message that was processed successfully but whose offset commit did not make it before a restart or partition rebalance is replayed on the next read. Offset commits are batched, so this gap is normal rather than exceptional.
+
+Consumer handlers must therefore be idempotent or deduplicate explicitly. See xref:sdk:dev-best-practices.adoc#message-deduplication[Message deduplication] for guidance.
 
 When publishing messages to Kafka from Akka, the `ce-subject` attribute, if present, is used as the Kafka partition key for the message.
 

--- a/docs/src/modules/sdk/nav.adoc
+++ b/docs/src/modules/sdk/nav.adoc
@@ -50,6 +50,7 @@
 *** xref:sdk:access-control.adoc[]
 *** xref:sdk:auth-with-jwts.adoc[]
 *** xref:sdk:running-locally.adoc[]
+*** xref:sdk:running-with-broker.adoc[]
 *** xref:sdk:model-provider-details.adoc[]
 *** xref:sdk:sanitization.adoc[Data sanitization]
 ** xref:sdk:dev-best-practices.adoc[]

--- a/docs/src/modules/sdk/pages/integrations/messaging-and-events.adoc
+++ b/docs/src/modules/sdk/pages/integrations/messaging-and-events.adoc
@@ -35,15 +35,15 @@ For more advanced streaming needs, you can use Akka Streams directly. See the ht
 
 When you need to integrate with systems outside Akka, use external message brokers. Akka offers built-in integrations for:
 
-* **Kafka** — via hosted services (Confluent Cloud, AWS MSK, Aiven)
-* **Google Cloud Pub/Sub**
-* **Azure Event Hubs**
+* **Kafka** — xref:operations:projects/broker-confluent.adoc[Confluent Cloud], xref:operations:projects/broker-aws-msk.adoc[AWS MSK], xref:operations:projects/broker-aiven.adoc[Aiven for Apache Kafka], or xref:operations:projects/broker-kafka.adoc[a self-hosted or other Kafka cluster]
+* xref:operations:projects/broker-google-pubsub.adoc[Google Cloud Pub/Sub]
+* xref:operations:projects/broker-azure-eventhubs.adoc[Azure Event Hubs]
 
 For these built-in technologies, Akka decouples the broker configuration from the implementation of the Consumer or Producer. The topic name is referenced independently of the broker technology, as demonstrated in xref:consuming-producing.adoc#consume_topic[Consume from a message broker Topic] and xref:consuming-producing.adoc#topic_producing[Producing to a message broker Topic]. All connection details are managed at the Akka project level. For configuration instructions, refer to xref:operations:projects/message-brokers.adoc[Configure message brokers].
 
 === Testing with message brokers
 
-The Akka SDK testkit has built-in support for simulating message brokers. See xref:sdk:consuming-producing.adoc#testing[Testing the integration] for details. For running locally with a broker, refer to xref:sdk:running-locally.adoc#_local_broker_support[running a service with broker support].
+The Akka SDK testkit has built-in support for simulating message brokers. See xref:sdk:consuming-producing.adoc#testing[Testing the integration] for details. For running locally against a real broker (Kafka or the Google Pub/Sub emulator), see xref:sdk:running-with-broker.adoc[Running locally with a message broker].
 
 === Other broker technologies
 

--- a/docs/src/modules/sdk/pages/running-locally.adoc
+++ b/docs/src/modules/sdk/pages/running-locally.adoc
@@ -114,6 +114,8 @@ For Google PubSub Emulator, use `akka.javasdk.dev-mode.eventing.support=google-p
 
 NOTE: For Kafka, the local Kafka broker is expected to be available on `localhost:9092`. For Google PubSub, the emulator is expected to be available on `localhost:8085`.
 
+For a deeper walkthrough — `docker-compose.yml` snippets, alternate hosts, authentication for Kafka, and Pub/Sub emulator setup — see xref:sdk:running-with-broker.adoc[Running locally with a message broker].
+
 [#multiple_services]
 == Running multiple services locally
 

--- a/docs/src/modules/sdk/pages/running-with-broker.adoc
+++ b/docs/src/modules/sdk/pages/running-with-broker.adoc
@@ -140,11 +140,11 @@ Defaults match the docker-compose snippet above: host `localhost`, port `8085`, 
 
 Topic and subscription creation is controlled by `akka.javasdk.eventing.google-pubsub.mode`:
 
-* `automatic-subscription` (default) — the runtime creates the subscription if it does not exist; topics must already exist.
-* `automatic` — the runtime creates both the topic and the subscription if they do not exist.
-* `manual` — both must be created out-of-band, using `gcloud pubsub` or the emulator's REST API.
+* `automatic-subscription` (default) — the runtime creates subscriptions if they do not exist; against the emulator, topics typically get created as well, so no out-of-band setup is needed for local runs.
+* `automatic` — the runtime creates both topics and subscriptions explicitly.
+* `manual` — neither is created by the runtime; create them with `gcloud pubsub` or the emulator's REST API.
 
-`automatic` is convenient for the emulator. For consistency with production, where topics are typically managed by another team, `automatic-subscription` is a reasonable default and matches what a real Pub/Sub deployment looks like.
+The default mode is enough for most local runs against the emulator. In production against real Pub/Sub, topics must exist before the service starts under `automatic-subscription`.
 
 [#_event_hubs]
 == Azure Event Hubs

--- a/docs/src/modules/sdk/pages/running-with-broker.adoc
+++ b/docs/src/modules/sdk/pages/running-with-broker.adoc
@@ -1,0 +1,165 @@
+= Running locally with a message broker
+include::ROOT:partial$include.adoc[]
+
+When a service uses xref:sdk:consuming-producing.adoc#consume_topic[topic consumers] or xref:sdk:consuming-producing.adoc#topic_producing[topic producers], one option during local development is to run the service against a real message broker. This page describes how to set that up for the broker technologies that Akka supports.
+
+For most day-to-day development and automated tests, the testkit's xref:sdk:consuming-producing.adoc#testing[mocked topic] is simpler — no broker process needed. Running against a real broker (or its emulator) is useful when you want end-to-end behavior with another system, want to inspect messages with the broker's own tooling, or are validating the broker integration itself.
+
+[#_kafka]
+== Kafka
+
+Akka can connect to any Kafka-compatible broker, including a single-node broker running locally in Docker.
+
+=== Starting a local Kafka broker
+
+The following `docker-compose.yml` starts Kafka on `localhost:9092` without authentication:
+
+[source, yaml]
+----
+services:
+  kafka:
+    image: confluentinc/cp-kafka:7.2.6
+    depends_on:
+      - zookeeper
+    ports:
+      - 9092:9092
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:29092,HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  zookeeper:
+    image: zookeeper:3.9
+    ports:
+      - "2181:2181"
+----
+
+Start it with:
+
+[source, command line]
+----
+docker compose up -d kafka
+----
+
+=== Configuring the service for Kafka
+
+Broker support in dev mode is disabled by default. Enable Kafka by setting `akka.javasdk.dev-mode.eventing.support=kafka`, either as a system property when starting the service or in `src/main/resources/application.conf`.
+
+The runtime will look for a broker on `localhost:9092` and connect without authentication, which matches the broker started above.
+
+[source, command line]
+----
+mvn compile exec:java -Dakka.javasdk.dev-mode.eventing.support=kafka
+----
+
+Or, equivalently, in `src/main/resources/application.conf`:
+
+[source, hocon]
+----
+akka.javasdk.dev-mode.eventing.support = "kafka"
+----
+
+=== Connecting to a different Kafka broker
+
+To point the service at a Kafka broker running somewhere other than `localhost:9092`, override the bootstrap servers. A comma-separated list of `host:port` entries is supported.
+
+[source, hocon]
+----
+akka.javasdk.dev-mode.eventing.support = "kafka"
+akka.javasdk.dev-mode.eventing.kafka.bootstrap-servers = "kafka1.example.com:9092,kafka2.example.com:9092"
+----
+
+The same values can also be set as system properties when starting the service.
+
+=== Kafka authentication
+
+For a local broker, leaving the defaults (`auth-mechanism = "NONE"`, no username/password, no CA certificate) is the right choice — the connection is plaintext and unauthenticated.
+
+When connecting to a Kafka broker that requires authentication, the same SASL mechanisms supported in production are available in dev mode: `PLAIN`, `SCRAM-SHA-256` and `SCRAM-SHA-512`. Any mechanism other than `NONE` requires TLS, and the broker certificate must be trusted by the JVM. If the broker uses a private CA, point `broker-ca-pem-file` at a PEM-encoded CA certificate readable from the local filesystem.
+
+[source, hocon]
+----
+akka.javasdk.dev-mode.eventing.support = "kafka"
+akka.javasdk.dev-mode.eventing.kafka {
+  bootstrap-servers = "kafka.example.com:9092"
+  auth-mechanism = "SCRAM-SHA-512"
+  auth-username = "my-user"
+  auth-password = "my-password"
+  # Optional, only needed when the broker's CA is not in the default JVM trust store
+  broker-ca-pem-file = "/path/to/ca.pem"
+}
+----
+
+NOTE: Storing passwords in `application.conf` is fine for local experimentation, but avoid committing secrets to source control. For local development against a shared broker, prefer reading the password from an environment variable, for example `auth-password = ${?KAFKA_PASSWORD}`.
+
+Other Kafka authentication mechanisms (mTLS, Kerberos/GSSAPI, OAUTHBEARER) are not supported.
+
+=== Topic creation
+
+Akka does not create Kafka topics. If a topic referenced by a consumer or producer does not exist when the service starts, the runtime logs an error but does not block startup. The topic may still be created on first use if the broker has `auto.create.topics.enable` turned on (the default in many local Kafka distributions), though that leaves the partition count and replication factor up to the broker. For predictable behavior — including a partition count that matches how you key messages — create the topics ahead of time, using the Kafka CLI tools bundled with the broker image.
+
+[#_pubsub]
+== Google Cloud Pub/Sub emulator
+
+For Google Cloud Pub/Sub, Google ships an emulator as part of the Cloud SDK. Akka has a dedicated dev-mode option that targets the emulator and bypasses credential checks.
+
+=== Starting the Pub/Sub emulator
+
+The following `docker-compose.yml` starts the emulator on `localhost:8085`:
+
+[source, yaml]
+----
+services:
+  gcloud-pubsub-emulator:
+    image: gcr.io/google.com/cloudsdktool/cloud-sdk:432.0.0-emulators
+    command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085
+    ports:
+      - 8085:8085
+----
+
+Start it with:
+
+[source, command line]
+----
+docker compose up -d gcloud-pubsub-emulator
+----
+
+=== Configuring the service for Pub/Sub
+
+Enable the emulator with `akka.javasdk.dev-mode.eventing.support=google-pubsub-emulator`, either as a system property or in `application.conf`.
+
+[source, command line]
+----
+mvn compile exec:java -Dakka.javasdk.dev-mode.eventing.support=google-pubsub-emulator
+----
+
+Defaults match the docker-compose snippet above: host `localhost`, port `8085`, project id `test`, no TLS, no credentials. The `PUBSUB_EMULATOR_HOST` and `PUBSUB_EMULATOR_PORT` environment variables — the same ones the Google client libraries honor — can be set to point at an emulator running elsewhere.
+
+Topic and subscription creation is controlled by `akka.javasdk.eventing.google-pubsub.mode`:
+
+* `automatic-subscription` (default) — the runtime creates the subscription if it does not exist; topics must already exist.
+* `automatic` — the runtime creates both the topic and the subscription if they do not exist.
+* `manual` — both must be created out-of-band, using `gcloud pubsub` or the emulator's REST API.
+
+`automatic` is convenient for the emulator. For consistency with production, where topics are typically managed by another team, `automatic-subscription` is a reasonable default and matches what a real Pub/Sub deployment looks like.
+
+[#_event_hubs]
+== Azure Event Hubs
+
+Azure Event Hubs does not have a built-in dev-mode emulator path. For local development and testing, prefer the testkit's xref:sdk:consuming-producing.adoc#testing[mocked topic], which works identically regardless of which broker the deployed service uses.
+
+If you need to validate the Event Hubs integration itself, you can connect a local service to a real Event Hubs namespace by setting `akka.javasdk.dev-mode.eventing.support=eventhubs` and providing the `AZURE_EVENT_HUBS_CONNECTION_STRING` environment variable (plus the Azure Blob Storage settings used for partition checkpointing). See xref:operations:projects/broker-azure-eventhubs.adoc[Using Azure Event Hubs] for the configuration keys involved.
+
+[#_using_the_local_console]
+== Local console
+
+The xref:sdk:running-locally.adoc#local_console[local console] continues to work as usual. Messages received from or produced to the broker show up in the service logs and traces.
+
+== See also
+
+* xref:sdk:running-locally.adoc[Run a service locally]
+* xref:sdk:consuming-producing.adoc[Consuming and producing]
+* xref:operations:projects/message-brokers.adoc[Configure message brokers]

--- a/docs/src/modules/sdk/pages/setup-and-configuration/index.adoc
+++ b/docs/src/modules/sdk/pages/setup-and-configuration/index.adoc
@@ -9,5 +9,6 @@ Akka provides several built-in features for dependency injection, data serializa
 * xref:sdk:access-control.adoc[Access Control]
 * xref:sdk:auth-with-jwts.adoc[Authentication with JWTs]
 * xref:sdk:running-locally.adoc[Running Locally]
+* xref:sdk:running-with-broker.adoc[Running locally with a message broker]
 * xref:sdk:model-provider-details.adoc[Configuring AI Agent Model Providers]
 * xref:sdk:sanitization.adoc[Sanitization of sensitive data]

--- a/docs/styles/config/vocabularies/Akka/accept.txt
+++ b/docs/styles/config/vocabularies/Akka/accept.txt
@@ -113,6 +113,7 @@ JVM's
 (?i)JWTs
 [Kk]afka
 [Kk]alix
+Kerberos
 Keycloak
 keyId
 keySets
@@ -183,12 +184,14 @@ Qodo
 Quatrini
 queryable
 [Qq]uickstarts
+reachability
 rebalance
 rebalances
 rebalancing
 recoverability
 recurse
 redeliveries
+Redpanda
 refreshInterval
 remoting
 Remoting
@@ -228,6 +231,7 @@ SREs
 stdin
 [Ss]tackdriver
 [Ss]treamable
+Strimzi
 subcommand
 subjectMatches
 subpage


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/akka/akka-sdk/issues/462

Good for review but keeping as draft until I have double checked all described paths actually works