### PR TITLE
fix: avoid infinite circular resolution in proto descriptor

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/reflection/Reflect.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/reflection/Reflect.scala
@@ -119,11 +119,20 @@ private[impl] object Reflect {
   }
 
   private def flattenDependencies(descriptor: Descriptors.Descriptor): Set[Descriptors.Descriptor] =
-    Set(descriptor) ++ descriptor.getFields.asScala.toSet.flatMap((field: Descriptors.FieldDescriptor) =>
-      if (field.getJavaType == JavaType.MESSAGE) {
-        val fieldDescriptor = field.getMessageType
-        Set(fieldDescriptor) ++ flattenDependencies(fieldDescriptor)
-      } else Set.empty)
+    flattenDependencies(descriptor, Set.empty)
+
+  private def flattenDependencies(
+      descriptor: Descriptors.Descriptor,
+      visited: Set[Descriptors.Descriptor]): Set[Descriptors.Descriptor] = {
+    if (visited.contains(descriptor)) Set.empty
+    else {
+      val nowVisited = visited + descriptor
+      Set(descriptor) ++ descriptor.getFields.asScala.toSet.flatMap { (field: Descriptors.FieldDescriptor) =>
+        if (field.getJavaType == JavaType.MESSAGE) flattenDependencies(field.getMessageType, nowVisited)
+        else Set.empty[Descriptors.Descriptor]
+      }
+    }
+  }
 
   def isRestEndpoint(cls: Class[_]): Boolean =
     cls.getAnnotation(classOf[HttpEndpoint]) != null

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/subscriptions/PubSubTestModels.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/subscriptions/PubSubTestModels.java
@@ -152,6 +152,14 @@ class PubSubTestModels { // TODO shall we remove this class and move things to A
     }
   }
 
+  @Consume.FromServiceStream(service = "some_service", id = "circular_events", ignoreUnknown = true)
+  public static class CircularProtoConsumer extends Consumer {
+
+    public Effect handle(EventsForConsumer.CircularParent event) {
+      return effects().done();
+    }
+  }
+
   @Component(id = "employee_view")
   public static class EventStreamSubscriptionView extends View {
 

--- a/akka-javasdk/src/test/proto/protoconsumer/events_for_consumer.proto
+++ b/akka-javasdk/src/test/proto/protoconsumer/events_for_consumer.proto
@@ -17,3 +17,13 @@ message EventForConsumer1 {
 message EventForConsumer2 {
   string text = 1;
 }
+
+message CircularParent {
+  string id = 1;
+  CircularChild child = 2;
+}
+
+message CircularChild {
+  string name = 1;
+  CircularParent parent = 2;
+}

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/reflection/ReflectSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/reflection/ReflectSpec.scala
@@ -8,9 +8,9 @@ import scala.concurrent.ExecutionContext
 
 import akka.Done
 import akka.javasdk.client.ComponentClient
+import akka.javasdk.impl.ComponentDescriptor
 import akka.javasdk.impl.client.ComponentClientImpl
 import akka.javasdk.impl.serialization.Serializer
-import akka.javasdk.impl.ComponentDescriptor
 import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.InvalidProtoEventSourcedEntityWrongEventType
 import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.ProtoConsumerAutoResolve
 import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.ProtoConsumerEntityWithoutAnnotation

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/reflection/ReflectSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/reflection/ReflectSpec.scala
@@ -10,12 +10,14 @@ import akka.Done
 import akka.javasdk.client.ComponentClient
 import akka.javasdk.impl.client.ComponentClientImpl
 import akka.javasdk.impl.serialization.Serializer
+import akka.javasdk.impl.ComponentDescriptor
 import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.InvalidProtoEventSourcedEntityWrongEventType
 import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.ProtoConsumerAutoResolve
 import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.ProtoConsumerEntityWithoutAnnotation
 import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.ProtoConsumerNoTypes
 import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.ProtoConsumerWithAnnotation
 import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.ValidProtoEventSourcedEntity
+import akka.javasdk.testmodels.subscriptions.PubSubTestModels.CircularProtoConsumer
 import akka.javasdk.testmodels.workflow.WorkflowState
 import akka.javasdk.testmodels.workflow.WorkflowTestModels.TransferWorkflow
 import akka.javasdk.testmodels.workflow.WorkflowTestModels.TransferWorkflowAnnotatedAbstractClass
@@ -237,6 +239,12 @@ class ReflectSpec extends AnyWordSpec with Matchers {
     "return empty when source ES entity has no @ProtoEventTypes" in {
       val types = Reflect.resolveProtoEventTypes(classOf[ProtoConsumerEntityWithoutAnnotation])
       types shouldBe empty
+    }
+
+    "handle circular proto message references in protoCommandHandlerInputOutput without infinite recursion" in {
+      val desc = ComponentDescriptor.descriptorFor(classOf[CircularProtoConsumer], serializer)
+      val result = Reflect.protoCommandHandlerInputOutput(desc)
+      result.map(_.getName) should contain allOf ("CircularParent", "CircularChild")
     }
   }
 }


### PR DESCRIPTION
The bug: `flattenDependencies` had no cycle detection. When two protobuf messages reference each other (e.g., CircularParent has a field of type CircularChild, and CircularChild has a field of type CircularParent), the method would recurse infinitely → StackOverflowError.

The fix: Added a visited set parameter to the overloaded private method. Before recursing into a field's message type, it checks if that descriptor has already been seen. If so, it returns Set.empty instead of recursing.