### PR TITLE
chore: Rename goal to instructions, and make description mandatory

### DIFF
--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/invalid/AutonomousAgentWithCommandHandler.java
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/invalid/AutonomousAgentWithCommandHandler.java
@@ -5,12 +5,12 @@ import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.agent.autonomous.AgentDefinition;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "autonomous-agent-with-handler")
+@Component(id = "autonomous-agent-with-handler", description = "Autonomous agent that wrongly defines a command handler")
 public class AutonomousAgentWithCommandHandler extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Test goal");
+    return define().instructions("Test instructions");
   }
 
   // This should be rejected — AutonomousAgent must not have command handlers

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/invalid/AutonomousAgentWithoutDescription.java
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/invalid/AutonomousAgentWithoutDescription.java
@@ -4,8 +4,8 @@ import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.agent.autonomous.AgentDefinition;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "valid-autonomous-agent", name = "Valid Autonomous Agent", description = "A test autonomous agent")
-public class ValidAutonomousAgent extends AutonomousAgent {
+@Component(id = "autonomous-agent-no-description")
+public class AutonomousAgentWithoutDescription extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/valid/ValidAutonomousAgentWithFunctionTool.java
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/valid/ValidAutonomousAgentWithFunctionTool.java
@@ -5,12 +5,12 @@ import akka.javasdk.agent.autonomous.AgentDefinition;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.annotations.FunctionTool;
 
-@Component(id = "autonomous-agent-with-tool")
+@Component(id = "autonomous-agent-with-tool", description = "Autonomous agent used to test function tools")
 public class ValidAutonomousAgentWithFunctionTool extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Test goal");
+    return define().instructions("Test instructions");
   }
 
   @FunctionTool(description = "A helper tool")

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/scala/com/example/AutonomousAgentValidationSpec.scala
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/scala/com/example/AutonomousAgentValidationSpec.scala
@@ -33,5 +33,11 @@ abstract class AbstractAutonomousAgentValidationSpec(val validationMode: Validat
         "invalid/AutonomousAgentWithCommandHandler.java",
         "AutonomousAgent must not define command handler methods")
     }
+
+    "reject AutonomousAgent without @Component description" in {
+      assertInvalid(
+        "invalid/AutonomousAgentWithoutDescription.java",
+        "@Component description is mandatory for AutonomousAgent")
+    }
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/AutonomousAgentIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/AutonomousAgentIntegrationTest.java
@@ -199,11 +199,13 @@ public class AutonomousAgentIntegrationTest extends TestKitSupport {
     assertThat(specialistInfo.description()).isEqualTo("Resolves billing disputes.");
     assertThat(specialistInfo.role()).isEqualTo("billing-specialist");
 
-    // CoordinatorAgent doesn't define name, description, or role — defaults apply
+    // CoordinatorAgent doesn't define name or role — defaults apply.
+    // @Component.description is mandatory for AutonomousAgent.
     var coordinatorInfo = testKit.getAgentRegistry().agentInfo("coordinator-agent");
     assertThat(coordinatorInfo.id()).isEqualTo("coordinator-agent");
     assertThat(coordinatorInfo.name()).isEqualTo("coordinator-agent");
-    assertThat(coordinatorInfo.description()).isEqualTo("");
+    assertThat(coordinatorInfo.description())
+        .isEqualTo("Coordinates research by delegating to workers and synthesizing results.");
     assertThat(coordinatorInfo.role()).isEqualTo("");
   }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/CoordinatorAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/CoordinatorAgent.java
@@ -10,13 +10,14 @@ import akka.javasdk.agent.autonomous.capability.Delegation;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "coordinator-agent")
+@Component(
+    id = "coordinator-agent",
+    description = "Coordinates research by delegating to workers and synthesizing results.")
 public class CoordinatorAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Coordinate research by delegating to workers and synthesising results.")
         .capability(TaskAcceptance.of(TestTasks.RESEARCH).maxIterationsPerTask(5))
         .capability(Delegation.to(WorkerAgent.class).maxParallelWorkers(2));
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/DebaterA.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/DebaterA.java
@@ -8,11 +8,11 @@ import akka.javasdk.agent.autonomous.AgentDefinition;
 import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "debater-a")
+@Component(id = "debater-a", description = "Argues in favor of the assigned position.")
 public class DebaterA extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Argue in favor of the assigned position.");
+    return define();
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/DebaterB.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/DebaterB.java
@@ -8,11 +8,11 @@ import akka.javasdk.agent.autonomous.AgentDefinition;
 import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "debater-b")
+@Component(id = "debater-b", description = "Argues against the assigned position.")
 public class DebaterB extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Argue against the assigned position.");
+    return define();
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/DirectedModerator.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/DirectedModerator.java
@@ -10,13 +10,14 @@ import akka.javasdk.agent.autonomous.capability.Moderation;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "directed-moderator")
+@Component(
+    id = "directed-moderator",
+    description = "Moderates directed conversations between participants.")
 public class DirectedModerator extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Moderate directed conversations between participants.")
         .capability(TaskAcceptance.of(TestTasks.MODERATE))
         .capability(Moderation.of(DebaterA.class, DebaterB.class).maxRounds(5));
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/RequestDelegatingAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/RequestDelegatingAgent.java
@@ -12,13 +12,14 @@ import akka.javasdk.annotations.Component;
 import akkajavasdk.components.agent.FactCheckAgent;
 import akkajavasdk.components.agent.SomeAgent;
 
-@Component(id = "request-delegating-agent")
+@Component(
+    id = "request-delegating-agent",
+    description = "Coordinates work by delegating fact-checking to a request-based agent.")
 public class RequestDelegatingAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Coordinate work by delegating fact-checking to a request-based agent.")
         .capability(TaskAcceptance.of(TestTasks.TEST_TASK).maxIterationsPerTask(5))
         .capability(Delegation.to(SomeAgent.class, FactCheckAgent.class));
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/SpecialistTestAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/SpecialistTestAgent.java
@@ -16,8 +16,6 @@ public class SpecialistTestAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define()
-        .goal("Resolve billing support requests.")
-        .capability(TaskAcceptance.of(TestTasks.RESOLVE).maxIterationsPerTask(3));
+    return define().capability(TaskAcceptance.of(TestTasks.RESOLVE).maxIterationsPerTask(3));
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TeamLeadAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TeamLeadAgent.java
@@ -11,13 +11,12 @@ import akka.javasdk.agent.autonomous.capability.TeamLeadership;
 import akka.javasdk.agent.autonomous.capability.TeamLeadership.TeamMember;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "team-lead-agent")
+@Component(id = "team-lead-agent", description = "Plans and coordinates work by leading a team.")
 public class TeamLeadAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Plan and coordinate work by leading a team.")
         .capability(TaskAcceptance.of(TestTasks.PLAN))
         .capability(TeamLeadership.of(TeamMember.of(TeamWorkerAgent.class).maxInstances(2)));
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TeamWorkerAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TeamWorkerAgent.java
@@ -9,13 +9,11 @@ import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "team-worker-agent")
+@Component(id = "team-worker-agent", description = "Implements assigned work items.")
 public class TeamWorkerAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define()
-        .goal("Implement work items.")
-        .capability(TaskAcceptance.of(TestTasks.WORK_ITEM));
+    return define().capability(TaskAcceptance.of(TestTasks.WORK_ITEM));
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TemplateDelegatingAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TemplateDelegatingAgent.java
@@ -10,13 +10,14 @@ import akka.javasdk.agent.autonomous.capability.Delegation;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "template-delegating-agent")
+@Component(
+    id = "template-delegating-agent",
+    description = "Coordinates research by delegating work items using task templates.")
 public class TemplateDelegatingAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Coordinate research by delegating work items using task templates.")
         .capability(TaskAcceptance.of(TestTasks.RESEARCH).maxIterationsPerTask(5))
         .capability(Delegation.to(TeamWorkerAgent.class));
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestAutonomousAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestAutonomousAgent.java
@@ -10,7 +10,9 @@ import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.client.ComponentClient;
 
-@Component(id = "test-autonomous-agent")
+@Component(
+    id = "test-autonomous-agent",
+    description = "Test agent used by autonomous agent integration tests.")
 public class TestAutonomousAgent extends AutonomousAgent {
 
   // Injected to exercise the SdkRunner scan-time wiring path: a ComponentClient
@@ -26,7 +28,6 @@ public class TestAutonomousAgent extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Test agent")
         .capability(
             TaskAcceptance.of(
                 TestTasks.TEST_TASK,

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestModerator.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestModerator.java
@@ -10,13 +10,14 @@ import akka.javasdk.agent.autonomous.capability.Moderation;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "test-moderator")
+@Component(
+    id = "test-moderator",
+    description = "Moderates structured conversations between participants.")
 public class TestModerator extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Moderate structured conversations between participants.")
         .capability(TaskAcceptance.of(TestTasks.MODERATE))
         .capability(Moderation.of(DebaterA.class, DebaterB.class).maxRounds(3));
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestTasks.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TestTasks.java
@@ -24,40 +24,38 @@ public class TestTasks {
   public record ModerationResult(String topic, String conclusion) {}
 
   public static final Task<TestResult> TEST_TASK =
-      Task.define("Test task").description("A test task").resultConformsTo(TestResult.class);
+      Task.name("Test task").description("A test task").resultConformsTo(TestResult.class);
 
   public static final Task<String> STRING_TASK =
-      Task.define("String task").description("A task with string result");
+      Task.name("String task").description("A task with string result");
 
   public static final Task<Integer> INTEGER_TASK =
-      Task.define("Integer task")
+      Task.name("Integer task")
           .description("A task with integer result")
           .resultConformsTo(Integer.class);
 
   public static final Task<Boolean> BOOLEAN_TASK =
-      Task.define("Boolean task")
+      Task.name("Boolean task")
           .description("A task with boolean result")
           .resultConformsTo(Boolean.class);
 
   public static final Task<ResearchResult> RESEARCH =
-      Task.define("Research")
+      Task.name("Research")
           .description("Produce a research summary")
           .resultConformsTo(ResearchResult.class);
 
   public static final Task<FindingsResult> FINDINGS =
-      Task.define("Findings")
+      Task.name("Findings")
           .description("Research a topic and produce findings")
           .resultConformsTo(FindingsResult.class);
 
   public static final Task<SupportResolution> RESOLVE =
-      Task.define("Resolve")
+      Task.name("Resolve")
           .description("Resolve a support request")
           .resultConformsTo(SupportResolution.class);
 
   public static final Task<PlanResult> PLAN =
-      Task.define("Plan")
-          .description("Plan and coordinate work")
-          .resultConformsTo(PlanResult.class);
+      Task.name("Plan").description("Plan and coordinate work").resultConformsTo(PlanResult.class);
 
   public static final TaskTemplate<WorkItemResult> WORK_ITEM =
       TaskTemplate.define("Work item")
@@ -66,12 +64,12 @@ public class TestTasks {
           .instructionTemplate("Implement: {item}. Requirements: {requirements}.");
 
   public static final Task<ModerationResult> MODERATE =
-      Task.define("Moderate")
+      Task.name("Moderate")
           .description("Moderate a conversation")
           .resultConformsTo(ModerationResult.class);
 
   public static final Task<TestResult> VALIDATED_TASK =
-      Task.define("Validated task")
+      Task.name("Validated task")
           .description("A task with rule validation")
           .resultConformsTo(TestResult.class)
           .rules(TestResultRule.class);

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/ToolUsingAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/ToolUsingAgent.java
@@ -10,13 +10,12 @@ import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.annotations.FunctionTool;
 
-@Component(id = "tool-using-agent")
+@Component(id = "tool-using-agent", description = "Answers questions using available tools.")
 public class ToolUsingAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Answer questions using available tools.")
         .capability(TaskAcceptance.of(TestTasks.TEST_TASK).maxIterationsPerTask(5))
         .tools(new DateService());
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TriageTestAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/TriageTestAgent.java
@@ -9,13 +9,14 @@ import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "triage-test-agent")
+@Component(
+    id = "triage-test-agent",
+    description = "Classifies support requests and hands off to the appropriate specialist.")
 public class TriageTestAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Classify support requests and hand off to the appropriate specialist.")
         .capability(
             TaskAcceptance.of(TestTasks.RESOLVE)
                 .maxIterationsPerTask(3)

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/ValidatedTaskAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/ValidatedTaskAgent.java
@@ -9,13 +9,11 @@ import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "validated-task-agent")
+@Component(id = "validated-task-agent", description = "Completes tasks subject to rule validation.")
 public class ValidatedTaskAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define()
-        .goal("Complete tasks with rule validation")
-        .capability(TaskAcceptance.of(TestTasks.VALIDATED_TASK));
+    return define().capability(TaskAcceptance.of(TestTasks.VALIDATED_TASK));
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/WorkerAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/autonomous/WorkerAgent.java
@@ -9,13 +9,11 @@ import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "worker-agent")
+@Component(id = "worker-agent", description = "Researches a topic and produces factual findings.")
 public class WorkerAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define()
-        .goal("Research a topic and produce factual findings.")
-        .capability(TaskAcceptance.of(TestTasks.FINDINGS).maxIterationsPerTask(3));
+    return define().capability(TaskAcceptance.of(TestTasks.FINDINGS).maxIterationsPerTask(3));
   }
 }

--- a/akka-javasdk-validations/src/main/java/akka/javasdk/tooling/validation/AutonomousAgentValidations.java
+++ b/akka-javasdk-validations/src/main/java/akka/javasdk/tooling/validation/AutonomousAgentValidations.java
@@ -6,7 +6,9 @@ package akka.javasdk.tooling.validation;
 
 import static akka.javasdk.tooling.validation.Validations.effectMethods;
 
+import akka.javasdk.validation.ast.AnnotationDef;
 import akka.javasdk.validation.ast.TypeDef;
+import java.util.Optional;
 
 /** Contains validation logic specific to AutonomousAgent components. */
 public class AutonomousAgentValidations {
@@ -16,7 +18,8 @@ public class AutonomousAgentValidations {
   };
 
   /**
-   * Validates an AutonomousAgent component. Must NOT have command handlers.
+   * Validates an AutonomousAgent component. Must NOT have command handlers and must declare a
+   * non-empty {@code @Component(description = ...)}.
    *
    * @param typeDef the AutonomousAgent class to validate
    * @return a Validation result indicating success or failure with error messages
@@ -26,7 +29,7 @@ public class AutonomousAgentValidations {
       return Validation.Valid.instance();
     }
 
-    return mustNotHaveCommandHandler(typeDef);
+    return mustNotHaveCommandHandler(typeDef).combine(mustHaveNonEmptyDescription(typeDef));
   }
 
   /** Validates that an AutonomousAgent has no command handlers. */
@@ -42,5 +45,29 @@ public class AutonomousAgentValidations {
                   + " returning Agent.Effect or Agent.StreamEffect."
                   + " Use strategy() to configure the agent's behavior."));
     }
+  }
+
+  /**
+   * Validates that an AutonomousAgent declares a non-empty {@code @Component(description = ...)}.
+   * The description is the agent's public identity, used by coordinators selecting delegation or
+   * handoff targets and injected into the model's system message.
+   */
+  private static Validation mustHaveNonEmptyDescription(TypeDef typeDef) {
+    Optional<AnnotationDef> componentAnn =
+        typeDef.findAnnotation("akka.javasdk.annotations.Component");
+    if (componentAnn.isEmpty()) {
+      return Validation.Valid.instance();
+    }
+    Optional<String> description = componentAnn.get().getStringValue("description");
+    if (description.isEmpty() || description.get().isBlank()) {
+      return Validation.of(
+          Validations.errorMessage(
+              typeDef,
+              "@Component description is mandatory for AutonomousAgent and must be a non-empty"
+                  + " string. The description identifies the agent to coordinators selecting a"
+                  + " delegation or handoff target, and is included in the model's system"
+                  + " message."));
+    }
+    return Validation.Valid.instance();
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/AgentDefinition.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/AgentDefinition.java
@@ -10,20 +10,40 @@ import akka.javasdk.agent.RemoteMcpTools;
 import akka.javasdk.agent.autonomous.capability.AgentCapability;
 
 /**
- * Defines an autonomous agent's configuration: goal, tools, model provider, guardrails, and
- * capabilities. Built via {@link AutonomousAgent#define()} and returned from {@link
+ * Defines an autonomous agent's configuration: tools, model provider, guardrails, capabilities, and
+ * optional instructions. Built via {@link AutonomousAgent#define()} and returned from {@link
  * AutonomousAgent#definition()}.
+ *
+ * <p>The {@link akka.javasdk.annotations.Component#description() @Component description} captures
+ * the agent's purpose and expected outcome: a short statement of what the agent does, when to use
+ * it, and what it produces. The runtime injects the description into the model's system message and
+ * uses it when other agents need to choose a delegation or handoff target. The description is
+ * mandatory for autonomous agents.
+ *
+ * <p>{@link #instructions(String) Instructions} are optional supplementary text for tone, persona,
+ * domain rules, or procedural guidance to the model, also appended to the system message.
+ * Multi-agent orchestration mechanics (when to delegate, when to hand off, who to message) do not
+ * belong in instructions — they are derived automatically from the capabilities and from the
+ * descriptions of the participating agents.
  *
  * <p>Each fluent method returns a new immutable instance.
  */
 public interface AgentDefinition {
 
   /**
-   * The agent's high-level purpose. Goal text should describe what the agent achieves, not how it
-   * coordinates. The runtime combines the goal with capability-specific context and tool
-   * descriptions to build the system message.
+   * Optional internal, LLM-facing instructions appended to the system message. Use this for tone,
+   * persona, role, domain rules (for example "Always cite sources" or "Never quote prices in
+   * non-USD currencies"), or procedural guidance on how the model should approach a task. The
+   * agent's purpose and expected outcome belong in {@link
+   * akka.javasdk.annotations.Component#description() @Component description}, not here.
+   *
+   * <p>Multi-agent orchestration mechanics do not belong here. Coordination details such as when to
+   * delegate, when to hand off, or who to message are derived automatically from the capabilities
+   * and from the descriptions of the participating agents. If you find yourself writing "delegate
+   * to X first, then to Y, then synthesize," the work belongs in capabilities and task definitions
+   * instead.
    */
-  AgentDefinition goal(String goal);
+  AgentDefinition instructions(String instructions);
 
   /** Add a capability to this agent: task acceptance, delegation, etc. */
   AgentDefinition capability(AgentCapability capability);

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/AgentSetup.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/AgentSetup.java
@@ -9,8 +9,11 @@ import akka.javasdk.impl.agent.autonomous.AgentSetupImpl;
 
 /**
  * Per-instance configuration applied on top of an agent's static {@link AgentDefinition}. Use this
- * to dynamically configure an agent instance at runtime — the goal overrides the static goal, and
- * capabilities extend the static capabilities.
+ * to dynamically configure an agent instance at runtime, the instructions override the static
+ * instructions, and capabilities extend the static capabilities.
+ *
+ * <p>The agent's {@link akka.javasdk.annotations.Component#description() @Component description} is
+ * bound to the component class and cannot be overridden per instance.
  *
  * <p>Each fluent method returns a new immutable instance.
  *
@@ -24,10 +27,10 @@ public interface AgentSetup {
   }
 
   /**
-   * Override the agent's goal for this instance. If not set, the static goal from {@link
-   * AgentDefinition} is used.
+   * Override the agent's instructions for this instance. If not set, the static instructions from
+   * {@link AgentDefinition} are used.
    */
-  AgentSetup goal(String goal);
+  AgentSetup instructions(String instructions);
 
   /** Add a capability for this instance, extending the static capabilities. */
   AgentSetup capability(AgentCapability capability);

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/AgentState.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/AgentState.java
@@ -19,7 +19,7 @@ public final class AgentState {
 
   private final String phase;
   private final boolean suspended;
-  private final String goal;
+  private final String instructions;
   private final AutonomousAgent.TokenUsage totalTokenUsage;
   private final Optional<TaskKey> currentTask;
   private final List<String> pendingTaskIds;
@@ -27,13 +27,13 @@ public final class AgentState {
   public AgentState(
       String phase,
       boolean suspended,
-      String goal,
+      String instructions,
       AutonomousAgent.TokenUsage totalTokenUsage,
       Optional<TaskKey> currentTask,
       List<String> pendingTaskIds) {
     this.phase = phase;
     this.suspended = suspended;
-    this.goal = goal;
+    this.instructions = instructions;
     this.totalTokenUsage = totalTokenUsage;
     this.currentTask = currentTask;
     this.pendingTaskIds = pendingTaskIds;
@@ -49,9 +49,9 @@ public final class AgentState {
     return suspended;
   }
 
-  /** The agent's current goal. */
-  public String goal() {
-    return goal;
+  /** The agent's current instructions. */
+  public String instructions() {
+    return instructions;
   }
 
   /** Total token usage for this agent instance. */

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/AutonomousAgent.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/autonomous/AutonomousAgent.java
@@ -14,11 +14,14 @@ import akka.javasdk.impl.agent.autonomous.AgentDefinitionImpl;
  * LLM, execute tools, check task status, repeat — until the task is complete or the iteration limit
  * is reached.
  *
- * <p>Subclasses must implement {@link #definition()} to configure the agent's behavior: goal,
- * tools, model provider, and capabilities.
+ * <p>Subclasses must implement {@link #definition()} to configure the agent's tools, model
+ * provider, capabilities, and optional instructions.
  *
  * <p><strong>Component Identification:</strong> The agent must be annotated with {@link
- * akka.javasdk.annotations.Component} to provide a unique identifier.
+ * akka.javasdk.annotations.Component} providing a unique {@code id} and a non-empty {@code
+ * description}. The description captures the agent's purpose and expected outcome: it is injected
+ * into the model's system message and used by other agents when choosing a delegation or handoff
+ * target.
  *
  * @see AgentDefinition
  */
@@ -28,8 +31,8 @@ public abstract class AutonomousAgent implements akka.javasdk.agent.AgentDelegat
   public record TokenUsage(int inputTokens, int outputTokens) {}
 
   /**
-   * Define this autonomous agent. The definition configures the agent's goal, tools, model
-   * provider, guardrails, and capabilities.
+   * Define this autonomous agent. The definition configures the agent's tools, model provider,
+   * guardrails, capabilities, and optional instructions.
    *
    * @return the agent definition
    */

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/task/Task.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/task/Task.java
@@ -11,9 +11,9 @@ import java.util.List;
 /**
  * A typed task definition — describes a kind of work and the expected result type.
  *
- * <p>Use {@link #define(String)} to create a definition, then {@link #resultConformsTo(Class)} to
- * set the result type. Task definitions are immutable and typically declared as {@code static
- * final} constants. The default result type is {@code String}.
+ * <p>Use {@link #name(String)} to create a definition, then {@link #resultConformsTo(Class)} to set
+ * the result type. Task definitions are immutable and typically declared as {@code static final}
+ * constants. The default result type is {@code String}.
  *
  * <p>Per-request methods like {@link #instructions(String)}, {@link #attach(MessageContent...)},
  * and {@link #dependsOn(String...)} return a new instance, leaving the original definition
@@ -54,7 +54,7 @@ public final class Task<R> implements TaskDefinition<R> {
    *
    * @param name a stable identifier for this task type
    */
-  public static Task<String> define(String name) {
+  public static Task<String> name(String name) {
     return new Task<>(name, "", String.class, "", List.of(), List.of(), List.of());
   }
 

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/Component.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/Component.java
@@ -26,6 +26,15 @@ public @interface Component {
   /** A human-readable name for this component (optional). */
   String name() default "";
 
-  /** A description of what this component does (optional). */
+  /**
+   * A description of what this component does.
+   *
+   * <p>Optional in general, but <strong>mandatory and non-empty</strong> for classes extending
+   * {@code AutonomousAgent}. For agents (both request-based and autonomous), the description
+   * captures the agent's purpose and expected outcome: it is injected into the model's system
+   * message and is used by other agents to decide whether to delegate or hand off to this agent.
+   * Write it as a short statement of what the agent does, when to use it, and what it produces,
+   * rather than as a procedure.
+   */
   String description() default "";
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/client/AutonomousAgentClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/client/AutonomousAgentClient.java
@@ -61,8 +61,8 @@ public interface AutonomousAgentClient {
   CompletionStage<Done> assignTasksAsync(String... taskIds);
 
   /**
-   * Apply per-instance configuration to this agent. The goal overrides the static goal from the
-   * agent's definition, and capabilities extend the static capabilities.
+   * Apply per-instance configuration to this agent. The instructions override the static
+   * instructions from the agent's definition, and capabilities extend the static capabilities.
    *
    * @param setup the per-instance configuration
    */

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -811,12 +811,7 @@ private final class Sdk(
             scanTimeAutonomousAgentInjects
           }
           tempAgent.definition() match {
-            case impl: AgentDefinitionImpl =>
-              if (impl.goal.isEmpty)
-                logger.debug(
-                  "AutonomousAgent [{}] has no goal configured at startup. The goal must be set per-instance via AgentSetup before assigning tasks.",
-                  clz.getName)
-              impl
+            case impl: AgentDefinitionImpl => impl
             case other =>
               throw new IllegalStateException(
                 s"AutonomousAgent ${clz.getName} definition() must return a definition created via define(), got: $other")
@@ -870,7 +865,7 @@ private final class Sdk(
             applicationConfig,
             system,
             agentDefinition,
-            goal = agentDefinition.goal,
+            instructions = agentDefinition.instructions,
             modelProvider = spiModelProvider,
             toolDescriptors = spiToolDescriptors,
             mcpClientDescriptors = spiMcpDescriptors,

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AutonomousAgentImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AutonomousAgentImpl.scala
@@ -74,7 +74,7 @@ private[impl] final class AutonomousAgentImpl(
     config: Config,
     _system: ActorSystem[_],
     agentDefinition: AgentDefinitionImpl,
-    override val goal: String,
+    override val instructions: String,
     override val modelProvider: SpiAgent.ModelProvider,
     override val toolDescriptors: Seq[SpiAgent.ToolDescriptor],
     override val mcpClientDescriptors: Seq[SpiAgent.McpToolEndpointDescriptor],

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/autonomous/AgentDefinitionImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/autonomous/AgentDefinitionImpl.scala
@@ -18,7 +18,7 @@ import akka.javasdk.agent.autonomous.capability.AgentCapability
  */
 @InternalApi
 final case class AgentDefinitionImpl(
-    goal: String,
+    instructions: String,
     modelProvider: ModelProvider,
     toolInstancesOrClasses: util.List[AnyRef],
     mcpTools: util.List[RemoteMcpTools],
@@ -27,8 +27,8 @@ final case class AgentDefinitionImpl(
     capabilities: util.List[AgentCapability])
     extends AgentDefinition {
 
-  override def goal(goal: String): AgentDefinition =
-    copy(goal = goal)
+  override def instructions(instructions: String): AgentDefinition =
+    copy(instructions = instructions)
 
   override def capability(capability: AgentCapability): AgentDefinition =
     copy(capabilities = concat(this.capabilities, Seq(capability)))
@@ -62,7 +62,7 @@ final case class AgentDefinitionImpl(
 object AgentDefinitionImpl {
   def empty(): AgentDefinitionImpl =
     AgentDefinitionImpl(
-      goal = "",
+      instructions = "",
       modelProvider = null,
       toolInstancesOrClasses = util.List.of(),
       mcpTools = util.List.of(),

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/autonomous/AgentSetupImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/autonomous/AgentSetupImpl.scala
@@ -14,10 +14,11 @@ import akka.javasdk.agent.autonomous.capability.AgentCapability
  * INTERNAL API
  */
 @InternalApi
-final case class AgentSetupImpl(goal: Option[String], capabilities: util.List[AgentCapability]) extends AgentSetup {
+final case class AgentSetupImpl(instructions: Option[String], capabilities: util.List[AgentCapability])
+    extends AgentSetup {
 
-  override def goal(goal: String): AgentSetup =
-    copy(goal = Some(goal))
+  override def instructions(instructions: String): AgentSetup =
+    copy(instructions = Some(instructions))
 
   override def capability(capability: AgentCapability): AgentSetup = {
     val result = new util.ArrayList[AgentCapability](this.capabilities)
@@ -32,5 +33,5 @@ final case class AgentSetupImpl(goal: Option[String], capabilities: util.List[Ag
 @InternalApi
 object AgentSetupImpl {
   def empty(): AgentSetupImpl =
-    AgentSetupImpl(goal = None, capabilities = util.List.of())
+    AgentSetupImpl(instructions = None, capabilities = util.List.of())
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AutonomousAgentClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AutonomousAgentClientImpl.scala
@@ -116,7 +116,7 @@ private[javasdk] final class AutonomousAgentClientImpl(
 
     val spiCapabilities = converter.toSpiCapabilities(setupImpl.capabilities)
     runtimeComponentClients.autonomousAgentClient
-      .applySetup(agentComponentId, agentInstanceId, setupImpl.goal, spiCapabilities)
+      .applySetup(agentComponentId, agentInstanceId, setupImpl.instructions, spiCapabilities)
       .asJava
   }
 
@@ -128,7 +128,7 @@ private[javasdk] final class AutonomousAgentClientImpl(
         new AgentState(
           spiState.phase,
           spiState.suspended,
-          spiState.goal,
+          spiState.instructions,
           new AutonomousAgent.TokenUsage(spiState.totalInputTokens, spiState.totalOutputTokens),
           spiState.currentTask.map(t => new TaskKey(t.id, t.name)).toJava,
           spiState.pendingTaskIds.asJava)

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/AgentSetupSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/AgentSetupSpec.scala
@@ -25,20 +25,20 @@ class AgentSetupSpec extends AnyWordSpec with Matchers with AutonomousAgentImplS
     "start empty" in {
       val setup = AgentSetup.create().impl
 
-      setup.goal shouldBe None
+      setup.instructions shouldBe None
       setup.capabilities.asScala shouldBe empty
     }
 
-    "set goal" in {
-      val setup = AgentSetup.create().goal("Do something").impl
+    "set instructions" in {
+      val setup = AgentSetup.create().instructions("Do something").impl
 
-      setup.goal shouldBe Some("Do something")
+      setup.instructions shouldBe Some("Do something")
     }
 
-    "override goal" in {
-      val setup = AgentSetup.create().goal("First goal").goal("Second goal").impl
+    "override instructions" in {
+      val setup = AgentSetup.create().instructions("First instructions").instructions("Second instructions").impl
 
-      setup.goal shouldBe Some("Second goal")
+      setup.instructions shouldBe Some("Second instructions")
     }
 
     "set capabilities" in {
@@ -60,30 +60,30 @@ class AgentSetupSpec extends AnyWordSpec with Matchers with AutonomousAgentImplS
       setup.capabilities.asScala(1).asDelegation
     }
 
-    "set goal and capabilities together" in {
+    "set instructions and capabilities together" in {
       val setup = AgentSetup
         .create()
-        .goal("Analyse data")
+        .instructions("Analyse data")
         .capability(TaskAcceptance.of(testTask).maxIterationsPerTask(5))
         .capability(DelegationImpl.create(Array()).maxParallelWorkers(2))
         .impl
 
-      setup.goal shouldBe Some("Analyse data")
+      setup.instructions shouldBe Some("Analyse data")
       setup.capabilities.asScala should have size 2
     }
 
     "be immutable — each method returns a new instance" in {
       val setup1 = AgentSetup.create()
-      val setup2 = setup1.goal("A goal")
+      val setup2 = setup1.instructions("Some instructions")
       val setup3 = setup2.capability(TaskAcceptance.of(testTask))
 
-      setup1.impl.goal shouldBe None
+      setup1.impl.instructions shouldBe None
       setup1.impl.capabilities.asScala shouldBe empty
 
-      setup2.impl.goal shouldBe Some("A goal")
+      setup2.impl.instructions shouldBe Some("Some instructions")
       setup2.impl.capabilities.asScala shouldBe empty
 
-      setup3.impl.goal shouldBe Some("A goal")
+      setup3.impl.instructions shouldBe Some("Some instructions")
       setup3.impl.capabilities.asScala should have size 1
     }
   }

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/AgentSetupSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/AgentSetupSpec.scala
@@ -16,7 +16,7 @@ import org.scalatest.wordspec.AnyWordSpec
 class AgentSetupSpec extends AnyWordSpec with Matchers with AutonomousAgentImplSupport {
 
   private val testTask = Task
-    .define("TestTask")
+    .name("TestTask")
     .description("A test task")
     .resultConformsTo(classOf[String])
 

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/CapabilityConverterSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/CapabilityConverterSpec.scala
@@ -22,12 +22,12 @@ class CapabilityConverterSpec extends AnyWordSpec with Matchers {
   case class TypedResult(value: String, score: Int)
 
   private val stringTask = Task
-    .define("StringTask")
+    .name("StringTask")
     .description("A task with String result")
     .resultConformsTo(classOf[String])
 
   private val typedTask = Task
-    .define("TypedTask")
+    .name("TypedTask")
     .description("A task with typed result")
     .resultConformsTo(classOf[TypedResult])
 

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/capability/CapabilityBuildersSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/autonomous/capability/CapabilityBuildersSpec.scala
@@ -19,12 +19,12 @@ import org.scalatest.wordspec.AnyWordSpec
 class CapabilityBuildersSpec extends AnyWordSpec with Matchers with AutonomousAgentImplSupport {
 
   private val task1 = Task
-    .define("Task1")
+    .name("Task1")
     .description("First task")
     .resultConformsTo(classOf[String])
 
   private val task2 = Task
-    .define("Task2")
+    .name("Task2")
     .description("Second task")
     .resultConformsTo(classOf[String])
 

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/client/TaskClientImplSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/client/TaskClientImplSpec.scala
@@ -77,12 +77,12 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
   }
 
   private val TEST_TASK: Task[TestResult] = Task
-    .define("Test task")
+    .name("Test task")
     .description("A test task")
     .resultConformsTo(classOf[TestResult])
 
   private val STRING_TASK: Task[String] = Task
-    .define("String task")
+    .name("String task")
     .description("A string task")
 
   private def taskState(
@@ -277,7 +277,7 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
 
     "throw TypeMismatch when task definition name does not match" in {
       val otherTask: Task[TestResult] = Task
-        .define("Other task")
+        .name("Other task")
         .description("A different task")
         .resultConformsTo(classOf[TestResult])
 
@@ -293,7 +293,7 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
 
     "throw TypeMismatch when result type does not match" in {
       val otherTask: Task[OtherResult] = Task
-        .define("Test task") // same name, different result type
+        .name("Test task") // same name, different result type
         .description("A different task")
         .resultConformsTo(classOf[OtherResult])
 
@@ -372,7 +372,7 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
 
     "throw TypeMismatch when task definition name does not match for already completed task" in {
       val otherTask: Task[TestResult] = Task
-        .define("Other task")
+        .name("Other task")
         .description("A different task")
         .resultConformsTo(classOf[TestResult])
 
@@ -387,7 +387,7 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
 
     "throw TypeMismatch when result type does not match for already completed task" in {
       val otherTask: Task[OtherResult] = Task
-        .define("Test task")
+        .name("Test task")
         .description("A different task")
         .resultConformsTo(classOf[OtherResult])
 
@@ -402,7 +402,7 @@ class TaskClientImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike 
 
     "throw TypeMismatch when task definition name does not match for in-progress task" in {
       val otherTask: Task[TestResult] = Task
-        .define("Other task")
+        .name("Other task")
         .description("A different task")
         .resultConformsTo(classOf[TestResult])
 

--- a/docs/src/modules/ROOT/attachments/AGENTS.md
+++ b/docs/src/modules/ROOT/attachments/AGENTS.md
@@ -341,13 +341,14 @@ public class ActivityAgent extends Agent {
 ### Autonomous Agent (basic)
 
 ```java
-@Component(id = "question-answerer")
+@Component(
+    id = "question-answerer",
+    description = "Answers questions clearly and concisely")
 public class QuestionAnswerer extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Answer questions clearly and concisely.")
         .capability(TaskAcceptance.of(QuestionTasks.ANSWER).maxIterationsPerTask(3));
   }
 
@@ -361,13 +362,14 @@ public class QuestionAnswerer extends AutonomousAgent {
 ### Autonomous Agent with Combined Capabilities
 
 ```java
-@Component(id = "research-coordinator")
+@Component(
+    id = "research-coordinator",
+    description = "Produces research briefs by synthesizing specialist findings")
 public class ResearchCoordinator extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-        .goal("Produce research briefs by synthesizing specialist findings.")
         .tools(new ResearchTools())
         .capability(
             TaskAcceptance.of(ResearchTasks.BRIEF)
@@ -780,9 +782,10 @@ Before presenting code, verify:
 **Autonomous Agent**
 - [ ] **STOP: Did you read `autonomous-agents.html.md` BEFORE writing any code?** (Required for first autonomous agent in session)
 - [ ] Extends `AutonomousAgent`, NOT `Agent`
-- [ ] Has `@Component(id = "...")` annotation
+- [ ] Has `@Component(id = "...", description = "...")` annotation with a non-empty description (mandatory)
+- [ ] `@Component` description captures the agent's purpose and expected outcome: used by coordinators, injected into the system message
 - [ ] Implements `definition()` method, NO command handlers
-- [ ] Goal describes purpose, not coordination mechanics
+- [ ] Optional `.instructions(...)` for tone, persona, domain rules, or procedural guidance to the model; not multi-agent orchestration mechanics (those belong in capabilities)
 - [ ] Declares accepted task types with `.capability(TaskAcceptance.of(...))`
 - [ ] Task definitions are `static final` constants with `.resultConformsTo()`
 - [ ] Result types are Java records

--- a/docs/src/modules/ROOT/pages/llms.txt
+++ b/docs/src/modules/ROOT/pages/llms.txt
@@ -117,7 +117,7 @@ Personas: Builders (Application Developers, AI/ML Engineers, Product Managers), 
 - [Orchestrating multiple agents](https://doc.akka.io/sdk/agents/orchestrating.html.md): Orchestrating and supervising multiple agents
 - [Evaluating model responses](https://doc.akka.io/sdk/agents/llm_eval.html.md): Evaluating and judging the responses from LLMs via agents
 - [Testing agents](https://doc.akka.io/sdk/agents/testing.html.md): Testing agents and agentic behavior
-- [Defining an autonomous agent](https://doc.akka.io/sdk/autonomous-agents/defining.html.md): Building an AgentDefinition with goal, accepted task types, tools, guardrails, iteration limit, and model
+- [Defining an autonomous agent](https://doc.akka.io/sdk/autonomous-agents/defining.html.md): Building an AgentDefinition with accepted task types, tools, guardrails, iteration limit, model, and optional instructions
 - [Autonomous agent tasks](https://doc.akka.io/sdk/autonomous-agents/tasks.html.md): Task definitions, instances, lifecycle, snapshots, dependencies, and notifications
 - [Autonomous agent coordination patterns](https://doc.akka.io/sdk/autonomous-agents/coordination.html.md): Sequential, delegative, collaborative, and emergent patterns for multi-agent systems
 - [Autonomous agent coordination capabilities](https://doc.akka.io/sdk/autonomous-agents/capabilities.html.md): Delegation, handoff, teams, moderation, external input, and capability composition

--- a/docs/src/modules/sdk/pages/autonomous-agents.adoc
+++ b/docs/src/modules/sdk/pages/autonomous-agents.adoc
@@ -11,13 +11,13 @@ include::ROOT:partial$include.adoc[]
 
 == Overview
 
-image:ROOT:agent.png[Autonomous Agent,width=100,float=left]An Autonomous Agent is a model-driven component that runs as a durable process. It works on typed tasks, each with its own identity, instructions, and result schema. The developer declares the agent's goal, the task types it accepts, the tools it can use, and any coordination capabilities. The runtime drives the model through a decision loop until each task is complete. Agent and task state is persisted along the way, so work survives crashes and restarts.
+image:ROOT:agent.png[Autonomous Agent,width=100,float=left]An Autonomous Agent is a model-driven component that runs as a durable process. It works on typed tasks, each with its own identity, instructions, and result schema. The developer declares the agent's description (via `@Component`), the task types it accepts, the tools it can use, and any coordination capabilities. The runtime drives the model through a decision loop until each task is complete. Agent and task state is persisted along the way, so work survives crashes and restarts.
 
-A task ends when the model decides its work on it is done. Success means the model produces a result that conforms to the task's declared result schema. Failure means the model reports it cannot make progress, and the runtime records a failure reason. As a safety net, an iteration limit terminates a task that reaches neither outcome. The agent's goal and the task's result schema together shape what "done" means for each task type.
+A task ends when the model decides its work on it is done. Success means the model produces a result that conforms to the task's declared result schema. Failure means the model reports it cannot make progress, and the runtime records a failure reason. As a safety net, an iteration limit terminates a task that reaches neither outcome. The agent's description, together with the task's result schema and any optional definition-level instructions, shape what "done" means for each task type.
 
 A task exists independently of any agent. It can be created up front with dependencies, queried by external clients while running, or handed between agents. Its typed result outlives the agent that produced it. The agent itself is stateless from the developer's perspective, while task and agent state are recovered automatically after crashes or restarts.
 
-Models perform best with focused context. A single agent loaded with too many concerns, competing objectives, and unrelated information loses clarity. Autonomous Agents are designed around this constraint: each agent has its own goal, its own accepted task types, and its own iteration loop, so context stays scoped to what one agent needs. Coordination then composes focused agents rather than overloading one.
+Models perform best with focused context. A single agent loaded with too many concerns, competing objectives, and unrelated information loses clarity. Autonomous Agents are designed around this constraint: each agent has its own description, its own accepted task types, and its own iteration loop, so context stays scoped to what one agent needs. Coordination then composes focused agents rather than overloading one.
 
 Coordination is part of the component model. An agent can declare that it delegates subtasks to specialist workers, hands off work to peers, leads a team that shares a task list, or moderates a turn-taking conversation. The runtime exposes these patterns to the model as tools, so the agent invokes them like any other tool. Multi-agent systems can be assembled from focused, single-purpose agents without writing orchestration code.
 
@@ -138,7 +138,7 @@ include::example$autonomous-agent-playground/src/main/java/demo/helloworld/api/Q
 
 == Topics
 
-xref:sdk:autonomous-agents/defining.adoc[Defining an autonomous agent]:: Building an `AgentDefinition`: goal, accepted task types, tools, MCP endpoints, guardrails, iteration limit, and model selection.
+xref:sdk:autonomous-agents/defining.adoc[Defining an autonomous agent]:: Building an `AgentDefinition`: accepted task types, tools, MCP endpoints, guardrails, iteration limit, model selection, and optional instructions. Covers how the `@Component` description captures the agent's purpose and expected outcome.
 
 xref:sdk:autonomous-agents/tasks.adoc[Tasks]:: Defining task types, creating instances with instructions and attachments, the task lifecycle, querying typed results, declaring dependencies between tasks.
 

--- a/docs/src/modules/sdk/pages/autonomous-agents/capabilities.adoc
+++ b/docs/src/modules/sdk/pages/autonomous-agents/capabilities.adoc
@@ -133,7 +133,7 @@ include::example$autonomous-agent-playground/src/main/java/demo/support/applicat
 [#moderation]
 == Moderation
 
-A moderator agent orchestrates turn-taking conversations between participant agents. The moderator declares which agent types can participate, and the framework manages conversation setup, turn-taking, and transcript collection. Participant agents are simple: they define a goal and the framework handles the conversation mechanics automatically.
+A moderator agent orchestrates turn-taking conversations between participant agents. The moderator declares which agent types can participate, and the framework manages conversation setup, turn-taking, and transcript collection. Participant agents are simple: their `@Component` description identifies them to the moderator and the framework handles the conversation mechanics automatically.
 
 [source,java,indent=0]
 ----
@@ -174,7 +174,7 @@ This mode suits structured processes with a known sequence: peer reviews where e
 include::example$autonomous-agent-playground/src/main/java/demo/peerreview/application/ReviewModerator.java[tag=class]
 ----
 
-Participant agents need only a goal. The framework provides the conversation tools:
+Participant agents need only a `@Component` description. The framework provides the conversation tools:
 
 [source,java,indent=0]
 .{sample-base-url}/autonomous-agent-playground/src/main/java/demo/peerreview/application/TechnicalReviewer.java[TechnicalReviewer.java]
@@ -218,12 +218,15 @@ The moderator's model can use multiple instances of the same participant type wi
 
 [source,java,indent=0]
 ----
-@Component(id = "critic", description = "Reviews and critiques from a specific perspective")
+@Component(
+  id = "critic",
+  description = "Provides critical analysis and critiques from a specific perspective"
+)
 public class Critic extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Provide critical analysis from the assigned perspective.");
+    return define();
   }
 }
 ----

--- a/docs/src/modules/sdk/pages/autonomous-agents/client.adoc
+++ b/docs/src/modules/sdk/pages/autonomous-agents/client.adoc
@@ -44,7 +44,7 @@ Tasks are queued if the agent is busy. A single agent instance processes one tas
 
 The `maxParallelWorkers` option on a `Delegation` capability (see xref:sdk:autonomous-agents/capabilities.adoc#delegation[Delegation]) caps how many worker instances a coordinator can run in parallel. It does not change the single-task-at-a-time behavior of any one instance.
 
-If the agent uses xref:sdk:autonomous-agents/defining.adoc#dynamic-configuration[dynamic configuration], call `setup(...)` on the same `forAutonomousAgent(...)` chain before `runSingleTask` or `assignTasks` so the runtime applies the per-instance goal and capabilities before iteration begins.
+If the agent uses xref:sdk:autonomous-agents/defining.adoc#dynamic-configuration[dynamic configuration], call `setup(...)` on the same `forAutonomousAgent(...)` chain before `runSingleTask` or `assignTasks` so the runtime applies the per-instance instructions and capabilities before iteration begins.
 
 *Terminate an agent:*
 
@@ -119,7 +119,7 @@ var state = componentClient
 
 state.phase();           // execution phase, e.g. "PHASE_MODEL", "PHASE_TOOLS", "PHASE_STOPPED"
 state.suspended();       // whether the agent is suspended
-state.goal();            // the agent's current goal
+state.instructions();    // the agent's current instructions
 state.totalTokenUsage(); // cumulative token usage (inputTokens, outputTokens)
 state.currentTask();     // Optional<TaskKey> with the task currently being worked on
 state.pendingTaskIds();  // List<String> with ids of tasks queued but not yet started

--- a/docs/src/modules/sdk/pages/autonomous-agents/coordination.adoc
+++ b/docs/src/modules/sdk/pages/autonomous-agents/coordination.adoc
@@ -8,19 +8,17 @@ The coordination pattern shapes system behavior in several ways: efficiency, coh
 
 Four patterns cover the design space. Each has a distinct view of how context is scoped and flows between agents, a corresponding single-agent approach, and an analogy to established concurrency models. In practice these patterns are conceptual tools for understanding the design space. Real systems often blend them.
 
-Before you can apply a pattern, you need to decide what each piece of work is. The next section walks through the four primitives, goal, task, tool, and agent, and how to choose between them.
+Before you can apply a pattern, you need to decide what each piece of work is. The next section walks through the three primitives, task, tool, and agent, and how to choose between them.
 
 == Choosing the unit of decomposition
 
 Designing an autonomous agent system means deciding which unit of decomposition fits each piece of work. The same operation, "check the weather", can reasonably be modeled as a tool, a task, or its own agent, and the choice has real consequences for context, persistence, and reuse. This section explains what each abstraction is for, then offers a rule of thumb for choosing between them.
 
-Goal:: A goal is an agent's high-level purpose: what it achieves. It is not a step or a procedure. The runtime puts the goal in the system message, so it shapes every iteration. Keep goals focused on outcomes, such as "Produce research briefs by synthesizing specialist findings", rather than mechanics like "Call the researcher, then call the analyst, then synthesize".
-
 Tool:: A tool is a function the model can request to fetch information, perform a computation, or trigger an action. The agent runs the tool on the model's behalf and feeds the return value back into the model's context, then the iteration continues. Tools are the right fit for quick lookups, deterministic computations, or for letting the model interact with entities and views. They have no lifecycle of their own and are not visible from outside the iteration.
 
 Task:: A task is a typed unit of work with its own identity, result schema, and lifecycle. Tasks persist independently of the agent that handles them. They can be queried by external clients, depend on other tasks, hand off between agents, and produce results that survive the agent. Use a task when the work has a meaningful structured result, when it might succeed or fail independently, when other tasks should depend on it, or when an external actor such as a human or another service needs to observe or complete it.
 
-Agent:: An autonomous agent is a process with its own goal, accepted task types, and tools. Use a separate agent when the work benefits from a focused context, a different goal phrasing, or a different model. The most common reasons are coordination, when you want to delegate, hand off, or moderate, and isolation, when you don't want the parent agent's context contaminated by the details of the sub-work.
+Agent:: An autonomous agent is a process with a `@Component` description, accepted task types, and tools. The description captures the agent's purpose and expected outcome: it tells coordinators when to delegate to it and is injected into its own system message. Use a separate agent when the work benefits from a focused context, a distinct purpose, or a different model. The most common reasons are coordination, when you want to delegate, hand off, or moderate, and isolation, when you don't want the parent agent's context contaminated by the details of the sub-work. Optional `instructions(...)` on the definition can add tone, persona, domain rules, or procedural guidance for the model; multi-agent orchestration mechanics belong in capabilities, not in instructions.
 
 === Choosing between them
 
@@ -28,7 +26,7 @@ Pick the smallest abstraction that still captures what you need. The escalation 
 
 * If the work is a fetch or a calculation that informs the model's decision in the same iteration, make it a *tool*. Example: `getWeather(location, date)` returns a forecast string the model can read and react to.
 * If the work has a typed result that should be tracked, depended on, or completed by an actor other than the agent, make it a *task*. The same agent can accept several task types, and tasks can declare dependencies between each other. Example: a `WeatherForecast` task whose result feeds into a downstream `TripPlan` task.
-* If the work needs its own goal, its own context, or specialized handling, make it a *separate agent*. Reach for it through a `Delegation` capability when you want a result back, a handoff when you want to transfer ownership, or `TeamLeadership` / `Moderation` when you want richer coordination.
+* If the work needs its own purpose, its own context, or specialized handling, make it a *separate agent*. Reach for it through a `Delegation` capability when you want a result back, a handoff when you want to transfer ownership, or `TeamLeadership` / `Moderation` when you want richer coordination.
 +
 The delegation target can be either an autonomous agent or a request-based xref:sdk:agents.adoc[Agent]:
 +

--- a/docs/src/modules/sdk/pages/autonomous-agents/defining.adoc
+++ b/docs/src/modules/sdk/pages/autonomous-agents/defining.adoc
@@ -2,21 +2,52 @@
 
 include::ROOT:partial$include.adoc[]
 
-An xref:sdk:autonomous-agents.adoc[Autonomous Agent] subclass implements a single `definition()` method that returns an `AgentDefinition`. The definition is the agent's contract: it tells the runtime what work the agent does, what tasks it accepts, which tools the model can call, and how the agent participates in multi-agent coordination.
+An xref:sdk:autonomous-agents.adoc[Autonomous Agent] subclass implements a single `definition()` method that returns an `AgentDefinition`. The definition is the agent's contract: it tells the runtime what tasks it accepts, which tools the model can call, and how the agent participates in multi-agent coordination.
 
-`AgentDefinition` is built with a fluent builder API. Call `define()` to start the builder, then chain configuration methods to declare the agent's goal, the task types it accepts, the tools it uses, guardrails, iteration limit, and model.
+`AgentDefinition` is built with a fluent builder API. Call `define()` to start the builder, then chain configuration methods to declare the task types the agent accepts, the tools it uses, guardrails, iteration limit, model, and optional instructions.
 
-== Goal
+== Purpose and instructions
 
-The goal is the agent's high-level purpose: what it achieves, not how it coordinates with other agents. The runtime combines the goal with capability-specific context and tool descriptions to build the system message sent to the model.
+The `@Component` description captures the agent's purpose and expected outcome: a short statement of what the agent does, when to use it, and what it produces. The description is *mandatory* for an autonomous agent and is enforced at compile time. It serves three audiences from a single source of truth:
+
+* Other agents use it to choose this agent as a delegation or handoff target.
+* The runtime injects it into the model's system message, so the agent's own LLM understands its purpose.
+* Documentation, observability, and other tooling pick it up to describe the agent.
+
+[source,java,indent=0]
+----
+@Component(
+  id = "question-answerer",
+  description = "Answers questions clearly and concisely, showing reasoning step by step"
+)
+public class QuestionAnswerer extends AutonomousAgent {
+  @Override
+  public AgentDefinition definition() {
+    return define().capability(TaskAcceptance.of(QuestionTasks.ANSWER));
+  }
+}
+----
+
+Because the description has to be understandable to a coordinator deciding whether to pick this agent, writing it well naturally produces outcome-oriented prose. Avoid procedure ("first call X, then call Y") — describe *what the agent is for*.
+
+The agent's behavior is then driven by its capabilities and the task types it accepts. Most autonomous agents need nothing else; their purpose comes from the description and their behavior emerges from the tasks, tools, and coordination structure.
+
+=== Optional instructions
+
+When you need to shape *how* the model speaks or judges, beyond the outcome statement in the description, add `instructions(...)` on the definition. Use this for tone, persona, role, or domain rules:
 
 [source,java,indent=0]
 ----
 define()
-  .goal("Answer questions clearly and concisely, showing reasoning step by step.")
+  .instructions("Respond in formal English. Always cite sources for factual claims.")
+  .capability(TaskAcceptance.of(QuestionTasks.ANSWER));
 ----
 
-Keep the goal focused on outcomes. Coordination mechanics (when to delegate, when to hand off, who to message) are derived automatically from the capabilities and from the descriptions on the participating agents.
+The runtime appends instructions to the system message alongside the description.
+
+Procedural guidance on how the LLM should approach a task is fine here — "read the input carefully, identify key claims, then check them against the supporting evidence" is the kind of prompt engineering instructions are for.
+
+What does *not* belong in instructions is multi-agent orchestration: when to delegate, when to hand off, who to message. Those mechanics are derived automatically from the capabilities and from the `@Component` descriptions of the participating agents. If you find yourself writing "delegate to Researcher first, then to Analyst, then synthesize" as instructions, the work belongs in capabilities and task definitions instead. See xref:sdk:autonomous-agents/coordination.adoc[] for how to decompose multi-agent work.
 
 == Accepted task types
 
@@ -125,7 +156,7 @@ define()
 
 == Complete definition example
 
-A coordinator that combines a goal, domain tools, an accepted task type with handoff to a senior consultant, and delegation to two specialist agents:
+A coordinator that combines a description, domain tools, an accepted task type with handoff to a senior consultant, and delegation to two specialist agents:
 
 [source,java,indent=0]
 .{sample-base-url}/autonomous-agent-playground/src/main/java/demo/consulting/application/ConsultingCoordinator.java[ConsultingCoordinator.java]
@@ -140,9 +171,9 @@ The combined definition declares everything the runtime needs to build the syste
 
 `AgentSetup` overrides parts of the definition for a single instance. The agent class declares whatever defaults make sense in `definition()`, and the call site supplements or overrides specific fields through `AgentSetup` before assigning work. Anything supplied through `AgentSetup` takes precedence over the corresponding field from `definition()`. Everything else falls back to the static definition.
 
-`AgentSetup.create()` supports `goal(...)` and `capability(...)`. These are the two pieces of the definition that are most useful to vary per instance. Tools, model provider, and guardrails are declared statically in `definition()` and cannot be overridden through `AgentSetup`. Call `setup(...)` once per instance, before `runSingleTask`, `assignTasks`, or any other client operation that triggers iteration.
+`AgentSetup.create()` supports `instructions(...)` and `capability(...)`. These are the two pieces of the definition that are most useful to vary per instance. The `@Component` description is bound to the component class and cannot be overridden per instance. Tools, model provider, and guardrails are declared statically in `definition()` and also cannot be overridden through `AgentSetup`. Call `setup(...)` once per instance, before `runSingleTask`, `assignTasks`, or any other client operation that triggers iteration.
 
-A typical use is to keep the static defaults in `definition()` (guardrails, model provider, the standard tool set) and override only the parts that change per instance. For example, a goal tailored to the user's request, or an extra accepted task type for that particular call.
+A typical use is to keep the static defaults in `definition()` (guardrails, model provider, the standard tool set) and override only the parts that change per instance. For example, instructions tailored to the user's request, or an extra accepted task type for that particular call.
 
 At the extreme, the definition can be a near-empty shell and everything comes from the client:
 
@@ -160,7 +191,7 @@ The endpoint then configures each instance just before assigning a task. The sam
 include::example$autonomous-agent-playground/src/main/java/demo/dynamic/api/DynamicEndpoint.java[tag=summarize]
 ----
 
-This pattern fits when many task variants share the same execution shape and the differences are best expressed as data rather than as separate agent classes: different goals over the same task types, runtime-supplied capability sets, or tool sets that depend on the user's permissions.
+This pattern fits when many task variants share the same execution shape and the differences are best expressed as data rather than as separate agent classes: different instructions over the same task types, runtime-supplied capability sets, or tool sets that depend on the user's permissions.
 
 == See Also
 

--- a/docs/src/modules/sdk/pages/use-cases/autonomous-agents.adoc
+++ b/docs/src/modules/sdk/pages/use-cases/autonomous-agents.adoc
@@ -4,7 +4,7 @@
 
 include::ROOT:partial$include.adoc[]
 
-Build agents that operate as durable processes, iterating a model decision loop over typed tasks until the work is done. The xref:sdk:autonomous-agents.adoc[Autonomous Agent] component is purpose-built for this. The developer declares the agent's goal, accepted task types, tools, and coordination capabilities, and the runtime takes care of execution, persistence, and recovery.
+Build agents that operate as durable processes, iterating a model decision loop over typed tasks until the work is done. The xref:sdk:autonomous-agents.adoc[Autonomous Agent] component is purpose-built for this. The developer declares the agent's description, accepted task types, tools, and coordination capabilities, and the runtime takes care of execution, persistence, and recovery.
 
 == Overview
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val ProtocolVersionMajor = 1
     val ProtocolVersionMinor = 1
   }
-  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.0-M3-49-30b2e53f-SNAPSHOT")
+  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.0-M3-51-812a2dad-SNAPSHOT")
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned
   // for prod code, they are marked as Provided, but testkit still requires the alignment

--- a/samples/autonomous-agent-playground/README.md
+++ b/samples/autonomous-agent-playground/README.md
@@ -15,7 +15,7 @@ A browser UI is bundled with the service. Boot the service (`mvn compile exec:ja
 | **helloworld** | None | Simplest usage — single agent, single task, no coordination |
 | **pipeline** | None (task dependencies) | 3-phase dependency chain: collect, analyze, report |
 | **docreview** | None (attachments) | Document review with text content attachments |
-| **dynamic** | None (runtime configuration) | One generic agent class configured per request with different goals and capabilities |
+| **dynamic** | None (runtime configuration) | One generic agent class configured per request with different instructions and capabilities |
 | **research** | Delegation | Coordinator delegates to researcher and analyst, synthesises findings |
 | **consulting** | Delegation + handoff | Delegate to specialists, hand off complex cases |
 | **support** | Handoff | Triage classifies request, hands off to billing or technical specialist |
@@ -78,17 +78,17 @@ A single agent reviews a document for compliance, receiving the document content
 
 ## dynamic
 
-A single generic agent class is configured per request with different goals and task capabilities. The same `DynamicAgent` code runs both the summarize and translate flows.
+A single generic agent class is configured per request with different instructions and task capabilities. The same `DynamicAgent` code runs both the summarize and translate flows.
 
-**Agents:** DynamicAgent — declared with no static goal or capabilities; configured at runtime via `AgentSetup` before each task is assigned
+**Agents:** DynamicAgent — declared with no static instructions or capabilities; configured at runtime via `AgentSetup` before each task is assigned
 
 **Tasks:**
 - SUMMARIZE → `String` — produces a concise summary of the input content
 - TRANSLATE → `String` — translates the input content to French
 
-**Flow:** Two HTTP routes (`POST /dynamic/summarize`, `POST /dynamic/translate`) each create a fresh DynamicAgent instance, configure its goal and accepted capability dynamically, then assign a single task. The summarize route sets a summarization goal and accepts only the SUMMARIZE task; the translate route sets a translation goal and accepts only the TRANSLATE task — same agent class, two different runtime specialisations.
+**Flow:** Two HTTP routes (`POST /dynamic/summarize`, `POST /dynamic/translate`) each create a fresh DynamicAgent instance, configure its instructions and accepted capability dynamically, then assign a single task. The summarize route sets summarization instructions and accepts only the SUMMARIZE task; the translate route sets translation instructions and accepts only the TRANSLATE task — same agent class, two different runtime specialisations.
 
-**Demonstrates:** Runtime agent configuration. The same `AutonomousAgent` subclass with no static goal or capabilities can be specialised per request via `AgentSetup`. Useful when many task variants share the same execution shape and the differences are best expressed as data rather than as separate agent classes.
+**Demonstrates:** Runtime agent configuration. The same `AutonomousAgent` subclass with no static instructions or capabilities can be specialised per request via `AgentSetup`. Useful when many task variants share the same execution shape and the differences are best expressed as data rather than as separate agent classes.
 
 ---
 

--- a/samples/autonomous-agent-playground/pom.xml
+++ b/samples/autonomous-agent-playground/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.akka</groupId>
     <artifactId>akka-javasdk-parent</artifactId>
-    <version>3.6.0-M3-9-7b5ee09d-dev-SNAPSHOT</version>
+    <version>3.6.0-M3-10-a796e986-dev-SNAPSHOT</version>
   </parent>
 
   <groupId>demo</groupId>

--- a/samples/autonomous-agent-playground/pom.xml
+++ b/samples/autonomous-agent-playground/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.akka</groupId>
     <artifactId>akka-javasdk-parent</artifactId>
-    <version>3.6.0-M3</version>
+    <version>3.6.0-M3-9-7b5ee09d-dev-SNAPSHOT</version>
   </parent>
 
   <groupId>demo</groupId>

--- a/samples/autonomous-agent-playground/src/main/java/demo/consulting/application/ConsultingCoordinator.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/consulting/application/ConsultingCoordinator.java
@@ -13,19 +13,18 @@ import akka.javasdk.annotations.Component;
  * senior consultant (handoff), and delegate fact-checking to a request-based agent.
  */
 // tag::class[]
-@Component(id = "consulting-coordinator")
+@Component(
+  id = "consulting-coordinator",
+  description = """
+    Delivers actionable consulting recommendations by assessing \
+    problem complexity and routing to the right expertise level\
+    """
+)
 public class ConsultingCoordinator extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
-        """
-        Deliver actionable consulting recommendations. Assess each client \
-        problem, determine its complexity, and ensure it reaches the right \
-        level of expertise for resolution. \
-        """
-      )
       .tools(new ConsultingTools())
       .capability(
         TaskAcceptance.of(ConsultingTasks.ENGAGEMENT).canHandoffTo(SeniorConsultant.class)

--- a/samples/autonomous-agent-playground/src/main/java/demo/consulting/application/ConsultingResearcher.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/consulting/application/ConsultingResearcher.java
@@ -14,12 +14,6 @@ public class ConsultingResearcher extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
-        """
-        Research the given topic thoroughly and produce a clear, \
-        factual summary of your findings. \
-        """
-      )
       .tools(new ConsultingTools())
       .capability(TaskAcceptance.of(ConsultingTasks.RESEARCH).maxIterationsPerTask(5));
   }

--- a/samples/autonomous-agent-playground/src/main/java/demo/consulting/application/ConsultingTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/consulting/application/ConsultingTasks.java
@@ -15,13 +15,13 @@ public class ConsultingTasks {
 
   // prettier-ignore
   public static final Task<ConsultingResult> ENGAGEMENT = Task
-    .define("Engagement")
+    .name("Engagement")
     .description("Consulting engagement — assess a client problem and deliver a recommendation")
     .resultConformsTo(ConsultingResult.class);
 
   // prettier-ignore
   public static final Task<ResearchSummary> RESEARCH = Task
-    .define("Research")
+    .name("Research")
     .description("Research a specific aspect of a client problem")
     .resultConformsTo(ResearchSummary.class);
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/consulting/application/SeniorConsultant.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/consulting/application/SeniorConsultant.java
@@ -7,21 +7,16 @@ import akka.javasdk.annotations.Component;
 
 @Component(
   id = "senior-consultant",
-  description = "Senior consultant for complex problems involving regulatory, M&A, " +
-  "or enterprise transformation"
+  description = """
+    Senior consultant for complex problems involving regulatory, M&A, \
+    or enterprise transformation\
+    """
 )
 public class SeniorConsultant extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
-        """
-        Resolve complex, high-stakes consulting problems — regulatory issues, \
-        M&A integration, enterprise transformation. Deliver a comprehensive \
-        recommendation with actionable next steps. \
-        """
-      )
       .tools(new ConsultingTools())
       .capability(TaskAcceptance.of(ConsultingTasks.ENGAGEMENT));
   }

--- a/samples/autonomous-agent-playground/src/main/java/demo/debate/application/Advocate.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/debate/application/Advocate.java
@@ -9,6 +9,6 @@ public class Advocate extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Present compelling arguments in favor of the assigned position.");
+    return define();
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/debate/application/Critic.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/debate/application/Critic.java
@@ -9,9 +9,6 @@ public class Critic extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define()
-      .goal(
-        "Present compelling counterarguments and identify weaknesses in the opposing position."
-      );
+    return define();
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/debate/application/DebateModerator.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/debate/application/DebateModerator.java
@@ -15,9 +15,6 @@ public class DebateModerator extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
-        "Moderate structured debates between participants and synthesize balanced conclusions."
-      )
       .capability(TaskAcceptance.of(DebateTasks.DEBATE))
       .capability(Moderation.of(Advocate.class, Critic.class).maxRounds(5));
   }

--- a/samples/autonomous-agent-playground/src/main/java/demo/debate/application/DebateTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/debate/application/DebateTasks.java
@@ -9,7 +9,7 @@ public class DebateTasks {
 
   // prettier-ignore
   public static final Task<DebateResult> DEBATE = Task
-    .define("Debate")
+    .name("Debate")
     .description("Moderate a structured debate between advocates and critics, then synthesize a balanced conclusion.")
     .resultConformsTo(DebateResult.class);
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/devteam/application/Developer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/devteam/application/Developer.java
@@ -12,9 +12,8 @@ public class Developer extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .instructions(
         """
-        Implement features with clean, tested code. \
         Coordinate with teammates when your work depends on or affects \
         their tasks — agree on shared contracts before implementing. \
         """

--- a/samples/autonomous-agent-playground/src/main/java/demo/devteam/application/ProjectLead.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/devteam/application/ProjectLead.java
@@ -10,16 +10,15 @@ import akka.javasdk.annotations.Component;
 // tag::class[]
 @Component(
   id = "project-lead",
-  description = "Leads software projects by coordinating a team"
+  description = "Delivers completed software projects by leading a team of developers"
 )
 public class ProjectLead extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
+      .instructions(
         """
-        Deliver completed software projects with all features implemented and tested. \
         Message team members directly when their tasks have dependencies or \
         shared interfaces that require coordination before implementation. \
         """

--- a/samples/autonomous-agent-playground/src/main/java/demo/devteam/application/ProjectTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/devteam/application/ProjectTasks.java
@@ -10,7 +10,7 @@ public class ProjectTasks {
 
   // prettier-ignore
   public static final Task<ProjectResult> PLAN = Task
-    .define("Plan")
+    .name("Plan")
     .description("Plan project: break work into tasks, coordinate a team, and deliver results.")
     .resultConformsTo(ProjectResult.class);
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/docreview/application/DocumentReviewer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/docreview/application/DocumentReviewer.java
@@ -9,18 +9,17 @@ import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "document-reviewer")
+@Component(
+  id = "document-reviewer",
+  description = """
+    Reviews documents for regulatory and compliance standards, \
+    producing structured assessments with specific findings\
+    """
+)
 public class DocumentReviewer extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define()
-      .goal(
-        """
-        Review documents for regulatory and compliance standards, \
-        providing structured assessments with specific findings. \
-        """
-      )
-      .capability(TaskAcceptance.of(ReviewTasks.REVIEW).maxIterationsPerTask(5));
+    return define().capability(TaskAcceptance.of(ReviewTasks.REVIEW).maxIterationsPerTask(5));
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/docreview/application/ReviewTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/docreview/application/ReviewTasks.java
@@ -12,7 +12,7 @@ public class ReviewTasks {
 
   // prettier-ignore
   public static final Task<ReviewResult> REVIEW = Task
-    .define("Review")
+    .name("Review")
     .description("Review a document for compliance")
     .resultConformsTo(ReviewResult.class);
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/dynamic/api/DynamicEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/dynamic/api/DynamicEndpoint.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 /**
  * Demonstrates dynamic agent setup — the same generic agent class is configured with different
- * goals and capabilities per request.
+ * instructions and capabilities per request.
  */
 @Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET))
 @HttpEndpoint("/dynamic")
@@ -42,7 +42,7 @@ public class DynamicEndpoint extends AbstractHttpEndpoint {
       .forAutonomousAgent(DynamicAgent.class, agentId)
       .setup(
         AgentSetup.create()
-          .goal("Produce a concise summary of the given content, highlighting key points.")
+          .instructions("Produce a concise summary of the given content, highlighting key points.")
           .capability(TaskAcceptance.of(DynamicTasks.SUMMARIZE))
       );
 
@@ -66,7 +66,7 @@ public class DynamicEndpoint extends AbstractHttpEndpoint {
       .forAutonomousAgent(DynamicAgent.class, agentId)
       .setup(
         AgentSetup.create()
-          .goal("Translate the given content to French, preserving tone and meaning.")
+          .instructions("Translate the given content to French, preserving tone and meaning.")
           .capability(TaskAcceptance.of(DynamicTasks.TRANSLATE))
       );
 

--- a/samples/autonomous-agent-playground/src/main/java/demo/dynamic/application/DynamicAgent.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/dynamic/application/DynamicAgent.java
@@ -5,11 +5,14 @@ import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.annotations.Component;
 
 /**
- * A generic agent with no static goal or capabilities. Configured dynamically at runtime via
- * AgentSetup before assigning tasks.
+ * A generic agent with no static instructions or capabilities. Configured dynamically at runtime
+ * via AgentSetup before assigning tasks.
  */
 // tag::class[]
-@Component(id = "dynamic-agent")
+@Component(
+  id = "dynamic-agent",
+  description = "Generic agent configured dynamically per request via AgentSetup"
+)
 public class DynamicAgent extends AutonomousAgent {
 
   @Override

--- a/samples/autonomous-agent-playground/src/main/java/demo/dynamic/application/DynamicTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/dynamic/application/DynamicTasks.java
@@ -4,11 +4,11 @@ import akka.javasdk.agent.task.Task;
 
 public class DynamicTasks {
 
-  public static final Task<String> SUMMARIZE = Task.define("Summarize")
+  public static final Task<String> SUMMARIZE = Task.name("Summarize")
     .description("Summarize the given content")
     .resultConformsTo(String.class);
 
-  public static final Task<String> TRANSLATE = Task.define("Translate")
+  public static final Task<String> TRANSLATE = Task.name("Translate")
     .description("Translate content to another language")
     .resultConformsTo(String.class);
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/helloworld/application/QuestionAnswerer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/helloworld/application/QuestionAnswerer.java
@@ -6,14 +6,15 @@ import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
 // tag::class[]
-@Component(id = "question-answerer") // <2>
+@Component( // <2>
+  id = "question-answerer",
+  description = "Answers questions clearly and concisely, showing reasoning step by step"
+)
 public class QuestionAnswerer extends AutonomousAgent { // <1>
 
   @Override
   public AgentDefinition definition() { // <3>
-    return define()
-      .goal("Answer questions clearly and concisely, showing reasoning step by step.")
-      .capability(TaskAcceptance.of(QuestionTasks.ANSWER).maxIterationsPerTask(3));
+    return define().capability(TaskAcceptance.of(QuestionTasks.ANSWER).maxIterationsPerTask(3));
   }
 }
 // end::class[]

--- a/samples/autonomous-agent-playground/src/main/java/demo/helloworld/application/QuestionTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/helloworld/application/QuestionTasks.java
@@ -7,7 +7,7 @@ public class QuestionTasks {
 
   // prettier-ignore
   public static final Task<Answer> ANSWER = Task
-    .define("Answer")
+    .name("Answer")
     .description("Answer a question")
     .resultConformsTo(Answer.class);
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Buyer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Buyer.java
@@ -4,11 +4,14 @@ import akka.javasdk.agent.autonomous.AgentDefinition;
 import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "buyer", description = "Negotiates from the buyer's perspective")
+@Component(
+  id = "buyer",
+  description = "Negotiates the best possible deal from the buyer's perspective"
+)
 public class Buyer extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Negotiate the best possible deal from the buyer's perspective.");
+    return define();
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Facilitator.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Facilitator.java
@@ -7,18 +7,18 @@ import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
 // tag::class[]
-@Component(id = "facilitator", description = "Facilitates negotiations between parties")
+@Component(
+  id = "facilitator",
+  description = """
+    Facilitates negotiations by directing parties through structured rounds \
+    of offers and counteroffers to reach agreement\
+    """
+)
 public class Facilitator extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
-        """
-        Facilitate negotiations by directing each psarty through structured rounds \
-        of offers and counteroffers to reach agreement.
-        """
-      )
       .capability(TaskAcceptance.of(NegotiationTasks.NEGOTIATE))
       .capability(Moderation.of(Buyer.class, Seller.class).maxRounds(10));
   }

--- a/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/NegotiationTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/NegotiationTasks.java
@@ -7,7 +7,7 @@ public class NegotiationTasks {
 
   public record NegotiationResult(String topic, String outcome, String finalOffer) {}
 
-  public static final Task<NegotiationResult> NEGOTIATE = Task.define("Negotiate")
+  public static final Task<NegotiationResult> NEGOTIATE = Task.name("Negotiate")
     .description("Facilitate a negotiation between buyer and seller.")
     .resultConformsTo(NegotiationResult.class);
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Seller.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/negotiation/application/Seller.java
@@ -4,11 +4,14 @@ import akka.javasdk.agent.autonomous.AgentDefinition;
 import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "seller", description = "Negotiates from the seller's perspective")
+@Component(
+  id = "seller",
+  description = "Negotiates the best possible deal from the seller's perspective"
+)
 public class Seller extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Negotiate the best possible deal from the seller's perspective.");
+    return define();
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ComplianceReviewer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ComplianceReviewer.java
@@ -4,11 +4,14 @@ import akka.javasdk.agent.autonomous.AgentDefinition;
 import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "compliance-reviewer", description = "Reviews documents for compliance")
+@Component(
+  id = "compliance-reviewer",
+  description = "Reviews documents for regulatory compliance and policy adherence"
+)
 public class ComplianceReviewer extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Review documents for regulatory compliance and policy adherence.");
+    return define();
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ReviewModerator.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ReviewModerator.java
@@ -16,7 +16,6 @@ public class ReviewModerator extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("Coordinate document peer review and synthesize reviewer findings.")
       .capability(TaskAcceptance.of(ReviewTasks.REVIEW))
       .capability(
         Moderation.of(TechnicalReviewer.class, StyleReviewer.class, ComplianceReviewer.class)

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ReviewTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/ReviewTasks.java
@@ -12,7 +12,7 @@ public class ReviewTasks {
     List<String> reviewerFindings
   ) {}
 
-  public static final Task<ReviewResult> REVIEW = Task.define("Review")
+  public static final Task<ReviewResult> REVIEW = Task.name("Review")
     .description(
       "Coordinate peer review of a document by technical, style, and compliance reviewers."
     )

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/StyleReviewer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/StyleReviewer.java
@@ -4,11 +4,14 @@ import akka.javasdk.agent.autonomous.AgentDefinition;
 import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "style-reviewer", description = "Reviews documents for clarity and style")
+@Component(
+  id = "style-reviewer",
+  description = "Reviews documents for clarity, readability, and consistent style"
+)
 public class StyleReviewer extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define().goal("Review documents for clarity, readability, and consistent style.");
+    return define();
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/TechnicalReviewer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/peerreview/application/TechnicalReviewer.java
@@ -7,14 +7,13 @@ import akka.javasdk.annotations.Component;
 // tag::class[]
 @Component(
   id = "technical-reviewer",
-  description = "Reviews documents for technical accuracy"
+  description = "Reviews documents for technical accuracy, correctness, and completeness"
 )
 public class TechnicalReviewer extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define()
-      .goal("Review documents for technical accuracy, correctness, and completeness.");
+    return define();
   }
 }
 // end::class[]

--- a/samples/autonomous-agent-playground/src/main/java/demo/pipeline/application/PipelineTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/pipeline/application/PipelineTasks.java
@@ -12,19 +12,19 @@ public class PipelineTasks {
 
   // prettier-ignore
   public static final Task<ReportResult> COLLECT = Task
-    .define("Collect")
+    .name("Collect")
     .description("Collect data on a topic")
     .resultConformsTo(ReportResult.class);
 
   // prettier-ignore
   public static final Task<ReportResult> ANALYZE = Task
-    .define("Analyze")
+    .name("Analyze")
     .description("Analyze collected data")
     .resultConformsTo(ReportResult.class);
 
   // prettier-ignore
   public static final Task<ReportResult> REPORT = Task
-    .define("Report")
+    .name("Report")
     .description("Write final report")
     .resultConformsTo(ReportResult.class);
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/pipeline/application/ReportAgent.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/pipeline/application/ReportAgent.java
@@ -11,15 +11,18 @@ import akka.javasdk.annotations.Component;
 import akka.javasdk.annotations.FunctionTool;
 
 // tag::class[]
-@Component(id = "report-agent")
+@Component(
+  id = "report-agent",
+  description = """
+    Processes report phases: collects data, analyzes findings, \
+    produces comprehensive reports\
+    """
+)
 public class ReportAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
-        "Process report phases: collect data, analyze findings, produce comprehensive reports."
-      )
       .capability(
         TaskAcceptance.of(
           PipelineTasks.COLLECT,

--- a/samples/autonomous-agent-playground/src/main/java/demo/publishing/application/ContentAgent.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/publishing/application/ContentAgent.java
@@ -5,13 +5,14 @@ import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "content-agent")
+@Component(
+  id = "content-agent",
+  description = "Drafts clear, engaging blog posts on a given topic"
+)
 public class ContentAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define()
-      .goal("Draft blog posts. Write clear, engaging content on the given topic.")
-      .capability(TaskAcceptance.of(PublishingTasks.DRAFT).maxIterationsPerTask(3));
+    return define().capability(TaskAcceptance.of(PublishingTasks.DRAFT).maxIterationsPerTask(3));
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/publishing/application/PublishingAgent.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/publishing/application/PublishingAgent.java
@@ -5,15 +5,14 @@ import akka.javasdk.agent.autonomous.AutonomousAgent;
 import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
-@Component(id = "publishing-agent")
+@Component(
+  id = "publishing-agent",
+  description = "Publishes approved blog posts, assigning a URL and timestamp"
+)
 public class PublishingAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define()
-      .goal(
-        "Publish approved blog posts. Generate a URL and timestamp for the published post."
-      )
-      .capability(TaskAcceptance.of(PublishingTasks.PUBLISH).maxIterationsPerTask(3));
+    return define().capability(TaskAcceptance.of(PublishingTasks.PUBLISH).maxIterationsPerTask(3));
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/publishing/application/PublishingTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/publishing/application/PublishingTasks.java
@@ -8,19 +8,19 @@ public class PublishingTasks {
 
   // prettier-ignore
   public static final Task<DraftPost> DRAFT = Task
-    .define("Draft post")
+    .name("Draft post")
     .description("Draft a blog post on a given topic")
     .resultConformsTo(DraftPost.class);
 
   // prettier-ignore
   public static final Task<ApprovalDecision> APPROVAL = Task
-    .define("Approval")
+    .name("Approval")
     .description("Human approval gate for publishing")
     .resultConformsTo(ApprovalDecision.class);
 
   // prettier-ignore
   public static final Task<PublishedPost> PUBLISH = Task
-    .define("Publish post")
+    .name("Publish post")
     .description("Publish an approved post")
     .resultConformsTo(PublishedPost.class);
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/research/application/Analyst.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/research/application/Analyst.java
@@ -14,14 +14,7 @@ public class Analyst extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define()
-      .goal(
-        """
-        You are an insightful analyst. When given a topic, analyse its implications, \
-        identify trends and patterns, and produce actionable insights. \
-        """
-      )
-      .capability(TaskAcceptance.of(ResearchTasks.ANALYSIS).maxIterationsPerTask(3));
+    return define().capability(TaskAcceptance.of(ResearchTasks.ANALYSIS).maxIterationsPerTask(3));
   }
 }
 // end::class[]

--- a/samples/autonomous-agent-playground/src/main/java/demo/research/application/ResearchCoordinator.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/research/application/ResearchCoordinator.java
@@ -7,18 +7,18 @@ import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
 // tag::class[]
-@Component(id = "research-coordinator")
+@Component(
+  id = "research-coordinator",
+  description = """
+    Produces comprehensive research briefs by synthesizing findings \
+    from multiple specialist perspectives\
+    """
+)
 public class ResearchCoordinator extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
-        """
-        Produce comprehensive research briefs by synthesising findings \
-        from multiple specialist perspectives. \
-        """
-      )
       .capability(TaskAcceptance.of(ResearchTasks.BRIEF).maxIterationsPerTask(5))
       .capability(Delegation.to(Researcher.class, Analyst.class).maxParallelWorkers(3));
   }

--- a/samples/autonomous-agent-playground/src/main/java/demo/research/application/ResearchTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/research/application/ResearchTasks.java
@@ -7,14 +7,14 @@ public class ResearchTasks {
 
   // prettier-ignore
   public static final Task<ResearchBrief> BRIEF = Task
-    .define("Brief")
+    .name("Brief")
     .description("Produce a research brief on a given topic")
     .resultConformsTo(ResearchBrief.class);
 
   // tag::with-rule[]
   // prettier-ignore
   public static final Task<ResearchFindings> FINDINGS = Task
-    .define("Findings")
+    .name("Findings")
     .description("Research a topic and produce factual findings")
     .resultConformsTo(ResearchFindings.class)
     .rules(ResearchFindingsRule.class);
@@ -22,7 +22,7 @@ public class ResearchTasks {
 
   // prettier-ignore
   public static final Task<AnalysisReport> ANALYSIS = Task
-    .define("Analysis")
+    .name("Analysis")
     .description("Analyse a topic and produce a trend analysis report")
     .resultConformsTo(AnalysisReport.class);
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/research/application/Researcher.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/research/application/Researcher.java
@@ -14,14 +14,7 @@ public class Researcher extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
-    return define()
-      .goal(
-        """
-        You are a thorough researcher. When given a topic, find key facts, \
-        important details, and relevant context. \
-        """
-      )
-      .capability(TaskAcceptance.of(ResearchTasks.FINDINGS).maxIterationsPerTask(3));
+    return define().capability(TaskAcceptance.of(ResearchTasks.FINDINGS).maxIterationsPerTask(3));
   }
 }
 // end::class[]

--- a/samples/autonomous-agent-playground/src/main/java/demo/support/application/BillingSpecialist.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/support/application/BillingSpecialist.java
@@ -15,7 +15,6 @@ public class BillingSpecialist extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("Resolve billing and payment issues for customers.")
       .capability(TaskAcceptance.of(SupportTasks.RESOLVE).maxIterationsPerTask(5));
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/support/application/SupportTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/support/application/SupportTasks.java
@@ -9,7 +9,7 @@ public class SupportTasks {
 
   // prettier-ignore
   public static final Task<SupportResolution> RESOLVE = Task
-    .define("Resolve")
+    .name("Resolve")
     .description("Resolve a customer support request")
     .resultConformsTo(SupportResolution.class);
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/support/application/TechnicalSpecialist.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/support/application/TechnicalSpecialist.java
@@ -15,7 +15,6 @@ public class TechnicalSpecialist extends AutonomousAgent {
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal("Diagnose and resolve technical issues for customers.")
       .capability(TaskAcceptance.of(SupportTasks.RESOLVE).maxIterationsPerTask(5));
   }
 }

--- a/samples/autonomous-agent-playground/src/main/java/demo/support/application/TriageAgent.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/support/application/TriageAgent.java
@@ -6,18 +6,18 @@ import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
 import akka.javasdk.annotations.Component;
 
 // tag::class[]
-@Component(id = "triage-agent")
+@Component(
+  id = "triage-agent",
+  description = """
+    Classifies customer support requests and routes them to the appropriate \
+    specialist via handoff\
+    """
+)
 public class TriageAgent extends AutonomousAgent {
 
   @Override
   public AgentDefinition definition() {
     return define()
-      .goal(
-        """
-        Classify customer support requests and ensure they are resolved \
-        by the appropriate specialist. \
-        """
-      )
       .capability(
         TaskAcceptance.of(SupportTasks.RESOLVE)
           .maxIterationsPerTask(3)


### PR DESCRIPTION
Requires runtime https://github.com/lightbend/akka-runtime/pull/5194#pullrequestreview-4280906377

Unrelated, but also renamed Task.define to Task.name as suggested by @octonato 