### PR TITLE
feat: optional suspend/terminate reasons for autonomous agents

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/client/AutonomousAgentClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/AutonomousAgentClient.java
@@ -89,13 +89,27 @@ public interface AutonomousAgentClient {
   /** Async variant of {@link #getState}. */
   CompletionStage<AgentState> getStateAsync();
 
-  /** Suspende the agent. A suspended agent stops iterating until resumed. */
+  /** Suspend the agent. A suspended agent stops iterating until resumed. */
   default void suspend() {
-    suspendAsync().toCompletableFuture().join();
+    suspend(null);
   }
 
-  /** Async variant of {@link #suspend}. */
-  CompletionStage<Done> suspendAsync();
+  /**
+   * Suspend the agent with a reason. A suspended agent stops iterating until resumed.
+   *
+   * @param reason a description of why the agent is being suspended
+   */
+  default void suspend(String reason) {
+    suspendAsync(reason).toCompletableFuture().join();
+  }
+
+  /** Async variant of {@link #suspend()}. */
+  default CompletionStage<Done> suspendAsync() {
+    return suspendAsync(null);
+  }
+
+  /** Async variant of {@link #suspend(String)}. */
+  CompletionStage<Done> suspendAsync(String reason);
 
   /** Resume a previously suspended agent. */
   default void resume() {
@@ -107,11 +121,25 @@ public interface AutonomousAgentClient {
 
   /** Terminate the agent. */
   default void terminate() {
-    terminateAsync().toCompletableFuture().join();
+    terminate(null);
   }
 
-  /** Async variant of {@link #terminate}. */
-  CompletionStage<Done> terminateAsync();
+  /**
+   * Terminate the agent with a reason.
+   *
+   * @param reason a description of why the agent is being terminated
+   */
+  default void terminate(String reason) {
+    terminateAsync(reason).toCompletableFuture().join();
+  }
+
+  /** Async variant of {@link #terminate()}. */
+  default CompletionStage<Done> terminateAsync() {
+    return terminateAsync(null);
+  }
+
+  /** Async variant of {@link #terminate(String)}. */
+  CompletionStage<Done> terminateAsync(String reason);
 
   /**
    * Subscribe to lifecycle notifications for this agent instance. Notifications are published by

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AutonomousAgentClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AutonomousAgentClientImpl.scala
@@ -136,10 +136,14 @@ private[javasdk] final class AutonomousAgentClientImpl(
       .asJava
   }
 
-  override def suspendAsync(): CompletionStage[Done] = {
-    log.debug("pause: agent [{}] instance [{}]", agentComponentId, agentInstanceId)
+  override def suspendAsync(reason: String): CompletionStage[Done] = {
+    log.debug("suspend: agent [{}] instance [{}] reason [{}]", agentComponentId, agentInstanceId, reason)
     runtimeComponentClients.autonomousAgentClient
-      .suspend(agentComponentId, agentInstanceId, callMetadata.flatMap(_.asInstanceOf[MetadataImpl].context))
+      .suspend(
+        agentComponentId,
+        agentInstanceId,
+        Option(reason),
+        callMetadata.flatMap(_.asInstanceOf[MetadataImpl].context))
       .asJava
   }
 
@@ -150,10 +154,14 @@ private[javasdk] final class AutonomousAgentClientImpl(
       .asJava
   }
 
-  override def terminateAsync(): CompletionStage[Done] = {
-    log.debug("stop: agent [{}] instance [{}]", agentComponentId, agentInstanceId)
+  override def terminateAsync(reason: String): CompletionStage[Done] = {
+    log.debug("terminate: agent [{}] instance [{}] reason [{}]", agentComponentId, agentInstanceId, reason)
     runtimeComponentClients.autonomousAgentClient
-      .terminate(agentComponentId, agentInstanceId, callMetadata.flatMap(_.asInstanceOf[MetadataImpl].context))
+      .terminate(
+        agentComponentId,
+        agentInstanceId,
+        Option(reason),
+        callMetadata.flatMap(_.asInstanceOf[MetadataImpl].context))
       .asJava
   }
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ComponentClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/ComponentClientImpl.scala
@@ -73,7 +73,7 @@ private[javasdk] final case class ComponentClientImpl(
   override def forWorkflow(workflowId: String): WorkflowClient =
     if (workflowId eq null) throw new NullPointerException("Workflow id is null")
     else if (workflowId.isEmpty) throw new IllegalArgumentException("Empty workflow id now allowed")
-    else WorkflowClientImpl(runtimeComponentClients.workFlowClient, serializer, callMetadata, workflowId)
+    else WorkflowClientImpl(runtimeComponentClients.workflowClient, serializer, callMetadata, workflowId)
 
   override def forView(): ViewClient = ViewClientImpl(runtimeComponentClients.viewClient, serializer, callMetadata)
 

--- a/akka-javasdk/src/test/java/akka/javasdk/client/ComponentClientTest.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/client/ComponentClientTest.java
@@ -41,7 +41,6 @@ class ComponentClientTest {
     // FIXME what are we actually testing here?
     var dummyComponentClients =
         new ComponentClients() {
-
           @Override
           public EntityClient eventSourcedEntityClient() {
             return null;
@@ -54,6 +53,11 @@ class ComponentClientTest {
 
           @Override
           public EntityClient workFlowClient() {
+            return null;
+          }
+
+          @Override
+          public akka.runtime.sdk.spi.WorkflowClient workflowClient() {
             return null;
           }
 
@@ -171,6 +175,5 @@ class ComponentClientTest {
         componentClient.forView().method(UserByEmailWithGet::getUser);
 
     // not much to assert here
-
   }
 }

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/client/TaskClientImplSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/client/TaskClientImplSpec.scala
@@ -139,6 +139,7 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
       override def eventSourcedEntityClient: EntityClient = entityClient
       override def keyValueEntityClient: EntityClient = null
       override def workFlowClient: EntityClient = null
+      override def workflowClient: WorkflowClient = null
       override def viewClient: ViewClient = null
       override def timedActionClient: TimedActionClient = null
       override def timerClient: TimerClient = null

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val ProtocolVersionMajor = 1
     val ProtocolVersionMinor = 1
   }
-  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.0-M3")
+  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.0-M3-49-30b2e53f-SNAPSHOT")
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned
   // for prod code, they are marked as Provided, but testkit still requires the alignment


### PR DESCRIPTION
Add the optional suspend and terminate reasons to the autonomous agent client. And switch to the new workflow client, which I assume is what we want to do. This is mainly to get things compiling on the latest runtime snapshot for autonomous agents. 