### PR TITLE
docs: documenting otel metrics and traces

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -32,9 +32,7 @@ Vale.Terms = warning
 Microsoft.Quotes = NO
 
 # Ignore auto-generated metrics reference (has many metric label names that fail spelling)
-[**/reference/pages/telemetry/metrics.adoc]
-[**/reference/pages/telemetry/deprecated-metrics.adoc]
-[**/reference/pages/telemetry/tracing.adoc]
+[**/reference/pages/telemetry/{metrics,deprecated-metrics,tracing}.adoc]
 BasedOnStyles =
 
 # Ignore auto-generated cli reference

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -33,6 +33,8 @@ Microsoft.Quotes = NO
 
 # Ignore auto-generated metrics reference (has many metric label names that fail spelling)
 [**/reference/pages/telemetry/metrics.adoc]
+[**/reference/pages/telemetry/deprecated-metrics.adoc]
+[**/reference/pages/telemetry/tracing.adoc]
 BasedOnStyles =
 
 # Ignore auto-generated cli reference

--- a/docs/src/modules/reference/nav.adoc
+++ b/docs/src/modules/reference/nav.adoc
@@ -388,3 +388,5 @@
 *** xref:cli/akka-cli/akka.adoc[]
 ** xref:telemetry/index.adoc[]
 *** xref:telemetry/metrics.adoc[]
+*** xref:telemetry/deprecated-metrics.adoc[]
+*** xref:telemetry/tracing.adoc[]

--- a/docs/src/modules/reference/pages/telemetry/deprecated-metrics.adoc
+++ b/docs/src/modules/reference/pages/telemetry/deprecated-metrics.adoc
@@ -1,0 +1,2465 @@
+= (Deprecated) Prometheus metrics reference
+
+[WARNING]
+====
+These Prometheus-style metrics are deprecated and will be removed in a future release. They are retained here for reference only. New deployments should use the OpenTelemetry-based metrics documented in the xref:telemetry/metrics.adoc[metrics reference].
+====
+
+Akka collects metrics for monitoring the runtime behavior of your services.
+
+These metrics are available for xref:operations:observability-and-monitoring/observability-exports.adoc[export] to external monitoring systems.
+
+== HTTP Endpoints
+
+=== `kalix_proxy_http_request_duration_seconds`
+
+Total duration of HTTP requests to a service endpoint, in seconds.
+
+Metric:: `kalix_proxy_http_request_duration_seconds`
+Type:: histogram
+Labels::
++
+--
+* `endpoint_class`
+* `endpoint_method`
+* `http_method`
+* `http_target`
+* `http_status_code`
+* `grpc_service`
+* `grpc_method`
+* `grpc_streaming`
+--
+Exported metrics::
++
+--
+* `kalix_proxy_http_request_duration_seconds_bucket` (with `le` label)
+* `kalix_proxy_http_request_duration_seconds_count`
+* `kalix_proxy_http_request_duration_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_proxy_http_requests_total`
+
+Total HTTP requests to a service endpoint.
+
+Metric:: `kalix_proxy_http_requests_total`
+Type:: counter
+Labels::
++
+--
+* `endpoint_class`
+* `endpoint_method`
+* `http_method`
+* `http_target`
+* `http_status_code`
+* `grpc_service`
+* `grpc_method`
+* `grpc_streaming`
+--
+
+== gRPC Endpoints
+
+=== `kalix_proxy_grpc_request_duration_seconds`
+
+Total duration of gRPC requests to a service endpoint, in seconds.
+
+Metric:: `kalix_proxy_grpc_request_duration_seconds`
+Type:: histogram
+Labels::
++
+--
+* `endpoint_class`
+* `grpc_service`
+* `grpc_method`
+* `grpc_streaming`
+* `grpc_status_code`
+--
+Exported metrics::
++
+--
+* `kalix_proxy_grpc_request_duration_seconds_bucket` (with `le` label)
+* `kalix_proxy_grpc_request_duration_seconds_count`
+* `kalix_proxy_grpc_request_duration_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_proxy_grpc_requests_total`
+
+Total gRPC requests to a service endpoint.
+
+Metric:: `kalix_proxy_grpc_requests_total`
+Type:: counter
+Labels::
++
+--
+* `endpoint_class`
+* `grpc_service`
+* `grpc_method`
+* `grpc_streaming`
+* `grpc_status_code`
+--
+
+== MCP Endpoints
+
+=== `kalix_proxy_mcp_request_duration_seconds`
+
+Request duration to an MCP endpoint, in seconds.
+
+Metric:: `kalix_proxy_mcp_request_duration_seconds`
+Type:: histogram
+Labels::
++
+--
+* `endpoint_path`
+* `rpc_method`
+* `rpc_error_code`
+--
+Exported metrics::
++
+--
+* `kalix_proxy_mcp_request_duration_seconds_bucket` (with `le` label)
+* `kalix_proxy_mcp_request_duration_seconds_count`
+* `kalix_proxy_mcp_request_duration_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_proxy_mcp_requests_total`
+
+Total requests to an MCP endpoint.
+
+Metric:: `kalix_proxy_mcp_requests_total`
+Type:: counter
+Labels::
++
+--
+* `endpoint_path`
+* `rpc_method`
+* `rpc_error_code`
+--
+
+== Agents
+
+=== `kalix_agent_command_processing_time_seconds`
+
+Total duration of a completed command to the Akka Agent, in seconds
+
+Metric:: `kalix_agent_command_processing_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `agent_id`
+--
+Exported metrics::
++
+--
+* `kalix_agent_command_processing_time_seconds_bucket` (with `le` label)
+* `kalix_agent_command_processing_time_seconds_count`
+* `kalix_agent_command_processing_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `15.0`, `Infinity`
+
+=== `kalix_agent_completed_commands_total`
+
+Total completed commands by the Akka Agent.
+
+Metric:: `kalix_agent_completed_commands_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+--
+
+=== `kalix_agent_evaluations_completed_total`
+
+Total completed agent evaluations.
+
+Metric:: `kalix_agent_evaluations_completed_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+--
+
+=== `kalix_agent_evaluations_failed_total`
+
+Total failed agent evaluations.
+
+Metric:: `kalix_agent_evaluations_failed_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+--
+
+=== `kalix_agent_failed_commands_total`
+
+Total failed commands by the Akka Agent.
+
+Metric:: `kalix_agent_failed_commands_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+--
+
+=== `kalix_agent_guardrail_completed_evaluations_total`
+
+Total completed guardrail evaluations for an agent.
+
+Metric:: `kalix_agent_guardrail_completed_evaluations_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+* `guardrail_category`
+* `guardrail_name`
+--
+
+=== `kalix_agent_guardrail_evaluation_processing_time_seconds`
+
+Total duration of a completed and failed guardrail evaluation, in seconds
+
+Metric:: `kalix_agent_guardrail_evaluation_processing_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `agent_id`
+* `guardrail_category`
+* `guardrail_name`
+--
+Exported metrics::
++
+--
+* `kalix_agent_guardrail_evaluation_processing_time_seconds_bucket` (with `le` label)
+* `kalix_agent_guardrail_evaluation_processing_time_seconds_count`
+* `kalix_agent_guardrail_evaluation_processing_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `15.0`, `Infinity`
+
+=== `kalix_agent_guardrail_evaluations_total`
+
+Total guardrail evaluations for an agent.
+
+Metric:: `kalix_agent_guardrail_evaluations_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+* `guardrail_category`
+* `guardrail_name`
+--
+
+=== `kalix_agent_guardrail_failed_evaluations_total`
+
+Total failed guardrail evaluations for an agent.
+
+Metric:: `kalix_agent_guardrail_failed_evaluations_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+* `guardrail_category`
+* `guardrail_name`
+--
+
+=== `kalix_agent_model_completed_requests_total`
+
+Total completed requests by the Model.
+
+Metric:: `kalix_agent_model_completed_requests_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+* `model_name`
+--
+
+=== `kalix_agent_model_failed_requests_total`
+
+Total failed requests by the Model.
+
+Metric:: `kalix_agent_model_failed_requests_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+* `model_name`
+--
+
+=== `kalix_agent_model_received_requests_total`
+
+Total received requests by the Model.
+
+Metric:: `kalix_agent_model_received_requests_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+* `model_name`
+--
+
+=== `kalix_agent_model_request_processing_time_seconds`
+
+Total duration of a completed command to the Model, in seconds
+
+Metric:: `kalix_agent_model_request_processing_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `agent_id`
+* `model_name`
+--
+Exported metrics::
++
+--
+* `kalix_agent_model_request_processing_time_seconds_bucket` (with `le` label)
+* `kalix_agent_model_request_processing_time_seconds_count`
+* `kalix_agent_model_request_processing_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `15.0`, `Infinity`
+
+=== `kalix_agent_model_token_input_total`
+
+Tokens used in the input by the model in the response.
+
+Metric:: `kalix_agent_model_token_input_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+* `model_name`
+--
+
+=== `kalix_agent_model_token_output_total`
+
+Tokens used in the output by the model in the response.
+
+Metric:: `kalix_agent_model_token_output_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+* `model_name`
+--
+
+=== `kalix_agent_received_commands_total`
+
+Total received commands by the Akka Agent.
+
+Metric:: `kalix_agent_received_commands_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+--
+
+=== `kalix_agent_tool_completed_requests_total`
+
+Total completed requests by a Tool.
+
+Metric:: `kalix_agent_tool_completed_requests_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+* `model_name`
+* `tool_name`
+--
+
+=== `kalix_agent_tool_failed_requests_total`
+
+Total failed requests by a Tool.
+
+Metric:: `kalix_agent_tool_failed_requests_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+* `model_name`
+* `tool_name`
+--
+
+=== `kalix_agent_tool_received_requests_total`
+
+Total received commands by a Tool.
+
+Metric:: `kalix_agent_tool_received_requests_total`
+Type:: counter
+Labels::
++
+--
+* `agent_id`
+* `model_name`
+* `tool_name`
+--
+
+=== `kalix_agent_tool_request_processing_time_seconds`
+
+Total duration of a completed command to a Tool, in seconds
+
+Metric:: `kalix_agent_tool_request_processing_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `agent_id`
+* `model_name`
+* `tool_name`
+--
+Exported metrics::
++
+--
+* `kalix_agent_tool_request_processing_time_seconds_bucket` (with `le` label)
+* `kalix_agent_tool_request_processing_time_seconds_count`
+* `kalix_agent_tool_request_processing_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+== Event Sourced Entities
+
+=== `kalix_eventsourced_activated_entities_total`
+
+Total entity instances that have activated.
+
+Metric:: `kalix_eventsourced_activated_entities_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_command_processing_time_seconds`
+
+Duration for command processing (until user service reply), in seconds.
+
+Metric:: `kalix_eventsourced_command_processing_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_eventsourced_command_processing_time_seconds_bucket` (with `le` label)
+* `kalix_eventsourced_command_processing_time_seconds_count`
+* `kalix_eventsourced_command_processing_time_seconds_sum`
+--
+Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_eventsourced_command_total_time_seconds`
+
+Total duration for command handling (including stash and persist), in seconds.
+
+Metric:: `kalix_eventsourced_command_total_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_eventsourced_command_total_time_seconds_bucket` (with `le` label)
+* `kalix_eventsourced_command_total_time_seconds_count`
+* `kalix_eventsourced_command_total_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_eventsourced_completed_commands_total`
+
+Total commands completed for an entity.
+
+Metric:: `kalix_eventsourced_completed_commands_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_conflicts_detected_total`
+
+Total conflicts detected for an entity.
+
+Metric:: `kalix_eventsourced_conflicts_detected_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_conflicts_resolved_total`
+
+Total conflicts resolved for an entity.
+
+Metric:: `kalix_eventsourced_conflicts_resolved_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_deleted_entities_total`
+
+Total entity instances that have been deleted.
+
+Metric:: `kalix_eventsourced_deleted_entities_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_deleted_events_failed_total`
+
+Total deleted events operations that have failed.
+
+Metric:: `kalix_eventsourced_deleted_events_failed_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_deleted_events_time_seconds`
+
+Duration for deleting events, in seconds.
+
+Metric:: `kalix_eventsourced_deleted_events_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_eventsourced_deleted_events_time_seconds_bucket` (with `le` label)
+* `kalix_eventsourced_deleted_events_time_seconds_count`
+* `kalix_eventsourced_deleted_events_time_seconds_sum`
+--
+Buckets:: `0.01`, `0.05`, `0.1`, `0.25`, `0.5`, `1.0`, `2.0`, `3.0`, `4.0`, `5.0`, `10.0`, `20.0`, `30.0`, `Infinity`
+
+=== `kalix_eventsourced_deleted_events_total`
+
+Total deleted events
+
+Metric:: `kalix_eventsourced_deleted_events_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_entity_active_time_seconds`
+
+Duration that entities are active, in seconds.
+
+Metric:: `kalix_eventsourced_entity_active_time_seconds`
+Type:: summary
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_eventsourced_entity_active_time_seconds` (with `quantile` label)
+* `kalix_eventsourced_entity_active_time_seconds_count`
+* `kalix_eventsourced_entity_active_time_seconds_sum`
+--
+Quantiles:: `0.5`, `0.95`, `0.99`, `1.0`
+
+=== `kalix_eventsourced_failed_commands_total`
+
+Total commands that have failed.
+
+Metric:: `kalix_eventsourced_failed_commands_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_failed_deleted_entities_total`
+
+Total failures when attempting to delete entities.
+
+Metric:: `kalix_eventsourced_failed_deleted_entities_total`
+Type:: counter
+
+=== `kalix_eventsourced_failed_entities_total`
+
+Total entity instances that have failed.
+
+Metric:: `kalix_eventsourced_failed_entities_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_loaded_event_bytes_total`
+
+Total event sizes loaded for an entity.
+
+Metric:: `kalix_eventsourced_loaded_event_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_loaded_events_total`
+
+Total events loaded for an entity.
+
+Metric:: `kalix_eventsourced_loaded_events_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_loaded_snapshot_bytes_total`
+
+Total snapshot sizes loaded for an entity.
+
+Metric:: `kalix_eventsourced_loaded_snapshot_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_loaded_snapshots_total`
+
+Total snapshots loaded for an entity.
+
+Metric:: `kalix_eventsourced_loaded_snapshots_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_passivated_entities_total`
+
+Total entity instances that have passivated.
+
+Metric:: `kalix_eventsourced_passivated_entities_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_persist_failed_total`
+
+Total persist operations that have failed.
+
+Metric:: `kalix_eventsourced_persist_failed_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_persist_time_seconds`
+
+Duration for persisting events from a command, in seconds.
+
+Metric:: `kalix_eventsourced_persist_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_eventsourced_persist_time_seconds_bucket` (with `le` label)
+* `kalix_eventsourced_persist_time_seconds_count`
+* `kalix_eventsourced_persist_time_seconds_sum`
+--
+Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `10.0`, `Infinity`
+
+=== `kalix_eventsourced_persisted_event_bytes_total`
+
+Total event sizes persisted for an entity.
+
+Metric:: `kalix_eventsourced_persisted_event_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_persisted_events_total`
+
+Total events persisted for an entity.
+
+Metric:: `kalix_eventsourced_persisted_events_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_persisted_replicated_event_bytes_total`
+
+Total replicated event sizes persisted for an entity.
+
+Metric:: `kalix_eventsourced_persisted_replicated_event_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_persisted_replicated_events_total`
+
+Total replicated events persisted for an entity.
+
+Metric:: `kalix_eventsourced_persisted_replicated_events_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_persisted_snapshot_bytes_total`
+
+Total snapshot sizes persisted for an entity.
+
+Metric:: `kalix_eventsourced_persisted_snapshot_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_persisted_snapshots_total`
+
+Total snapshots persisted for an entity.
+
+Metric:: `kalix_eventsourced_persisted_snapshots_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_received_commands_total`
+
+Total commands received for an entity.
+
+Metric:: `kalix_eventsourced_received_commands_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_recovery_failed_total`
+
+Total entity recoveries that have failed.
+
+Metric:: `kalix_eventsourced_recovery_failed_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_recovery_from_events_total`
+
+If events were loaded to recover an entity.
+
+Metric:: `kalix_eventsourced_recovery_from_events_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_recovery_time_seconds`
+
+Duration for entity recovery, in seconds.
+
+Metric:: `kalix_eventsourced_recovery_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_eventsourced_recovery_time_seconds_bucket` (with `le` label)
+* `kalix_eventsourced_recovery_time_seconds_count`
+* `kalix_eventsourced_recovery_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `10.0`, `Infinity`
+
+=== `kalix_eventsourced_registered_for_deletion_total`
+
+Total entity instances registered to be deleted
+
+Metric:: `kalix_eventsourced_registered_for_deletion_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_switch_primary_failed_total`
+
+Total primary switches that have failed.
+
+Metric:: `kalix_eventsourced_switch_primary_failed_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_eventsourced_switch_primary_time_seconds`
+
+Duration for switching primary, in seconds.
+
+Metric:: `kalix_eventsourced_switch_primary_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_eventsourced_switch_primary_time_seconds_bucket` (with `le` label)
+* `kalix_eventsourced_switch_primary_time_seconds_count`
+* `kalix_eventsourced_switch_primary_time_seconds_sum`
+--
+Buckets:: `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.05`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `5.0`, `10.0`, `20.0`, `Infinity`
+
+=== `kalix_eventsourced_switch_primary_total`
+
+Total primary switches completed for an entity.
+
+Metric:: `kalix_eventsourced_switch_primary_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+== Key Value Entities
+
+=== `kalix_valueentity_activated_entities_total`
+
+Total entity instances that have activated.
+
+Metric:: `kalix_valueentity_activated_entities_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_command_processing_time_seconds`
+
+Duration for command processing (until user service reply), in seconds.
+
+Metric:: `kalix_valueentity_command_processing_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_valueentity_command_processing_time_seconds_bucket` (with `le` label)
+* `kalix_valueentity_command_processing_time_seconds_count`
+* `kalix_valueentity_command_processing_time_seconds_sum`
+--
+Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_valueentity_command_stash_time_seconds`
+
+Duration that commands are stashed, in seconds.
+
+Metric:: `kalix_valueentity_command_stash_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_valueentity_command_stash_time_seconds_bucket` (with `le` label)
+* `kalix_valueentity_command_stash_time_seconds_count`
+* `kalix_valueentity_command_stash_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_valueentity_command_total_time_seconds`
+
+Total duration for command handling (including stash and persist), in seconds.
+
+Metric:: `kalix_valueentity_command_total_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_valueentity_command_total_time_seconds_bucket` (with `le` label)
+* `kalix_valueentity_command_total_time_seconds_count`
+* `kalix_valueentity_command_total_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_valueentity_completed_commands_total`
+
+Total commands completed for an entity.
+
+Metric:: `kalix_valueentity_completed_commands_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_conflicts_detected_total`
+
+Total conflicts detected for an entity.
+
+Metric:: `kalix_valueentity_conflicts_detected_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_conflicts_resolved_total`
+
+Total conflicts resolved for an entity.
+
+Metric:: `kalix_valueentity_conflicts_resolved_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_deleted_events_failed_total`
+
+Total deleted events operations that have failed.
+
+Metric:: `kalix_valueentity_deleted_events_failed_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_deleted_events_time_seconds`
+
+Duration for deleting events, in seconds.
+
+Metric:: `kalix_valueentity_deleted_events_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_valueentity_deleted_events_time_seconds_bucket` (with `le` label)
+* `kalix_valueentity_deleted_events_time_seconds_count`
+* `kalix_valueentity_deleted_events_time_seconds_sum`
+--
+Buckets:: `0.01`, `0.05`, `0.1`, `0.25`, `0.5`, `1.0`, `2.0`, `3.0`, `4.0`, `5.0`, `10.0`, `20.0`, `30.0`, `Infinity`
+
+=== `kalix_valueentity_deleted_events_total`
+
+Total deleted events
+
+Metric:: `kalix_valueentity_deleted_events_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_entity_active_time_seconds`
+
+Duration that entities are active, in seconds.
+
+Metric:: `kalix_valueentity_entity_active_time_seconds`
+Type:: summary
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_valueentity_entity_active_time_seconds` (with `quantile` label)
+* `kalix_valueentity_entity_active_time_seconds_count`
+* `kalix_valueentity_entity_active_time_seconds_sum`
+--
+Quantiles:: `0.5`, `0.95`, `0.99`, `1.0`
+
+=== `kalix_valueentity_failed_commands_total`
+
+Total commands that have failed.
+
+Metric:: `kalix_valueentity_failed_commands_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_failed_entities_total`
+
+Total entity instances that have failed.
+
+Metric:: `kalix_valueentity_failed_entities_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_loaded_state_bytes_total`
+
+Total state sizes loaded for an entity.
+
+Metric:: `kalix_valueentity_loaded_state_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_loaded_state_total`
+
+Total states loaded for an entity.
+
+Metric:: `kalix_valueentity_loaded_state_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_passivated_entities_total`
+
+Total entity instances that have passivated.
+
+Metric:: `kalix_valueentity_passivated_entities_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_persist_failed_total`
+
+Total persist operations that have failed.
+
+Metric:: `kalix_valueentity_persist_failed_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_persist_time_seconds`
+
+Duration for persisting events from a command, in seconds.
+
+Metric:: `kalix_valueentity_persist_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_valueentity_persist_time_seconds_bucket` (with `le` label)
+* `kalix_valueentity_persist_time_seconds_count`
+* `kalix_valueentity_persist_time_seconds_sum`
+--
+Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `10.0`, `Infinity`
+
+=== `kalix_valueentity_persisted_replicated_state_bytes_total`
+
+Total replicated state sizes persisted for an entity.
+
+Metric:: `kalix_valueentity_persisted_replicated_state_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_persisted_replicated_states_total`
+
+Total replicated states persisted for an entity.
+
+Metric:: `kalix_valueentity_persisted_replicated_states_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_persisted_state_bytes_total`
+
+Total state sizes persisted for an entity.
+
+Metric:: `kalix_valueentity_persisted_state_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_persisted_states_total`
+
+Total states persisted for an entity.
+
+Metric:: `kalix_valueentity_persisted_states_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_received_commands_total`
+
+Total commands received for an entity.
+
+Metric:: `kalix_valueentity_received_commands_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_recovery_failed_total`
+
+Total entity recoveries that have failed.
+
+Metric:: `kalix_valueentity_recovery_failed_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_recovery_time_seconds`
+
+Duration for entity recovery, in seconds.
+
+Metric:: `kalix_valueentity_recovery_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_valueentity_recovery_time_seconds_bucket` (with `le` label)
+* `kalix_valueentity_recovery_time_seconds_count`
+* `kalix_valueentity_recovery_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `10.0`, `Infinity`
+
+=== `kalix_valueentity_registered_for_deletion_total`
+
+Total entity instances registered to be deleted
+
+Metric:: `kalix_valueentity_registered_for_deletion_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_stashed_commands_total`
+
+Total commands stashed for an entity.
+
+Metric:: `kalix_valueentity_stashed_commands_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_switch_primary_failed_total`
+
+Total primary switches that have failed.
+
+Metric:: `kalix_valueentity_switch_primary_failed_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_switch_primary_time_seconds`
+
+Duration for switching primary, in seconds.
+
+Metric:: `kalix_valueentity_switch_primary_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_valueentity_switch_primary_time_seconds_bucket` (with `le` label)
+* `kalix_valueentity_switch_primary_time_seconds_count`
+* `kalix_valueentity_switch_primary_time_seconds_sum`
+--
+Buckets:: `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.05`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `5.0`, `10.0`, `20.0`, `Infinity`
+
+=== `kalix_valueentity_switch_primary_total`
+
+Total primary switches completed for an entity.
+
+Metric:: `kalix_valueentity_switch_primary_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_valueentity_unstashed_commands_total`
+
+Total commands unstashed for an entity.
+
+Metric:: `kalix_valueentity_unstashed_commands_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+== Workflows
+
+=== `kalix_workflowentity_activated_entities_total`
+
+Total workflow instances that have been activated.
+
+Metric:: `kalix_workflowentity_activated_entities_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_command_processing_time_seconds`
+
+Duration for command processing (until user service reply), in seconds.
+
+Metric:: `kalix_workflowentity_command_processing_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_workflowentity_command_processing_time_seconds_bucket` (with `le` label)
+* `kalix_workflowentity_command_processing_time_seconds_count`
+* `kalix_workflowentity_command_processing_time_seconds_sum`
+--
+Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_workflowentity_command_total_time_seconds`
+
+Total duration for command handling (including stash and persist), in seconds.
+
+Metric:: `kalix_workflowentity_command_total_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_workflowentity_command_total_time_seconds_bucket` (with `le` label)
+* `kalix_workflowentity_command_total_time_seconds_count`
+* `kalix_workflowentity_command_total_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_workflowentity_completed_commands_total`
+
+Total commands completed for an entity.
+
+Metric:: `kalix_workflowentity_completed_commands_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_completed_steps_total`
+
+Total steps completed.
+
+Metric:: `kalix_workflowentity_completed_steps_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_conflicts_detected_total`
+
+Total conflicts detected for an entity.
+
+Metric:: `kalix_workflowentity_conflicts_detected_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_conflicts_resolved_total`
+
+Total conflicts resolved for an entity.
+
+Metric:: `kalix_workflowentity_conflicts_resolved_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_entity_active_time_seconds`
+
+Duration that entities are active, in seconds.
+
+Metric:: `kalix_workflowentity_entity_active_time_seconds`
+Type:: summary
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_workflowentity_entity_active_time_seconds` (with `quantile` label)
+* `kalix_workflowentity_entity_active_time_seconds_count`
+* `kalix_workflowentity_entity_active_time_seconds_sum`
+--
+Quantiles:: `0.5`, `0.95`, `0.99`, `1.0`
+
+=== `kalix_workflowentity_failed_commands_total`
+
+Total commands that have failed.
+
+Metric:: `kalix_workflowentity_failed_commands_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_failed_entities_total`
+
+Total workflow instances that have failed.
+
+Metric:: `kalix_workflowentity_failed_entities_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_failed_steps_total`
+
+Total steps that have failed.
+
+Metric:: `kalix_workflowentity_failed_steps_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_loaded_event_bytes_total`
+
+Total event sizes loaded for an entity.
+
+Metric:: `kalix_workflowentity_loaded_event_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_loaded_events_total`
+
+Total events loaded for an entity.
+
+Metric:: `kalix_workflowentity_loaded_events_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_loaded_snapshot_bytes_total`
+
+Total snapshot sizes loaded for an entity.
+
+Metric:: `kalix_workflowentity_loaded_snapshot_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_loaded_snapshots_total`
+
+Total snapshots loaded for an entity.
+
+Metric:: `kalix_workflowentity_loaded_snapshots_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_passivated_entities_total`
+
+Total workflow instances that have been passivated.
+
+Metric:: `kalix_workflowentity_passivated_entities_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_persist_time_seconds`
+
+Duration for persisting events, in seconds.
+
+Metric:: `kalix_workflowentity_persist_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_workflowentity_persist_time_seconds_bucket` (with `le` label)
+* `kalix_workflowentity_persist_time_seconds_count`
+* `kalix_workflowentity_persist_time_seconds_sum`
+--
+Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `10.0`, `Infinity`
+
+=== `kalix_workflowentity_persisted_event_bytes_total`
+
+Total event sizes persisted for an entity.
+
+Metric:: `kalix_workflowentity_persisted_event_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_persisted_events_total`
+
+Total events persisted for an entity.
+
+Metric:: `kalix_workflowentity_persisted_events_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_persisted_replicated_event_bytes_total`
+
+Total replicated event sizes persisted for an entity.
+
+Metric:: `kalix_workflowentity_persisted_replicated_event_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_persisted_replicated_events_total`
+
+Total replicated events persisted for an entity.
+
+Metric:: `kalix_workflowentity_persisted_replicated_events_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_persisted_snapshot_bytes_total`
+
+Total snapshot sizes persisted for an entity.
+
+Metric:: `kalix_workflowentity_persisted_snapshot_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_persisted_snapshots_total`
+
+Total snapshots persisted for an entity.
+
+Metric:: `kalix_workflowentity_persisted_snapshots_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_received_commands_total`
+
+Total commands received for an entity.
+
+Metric:: `kalix_workflowentity_received_commands_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_recovery_failed_total`
+
+Total recovery process that have failed.
+
+Metric:: `kalix_workflowentity_recovery_failed_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_recovery_from_events_total`
+
+If events were loaded to recover an entity.
+
+Metric:: `kalix_workflowentity_recovery_from_events_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_recovery_time_seconds`
+
+Duration for workflow recovery, in seconds.
+
+Metric:: `kalix_workflowentity_recovery_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_workflowentity_recovery_time_seconds_bucket` (with `le` label)
+* `kalix_workflowentity_recovery_time_seconds_count`
+* `kalix_workflowentity_recovery_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `10.0`, `Infinity`
+
+=== `kalix_workflowentity_registered_for_deletion_total`
+
+Total workflow instances registered to be deleted
+
+Metric:: `kalix_workflowentity_registered_for_deletion_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_started_commands_total`
+
+Commands sent from workflow to other components or user service.
+
+Metric:: `kalix_workflowentity_started_commands_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_started_steps_total`
+
+Total steps started.
+
+Metric:: `kalix_workflowentity_started_steps_total`
+Type:: counter
+Labels::
++
+--
+* `entity_name`
+--
+
+=== `kalix_workflowentity_step_processing_time_seconds`
+
+Duration for step processing (until user service reply), in seconds.
+
+Metric:: `kalix_workflowentity_step_processing_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_workflowentity_step_processing_time_seconds_bucket` (with `le` label)
+* `kalix_workflowentity_step_processing_time_seconds_count`
+* `kalix_workflowentity_step_processing_time_seconds_sum`
+--
+Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_workflowentity_step_total_time_seconds`
+
+Total duration for step handling (including persist), in seconds.
+
+Metric:: `kalix_workflowentity_step_total_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `entity_name`
+--
+Exported metrics::
++
+--
+* `kalix_workflowentity_step_total_time_seconds_bucket` (with `le` label)
+* `kalix_workflowentity_step_total_time_seconds_count`
+* `kalix_workflowentity_step_total_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+== Views
+
+=== `kalix_view_conflict_resolution_total_time_seconds`
+
+Total duration for conflict resolution, in seconds.
+
+Metric:: `kalix_view_conflict_resolution_total_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `view_name`
+* `command_name`
+--
+Exported metrics::
++
+--
+* `kalix_view_conflict_resolution_total_time_seconds_bucket` (with `le` label)
+* `kalix_view_conflict_resolution_total_time_seconds_count`
+* `kalix_view_conflict_resolution_total_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_view_conflict_resolutions_total`
+
+Total conflict resolutions started for an update method.
+
+Metric:: `kalix_view_conflict_resolutions_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+* `command_name`
+--
+
+=== `kalix_view_delete_rows_total`
+
+Total deleted rows.
+
+Metric:: `kalix_view_delete_rows_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+--
+
+=== `kalix_view_load_bytes_total`
+
+Total bytes loaded from store.
+
+Metric:: `kalix_view_load_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+--
+
+=== `kalix_view_load_failed_total`
+
+Total failures loading from store.
+
+Metric:: `kalix_view_load_failed_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+--
+
+=== `kalix_view_load_rows_total`
+
+Total rows loaded from store.
+
+Metric:: `kalix_view_load_rows_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+--
+
+=== `kalix_view_query_process_failed_total`
+
+Total failures processing a query.
+
+Metric:: `kalix_view_query_process_failed_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+--
+
+=== `kalix_view_query_received_requests_total`
+
+Total query requests received for a view.
+
+Metric:: `kalix_view_query_received_requests_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+--
+
+=== `kalix_view_query_result_bytes_total`
+
+Total query result bytes.
+
+Metric:: `kalix_view_query_result_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+--
+
+=== `kalix_view_query_result_rows_total`
+
+Total query result rows.
+
+Metric:: `kalix_view_query_result_rows_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+--
+
+=== `kalix_view_query_total_time_seconds`
+
+Total duration for queries, in seconds.
+
+Metric:: `kalix_view_query_total_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `view_name`
+--
+Exported metrics::
++
+--
+* `kalix_view_query_total_time_seconds_bucket` (with `le` label)
+* `kalix_view_query_total_time_seconds_count`
+* `kalix_view_query_total_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_view_query_view_store_limit_load_bytes_exceeded_total`
+
+Total failures from exceeding limit bytes loaded from view store.
+
+Metric:: `kalix_view_query_view_store_limit_load_bytes_exceeded_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+--
+
+=== `kalix_view_query_view_store_limit_load_rows_exceeded_total`
+
+Total failures from exceeding limit for rows loaded from view store.
+
+Metric:: `kalix_view_query_view_store_limit_load_rows_exceeded_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+--
+
+=== `kalix_view_update_load_time_seconds`
+
+Duration for loading existing entries (if transforming updates), in seconds.
+
+Metric:: `kalix_view_update_load_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `view_name`
+* `command_name`
+--
+Exported metrics::
++
+--
+* `kalix_view_update_load_time_seconds_bucket` (with `le` label)
+* `kalix_view_update_load_time_seconds_count`
+* `kalix_view_update_load_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_view_update_store_time_seconds`
+
+Duration for storing updates, in seconds.
+
+Metric:: `kalix_view_update_store_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `view_name`
+* `command_name`
+--
+Exported metrics::
++
+--
+* `kalix_view_update_store_time_seconds_bucket` (with `le` label)
+* `kalix_view_update_store_time_seconds_count`
+* `kalix_view_update_store_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_view_update_total_time_seconds`
+
+Total duration for updates, in seconds.
+
+Metric:: `kalix_view_update_total_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `view_name`
+* `command_name`
+--
+Exported metrics::
++
+--
+* `kalix_view_update_total_time_seconds_bucket` (with `le` label)
+* `kalix_view_update_total_time_seconds_count`
+* `kalix_view_update_total_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_view_update_transform_time_seconds`
+
+Duration for transforming updates in the user service, in seconds.
+
+Metric:: `kalix_view_update_transform_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `view_name`
+* `command_name`
+--
+Exported metrics::
++
+--
+* `kalix_view_update_transform_time_seconds_bucket` (with `le` label)
+* `kalix_view_update_transform_time_seconds_count`
+* `kalix_view_update_transform_time_seconds_sum`
+--
+Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_view_updates_deduplicated_total`
+
+Total updates that have been automatically deduplicated.
+
+Metric:: `kalix_view_updates_deduplicated_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+* `table_name`
+--
+
+=== `kalix_view_updates_filtered_total`
+
+Total updates that have been automatically filtered (for internal messages).
+
+Metric:: `kalix_view_updates_filtered_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+* `table_name`
+--
+
+=== `kalix_view_updates_ignored_total`
+
+Total updates that have been ignored.
+
+Metric:: `kalix_view_updates_ignored_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+* `table_name`
+--
+
+=== `kalix_view_updates_processed_total`
+
+Total updates that have been actually processed.
+
+Metric:: `kalix_view_updates_processed_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+* `table_name`
+--
+
+=== `kalix_view_updates_skipped_total`
+
+Total updates that have been skipped (based on sequence gap detection).
+
+Metric:: `kalix_view_updates_skipped_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+* `table_name`
+--
+
+=== `kalix_view_updates_total`
+
+Total updates received for an update method.
+
+Metric:: `kalix_view_updates_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+* `command_name`
+--
+
+=== `kalix_view_upsert_byte_limit_exceeded_total`
+
+Total failures from exceeding byte size limit for single view store upsert.
+
+Metric:: `kalix_view_upsert_byte_limit_exceeded_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+--
+
+=== `kalix_view_upsert_bytes_total`
+
+Total upsert bytes.
+
+Metric:: `kalix_view_upsert_bytes_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+--
+
+=== `kalix_view_upsert_failed_total`
+
+Total failed upserts.
+
+Metric:: `kalix_view_upsert_failed_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+--
+
+=== `kalix_view_upsert_rows_total`
+
+Total upsert rows.
+
+Metric:: `kalix_view_upsert_rows_total`
+Type:: counter
+Labels::
++
+--
+* `view_name`
+--
+
+== Eventing
+
+=== `kalix_eventing_broker_used_total`
+
+Kalix eventing message broker type
+
+Metric:: `kalix_eventing_broker_used_total`
+Type:: counter
+Labels::
++
+--
+* `broker_type`
+--
+
+=== `kalix_eventing_event_failed_total`
+
+Total events leading to event stream failure
+
+Metric:: `kalix_eventing_event_failed_total`
+Type:: counter
+Labels::
++
+--
+* `consumer_service`
+* `event_source_type`
+* `event_source`
+--
+
+=== `kalix_eventing_event_handled_total`
+
+Total events processed by a consumer
+
+Metric:: `kalix_eventing_event_handled_total`
+Type:: counter
+Labels::
++
+--
+* `consumer_service`
+* `event_source_type`
+* `event_source`
+--
+
+=== `kalix_eventing_service_to_service_consumer_total`
+
+Service to Service stream consumers, each stream_id counted
+
+Metric:: `kalix_eventing_service_to_service_consumer_total`
+Type:: counter
+
+=== `kalix_eventing_service_to_service_producer_total`
+
+Service to Service stream producer, each stream_id counted
+
+Metric:: `kalix_eventing_service_to_service_producer_total`
+Type:: counter
+
+=== `kalix_eventing_source_stream_started_total`
+
+Total event source streams that have started
+
+Metric:: `kalix_eventing_source_stream_started_total`
+Type:: counter
+Labels::
++
+--
+* `consumer_service`
+* `event_source_type`
+* `event_source`
+--
+
+== Projections
+
+=== `kalix_projection_backlog_lag_seconds`
+
+Time in seconds the projection is lagging behind the latest event
+
+Metric:: `kalix_projection_backlog_lag_seconds`
+Type:: gauge
+Labels::
++
+--
+* `projection_name`
+* `projection_key`
+* `projection_type`
+--
+
+=== `kalix_projection_completed_total`
+
+Total envelopes completed for a projection.
+
+Metric:: `kalix_projection_completed_total`
+Type:: counter
+Labels::
++
+--
+* `projection_name`
+* `projection_key`
+* `projection_type`
+* `envelope_source`
+--
+
+=== `kalix_projection_consumer_lag_seconds`
+
+Consumer lag, duration for envelope processing from when the envelope was created, in seconds.
+
+Metric:: `kalix_projection_consumer_lag_seconds`
+Type:: histogram
+Labels::
++
+--
+* `projection_name`
+* `projection_key`
+* `projection_type`
+* `envelope_source`
+--
+Exported metrics::
++
+--
+* `kalix_projection_consumer_lag_seconds_bucket` (with `le` label)
+* `kalix_projection_consumer_lag_seconds_count`
+* `kalix_projection_consumer_lag_seconds_sum`
+--
+Buckets:: `0.01`, `0.05`, `0.1`, `0.25`, `0.5`, `1.0`, `2.0`, `3.0`, `4.0`, `5.0`, `10.0`, `20.0`, `30.0`, `Infinity`
+
+=== `kalix_projection_failed_total`
+
+Total projection instances that have failed.
+
+Metric:: `kalix_projection_failed_total`
+Type:: counter
+Labels::
++
+--
+* `projection_name`
+* `projection_key`
+* `projection_type`
+--
+
+=== `kalix_projection_processing_time_seconds`
+
+Duration for envelope processing (including user service and persist), in seconds.
+
+Metric:: `kalix_projection_processing_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `projection_name`
+* `projection_key`
+* `projection_type`
+* `envelope_source`
+--
+Exported metrics::
++
+--
+* `kalix_projection_processing_time_seconds_bucket` (with `le` label)
+* `kalix_projection_processing_time_seconds_count`
+* `kalix_projection_processing_time_seconds_sum`
+--
+Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `10.0`, `Infinity`
+
+=== `kalix_projection_received_total`
+
+Total envelopes received for a projection (before de-duplication).
+
+Metric:: `kalix_projection_received_total`
+Type:: counter
+Labels::
++
+--
+* `projection_name`
+* `projection_key`
+* `projection_type`
+* `envelope_source`
+--
+
+=== `kalix_projection_started_total`
+
+Total projection instances that have started.
+
+Metric:: `kalix_projection_started_total`
+Type:: counter
+Labels::
++
+--
+* `projection_name`
+* `projection_key`
+* `projection_type`
+--
+
+=== `kalix_projection_stopped_total`
+
+Total projection instances that have stopped.
+
+Metric:: `kalix_projection_stopped_total`
+Type:: counter
+Labels::
++
+--
+* `projection_name`
+* `projection_key`
+* `projection_type`
+--
+
+== Actions
+
+=== `kalix_action_completed_messages_total`
+
+Total messages completed for an action.
+
+Metric:: `kalix_action_completed_messages_total`
+Type:: counter
+Labels::
++
+--
+* `action_name`
+--
+
+=== `kalix_action_message_processing_time_seconds`
+
+Duration for message processing (until first user service reply), in seconds.
+
+Metric:: `kalix_action_message_processing_time_seconds`
+Type:: histogram
+Labels::
++
+--
+* `action_name`
+--
+Exported metrics::
++
+--
+* `kalix_action_message_processing_time_seconds_bucket` (with `le` label)
+* `kalix_action_message_processing_time_seconds_count`
+* `kalix_action_message_processing_time_seconds_sum`
+--
+Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+
+=== `kalix_action_received_messages_total`
+
+Total messages received for an action.
+
+Metric:: `kalix_action_received_messages_total`
+Type:: counter
+Labels::
++
+--
+* `action_name`
+--
+
+== Runtime
+
+=== `kalix_component_types_total`
+
+Kalix component type counts
+
+Metric:: `kalix_component_types_total`
+Type:: counter
+Labels::
++
+--
+* `component_type`
+--
+
+=== `kalix_instance_size`
+
+Kalix instance size.
+
+Metric:: `kalix_instance_size`
+Type:: gauge
+
+=== `kalix_proxy_info`
+
+Kalix proxy and SDK details
+
+Metric:: `kalix_proxy_info`
+Type:: info
+Labels::
++
+--
+* `proxy_version`
+* `sdk_name`
+* `sdk_version`
+--
+
+=== `kalix_service_revision`
+
+Kalix user service version. I.e. Kubernetes/revision
+
+Metric:: `kalix_service_revision`
+Type:: gauge

--- a/docs/src/modules/reference/pages/telemetry/index.adoc
+++ b/docs/src/modules/reference/pages/telemetry/index.adoc
@@ -3,3 +3,5 @@
 This section provides reference documentation for the telemetry recorded by Akka.
 
 * xref:telemetry/metrics.adoc[]
+* xref:telemetry/deprecated-metrics.adoc[]
+* xref:telemetry/tracing.adoc[]

--- a/docs/src/modules/reference/pages/telemetry/metrics.adoc
+++ b/docs/src/modules/reference/pages/telemetry/metrics.adoc
@@ -4,2457 +4,3048 @@ Akka collects metrics for monitoring the runtime behavior of your services.
 
 These metrics are available for xref:operations:observability-and-monitoring/observability-exports.adoc[export] to external monitoring systems.
 
+In addition to the Akka-specific metrics listed below, standard JVM runtime metrics (memory, garbage collection, threads, class loading, CPU, etc.) are also collected and exported. These follow the OpenTelemetry semantic conventions for JVM metrics — see https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/[OpenTelemetry JVM metrics] for the full list and attribute definitions.
+
+
 == HTTP Endpoints
 
-=== `kalix_proxy_http_request_duration_seconds`
 
-Total duration of HTTP requests to a service endpoint, in seconds.
+=== HTTP server active requests
 
-Metric:: `kalix_proxy_http_request_duration_seconds`
+Number of active HTTP server requests.
+Metric:: `http.server.active_requests`
+Type:: up-down counter
+Unit:: `{request}`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Endpoint attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.endpoint.method`
+| string
+| Yes
+| Name of the endpoint method being invoked.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `http.request.method`
+| string
+| Yes
+| HTTP request method.
+
+| `http.route`
+| string
+| Conditionally required: If and only if it's available
+| The matched route template, e.g. `/pets/{id}`.
+
+| `server.address`
+| string
+| Recommended
+| The client-facing server hostname.
+
+|===
+
+
+=== HTTP server request body size
+
+Size of HTTP server request bodies.
+Metric:: `http.server.request.body.size`
 Type:: histogram
-Labels::
-+
---
-* `endpoint_class`
-* `endpoint_method`
-* `http_method`
-* `http_target`
-* `http_status_code`
-* `grpc_service`
-* `grpc_method`
-* `grpc_streaming`
---
-Exported metrics::
-+
---
-* `kalix_proxy_http_request_duration_seconds_bucket` (with `le` label)
-* `kalix_proxy_http_request_duration_seconds_count`
-* `kalix_proxy_http_request_duration_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+Unit:: `By`
 
-=== `kalix_proxy_http_requests_total`
 
-Total HTTP requests to a service endpoint.
 
-Metric:: `kalix_proxy_http_requests_total`
-Type:: counter
-Labels::
+Component attributes::
 +
---
-* `endpoint_class`
-* `endpoint_method`
-* `http_method`
-* `http_target`
-* `http_status_code`
-* `grpc_service`
-* `grpc_method`
-* `grpc_streaming`
---
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Endpoint attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.endpoint.method`
+| string
+| Yes
+| Name of the endpoint method being invoked.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `http.request.method`
+| string
+| Yes
+| HTTP request method.
+
+| `http.route`
+| string
+| Conditionally required: If and only if it's available
+| The matched route template, e.g. `/pets/{id}`.
+
+| `server.address`
+| string
+| Recommended
+| The client-facing server hostname.
+
+|===
+
+
+=== HTTP server request duration
+
+Duration of HTTP server requests.
+Metric:: `http.server.request.duration`
+Type:: histogram
+Unit:: `s`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Endpoint attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.endpoint.method`
+| string
+| Yes
+| Name of the endpoint method being invoked.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if and only if an error has occurred.
+| Describes the error condition, such as the HTTP status code.
+
+| `http.request.method`
+| string
+| Yes
+| HTTP request method.
+
+| `http.response.status_code`
+| int
+| Conditionally required: If and only if one was received/sent.
+| link:https://tools.ietf.org/html/rfc7231#section-6[HTTP response status code].
+
+| `http.route`
+| string
+| Conditionally required: If and only if it's available
+| The matched route template, e.g. `/pets/{id}`.
+
+| `server.address`
+| string
+| Recommended
+| The client-facing server hostname.
+
+|===
+
+
+=== HTTP server response body size
+
+Size of HTTP server response bodies.
+Metric:: `http.server.response.body.size`
+Type:: histogram
+Unit:: `By`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Endpoint attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.endpoint.method`
+| string
+| Yes
+| Name of the endpoint method being invoked.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if and only if an error has occurred.
+| Describes the error condition, such as the HTTP status code.
+
+| `http.request.method`
+| string
+| Yes
+| HTTP request method.
+
+| `http.response.status_code`
+| int
+| Conditionally required: If and only if one was received/sent.
+| link:https://tools.ietf.org/html/rfc7231#section-6[HTTP response status code].
+
+| `http.route`
+| string
+| Conditionally required: If and only if it's available
+| The matched route template, e.g. `/pets/{id}`.
+
+| `server.address`
+| string
+| Recommended
+| The client-facing server hostname.
+
+|===
+
 
 == gRPC Endpoints
 
-=== `kalix_proxy_grpc_request_duration_seconds`
 
-Total duration of gRPC requests to a service endpoint, in seconds.
+=== RPC server call duration
 
-Metric:: `kalix_proxy_grpc_request_duration_seconds`
+Duration of incoming gRPC server calls.
+Metric:: `rpc.server.call.duration`
 Type:: histogram
-Labels::
-+
---
-* `endpoint_class`
-* `grpc_service`
-* `grpc_method`
-* `grpc_streaming`
-* `grpc_status_code`
---
-Exported metrics::
-+
---
-* `kalix_proxy_grpc_request_duration_seconds_bucket` (with `le` label)
-* `kalix_proxy_grpc_request_duration_seconds_count`
-* `kalix_proxy_grpc_request_duration_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+Unit:: `s`
 
-=== `kalix_proxy_grpc_requests_total`
 
-Total gRPC requests to a service endpoint.
 
-Metric:: `kalix_proxy_grpc_requests_total`
-Type:: counter
-Labels::
+Component attributes::
 +
---
-* `endpoint_class`
-* `grpc_service`
-* `grpc_method`
-* `grpc_streaming`
-* `grpc_status_code`
---
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Endpoint attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.endpoint.method`
+| string
+| Yes
+| Name of the endpoint method being invoked.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if and only if an error has occurred.
+| Describes the error condition, such as the gRPC status code.
+
+| `rpc.method`
+| string
+| Yes
+| The gRPC service and method name, e.g. `com.example.MyService/MyMethod`.
+
+| `rpc.response.status_code`
+| string
+| Conditionally required: if available.
+| The gRPC status code.
+
+| `rpc.system.name`
+| enum
+| Yes
+| The Remote Procedure Call (RPC) system.
+
+| `server.address`
+| string
+| Recommended
+| The client-facing server hostname.
+
+|===
+
+
+=== RPC server response size
+
+Size of RPC server response messages.
+Metric:: `rpc.server.response.size`
+Type:: histogram
+Unit:: `By`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Endpoint attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.endpoint.method`
+| string
+| Yes
+| Name of the endpoint method being invoked.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if and only if an error has occurred.
+| Describes the error condition, such as the gRPC status code.
+
+| `rpc.method`
+| string
+| Yes
+| The gRPC service and method name, e.g. `com.example.MyService/MyMethod`.
+
+| `rpc.response.status_code`
+| string
+| Conditionally required: if available.
+| The gRPC status code.
+
+| `rpc.system.name`
+| enum
+| Yes
+| The Remote Procedure Call (RPC) system.
+
+| `server.address`
+| string
+| Recommended
+| The client-facing server hostname.
+
+|===
+
 
 == MCP Endpoints
 
-=== `kalix_proxy_mcp_request_duration_seconds`
 
-Request duration to an MCP endpoint, in seconds.
+=== MCP server operation duration
 
-Metric:: `kalix_proxy_mcp_request_duration_seconds`
+Duration of incoming MCP server operations.
+Metric:: `mcp.server.operation.duration`
 Type:: histogram
-Labels::
-+
---
-* `endpoint_path`
-* `rpc_method`
-* `rpc_error_code`
---
-Exported metrics::
-+
---
-* `kalix_proxy_mcp_request_duration_seconds_bucket` (with `le` label)
-* `kalix_proxy_mcp_request_duration_seconds_count`
-* `kalix_proxy_mcp_request_duration_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+Unit:: `s`
 
-=== `kalix_proxy_mcp_requests_total`
 
-Total requests to an MCP endpoint.
 
-Metric:: `kalix_proxy_mcp_requests_total`
-Type:: counter
-Labels::
+Component attributes::
 +
---
-* `endpoint_path`
-* `rpc_method`
-* `rpc_error_code`
---
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if and only if an error has occurred.
+| Describes the error condition.
+
+| `gen_ai.operation.name`
+| enum
+| Conditionally required: when applicable for the MCP method
+| The name of the operation being performed.
+
+| `gen_ai.prompt.name`
+| string
+| Conditionally required: When operation is related to a specific prompt.
+| The MCP prompt name.
+
+| `gen_ai.tool.name`
+| string
+| Conditionally required: When operation is related to a specific tool.
+| The MCP tool name.
+
+| `mcp.method.name`
+| enum
+| Yes
+| The name of the request or notification method.
+
+| `rpc.response.status_code`
+| string
+| Conditionally required: if available.
+| The gRPC status code for the MCP transport.
+
+|===
+
 
 == Agents
 
-=== `kalix_agent_command_processing_time_seconds`
 
-Total duration of a completed command to the Akka Agent, in seconds
+=== Agent command duration
 
-Metric:: `kalix_agent_command_processing_time_seconds`
+Duration of agent command handling.
+Metric:: `akka.agent.command.duration`
 Type:: histogram
-Labels::
+Unit:: `s`
+
+
+
+Component attributes::
 +
---
-* `agent_id`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+OpenTelemetry semantic convention attributes::
 +
---
-* `kalix_agent_command_processing_time_seconds_bucket` (with `le` label)
-* `kalix_agent_command_processing_time_seconds_count`
-* `kalix_agent_command_processing_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `15.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_agent_completed_commands_total`
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
 
-Total completed commands by the Akka Agent.
+|===
 
-Metric:: `kalix_agent_completed_commands_total`
-Type:: counter
-Labels::
-+
---
-* `agent_id`
---
 
-=== `kalix_agent_evaluations_completed_total`
+=== Agent content load duration
 
-Total completed agent evaluations.
-
-Metric:: `kalix_agent_evaluations_completed_total`
-Type:: counter
-Labels::
-+
---
-* `agent_id`
---
-
-=== `kalix_agent_evaluations_failed_total`
-
-Total failed agent evaluations.
-
-Metric:: `kalix_agent_evaluations_failed_total`
-Type:: counter
-Labels::
-+
---
-* `agent_id`
---
-
-=== `kalix_agent_failed_commands_total`
-
-Total failed commands by the Akka Agent.
-
-Metric:: `kalix_agent_failed_commands_total`
-Type:: counter
-Labels::
-+
---
-* `agent_id`
---
-
-=== `kalix_agent_guardrail_completed_evaluations_total`
-
-Total completed guardrail evaluations for an agent.
-
-Metric:: `kalix_agent_guardrail_completed_evaluations_total`
-Type:: counter
-Labels::
-+
---
-* `agent_id`
-* `guardrail_category`
-* `guardrail_name`
---
-
-=== `kalix_agent_guardrail_evaluation_processing_time_seconds`
-
-Total duration of a completed and failed guardrail evaluation, in seconds
-
-Metric:: `kalix_agent_guardrail_evaluation_processing_time_seconds`
+Duration of agent content loading operations.
+Metric:: `akka.agent.content.load.duration`
 Type:: histogram
-Labels::
+Unit:: `s`
+
+
+
+Agent Content attributes::
 +
---
-* `agent_id`
-* `guardrail_category`
-* `guardrail_name`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.agent.content.kind`
+| string
+| Yes
+| The kind of content being loaded.
+
+| `akka.agent.content.loader.class`
+| string
+| Recommended: if available
+| The class name of the content loader used.
+
+| `akka.agent.content.size`
+| int
+| Recommended: if available
+| The size of the loaded content in bytes.
+
+| `akka.agent.content.uri`
+| string
+| Yes
+| The URI of the content being loaded.
+
+|===
+
+Component attributes::
 +
---
-* `kalix_agent_guardrail_evaluation_processing_time_seconds_bucket` (with `le` label)
-* `kalix_agent_guardrail_evaluation_processing_time_seconds_count`
-* `kalix_agent_guardrail_evaluation_processing_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `15.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_agent_guardrail_evaluations_total`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total guardrail evaluations for an agent.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_agent_guardrail_evaluations_total`
-Type:: counter
-Labels::
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+OpenTelemetry semantic convention attributes::
 +
---
-* `agent_id`
-* `guardrail_category`
-* `guardrail_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_agent_guardrail_failed_evaluations_total`
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
 
-Total failed guardrail evaluations for an agent.
+|===
 
-Metric:: `kalix_agent_guardrail_failed_evaluations_total`
-Type:: counter
-Labels::
-+
---
-* `agent_id`
-* `guardrail_category`
-* `guardrail_name`
---
 
-=== `kalix_agent_model_completed_requests_total`
+=== Agent content load size
 
-Total completed requests by the Model.
-
-Metric:: `kalix_agent_model_completed_requests_total`
-Type:: counter
-Labels::
-+
---
-* `agent_id`
-* `model_name`
---
-
-=== `kalix_agent_model_failed_requests_total`
-
-Total failed requests by the Model.
-
-Metric:: `kalix_agent_model_failed_requests_total`
-Type:: counter
-Labels::
-+
---
-* `agent_id`
-* `model_name`
---
-
-=== `kalix_agent_model_received_requests_total`
-
-Total received requests by the Model.
-
-Metric:: `kalix_agent_model_received_requests_total`
-Type:: counter
-Labels::
-+
---
-* `agent_id`
-* `model_name`
---
-
-=== `kalix_agent_model_request_processing_time_seconds`
-
-Total duration of a completed command to the Model, in seconds
-
-Metric:: `kalix_agent_model_request_processing_time_seconds`
+Size of content loaded by the agent.
+Metric:: `akka.agent.content.load.size`
 Type:: histogram
-Labels::
+Unit:: `By`
+
+
+
+Agent Content attributes::
 +
---
-* `agent_id`
-* `model_name`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.agent.content.kind`
+| string
+| Yes
+| The kind of content being loaded.
+
+| `akka.agent.content.loader.class`
+| string
+| Recommended: if available
+| The class name of the content loader used.
+
+| `akka.agent.content.size`
+| int
+| Recommended: if available
+| The size of the loaded content in bytes.
+
+| `akka.agent.content.uri`
+| string
+| Yes
+| The URI of the content being loaded.
+
+|===
+
+Component attributes::
 +
---
-* `kalix_agent_model_request_processing_time_seconds_bucket` (with `le` label)
-* `kalix_agent_model_request_processing_time_seconds_count`
-* `kalix_agent_model_request_processing_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `15.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_agent_model_token_input_total`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Tokens used in the input by the model in the response.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_agent_model_token_input_total`
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+
+=== Agent evaluation result
+
+Number of agent evaluation results.
+Metric:: `akka.agent.evaluation.result`
 Type:: counter
-Labels::
+Unit:: `{result}`
+
+
+
+Agent Evaluation attributes::
 +
---
-* `agent_id`
-* `model_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_agent_model_token_output_total`
+| `akka.agent.evaluation.result`
+| enum
+| Yes
+| The result of an agent evaluation.
 
-Tokens used in the output by the model in the response.
+|===
 
-Metric:: `kalix_agent_model_token_output_total`
-Type:: counter
-Labels::
+Component attributes::
 +
---
-* `agent_id`
-* `model_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_agent_received_commands_total`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total received commands by the Akka Agent.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_agent_received_commands_total`
-Type:: counter
-Labels::
-+
---
-* `agent_id`
---
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
 
-=== `kalix_agent_tool_completed_requests_total`
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
 
-Total completed requests by a Tool.
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
 
-Metric:: `kalix_agent_tool_completed_requests_total`
-Type:: counter
-Labels::
-+
---
-* `agent_id`
-* `model_name`
-* `tool_name`
---
+|===
 
-=== `kalix_agent_tool_failed_requests_total`
 
-Total failed requests by a Tool.
+=== Agent guardrail evaluation duration
 
-Metric:: `kalix_agent_tool_failed_requests_total`
-Type:: counter
-Labels::
-+
---
-* `agent_id`
-* `model_name`
-* `tool_name`
---
-
-=== `kalix_agent_tool_received_requests_total`
-
-Total received commands by a Tool.
-
-Metric:: `kalix_agent_tool_received_requests_total`
-Type:: counter
-Labels::
-+
---
-* `agent_id`
-* `model_name`
-* `tool_name`
---
-
-=== `kalix_agent_tool_request_processing_time_seconds`
-
-Total duration of a completed command to a Tool, in seconds
-
-Metric:: `kalix_agent_tool_request_processing_time_seconds`
+Duration of agent guardrail evaluations.
+Metric:: `akka.agent.guardrail.duration`
 Type:: histogram
-Labels::
+Unit:: `s`
+
+
+
+Agent Guardrail attributes::
 +
---
-* `agent_id`
-* `model_name`
-* `tool_name`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.agent.guardrail.category`
+| string
+| Yes
+| The category of the guardrail being evaluated.
+
+| `akka.agent.guardrail.name`
+| string
+| Yes
+| The name of the guardrail being evaluated.
+
+| `akka.agent.guardrail.result`
+| enum
+| Yes
+| The result of a guardrail evaluation.
+
+|===
+
+Component attributes::
 +
---
-* `kalix_agent_tool_request_processing_time_seconds_bucket` (with `le` label)
-* `kalix_agent_tool_request_processing_time_seconds_count`
-* `kalix_agent_tool_request_processing_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-== Event Sourced Entities
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-=== `kalix_eventsourced_activated_entities_total`
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Total entity instances that have activated.
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
 
-Metric:: `kalix_eventsourced_activated_entities_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
 
-=== `kalix_eventsourced_command_processing_time_seconds`
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
 
-Duration for command processing (until user service reply), in seconds.
+|===
 
-Metric:: `kalix_eventsourced_command_processing_time_seconds`
+
+=== GenAI client operation duration
+
+Duration of GenAI client operations.
+Metric:: `gen_ai.client.operation.duration`
 Type:: histogram
-Labels::
+Unit:: `s`
+
+
+
+Component attributes::
 +
---
-* `entity_name`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+OpenTelemetry semantic convention attributes::
 +
---
-* `kalix_eventsourced_command_processing_time_seconds_bucket` (with `le` label)
-* `kalix_eventsourced_command_processing_time_seconds_count`
-* `kalix_eventsourced_command_processing_time_seconds_sum`
---
-Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_eventsourced_command_total_time_seconds`
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
 
-Total duration for command handling (including stash and persist), in seconds.
+| `gen_ai.operation.name`
+| enum
+| Yes
+| The name of the operation being performed.
 
-Metric:: `kalix_eventsourced_command_total_time_seconds`
+| `gen_ai.provider.name`
+| enum
+| Yes
+| The Generative AI provider as identified by the client or server instrumentation.
+
+| `gen_ai.request.model`
+| string
+| Conditionally required: If available.
+| The name of the GenAI model a request is being made to.
+
+| `gen_ai.tool.name`
+| string
+| Conditionally required: when gen_ai.operation.name is execute_tool
+| Name of the tool utilized by the agent.
+
+|===
+
+
+=== GenAI client token usage
+
+Number of input and output tokens used in GenAI operations.
+Metric:: `gen_ai.client.token.usage`
 Type:: histogram
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_eventsourced_command_total_time_seconds_bucket` (with `le` label)
-* `kalix_eventsourced_command_total_time_seconds_count`
-* `kalix_eventsourced_command_total_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
-
-=== `kalix_eventsourced_completed_commands_total`
-
-Total commands completed for an entity.
-
-Metric:: `kalix_eventsourced_completed_commands_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_conflicts_detected_total`
-
-Total conflicts detected for an entity.
-
-Metric:: `kalix_eventsourced_conflicts_detected_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_conflicts_resolved_total`
-
-Total conflicts resolved for an entity.
-
-Metric:: `kalix_eventsourced_conflicts_resolved_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_deleted_entities_total`
-
-Total entity instances that have been deleted.
-
-Metric:: `kalix_eventsourced_deleted_entities_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_deleted_events_failed_total`
-
-Total deleted events operations that have failed.
-
-Metric:: `kalix_eventsourced_deleted_events_failed_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_deleted_events_time_seconds`
-
-Duration for deleting events, in seconds.
-
-Metric:: `kalix_eventsourced_deleted_events_time_seconds`
-Type:: histogram
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_eventsourced_deleted_events_time_seconds_bucket` (with `le` label)
-* `kalix_eventsourced_deleted_events_time_seconds_count`
-* `kalix_eventsourced_deleted_events_time_seconds_sum`
---
-Buckets:: `0.01`, `0.05`, `0.1`, `0.25`, `0.5`, `1.0`, `2.0`, `3.0`, `4.0`, `5.0`, `10.0`, `20.0`, `30.0`, `Infinity`
-
-=== `kalix_eventsourced_deleted_events_total`
-
-Total deleted events
-
-Metric:: `kalix_eventsourced_deleted_events_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_entity_active_time_seconds`
-
-Duration that entities are active, in seconds.
-
-Metric:: `kalix_eventsourced_entity_active_time_seconds`
-Type:: summary
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_eventsourced_entity_active_time_seconds` (with `quantile` label)
-* `kalix_eventsourced_entity_active_time_seconds_count`
-* `kalix_eventsourced_entity_active_time_seconds_sum`
---
-Quantiles:: `0.5`, `0.95`, `0.99`, `1.0`
-
-=== `kalix_eventsourced_failed_commands_total`
-
-Total commands that have failed.
-
-Metric:: `kalix_eventsourced_failed_commands_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_failed_deleted_entities_total`
-
-Total failures when attempting to delete entities.
-
-Metric:: `kalix_eventsourced_failed_deleted_entities_total`
-Type:: counter
-
-=== `kalix_eventsourced_failed_entities_total`
-
-Total entity instances that have failed.
-
-Metric:: `kalix_eventsourced_failed_entities_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_loaded_event_bytes_total`
-
-Total event sizes loaded for an entity.
-
-Metric:: `kalix_eventsourced_loaded_event_bytes_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_loaded_events_total`
-
-Total events loaded for an entity.
-
-Metric:: `kalix_eventsourced_loaded_events_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_loaded_snapshot_bytes_total`
-
-Total snapshot sizes loaded for an entity.
-
-Metric:: `kalix_eventsourced_loaded_snapshot_bytes_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_loaded_snapshots_total`
-
-Total snapshots loaded for an entity.
-
-Metric:: `kalix_eventsourced_loaded_snapshots_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_passivated_entities_total`
-
-Total entity instances that have passivated.
-
-Metric:: `kalix_eventsourced_passivated_entities_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_persist_failed_total`
-
-Total persist operations that have failed.
-
-Metric:: `kalix_eventsourced_persist_failed_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_persist_time_seconds`
-
-Duration for persisting events from a command, in seconds.
-
-Metric:: `kalix_eventsourced_persist_time_seconds`
-Type:: histogram
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_eventsourced_persist_time_seconds_bucket` (with `le` label)
-* `kalix_eventsourced_persist_time_seconds_count`
-* `kalix_eventsourced_persist_time_seconds_sum`
---
-Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `10.0`, `Infinity`
-
-=== `kalix_eventsourced_persisted_event_bytes_total`
-
-Total event sizes persisted for an entity.
-
-Metric:: `kalix_eventsourced_persisted_event_bytes_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_persisted_events_total`
-
-Total events persisted for an entity.
-
-Metric:: `kalix_eventsourced_persisted_events_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_persisted_replicated_event_bytes_total`
-
-Total replicated event sizes persisted for an entity.
-
-Metric:: `kalix_eventsourced_persisted_replicated_event_bytes_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_persisted_replicated_events_total`
-
-Total replicated events persisted for an entity.
-
-Metric:: `kalix_eventsourced_persisted_replicated_events_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_persisted_snapshot_bytes_total`
-
-Total snapshot sizes persisted for an entity.
-
-Metric:: `kalix_eventsourced_persisted_snapshot_bytes_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_persisted_snapshots_total`
-
-Total snapshots persisted for an entity.
-
-Metric:: `kalix_eventsourced_persisted_snapshots_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_received_commands_total`
-
-Total commands received for an entity.
-
-Metric:: `kalix_eventsourced_received_commands_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_recovery_failed_total`
-
-Total entity recoveries that have failed.
-
-Metric:: `kalix_eventsourced_recovery_failed_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_recovery_from_events_total`
-
-If events were loaded to recover an entity.
-
-Metric:: `kalix_eventsourced_recovery_from_events_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_recovery_time_seconds`
-
-Duration for entity recovery, in seconds.
-
-Metric:: `kalix_eventsourced_recovery_time_seconds`
-Type:: histogram
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_eventsourced_recovery_time_seconds_bucket` (with `le` label)
-* `kalix_eventsourced_recovery_time_seconds_count`
-* `kalix_eventsourced_recovery_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `10.0`, `Infinity`
-
-=== `kalix_eventsourced_registered_for_deletion_total`
-
-Total entity instances registered to be deleted
-
-Metric:: `kalix_eventsourced_registered_for_deletion_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_switch_primary_failed_total`
-
-Total primary switches that have failed.
-
-Metric:: `kalix_eventsourced_switch_primary_failed_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_eventsourced_switch_primary_time_seconds`
-
-Duration for switching primary, in seconds.
-
-Metric:: `kalix_eventsourced_switch_primary_time_seconds`
-Type:: histogram
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_eventsourced_switch_primary_time_seconds_bucket` (with `le` label)
-* `kalix_eventsourced_switch_primary_time_seconds_count`
-* `kalix_eventsourced_switch_primary_time_seconds_sum`
---
-Buckets:: `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.05`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `5.0`, `10.0`, `20.0`, `Infinity`
-
-=== `kalix_eventsourced_switch_primary_total`
-
-Total primary switches completed for an entity.
-
-Metric:: `kalix_eventsourced_switch_primary_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-== Key Value Entities
-
-=== `kalix_valueentity_activated_entities_total`
-
-Total entity instances that have activated.
-
-Metric:: `kalix_valueentity_activated_entities_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_command_processing_time_seconds`
-
-Duration for command processing (until user service reply), in seconds.
-
-Metric:: `kalix_valueentity_command_processing_time_seconds`
-Type:: histogram
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_valueentity_command_processing_time_seconds_bucket` (with `le` label)
-* `kalix_valueentity_command_processing_time_seconds_count`
-* `kalix_valueentity_command_processing_time_seconds_sum`
---
-Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
-
-=== `kalix_valueentity_command_stash_time_seconds`
-
-Duration that commands are stashed, in seconds.
-
-Metric:: `kalix_valueentity_command_stash_time_seconds`
-Type:: histogram
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_valueentity_command_stash_time_seconds_bucket` (with `le` label)
-* `kalix_valueentity_command_stash_time_seconds_count`
-* `kalix_valueentity_command_stash_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
-
-=== `kalix_valueentity_command_total_time_seconds`
-
-Total duration for command handling (including stash and persist), in seconds.
-
-Metric:: `kalix_valueentity_command_total_time_seconds`
-Type:: histogram
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_valueentity_command_total_time_seconds_bucket` (with `le` label)
-* `kalix_valueentity_command_total_time_seconds_count`
-* `kalix_valueentity_command_total_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
-
-=== `kalix_valueentity_completed_commands_total`
-
-Total commands completed for an entity.
-
-Metric:: `kalix_valueentity_completed_commands_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_conflicts_detected_total`
-
-Total conflicts detected for an entity.
-
-Metric:: `kalix_valueentity_conflicts_detected_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_conflicts_resolved_total`
-
-Total conflicts resolved for an entity.
-
-Metric:: `kalix_valueentity_conflicts_resolved_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_deleted_events_failed_total`
-
-Total deleted events operations that have failed.
-
-Metric:: `kalix_valueentity_deleted_events_failed_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_deleted_events_time_seconds`
-
-Duration for deleting events, in seconds.
-
-Metric:: `kalix_valueentity_deleted_events_time_seconds`
-Type:: histogram
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_valueentity_deleted_events_time_seconds_bucket` (with `le` label)
-* `kalix_valueentity_deleted_events_time_seconds_count`
-* `kalix_valueentity_deleted_events_time_seconds_sum`
---
-Buckets:: `0.01`, `0.05`, `0.1`, `0.25`, `0.5`, `1.0`, `2.0`, `3.0`, `4.0`, `5.0`, `10.0`, `20.0`, `30.0`, `Infinity`
-
-=== `kalix_valueentity_deleted_events_total`
-
-Total deleted events
-
-Metric:: `kalix_valueentity_deleted_events_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_entity_active_time_seconds`
-
-Duration that entities are active, in seconds.
-
-Metric:: `kalix_valueentity_entity_active_time_seconds`
-Type:: summary
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_valueentity_entity_active_time_seconds` (with `quantile` label)
-* `kalix_valueentity_entity_active_time_seconds_count`
-* `kalix_valueentity_entity_active_time_seconds_sum`
---
-Quantiles:: `0.5`, `0.95`, `0.99`, `1.0`
-
-=== `kalix_valueentity_failed_commands_total`
-
-Total commands that have failed.
+Unit:: `{token}`
 
-Metric:: `kalix_valueentity_failed_commands_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_failed_entities_total`
-
-Total entity instances that have failed.
-
-Metric:: `kalix_valueentity_failed_entities_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_loaded_state_bytes_total`
-
-Total state sizes loaded for an entity.
-
-Metric:: `kalix_valueentity_loaded_state_bytes_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_loaded_state_total`
-
-Total states loaded for an entity.
-
-Metric:: `kalix_valueentity_loaded_state_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_passivated_entities_total`
-
-Total entity instances that have passivated.
-
-Metric:: `kalix_valueentity_passivated_entities_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_persist_failed_total`
-
-Total persist operations that have failed.
-
-Metric:: `kalix_valueentity_persist_failed_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_persist_time_seconds`
-
-Duration for persisting events from a command, in seconds.
-
-Metric:: `kalix_valueentity_persist_time_seconds`
-Type:: histogram
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_valueentity_persist_time_seconds_bucket` (with `le` label)
-* `kalix_valueentity_persist_time_seconds_count`
-* `kalix_valueentity_persist_time_seconds_sum`
---
-Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `10.0`, `Infinity`
-
-=== `kalix_valueentity_persisted_replicated_state_bytes_total`
-
-Total replicated state sizes persisted for an entity.
-
-Metric:: `kalix_valueentity_persisted_replicated_state_bytes_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_persisted_replicated_states_total`
 
-Total replicated states persisted for an entity.
 
-Metric:: `kalix_valueentity_persisted_replicated_states_total`
-Type:: counter
-Labels::
+Component attributes::
 +
---
-* `entity_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_valueentity_persisted_state_bytes_total`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total state sizes persisted for an entity.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_valueentity_persisted_state_bytes_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_persisted_states_total`
-
-Total states persisted for an entity.
-
-Metric:: `kalix_valueentity_persisted_states_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_received_commands_total`
-
-Total commands received for an entity.
-
-Metric:: `kalix_valueentity_received_commands_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_recovery_failed_total`
-
-Total entity recoveries that have failed.
-
-Metric:: `kalix_valueentity_recovery_failed_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_recovery_time_seconds`
-
-Duration for entity recovery, in seconds.
-
-Metric:: `kalix_valueentity_recovery_time_seconds`
-Type:: histogram
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_valueentity_recovery_time_seconds_bucket` (with `le` label)
-* `kalix_valueentity_recovery_time_seconds_count`
-* `kalix_valueentity_recovery_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `10.0`, `Infinity`
-
-=== `kalix_valueentity_registered_for_deletion_total`
-
-Total entity instances registered to be deleted
-
-Metric:: `kalix_valueentity_registered_for_deletion_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_stashed_commands_total`
-
-Total commands stashed for an entity.
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
 
-Metric:: `kalix_valueentity_stashed_commands_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_valueentity_switch_primary_failed_total`
-
-Total primary switches that have failed.
-
-Metric:: `kalix_valueentity_switch_primary_failed_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
 
-=== `kalix_valueentity_switch_primary_time_seconds`
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
 
-Duration for switching primary, in seconds.
+|===
 
-Metric:: `kalix_valueentity_switch_primary_time_seconds`
-Type:: histogram
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
+OpenTelemetry semantic convention attributes::
 +
---
-* `kalix_valueentity_switch_primary_time_seconds_bucket` (with `le` label)
-* `kalix_valueentity_switch_primary_time_seconds_count`
-* `kalix_valueentity_switch_primary_time_seconds_sum`
---
-Buckets:: `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.05`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `5.0`, `10.0`, `20.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_valueentity_switch_primary_total`
+| `gen_ai.operation.name`
+| enum
+| Yes
+| The name of the operation being performed.
 
-Total primary switches completed for an entity.
+| `gen_ai.provider.name`
+| enum
+| Yes
+| The Generative AI provider as identified by the client or server instrumentation.
 
-Metric:: `kalix_valueentity_switch_primary_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
+| `gen_ai.request.model`
+| string
+| Conditionally required: If available.
+| The name of the GenAI model a request is being made to.
 
-=== `kalix_valueentity_unstashed_commands_total`
+| `gen_ai.token.type`
+| enum
+| Yes
+| The type of token being counted.
 
-Total commands unstashed for an entity.
+|===
 
-Metric:: `kalix_valueentity_unstashed_commands_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
 
 == Workflows
 
-=== `kalix_workflowentity_activated_entities_total`
 
-Total workflow instances that have been activated.
+=== Active workflows
 
-Metric:: `kalix_workflowentity_activated_entities_total`
-Type:: counter
-Labels::
+Number of currently active workflow instances.
+Metric:: `akka.workflow.active`
+Type:: up-down counter
+Unit:: `{workflow}`
+
+
+
+Component attributes::
 +
---
-* `entity_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_workflowentity_command_processing_time_seconds`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Duration for command processing (until user service reply), in seconds.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_workflowentity_command_processing_time_seconds`
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+
+=== Workflow active duration
+
+Duration that a workflow instance was active (from activation to passivation or failure).
+Metric:: `akka.workflow.active.duration`
 Type:: histogram
-Labels::
+Unit:: `s`
+
+
+
+Component attributes::
 +
---
-* `entity_name`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+OpenTelemetry semantic convention attributes::
 +
---
-* `kalix_workflowentity_command_processing_time_seconds_bucket` (with `le` label)
-* `kalix_workflowentity_command_processing_time_seconds_count`
-* `kalix_workflowentity_command_processing_time_seconds_sum`
---
-Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_workflowentity_command_total_time_seconds`
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
 
-Total duration for command handling (including stash and persist), in seconds.
+|===
 
-Metric:: `kalix_workflowentity_command_total_time_seconds`
+
+=== Workflow command duration
+
+Total duration of workflow command handling (from received to completed).
+Metric:: `akka.workflow.command.duration`
 Type:: histogram
-Labels::
+Unit:: `s`
+
+
+
+Component attributes::
 +
---
-* `entity_name`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Workflow Command attributes::
 +
---
-* `kalix_workflowentity_command_total_time_seconds_bucket` (with `le` label)
-* `kalix_workflowentity_command_total_time_seconds_count`
-* `kalix_workflowentity_command_total_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_workflowentity_completed_commands_total`
+| `akka.workflow.command.name`
+| string
+| Yes
+| The name of the workflow command.
 
-Total commands completed for an entity.
+|===
 
-Metric:: `kalix_workflowentity_completed_commands_total`
-Type:: counter
-Labels::
+OpenTelemetry semantic convention attributes::
 +
---
-* `entity_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_workflowentity_completed_steps_total`
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
 
-Total steps completed.
+|===
 
-Metric:: `kalix_workflowentity_completed_steps_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
 
-=== `kalix_workflowentity_conflicts_detected_total`
+=== Workflow command processing duration
 
-Total conflicts detected for an entity.
-
-Metric:: `kalix_workflowentity_conflicts_detected_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_conflicts_resolved_total`
-
-Total conflicts resolved for an entity.
-
-Metric:: `kalix_workflowentity_conflicts_resolved_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_entity_active_time_seconds`
-
-Duration that entities are active, in seconds.
-
-Metric:: `kalix_workflowentity_entity_active_time_seconds`
-Type:: summary
-Labels::
-+
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_workflowentity_entity_active_time_seconds` (with `quantile` label)
-* `kalix_workflowentity_entity_active_time_seconds_count`
-* `kalix_workflowentity_entity_active_time_seconds_sum`
---
-Quantiles:: `0.5`, `0.95`, `0.99`, `1.0`
-
-=== `kalix_workflowentity_failed_commands_total`
-
-Total commands that have failed.
-
-Metric:: `kalix_workflowentity_failed_commands_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_failed_entities_total`
-
-Total workflow instances that have failed.
-
-Metric:: `kalix_workflowentity_failed_entities_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_failed_steps_total`
-
-Total steps that have failed.
-
-Metric:: `kalix_workflowentity_failed_steps_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_loaded_event_bytes_total`
-
-Total event sizes loaded for an entity.
-
-Metric:: `kalix_workflowentity_loaded_event_bytes_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_loaded_events_total`
-
-Total events loaded for an entity.
-
-Metric:: `kalix_workflowentity_loaded_events_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_loaded_snapshot_bytes_total`
-
-Total snapshot sizes loaded for an entity.
-
-Metric:: `kalix_workflowentity_loaded_snapshot_bytes_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_loaded_snapshots_total`
-
-Total snapshots loaded for an entity.
-
-Metric:: `kalix_workflowentity_loaded_snapshots_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_passivated_entities_total`
-
-Total workflow instances that have been passivated.
-
-Metric:: `kalix_workflowentity_passivated_entities_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_persist_time_seconds`
-
-Duration for persisting events, in seconds.
-
-Metric:: `kalix_workflowentity_persist_time_seconds`
+Duration of workflow command processing in the user function (excludes persist).
+Metric:: `akka.workflow.command.processing.duration`
 Type:: histogram
-Labels::
+Unit:: `s`
+
+
+
+Component attributes::
 +
---
-* `entity_name`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Workflow Command attributes::
 +
---
-* `kalix_workflowentity_persist_time_seconds_bucket` (with `le` label)
-* `kalix_workflowentity_persist_time_seconds_count`
-* `kalix_workflowentity_persist_time_seconds_sum`
---
-Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `10.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_workflowentity_persisted_event_bytes_total`
+| `akka.workflow.command.name`
+| string
+| Yes
+| The name of the workflow command.
 
-Total event sizes persisted for an entity.
+|===
 
-Metric:: `kalix_workflowentity_persisted_event_bytes_total`
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
+
+|===
+
+
+=== Workflow conflicts detected
+
+Number of workflow replication conflicts detected.
+Metric:: `akka.workflow.conflicts_detected`
 Type:: counter
-Labels::
+Unit:: `{conflict}`
+
+
+
+Component attributes::
 +
---
-* `entity_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_workflowentity_persisted_events_total`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total events persisted for an entity.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_workflowentity_persisted_events_total`
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+
+=== Workflow conflicts resolved
+
+Number of workflow replication conflicts resolved.
+Metric:: `akka.workflow.conflicts_resolved`
 Type:: counter
-Labels::
+Unit:: `{conflict}`
+
+
+
+Component attributes::
 +
---
-* `entity_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_workflowentity_persisted_replicated_event_bytes_total`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total replicated event sizes persisted for an entity.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_workflowentity_persisted_replicated_event_bytes_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
 
-=== `kalix_workflowentity_persisted_replicated_events_total`
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
 
-Total replicated events persisted for an entity.
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
 
-Metric:: `kalix_workflowentity_persisted_replicated_events_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
+|===
 
-=== `kalix_workflowentity_persisted_snapshot_bytes_total`
 
-Total snapshot sizes persisted for an entity.
+=== Workflow loaded size
 
-Metric:: `kalix_workflowentity_persisted_snapshot_bytes_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_persisted_snapshots_total`
-
-Total snapshots persisted for an entity.
-
-Metric:: `kalix_workflowentity_persisted_snapshots_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_received_commands_total`
-
-Total commands received for an entity.
-
-Metric:: `kalix_workflowentity_received_commands_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_recovery_failed_total`
-
-Total recovery process that have failed.
-
-Metric:: `kalix_workflowentity_recovery_failed_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_recovery_from_events_total`
-
-If events were loaded to recover an entity.
-
-Metric:: `kalix_workflowentity_recovery_from_events_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_recovery_time_seconds`
-
-Duration for workflow recovery, in seconds.
-
-Metric:: `kalix_workflowentity_recovery_time_seconds`
+Size in bytes of loaded workflow data (events, snapshots) during recovery. Each record represents one loaded item.
+Metric:: `akka.workflow.loaded.size`
 Type:: histogram
-Labels::
+Unit:: `By`
+
+
+
+Component attributes::
 +
---
-* `entity_name`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Workflow Persistence attributes::
 +
---
-* `kalix_workflowentity_recovery_time_seconds_bucket` (with `le` label)
-* `kalix_workflowentity_recovery_time_seconds_count`
-* `kalix_workflowentity_recovery_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `10.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_workflowentity_registered_for_deletion_total`
+| `akka.workflow.persistence.type`
+| enum
+| Yes
+| The type of workflow persistence operation.
 
-Total workflow instances registered to be deleted
+|===
 
-Metric:: `kalix_workflowentity_registered_for_deletion_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
 
-=== `kalix_workflowentity_started_commands_total`
+=== Workflow persist duration
 
-Commands sent from workflow to other components or user service.
-
-Metric:: `kalix_workflowentity_started_commands_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_started_steps_total`
-
-Total steps started.
-
-Metric:: `kalix_workflowentity_started_steps_total`
-Type:: counter
-Labels::
-+
---
-* `entity_name`
---
-
-=== `kalix_workflowentity_step_processing_time_seconds`
-
-Duration for step processing (until user service reply), in seconds.
-
-Metric:: `kalix_workflowentity_step_processing_time_seconds`
+Duration of workflow persistence operations.
+Metric:: `akka.workflow.persist.duration`
 Type:: histogram
-Labels::
+Unit:: `s`
+
+
+
+Component attributes::
 +
---
-* `entity_name`
---
-Exported metrics::
-+
---
-* `kalix_workflowentity_step_processing_time_seconds_bucket` (with `le` label)
-* `kalix_workflowentity_step_processing_time_seconds_count`
-* `kalix_workflowentity_step_processing_time_seconds_sum`
---
-Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_workflowentity_step_total_time_seconds`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total duration for step handling (including persist), in seconds.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_workflowentity_step_total_time_seconds`
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+
+=== Workflow persisted size
+
+Size in bytes of persisted workflow data (events, snapshots, replicated events). Each record represents one persisted item.
+Metric:: `akka.workflow.persisted.size`
 Type:: histogram
-Labels::
+Unit:: `By`
+
+
+
+Component attributes::
 +
---
-* `entity_name`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Workflow Persistence attributes::
 +
---
-* `kalix_workflowentity_step_total_time_seconds_bucket` (with `le` label)
-* `kalix_workflowentity_step_total_time_seconds_count`
-* `kalix_workflowentity_step_total_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
+
+| `akka.workflow.persistence.type`
+| enum
+| Yes
+| The type of workflow persistence operation.
+
+|===
+
+
+=== Workflow recovery duration
+
+Duration of workflow recovery.
+Metric:: `akka.workflow.recovery.duration`
+Type:: histogram
+Unit:: `s`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
+
+|===
+
+
+=== Workflow recovery events loaded
+
+Number of workflow recoveries that loaded from events (not snapshot-only).
+Metric:: `akka.workflow.recovery.events_loaded`
+Type:: counter
+Unit:: `{recovery}`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+
+=== Workflows registered for deletion
+
+Number of workflows registered for deletion.
+Metric:: `akka.workflow.registered_for_deletion`
+Type:: counter
+Unit:: `{workflow}`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+
+=== Workflow step duration
+
+Duration of workflow step execution.
+Metric:: `akka.workflow.step.duration`
+Type:: histogram
+Unit:: `s`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Workflow Step attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.workflow.step.id`
+| int
+| Yes
+| The ID of the workflow step.
+
+| `akka.workflow.step.name`
+| string
+| Yes
+| The name of the workflow step.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
+
+|===
+
+
+=== Workflow step processing duration
+
+Duration of workflow step processing in the user function.
+Metric:: `akka.workflow.step.processing.duration`
+Type:: histogram
+Unit:: `s`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Workflow Step attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.workflow.step.id`
+| int
+| Yes
+| The ID of the workflow step.
+
+| `akka.workflow.step.name`
+| string
+| Yes
+| The name of the workflow step.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
+
+|===
+
+
+=== Workflow transition duration
+
+Total duration of workflow transition handling (from started to completed).
+Metric:: `akka.workflow.transition.duration`
+Type:: histogram
+Unit:: `s`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
+
+|===
+
+
+=== Workflow transition processing duration
+
+Duration of workflow transition processing in the user function.
+Metric:: `akka.workflow.transition.processing.duration`
+Type:: histogram
+Unit:: `s`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
+
+|===
+
 
 == Views
 
-=== `kalix_view_conflict_resolution_total_time_seconds`
 
-Total duration for conflict resolution, in seconds.
+=== View conflict resolution duration
 
-Metric:: `kalix_view_conflict_resolution_total_time_seconds`
+Total duration of view conflict resolution.
+Metric:: `akka.view.conflict_resolution.duration`
 Type:: histogram
-Labels::
+Unit:: `s`
+
+
+
+Component attributes::
 +
---
-* `view_name`
-* `command_name`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+View Update attributes::
 +
---
-* `kalix_view_conflict_resolution_total_time_seconds_bucket` (with `le` label)
-* `kalix_view_conflict_resolution_total_time_seconds_count`
-* `kalix_view_conflict_resolution_total_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_conflict_resolutions_total`
+| `akka.view.table`
+| string
+| Yes
+| The view table name.
 
-Total conflict resolutions started for an update method.
+|===
 
-Metric:: `kalix_view_conflict_resolutions_total`
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
+
+|===
+
+
+=== View conflict resolutions
+
+Number of view conflict resolutions completed.
+Metric:: `akka.view.conflict_resolutions`
 Type:: counter
-Labels::
+Unit:: `{resolution}`
+
+
+
+Component attributes::
 +
---
-* `view_name`
-* `command_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_delete_rows_total`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total deleted rows.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_view_delete_rows_total`
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+View Update attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.view.table`
+| string
+| Yes
+| The view table name.
+
+|===
+
+
+=== View load rows
+
+Number of rows loaded from the view store.
+Metric:: `akka.view.load.rows`
 Type:: counter
-Labels::
+Unit:: `{row}`
+
+
+
+Component attributes::
 +
---
-* `view_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_load_bytes_total`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total bytes loaded from store.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_view_load_bytes_total`
-Type:: counter
-Labels::
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+View Update attributes::
 +
---
-* `view_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_load_failed_total`
+| `akka.view.table`
+| string
+| Yes
+| The view table name.
 
-Total failures loading from store.
+|===
 
-Metric:: `kalix_view_load_failed_total`
-Type:: counter
-Labels::
-+
---
-* `view_name`
---
 
-=== `kalix_view_load_rows_total`
+=== View load size
 
-Total rows loaded from store.
-
-Metric:: `kalix_view_load_rows_total`
-Type:: counter
-Labels::
-+
---
-* `view_name`
---
-
-=== `kalix_view_query_process_failed_total`
-
-Total failures processing a query.
-
-Metric:: `kalix_view_query_process_failed_total`
-Type:: counter
-Labels::
-+
---
-* `view_name`
---
-
-=== `kalix_view_query_received_requests_total`
-
-Total query requests received for a view.
-
-Metric:: `kalix_view_query_received_requests_total`
-Type:: counter
-Labels::
-+
---
-* `view_name`
---
-
-=== `kalix_view_query_result_bytes_total`
-
-Total query result bytes.
-
-Metric:: `kalix_view_query_result_bytes_total`
-Type:: counter
-Labels::
-+
---
-* `view_name`
---
-
-=== `kalix_view_query_result_rows_total`
-
-Total query result rows.
-
-Metric:: `kalix_view_query_result_rows_total`
-Type:: counter
-Labels::
-+
---
-* `view_name`
---
-
-=== `kalix_view_query_total_time_seconds`
-
-Total duration for queries, in seconds.
-
-Metric:: `kalix_view_query_total_time_seconds`
+Size in bytes per loaded view entry.
+Metric:: `akka.view.load.size`
 Type:: histogram
-Labels::
+Unit:: `By`
+
+
+
+Component attributes::
 +
---
-* `view_name`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+View Update attributes::
 +
---
-* `kalix_view_query_total_time_seconds_bucket` (with `le` label)
-* `kalix_view_query_total_time_seconds_count`
-* `kalix_view_query_total_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_query_view_store_limit_load_bytes_exceeded_total`
+| `akka.view.table`
+| string
+| Yes
+| The view table name.
 
-Total failures from exceeding limit bytes loaded from view store.
+|===
 
-Metric:: `kalix_view_query_view_store_limit_load_bytes_exceeded_total`
+
+=== View query byte limit exceeded
+
+Number of view queries that exceeded the byte limit for loading from the view store.
+Metric:: `akka.view.query.byte_limit_exceeded`
 Type:: counter
-Labels::
+Unit:: `{error}`
+
+
+
+Component attributes::
 +
---
-* `view_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_query_view_store_limit_load_rows_exceeded_total`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total failures from exceeding limit for rows loaded from view store.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_view_query_view_store_limit_load_rows_exceeded_total`
-Type:: counter
-Labels::
-+
---
-* `view_name`
---
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
 
-=== `kalix_view_update_load_time_seconds`
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
 
-Duration for loading existing entries (if transforming updates), in seconds.
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
 
-Metric:: `kalix_view_update_load_time_seconds`
+|===
+
+
+=== View query duration
+
+Total duration of view query execution.
+Metric:: `akka.view.query.duration`
 Type:: histogram
-Labels::
+Unit:: `s`
+
+
+
+Component attributes::
 +
---
-* `view_name`
-* `command_name`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+OpenTelemetry semantic convention attributes::
 +
---
-* `kalix_view_update_load_time_seconds_bucket` (with `le` label)
-* `kalix_view_update_load_time_seconds_count`
-* `kalix_view_update_load_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_update_store_time_seconds`
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
 
-Duration for storing updates, in seconds.
+|===
 
-Metric:: `kalix_view_update_store_time_seconds`
+
+=== View query result rows
+
+Number of rows returned per view query.
+Metric:: `akka.view.query.result.rows`
 Type:: histogram
-Labels::
+Unit:: `{row}`
+
+
+
+Component attributes::
 +
---
-* `view_name`
-* `command_name`
---
-Exported metrics::
-+
---
-* `kalix_view_update_store_time_seconds_bucket` (with `le` label)
-* `kalix_view_update_store_time_seconds_count`
-* `kalix_view_update_store_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_update_total_time_seconds`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total duration for updates, in seconds.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_view_update_total_time_seconds`
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+
+=== View query result size
+
+Size in bytes of view query results.
+Metric:: `akka.view.query.result.size`
 Type:: histogram
-Labels::
+Unit:: `By`
+
+
+
+Component attributes::
 +
---
-* `view_name`
-* `command_name`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+
+=== View query row limit exceeded
+
+Number of view queries that exceeded the row limit for loading from the view store.
+Metric:: `akka.view.query.row_limit_exceeded`
+Type:: counter
+Unit:: `{error}`
+
+
+
+Component attributes::
 +
---
-* `kalix_view_update_total_time_seconds_bucket` (with `le` label)
-* `kalix_view_update_total_time_seconds_count`
-* `kalix_view_update_total_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_update_transform_time_seconds`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Duration for transforming updates in the user service, in seconds.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_view_update_transform_time_seconds`
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+
+=== View update duration
+
+Total duration of view update handling.
+Metric:: `akka.view.update.duration`
 Type:: histogram
-Labels::
+Unit:: `s`
+
+
+
+Component attributes::
 +
---
-* `view_name`
-* `command_name`
---
-Exported metrics::
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+View Update attributes::
 +
---
-* `kalix_view_update_transform_time_seconds_bucket` (with `le` label)
-* `kalix_view_update_transform_time_seconds_count`
-* `kalix_view_update_transform_time_seconds_sum`
---
-Buckets:: `0.002`, `0.005`, `0.01`, `0.015`, `0.02`, `0.03`, `0.04`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_updates_deduplicated_total`
+| `akka.view.table`
+| string
+| Yes
+| The view table name.
 
-Total updates that have been automatically deduplicated.
+|===
 
-Metric:: `kalix_view_updates_deduplicated_total`
-Type:: counter
-Labels::
+View Update Outcome attributes::
 +
---
-* `view_name`
-* `table_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_updates_filtered_total`
+| `akka.view.update.outcome`
+| enum
+| Yes
+| The outcome of the view update.
 
-Total updates that have been automatically filtered (for internal messages).
+|===
 
-Metric:: `kalix_view_updates_filtered_total`
-Type:: counter
-Labels::
+OpenTelemetry semantic convention attributes::
 +
---
-* `view_name`
-* `table_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_updates_ignored_total`
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
 
-Total updates that have been ignored.
+|===
 
-Metric:: `kalix_view_updates_ignored_total`
-Type:: counter
-Labels::
+
+=== View update load duration
+
+Duration for loading existing entries from the view store.
+Metric:: `akka.view.update.load.duration`
+Type:: histogram
+Unit:: `s`
+
+
+
+Component attributes::
 +
---
-* `view_name`
-* `table_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_updates_processed_total`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total updates that have been actually processed.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_view_updates_processed_total`
-Type:: counter
-Labels::
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+View Update attributes::
 +
---
-* `view_name`
-* `table_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_updates_skipped_total`
+| `akka.view.table`
+| string
+| Yes
+| The view table name.
 
-Total updates that have been skipped (based on sequence gap detection).
+|===
 
-Metric:: `kalix_view_updates_skipped_total`
-Type:: counter
-Labels::
+OpenTelemetry semantic convention attributes::
 +
---
-* `view_name`
-* `table_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_updates_total`
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
 
-Total updates received for an update method.
+|===
 
-Metric:: `kalix_view_updates_total`
+
+=== View update sequence gaps
+
+Number of sequence gaps detected in view updates.
+Metric:: `akka.view.update.sequence_gaps`
 Type:: counter
-Labels::
+Unit:: `{gap}`
+
+
+
+Component attributes::
 +
---
-* `view_name`
-* `command_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_upsert_byte_limit_exceeded_total`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total failures from exceeding byte size limit for single view store upsert.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_view_upsert_byte_limit_exceeded_total`
-Type:: counter
-Labels::
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+View Update attributes::
 +
---
-* `view_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_upsert_bytes_total`
+| `akka.view.table`
+| string
+| Yes
+| The view table name.
 
-Total upsert bytes.
+|===
 
-Metric:: `kalix_view_upsert_bytes_total`
-Type:: counter
-Labels::
+
+=== View update store duration
+
+Duration for storing updates in the view store.
+Metric:: `akka.view.update.store.duration`
+Type:: histogram
+Unit:: `s`
+
+
+
+Component attributes::
 +
---
-* `view_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_upsert_failed_total`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total failed upserts.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_view_upsert_failed_total`
-Type:: counter
-Labels::
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+View Update attributes::
 +
---
-* `view_name`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_view_upsert_rows_total`
+| `akka.view.table`
+| string
+| Yes
+| The view table name.
 
-Total upsert rows.
+|===
 
-Metric:: `kalix_view_upsert_rows_total`
-Type:: counter
-Labels::
+OpenTelemetry semantic convention attributes::
 +
---
-* `view_name`
---
+|===
+| Attribute | Type | Required | Description
 
-== Eventing
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
 
-=== `kalix_eventing_broker_used_total`
+|===
 
-Kalix eventing message broker type
 
-Metric:: `kalix_eventing_broker_used_total`
-Type:: counter
-Labels::
+=== View update transform duration
+
+Duration for transforming updates in the user service.
+Metric:: `akka.view.update.transform.duration`
+Type:: histogram
+Unit:: `s`
+
+
+
+Component attributes::
 +
---
-* `broker_type`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_eventing_event_failed_total`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total events leading to event stream failure
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_eventing_event_failed_total`
-Type:: counter
-Labels::
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+View Update attributes::
 +
---
-* `consumer_service`
-* `event_source_type`
-* `event_source`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_eventing_event_handled_total`
+| `akka.view.table`
+| string
+| Yes
+| The view table name.
 
-Total events processed by a consumer
+|===
 
-Metric:: `kalix_eventing_event_handled_total`
-Type:: counter
-Labels::
+OpenTelemetry semantic convention attributes::
 +
---
-* `consumer_service`
-* `event_source_type`
-* `event_source`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_eventing_service_to_service_consumer_total`
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
 
-Service to Service stream consumers, each stream_id counted
+|===
 
-Metric:: `kalix_eventing_service_to_service_consumer_total`
+
+=== View upsert byte limit exceeded
+
+Number of view upsert operations that exceeded the byte size limit.
+Metric:: `akka.view.upsert.byte_limit_exceeded`
 Type:: counter
+Unit:: `{error}`
 
-=== `kalix_eventing_service_to_service_producer_total`
 
-Service to Service stream producer, each stream_id counted
 
-Metric:: `kalix_eventing_service_to_service_producer_total`
-Type:: counter
-
-=== `kalix_eventing_source_stream_started_total`
-
-Total event source streams that have started
-
-Metric:: `kalix_eventing_source_stream_started_total`
-Type:: counter
-Labels::
+Component attributes::
 +
---
-* `consumer_service`
-* `event_source_type`
-* `event_source`
---
+|===
+| Attribute | Type | Required | Description
 
-== Projections
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-=== `kalix_projection_backlog_lag_seconds`
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Time in seconds the projection is lagging behind the latest event
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
 
-Metric:: `kalix_projection_backlog_lag_seconds`
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+
+=== View upsert rows
+
+Number of rows upserted to the view store.
+Metric:: `akka.view.upsert.rows`
+Type:: counter
+Unit:: `{row}`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+View Update attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.view.table`
+| string
+| Yes
+| The view table name.
+
+|===
+
+
+=== View upsert size
+
+Size in bytes per upserted view entry.
+Metric:: `akka.view.upsert.size`
+Type:: histogram
+Unit:: `By`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+View Update attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.view.table`
+| string
+| Yes
+| The view table name.
+
+|===
+
+
+== Consumers
+
+
+=== Consumer message duration
+
+Duration of consumer message processing.
+Metric:: `akka.consumer.message.duration`
+Type:: histogram
+Unit:: `s`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Consumer attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.consumer.source`
+| enum
+| Yes
+| The type of source the consumer is consuming from.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
+
+|===
+
+
+== Timers
+
+
+=== Timer call duration
+
+Duration of timer call executions.
+Metric:: `akka.timer.call.duration`
+Type:: histogram
+Unit:: `s`
+
+
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
+
+|===
+
+
+=== Timer operation duration
+
+Duration of internal timer operations (register, unregister, confirm, max_retries).
+Metric:: `akka.timer.operation.duration`
+Type:: histogram
+Unit:: `s`
+
+
+
+Timer Operation attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.timer.operation`
+| enum
+| Yes
+| The type of timer operation.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if the operation ended in an error
+| Describes the error condition.
+
+|===
+
+
+=== Timer persisted size
+
+Size in bytes of persisted timer data. Each record represents one persisted item.
+Metric:: `akka.timer.persisted.size`
+Type:: histogram
+Unit:: `By`
+
+
+
+
+=== Registered timers
+
+Number of currently registered timer calls per worker.
+Metric:: `akka.timer.registered`
 Type:: gauge
-Labels::
+Unit:: `{timer}`
+
+
+
+Timer Worker attributes::
 +
---
-* `projection_name`
-* `projection_key`
-* `projection_type`
---
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_projection_completed_total`
+| `akka.timer.worker_id`
+| string
+| Yes
+| Identifier of the timer worker actor (shard).
 
-Total envelopes completed for a projection.
+|===
 
-Metric:: `kalix_projection_completed_total`
-Type:: counter
-Labels::
-+
---
-* `projection_name`
-* `projection_key`
-* `projection_type`
-* `envelope_source`
---
 
-=== `kalix_projection_consumer_lag_seconds`
+== Timed Actions
 
-Consumer lag, duration for envelope processing from when the envelope was created, in seconds.
 
-Metric:: `kalix_projection_consumer_lag_seconds`
+=== Timed action message duration
+
+Duration of timed action message processing.
+Metric:: `akka.timed_action.message.duration`
 Type:: histogram
-Labels::
+Unit:: `s`
+
+
+
+Component attributes::
 +
---
-* `projection_name`
-* `projection_key`
-* `projection_type`
-* `envelope_source`
---
-Exported metrics::
-+
---
-* `kalix_projection_consumer_lag_seconds_bucket` (with `le` label)
-* `kalix_projection_consumer_lag_seconds_count`
-* `kalix_projection_consumer_lag_seconds_sum`
---
-Buckets:: `0.01`, `0.05`, `0.1`, `0.25`, `0.5`, `1.0`, `2.0`, `3.0`, `4.0`, `5.0`, `10.0`, `20.0`, `30.0`, `Infinity`
+|===
+| Attribute | Type | Required | Description
 
-=== `kalix_projection_failed_total`
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
 
-Total projection instances that have failed.
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
 
-Metric:: `kalix_projection_failed_total`
-Type:: counter
-Labels::
-+
---
-* `projection_name`
-* `projection_key`
-* `projection_type`
---
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
 
-=== `kalix_projection_processing_time_seconds`
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
 
-Duration for envelope processing (including user service and persist), in seconds.
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
 
-Metric:: `kalix_projection_processing_time_seconds`
-Type:: histogram
-Labels::
-+
---
-* `projection_name`
-* `projection_key`
-* `projection_type`
-* `envelope_source`
---
-Exported metrics::
-+
---
-* `kalix_projection_processing_time_seconds_bucket` (with `le` label)
-* `kalix_projection_processing_time_seconds_count`
-* `kalix_projection_processing_time_seconds_sum`
---
-Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `10.0`, `Infinity`
+|===
 
-=== `kalix_projection_received_total`
-
-Total envelopes received for a projection (before de-duplication).
-
-Metric:: `kalix_projection_received_total`
-Type:: counter
-Labels::
-+
---
-* `projection_name`
-* `projection_key`
-* `projection_type`
-* `envelope_source`
---
-
-=== `kalix_projection_started_total`
-
-Total projection instances that have started.
-
-Metric:: `kalix_projection_started_total`
-Type:: counter
-Labels::
-+
---
-* `projection_name`
-* `projection_key`
-* `projection_type`
---
-
-=== `kalix_projection_stopped_total`
-
-Total projection instances that have stopped.
-
-Metric:: `kalix_projection_stopped_total`
-Type:: counter
-Labels::
-+
---
-* `projection_name`
-* `projection_key`
-* `projection_type`
---
-
-== Actions
-
-=== `kalix_action_completed_messages_total`
-
-Total messages completed for an action.
-
-Metric:: `kalix_action_completed_messages_total`
-Type:: counter
-Labels::
-+
---
-* `action_name`
---
-
-=== `kalix_action_message_processing_time_seconds`
-
-Duration for message processing (until first user service reply), in seconds.
-
-Metric:: `kalix_action_message_processing_time_seconds`
-Type:: histogram
-Labels::
-+
---
-* `action_name`
---
-Exported metrics::
-+
---
-* `kalix_action_message_processing_time_seconds_bucket` (with `le` label)
-* `kalix_action_message_processing_time_seconds_count`
-* `kalix_action_message_processing_time_seconds_sum`
---
-Buckets:: `0.001`, `0.002`, `0.003`, `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.2`, `0.5`, `1.0`, `2.0`, `3.0`, `5.0`, `7.5`, `10.0`, `Infinity`
-
-=== `kalix_action_received_messages_total`
-
-Total messages received for an action.
-
-Metric:: `kalix_action_received_messages_total`
-Type:: counter
-Labels::
-+
---
-* `action_name`
---
-
-== Runtime
-
-=== `kalix_component_types_total`
-
-Kalix component type counts
-
-Metric:: `kalix_component_types_total`
-Type:: counter
-Labels::
-+
---
-* `component_type`
---
-
-=== `kalix_instance_size`
-
-Kalix instance size.
-
-Metric:: `kalix_instance_size`
-Type:: gauge
-
-=== `kalix_proxy_info`
-
-Kalix proxy and SDK details
-
-Metric:: `kalix_proxy_info`
-Type:: info
-Labels::
-+
---
-* `proxy_version`
-* `sdk_name`
-* `sdk_version`
---
-
-=== `kalix_service_revision`
-
-Kalix user service version. I.e. Kubernetes/revision
-
-Metric:: `kalix_service_revision`
-Type:: gauge

--- a/docs/src/modules/reference/pages/telemetry/metrics.adoc
+++ b/docs/src/modules/reference/pages/telemetry/metrics.adoc
@@ -15,7 +15,7 @@ In addition to the Akka-specific metrics listed below, standard JVM runtime metr
 Number of active HTTP server requests.
 Metric:: `http.server.active_requests`
 Type:: up-down counter
-Unit:: `{request}`
+Unit:: `\{request}`
 
 
 
@@ -76,7 +76,7 @@ OpenTelemetry semantic convention attributes::
 | `http.route`
 | string
 | Conditionally required: If and only if it's available
-| The matched route template, e.g. `/pets/{id}`.
+| The matched route template, e.g. `/pets/\{id}`.
 
 | `server.address`
 | string
@@ -152,7 +152,7 @@ OpenTelemetry semantic convention attributes::
 | `http.route`
 | string
 | Conditionally required: If and only if it's available
-| The matched route template, e.g. `/pets/{id}`.
+| The matched route template, e.g. `/pets/\{id}`.
 
 | `server.address`
 | string
@@ -238,7 +238,7 @@ OpenTelemetry semantic convention attributes::
 | `http.route`
 | string
 | Conditionally required: If and only if it's available
-| The matched route template, e.g. `/pets/{id}`.
+| The matched route template, e.g. `/pets/\{id}`.
 
 | `server.address`
 | string
@@ -324,7 +324,7 @@ OpenTelemetry semantic convention attributes::
 | `http.route`
 | string
 | Conditionally required: If and only if it's available
-| The matched route template, e.g. `/pets/{id}`.
+| The matched route template, e.g. `/pets/\{id}`.
 
 | `server.address`
 | string
@@ -803,7 +803,7 @@ Component attributes::
 Number of agent evaluation results.
 Metric:: `akka.agent.evaluation.result`
 Type:: counter
-Unit:: `{result}`
+Unit:: `\{result}`
 
 
 
@@ -995,7 +995,7 @@ OpenTelemetry semantic convention attributes::
 Number of input and output tokens used in GenAI operations.
 Metric:: `gen_ai.client.token.usage`
 Type:: histogram
-Unit:: `{token}`
+Unit:: `\{token}`
 
 
 
@@ -1067,7 +1067,7 @@ OpenTelemetry semantic convention attributes::
 Number of currently active workflow instances.
 Metric:: `akka.workflow.active`
 Type:: up-down counter
-Unit:: `{workflow}`
+Unit:: `\{workflow}`
 
 
 
@@ -1295,7 +1295,7 @@ OpenTelemetry semantic convention attributes::
 Number of workflow replication conflicts detected.
 Metric:: `akka.workflow.conflicts_detected`
 Type:: counter
-Unit:: `{conflict}`
+Unit:: `\{conflict}`
 
 
 
@@ -1337,7 +1337,7 @@ Component attributes::
 Number of workflow replication conflicts resolved.
 Metric:: `akka.workflow.conflicts_resolved`
 Type:: counter
-Unit:: `{conflict}`
+Unit:: `\{conflict}`
 
 
 
@@ -1583,7 +1583,7 @@ OpenTelemetry semantic convention attributes::
 Number of workflow recoveries that loaded from events (not snapshot-only).
 Metric:: `akka.workflow.recovery.events_loaded`
 Type:: counter
-Unit:: `{recovery}`
+Unit:: `\{recovery}`
 
 
 
@@ -1625,7 +1625,7 @@ Component attributes::
 Number of workflows registered for deletion.
 Metric:: `akka.workflow.registered_for_deletion`
 Type:: counter
-Unit:: `{workflow}`
+Unit:: `\{workflow}`
 
 
 
@@ -1986,7 +1986,7 @@ OpenTelemetry semantic convention attributes::
 Number of view conflict resolutions completed.
 Metric:: `akka.view.conflict_resolutions`
 Type:: counter
-Unit:: `{resolution}`
+Unit:: `\{resolution}`
 
 
 
@@ -2040,7 +2040,7 @@ View Update attributes::
 Number of rows loaded from the view store.
 Metric:: `akka.view.load.rows`
 Type:: counter
-Unit:: `{row}`
+Unit:: `\{row}`
 
 
 
@@ -2148,7 +2148,7 @@ View Update attributes::
 Number of view queries that exceeded the byte limit for loading from the view store.
 Metric:: `akka.view.query.byte_limit_exceeded`
 Type:: counter
-Unit:: `{error}`
+Unit:: `\{error}`
 
 
 
@@ -2244,7 +2244,7 @@ OpenTelemetry semantic convention attributes::
 Number of rows returned per view query.
 Metric:: `akka.view.query.result.rows`
 Type:: histogram
-Unit:: `{row}`
+Unit:: `\{row}`
 
 
 
@@ -2328,7 +2328,7 @@ Component attributes::
 Number of view queries that exceeded the row limit for loading from the view store.
 Metric:: `akka.view.query.row_limit_exceeded`
 Type:: counter
-Unit:: `{error}`
+Unit:: `\{error}`
 
 
 
@@ -2514,7 +2514,7 @@ OpenTelemetry semantic convention attributes::
 Number of sequence gaps detected in view updates.
 Metric:: `akka.view.update.sequence_gaps`
 Type:: counter
-Unit:: `{gap}`
+Unit:: `\{gap}`
 
 
 
@@ -2700,7 +2700,7 @@ OpenTelemetry semantic convention attributes::
 Number of view upsert operations that exceeded the byte size limit.
 Metric:: `akka.view.upsert.byte_limit_exceeded`
 Type:: counter
-Unit:: `{error}`
+Unit:: `\{error}`
 
 
 
@@ -2742,7 +2742,7 @@ Component attributes::
 Number of rows upserted to the view store.
 Metric:: `akka.view.upsert.rows`
 Type:: counter
-Unit:: `{row}`
+Unit:: `\{row}`
 
 
 
@@ -2988,7 +2988,7 @@ Unit:: `By`
 Number of currently registered timer calls per worker.
 Metric:: `akka.timer.registered`
 Type:: gauge
-Unit:: `{timer}`
+Unit:: `\{timer}`
 
 
 

--- a/docs/src/modules/reference/pages/telemetry/tracing.adoc
+++ b/docs/src/modules/reference/pages/telemetry/tracing.adoc
@@ -1,0 +1,1985 @@
+= Tracing reference
+
+Akka can collect traces for observing the runtime behavior of your services.
+
+These trace spans are available for xref:operations:observability-and-monitoring/observability-exports.adoc[export] to external monitoring systems.
+
+
+== HTTP Endpoints
+
+
+=== HTTP server span
+
+This span represents an inbound HTTP request.
+Span kind:: server
+Akka span kind:: `endpoint.request`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Endpoint attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.endpoint.method`
+| string
+| Yes
+| Name of the endpoint method being invoked.
+
+|===
+
+Debug attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.debug.auto`
+| boolean
+| Conditionally required: when debug tracing is enabled
+| Whether debug mode was automatically enabled.
+
+| `akka.debug.id`
+| string
+| Conditionally required: when debug tracing is enabled
+| Debug identifier for correlating traces.
+
+|===
+
+Http Debug attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `http.request.body.content`
+| string
+| Conditionally required: when debug tracing is enabled
+| Captured content of the HTTP request body.
+
+| `http.request.body.encoding`
+| string
+| Conditionally required: when debug tracing is enabled
+| Encoding format of the captured request body.
+
+| `http.request.body.type`
+| string
+| Conditionally required: when debug tracing is enabled
+| The expected type used to deserialize the request body.
+
+| `http.response.body.content`
+| string
+| Conditionally required: when debug tracing is enabled
+| Captured content of the HTTP response body.
+
+| `http.response.body.encoding`
+| string
+| Conditionally required: when debug tracing is enabled
+| Encoding format of the captured response body.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if and only if an error has occurred.
+| Describes the error condition, such as the HTTP status code.
+
+| `http.request.method`
+| string
+| Yes
+| HTTP request method.
+
+| `http.response.status_code`
+| int
+| Conditionally required: If and only if one was received/sent.
+| link:https://tools.ietf.org/html/rfc7231#section-6[HTTP response status code].
+
+| `http.route`
+| string
+| Conditionally required: If and only if it's available
+| The matched route template, e.g. `/pets/{id}`.
+
+| `server.address`
+| string
+| Recommended
+| The client-facing server hostname.
+
+| `url.path`
+| string
+| Recommended
+| The link:https://www.rfc-editor.org/rfc/rfc3986#section-3.3[URI path] component
+
+| `url.query`
+| string
+| Recommended
+| The link:https://www.rfc-editor.org/rfc/rfc3986#section-3.4[URI query] component
+
+|===
+
+
+== gRPC Endpoints
+
+
+=== gRPC server span
+
+This span represents an incoming gRPC server call.
+Span kind:: server
+Akka span kind:: `endpoint.request`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Endpoint attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.endpoint.method`
+| string
+| Yes
+| Name of the endpoint method being invoked.
+
+|===
+
+Debug attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.debug.auto`
+| boolean
+| Conditionally required: when debug tracing is enabled
+| Whether debug mode was automatically enabled.
+
+| `akka.debug.id`
+| string
+| Conditionally required: when debug tracing is enabled
+| Debug identifier for correlating traces.
+
+|===
+
+Grpc Debug attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `grpc.input.message.content`
+| string
+| Conditionally required: when debug tracing is enabled
+| Captured content of the gRPC input message (unary).
+
+| `grpc.input.message.type`
+| string
+| Conditionally required: when debug tracing is enabled
+| The fully qualified protobuf type name of the input message.
+
+| `grpc.input.stream.message.content`
+| string[]
+| Conditionally required: when debug tracing is enabled and input is streaming
+| Captured content of gRPC input stream messages.
+
+| `grpc.input.streaming`
+| boolean
+| Conditionally required: when debug tracing is enabled and input is streaming
+| Whether the input is a client stream.
+
+| `grpc.output.message.content`
+| string
+| Conditionally required: when debug tracing is enabled
+| Captured content of the gRPC output message (unary).
+
+| `grpc.output.message.type`
+| string
+| Conditionally required: when debug tracing is enabled
+| The fully qualified protobuf type name of the output message.
+
+| `grpc.output.stream.message.content`
+| string[]
+| Conditionally required: when debug tracing is enabled and output is streaming
+| Captured content of gRPC output stream messages.
+
+| `grpc.output.streaming`
+| boolean
+| Conditionally required: when debug tracing is enabled and output is streaming
+| Whether the output is a server stream.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if and only if an error has occurred.
+| Describes the error condition, such as the gRPC status code.
+
+| `rpc.method`
+| string
+| Yes
+| The gRPC service and method name, e.g. `com.example.MyService/MyMethod`.
+
+| `rpc.response.status_code`
+| string
+| Conditionally required: if available.
+| The gRPC status code.
+
+| `rpc.system.name`
+| enum
+| Yes
+| The Remote Procedure Call (RPC) system.
+
+| `server.address`
+| string
+| Recommended
+| The client-facing server hostname.
+
+|===
+
+
+== MCP Endpoints
+
+
+=== MCP server span
+
+This span represents an incoming MCP server operation.
+Span kind:: server
+Akka span kind:: `endpoint.request`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Debug attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.debug.auto`
+| boolean
+| Conditionally required: when debug tracing is enabled
+| Whether debug mode was automatically enabled.
+
+| `akka.debug.id`
+| string
+| Conditionally required: when debug tracing is enabled
+| Debug identifier for correlating traces.
+
+|===
+
+Mcp Debug attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `mcp.request.content`
+| string
+| Conditionally required: when debug tracing is enabled
+| Captured content of the MCP JSON-RPC request.
+
+| `mcp.response.content`
+| string
+| Conditionally required: when debug tracing is enabled
+| Captured content of the MCP JSON-RPC response.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `error.type`
+| string
+| Conditionally required: if and only if an error has occurred.
+| Describes the error condition.
+
+| `gen_ai.operation.name`
+| enum
+| Conditionally required: when applicable for the MCP method
+| The name of the operation being performed.
+
+| `gen_ai.prompt.name`
+| string
+| Conditionally required: When operation is related to a specific prompt.
+| The MCP prompt name.
+
+| `gen_ai.tool.name`
+| string
+| Conditionally required: When operation is related to a specific tool.
+| The MCP tool name.
+
+| `jsonrpc.request.id`
+| string
+| Recommended
+| A string representation of the `id` property of the request and its corresponding response.
+
+| `mcp.method.name`
+| enum
+| Yes
+| The name of the request or notification method.
+
+| `mcp.resource.uri`
+| string
+| Conditionally required: when applicable for the MCP method
+| The value of the resource uri.
+
+| `rpc.response.status_code`
+| string
+| Conditionally required: if available.
+| The gRPC status code for the MCP transport.
+
+|===
+
+
+== Agents
+
+
+=== Agent command span
+
+This span represents an agent command invocation.
+Span kind:: server
+Akka span kind:: `agent.command`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `gen_ai.agent.id`
+| string
+| Recommended
+| The unique identifier of the GenAI agent.
+
+| `gen_ai.agent.name`
+| string
+| Recommended
+| Human-readable name of the GenAI agent provided by the application.
+
+| `gen_ai.conversation.id`
+| string
+| Conditionally required: when available
+| The unique identifier for a conversation (session, thread), used to store and correlate messages within this conversation.
+
+| `gen_ai.operation.name`
+| enum
+| Yes
+| The name of the operation being performed.
+
+|===
+
+
+=== Agent content loading span
+
+This span represents content loading within an agent invocation.
+Span kind:: internal
+Akka span kind:: `agent.content.loading`
+
+
+
+Agent Content attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.agent.content.kind`
+| string
+| Yes
+| The kind of content being loaded.
+
+| `akka.agent.content.loader.class`
+| string
+| Recommended: if available
+| The class name of the content loader used.
+
+| `akka.agent.content.size`
+| int
+| Recommended: if available
+| The size of the loaded content in bytes.
+
+| `akka.agent.content.uri`
+| string
+| Yes
+| The URI of the content being loaded.
+
+|===
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+
+=== Agent guardrail span
+
+This span represents a guardrail evaluation within an agent invocation.
+Span kind:: internal
+Akka span kind:: `agent.guardrail`
+
+
+
+Agent Guardrail attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.agent.guardrail.category`
+| string
+| Yes
+| The category of the guardrail being evaluated.
+
+| `akka.agent.guardrail.name`
+| string
+| Yes
+| The name of the guardrail being evaluated.
+
+| `akka.agent.guardrail.result`
+| enum
+| Yes
+| The result of a guardrail evaluation.
+
+|===
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+
+=== Agent model call span
+
+This span represents an LLM model call within an agent invocation.
+Span kind:: client
+Akka span kind:: `agent.model.call`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `gen_ai.conversation.id`
+| string
+| Conditionally required: when available
+| The unique identifier for a conversation (session, thread), used to store and correlate messages within this conversation.
+
+| `gen_ai.input.messages`
+| any
+| Opt-in
+| The chat history provided to the model as an input.
+
+| `gen_ai.operation.name`
+| enum
+| Yes
+| The name of the operation being performed.
+
+| `gen_ai.output.messages`
+| any
+| Opt-in
+| Messages returned by the model where each message represents a specific model response (choice, candidate).
+
+| `gen_ai.output.type`
+| enum
+| Conditionally required: when applicable and if the request includes an output format.
+| Represents the content type requested by the client.
+
+| `gen_ai.provider.name`
+| enum
+| Yes
+| The Generative AI provider as identified by the client or server instrumentation.
+
+| `gen_ai.request.max_tokens`
+| int
+| Recommended
+| The maximum number of tokens the model generates for a request.
+
+| `gen_ai.request.model`
+| string
+| Conditionally required: If available.
+| The name of the GenAI model a request is being made to.
+
+| `gen_ai.request.temperature`
+| double
+| Recommended
+| The temperature setting for the GenAI request.
+
+| `gen_ai.request.top_k`
+| double
+| Recommended
+| The top_k sampling setting for the GenAI request.
+
+| `gen_ai.request.top_p`
+| double
+| Recommended
+| The top_p sampling setting for the GenAI request.
+
+| `gen_ai.response.finish_reasons`
+| string[]
+| Recommended
+| Array of reasons the model stopped generating tokens, corresponding to each generation received.
+
+| `gen_ai.response.id`
+| string
+| Recommended
+| The unique identifier for the completion.
+
+| `gen_ai.response.model`
+| string
+| Recommended
+| The name of the model that generated the response.
+
+| `gen_ai.usage.input_tokens`
+| int
+| Recommended
+| The number of tokens used in the GenAI input (prompt).
+
+| `gen_ai.usage.output_tokens`
+| int
+| Recommended
+| The number of tokens used in the GenAI response (completion).
+
+|===
+
+
+=== Agent tool call span
+
+This span represents a tool execution within an agent invocation.
+Span kind:: internal
+Akka span kind:: `agent.tool.call`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Agent Mcp attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.agent.mcp.endpoint`
+| string
+| Conditionally required: when the tool is from an MCP endpoint
+| The MCP endpoint from which the tool was discovered.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `gen_ai.operation.name`
+| enum
+| Yes
+| The name of the operation being performed.
+
+| `gen_ai.tool.call.id`
+| string
+| Recommended
+| The tool call identifier.
+
+| `gen_ai.tool.description`
+| string
+| Recommended
+| The tool description.
+
+| `gen_ai.tool.name`
+| string
+| Conditionally required: When operation is related to a specific tool.
+| Name of the tool utilized by the agent.
+
+| `gen_ai.tool.type`
+| string
+| Recommended
+| Type of the tool utilized by the agent
+
+|===
+
+
+=== Agent tool discovery span
+
+This span represents MCP tool discovery within an agent invocation.
+Span kind:: internal
+Akka span kind:: `agent.tool.discovery`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Agent Mcp attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.agent.mcp.endpoint`
+| string
+| Conditionally required: when the tool is from an MCP endpoint
+| The MCP endpoint from which the tool was discovered.
+
+|===
+
+
+== Agents (OpenInference)
+
+
+=== Agent command span (OpenInference)
+
+This span represents an agent command invocation with OpenInference attributes.
+Span kind:: server
+Akka span kind:: `agent.command`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Open Inference attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `open_inference.session.id`
+| string
+| Recommended: if available
+| The session identifier for the conversation.
+
+| `open_inference.span.kind`
+| enum
+| Yes
+| The kind of span in OpenInference semantic conventions.
+
+|===
+
+Open Inference Agent attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `open_inference.agent.name`
+| string
+| Recommended: if available
+| The name of the agent.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `gen_ai.agent.id`
+| string
+| Recommended
+| The unique identifier of the GenAI agent.
+
+| `gen_ai.agent.name`
+| string
+| Recommended
+| Human-readable name of the GenAI agent provided by the application.
+
+| `gen_ai.conversation.id`
+| string
+| Conditionally required: when available
+| The unique identifier for a conversation (session, thread), used to store and correlate messages within this conversation.
+
+| `gen_ai.operation.name`
+| enum
+| Yes
+| The name of the operation being performed.
+
+|===
+
+
+=== Agent guardrail span (OpenInference)
+
+This span represents a guardrail evaluation with OpenInference attributes.
+Span kind:: internal
+Akka span kind:: `agent.guardrail`
+
+
+
+Agent Guardrail attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.agent.guardrail.category`
+| string
+| Yes
+| The category of the guardrail being evaluated.
+
+| `akka.agent.guardrail.name`
+| string
+| Yes
+| The name of the guardrail being evaluated.
+
+| `akka.agent.guardrail.result`
+| enum
+| Yes
+| The result of a guardrail evaluation.
+
+|===
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Open Inference attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `open_inference.session.id`
+| string
+| Recommended: if available
+| The session identifier for the conversation.
+
+| `open_inference.span.kind`
+| enum
+| Yes
+| The kind of span in OpenInference semantic conventions.
+
+|===
+
+Open Inference Agent Guardrail attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `open_inference.agent.guardrail.category`
+| string
+| Recommended: if available
+| The category of the guardrail being evaluated.
+
+| `open_inference.agent.guardrail.name`
+| string
+| Recommended: if available
+| The name of the guardrail being evaluated.
+
+|===
+
+
+=== Agent model call span (OpenInference)
+
+This span represents an LLM model call with OpenInference attributes.
+Span kind:: client
+Akka span kind:: `agent.model.call`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Open Inference attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `open_inference.session.id`
+| string
+| Recommended: if available
+| The session identifier for the conversation.
+
+| `open_inference.span.kind`
+| enum
+| Yes
+| The kind of span in OpenInference semantic conventions.
+
+|===
+
+Open Inference Io attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `open_inference.input.mime_type`
+| string
+| Recommended: if available
+| The MIME type of the input.
+
+| `open_inference.input.value`
+| string
+| Recommended: if available
+| The input value.
+
+| `open_inference.output.mime_type`
+| string
+| Recommended: if available
+| The MIME type of the output.
+
+| `open_inference.output.value`
+| string
+| Recommended: if available
+| The output value.
+
+|===
+
+Open Inference Llm attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `open_inference.llm.input_messages`
+| string
+| Recommended: if available
+| JSON string of the input messages.
+
+| `open_inference.llm.invocation_parameters`
+| string
+| Recommended: if available
+| JSON string of the invocation parameters.
+
+| `open_inference.llm.model_name`
+| string
+| Recommended: if available
+| The name of the LLM model.
+
+| `open_inference.llm.output_messages`
+| string
+| Recommended: if available
+| JSON string of the output messages.
+
+| `open_inference.llm.provider`
+| string
+| Recommended: if available
+| The LLM provider name.
+
+| `open_inference.llm.response.finish_reasons`
+| string[]
+| Recommended: if available
+| The finish reasons from the LLM response.
+
+| `open_inference.llm.system`
+| string
+| Recommended: if available
+| The LLM system being used.
+
+| `open_inference.llm.token_count.completion`
+| int
+| Recommended: if available
+| The number of tokens in the completion.
+
+| `open_inference.llm.token_count.prompt`
+| int
+| Recommended: if available
+| The number of tokens in the prompt.
+
+| `open_inference.llm.token_count.total`
+| int
+| Recommended: if available
+| The total number of tokens.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `gen_ai.conversation.id`
+| string
+| Conditionally required: when available
+| The unique identifier for a conversation (session, thread), used to store and correlate messages within this conversation.
+
+| `gen_ai.input.messages`
+| any
+| Opt-in
+| The chat history provided to the model as an input.
+
+| `gen_ai.operation.name`
+| enum
+| Yes
+| The name of the operation being performed.
+
+| `gen_ai.output.messages`
+| any
+| Opt-in
+| Messages returned by the model where each message represents a specific model response (choice, candidate).
+
+| `gen_ai.output.type`
+| enum
+| Conditionally required: when applicable and if the request includes an output format.
+| Represents the content type requested by the client.
+
+| `gen_ai.provider.name`
+| enum
+| Yes
+| The Generative AI provider as identified by the client or server instrumentation.
+
+| `gen_ai.request.max_tokens`
+| int
+| Recommended
+| The maximum number of tokens the model generates for a request.
+
+| `gen_ai.request.model`
+| string
+| Conditionally required: If available.
+| The name of the GenAI model a request is being made to.
+
+| `gen_ai.request.temperature`
+| double
+| Recommended
+| The temperature setting for the GenAI request.
+
+| `gen_ai.request.top_k`
+| double
+| Recommended
+| The top_k sampling setting for the GenAI request.
+
+| `gen_ai.request.top_p`
+| double
+| Recommended
+| The top_p sampling setting for the GenAI request.
+
+| `gen_ai.response.finish_reasons`
+| string[]
+| Recommended
+| Array of reasons the model stopped generating tokens, corresponding to each generation received.
+
+| `gen_ai.response.id`
+| string
+| Recommended
+| The unique identifier for the completion.
+
+| `gen_ai.response.model`
+| string
+| Recommended
+| The name of the model that generated the response.
+
+| `gen_ai.usage.input_tokens`
+| int
+| Recommended
+| The number of tokens used in the GenAI input (prompt).
+
+| `gen_ai.usage.output_tokens`
+| int
+| Recommended
+| The number of tokens used in the GenAI response (completion).
+
+|===
+
+
+=== Agent tool call span (OpenInference)
+
+This span represents a tool execution with OpenInference attributes.
+Span kind:: internal
+Akka span kind:: `agent.tool.call`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Open Inference attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `open_inference.session.id`
+| string
+| Recommended: if available
+| The session identifier for the conversation.
+
+| `open_inference.span.kind`
+| enum
+| Yes
+| The kind of span in OpenInference semantic conventions.
+
+|===
+
+Open Inference Tool attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `open_inference.tool.description`
+| string
+| Recommended: if available
+| The description of the tool.
+
+| `open_inference.tool.name`
+| string
+| Recommended: if available
+| The name of the tool.
+
+| `open_inference.tool_call.id`
+| string
+| Recommended: if available
+| The identifier of the tool call.
+
+|===
+
+Agent Mcp attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.agent.mcp.endpoint`
+| string
+| Conditionally required: when the tool is from an MCP endpoint
+| The MCP endpoint from which the tool was discovered.
+
+|===
+
+OpenTelemetry semantic convention attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `gen_ai.operation.name`
+| enum
+| Yes
+| The name of the operation being performed.
+
+| `gen_ai.tool.call.id`
+| string
+| Recommended
+| The tool call identifier.
+
+| `gen_ai.tool.description`
+| string
+| Recommended
+| The tool description.
+
+| `gen_ai.tool.name`
+| string
+| Conditionally required: When operation is related to a specific tool.
+| Name of the tool utilized by the agent.
+
+| `gen_ai.tool.type`
+| string
+| Recommended
+| Type of the tool utilized by the agent
+
+|===
+
+
+=== Agent tool discovery span (OpenInference)
+
+This span represents MCP tool discovery with OpenInference attributes.
+Span kind:: internal
+Akka span kind:: `agent.tool.discovery`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Open Inference attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `open_inference.session.id`
+| string
+| Recommended: if available
+| The session identifier for the conversation.
+
+| `open_inference.span.kind`
+| enum
+| Yes
+| The kind of span in OpenInference semantic conventions.
+
+|===
+
+Agent Mcp attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.agent.mcp.endpoint`
+| string
+| Conditionally required: when the tool is from an MCP endpoint
+| The MCP endpoint from which the tool was discovered.
+
+|===
+
+
+== Workflows
+
+
+=== Workflow command span
+
+This span represents a workflow command invocation.
+Span kind:: server
+Akka span kind:: `workflow.command`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Workflow Command attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.workflow.command.name`
+| string
+| Yes
+| The name of the workflow command.
+
+|===
+
+Workflow Span attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.workflow.id`
+| string
+| Yes
+| The workflow ID.
+
+|===
+
+Workflow Debug attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.workflow.command.content`
+| string
+| Conditionally required: when debug tracing is enabled
+| The JSON content of the workflow command payload.
+
+| `akka.workflow.command.type`
+| string
+| Conditionally required: when debug tracing is enabled
+| The protobuf type name of the workflow command payload.
+
+| `akka.workflow.reply.content`
+| string
+| Conditionally required: when debug tracing is enabled
+| The JSON content of the workflow reply payload.
+
+| `akka.workflow.reply.type`
+| string
+| Conditionally required: when debug tracing is enabled
+| The protobuf type name of the workflow reply payload.
+
+|===
+
+
+=== Workflow step span
+
+This span represents a workflow step execution.
+Span kind:: server
+Akka span kind:: `workflow.step`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Workflow Span attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.workflow.id`
+| string
+| Yes
+| The workflow ID.
+
+|===
+
+Workflow Step attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.workflow.step.attempt`
+| int
+| Yes
+| The attempt number for the workflow step.
+
+| `akka.workflow.step.id`
+| int
+| Yes
+| The ID of the workflow step.
+
+| `akka.workflow.step.name`
+| string
+| Yes
+| The name of the workflow step.
+
+|===
+
+Workflow Debug attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.workflow.step.input.content`
+| string
+| Conditionally required: when debug tracing is enabled
+| The JSON content of the workflow step input payload.
+
+| `akka.workflow.step.input.type`
+| string
+| Conditionally required: when debug tracing is enabled
+| The protobuf type name of the workflow step input payload.
+
+|===
+
+
+== Views
+
+
+=== View query span
+
+This span represents a view query execution.
+Span kind:: internal
+Akka span kind:: `view.query`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+View Debug attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.view.query`
+| string
+| Conditionally required: when debug tracing is enabled
+| The view query string.
+
+|===
+
+
+=== View update span
+
+This span represents a view update processing invocation.
+Span kind:: internal
+Akka span kind:: `view.update`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Consumer attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.consumer.source`
+| enum
+| Yes
+| The type of source the consumer is consuming from.
+
+|===
+
+View Update attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.view.table`
+| string
+| Yes
+| The view table name.
+
+|===
+
+Consumer Debug attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.consumer.message.content`
+| string
+| Conditionally required: when debug tracing is enabled
+| The JSON content of the consumer message payload.
+
+| `akka.consumer.message.type`
+| string
+| Conditionally required: when debug tracing is enabled
+| The protobuf type name of the consumer message payload.
+
+| `akka.consumer.output.content`
+| string
+| Conditionally required: when debug tracing is enabled
+| The JSON content of the consumer output payload.
+
+| `akka.consumer.output.type`
+| string
+| Conditionally required: when debug tracing is enabled
+| The protobuf type name of the consumer output payload.
+
+|===
+
+Consumer Span attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.consumer.source.group`
+| string
+| Conditionally required: when the source has a consumer group
+| The consumer group for the source.
+
+| `akka.consumer.source.id`
+| string
+| Conditionally required: when debug tracing is enabled
+| The identifier of the consumer source.
+
+| `akka.consumer.subject`
+| string
+| Conditionally required: when the message has a subject
+| The subject of the consumer message.
+
+|===
+
+
+== Consumers
+
+
+=== Consumer message span
+
+This span represents a consumer message processing invocation.
+Span kind:: server
+Akka span kind:: `consumer.message`
+
+
+
+Component attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.component.description`
+| string
+| Recommended: if available
+| User-defined description of the component.
+
+| `akka.component.id`
+| string
+| Yes
+| Unique identifier for the component instance.
+
+| `akka.component.implementation.name`
+| string
+| Recommended: if available
+| Fully qualified class name of the component implementation.
+
+| `akka.component.name`
+| string
+| Recommended: if available
+| User-defined name of the component.
+
+| `akka.component.type`
+| enum
+| Yes
+| The type of Akka component.
+
+|===
+
+Consumer attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.consumer.source`
+| enum
+| Yes
+| The type of source the consumer is consuming from.
+
+|===
+
+Consumer Debug attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.consumer.message.content`
+| string
+| Conditionally required: when debug tracing is enabled
+| The JSON content of the consumer message payload.
+
+| `akka.consumer.message.type`
+| string
+| Conditionally required: when debug tracing is enabled
+| The protobuf type name of the consumer message payload.
+
+| `akka.consumer.output.content`
+| string
+| Conditionally required: when debug tracing is enabled
+| The JSON content of the consumer output payload.
+
+| `akka.consumer.output.destination`
+| string
+| Conditionally required: when debug tracing is enabled and output has a destination
+| The destination for the consumer output.
+
+| `akka.consumer.output.type`
+| string
+| Conditionally required: when debug tracing is enabled
+| The protobuf type name of the consumer output payload.
+
+|===
+
+Consumer Span attributes::
++
+|===
+| Attribute | Type | Required | Description
+
+| `akka.consumer.source.group`
+| string
+| Conditionally required: when the source has a consumer group
+| The consumer group for the source.
+
+| `akka.consumer.source.id`
+| string
+| Conditionally required: when debug tracing is enabled
+| The identifier of the consumer source.
+
+| `akka.consumer.subject`
+| string
+| Conditionally required: when the message has a subject
+| The subject of the consumer message.
+
+|===
+

--- a/docs/src/modules/reference/pages/telemetry/tracing.adoc
+++ b/docs/src/modules/reference/pages/telemetry/tracing.adoc
@@ -132,7 +132,7 @@ OpenTelemetry semantic convention attributes::
 | `http.route`
 | string
 | Conditionally required: If and only if it's available
-| The matched route template, e.g. `/pets/{id}`.
+| The matched route template, e.g. `/pets/id`.
 
 | `server.address`
 | string


### PR DESCRIPTION
Fenerated with `runtime-core/weaverGenerateDocs`. Eventually, we will create some automation around that. 