### PR TITLE
sample: add autonomous agent editorial sample

### DIFF
--- a/samples/autonomous-agent-playground/README.md
+++ b/samples/autonomous-agent-playground/README.md
@@ -26,8 +26,7 @@ A browser UI is bundled with the service. Boot the service (`mvn compile exec:ja
 | **peerreview** | Moderation | Moderator coordinates a panel of technical, style, and compliance reviewers |
 | **devteam** | Team | Team lead decomposes project into tasks, developers self-coordinate |
 | **brainstorm** *(not yet implemented)* | Team (emergent) | Team generates ideas on shared board, lead curates |
-| **editorial** *(not yet implemented)* | Team + external input | Team lead with writers, human approval of final publication |
-| **deepdive** *(not yet implemented)* | All capabilities | Comprehensive demo: handoff, delegation, teams, emergent, task deps, external input, nested orchestration |
+| **editorial** | Delegation + team + moderation | Editor-in-chief delegates stage tasks to section leads; each lead uses a different coordination capability internally |
 
 ---
 
@@ -255,23 +254,35 @@ A team generates ideas on a shared board. Each agent contributes independently, 
 
 ## editorial
 
-*Not yet implemented.*
+An editor-in-chief coordinates three section leads by delegating a stage task to each. Each lead is itself a coordinator that uses a different capability internally — delegation, team leadership, and moderation — so the sample exercises capability mixing across a small hierarchy.
 
-A team lead coordinates writers who collaborate on a publication. Writers work on assigned sections, review each other's work, and refine through peer feedback. The final publication requires human editorial approval before completion.
+**Agents:**
+- EditorInChief — top-level coordinator; delegates the research, writing, and review stages and synthesises the final article
+- ResearchEditor — accepts a RESEARCH stage task; internally delegates to two Reporter instances on different angles, returns a digest
+- Reporter — accepts a FINDINGS task; saves findings to the shared workspace
+- WritingLead — accepts a DRAFT stage task; internally leads a writing team
+- SectionWriter, CopyEditor — team members; accept SECTION tasks; share the workspace
+- ReviewEditor — accepts a REVIEW stage task; internally runs a nested moderation over reviewers
+- AccuracyReviewer, ReadabilityReviewer — review-panel participants
 
-**Agents:** Editorial lead (team lead), writer agents (team members)
+**Tasks:**
+- ARTICLE → `Article(title, body, keyPoints)` — top-level, accepted by EditorInChief
+- RESEARCH → `ResearchDigest(summary, documentIds)` — delegated to ResearchEditor
+- FINDINGS → `ResearchFindings(angle, summary, documentId)` — delegated to Reporter
+- DRAFT → `ArticleDraft(title, body, documentIds)` — delegated to WritingLead
+- SECTION → `SectionDraft(sectionTitle, summary, documentId)` — claimed by writing-team members
+- REVIEW → `ReviewReport(assessment, notes)` — delegated to ReviewEditor
 
-**Demonstrates:** Team capability with external input. Collaborative writing with peer review. Human-in-the-loop approval for the final publication. Combines the team coordination pattern with external gating — the team produces the work, but a human makes the final call.
+**Flow:** A topic arrives at `POST /editorial`. The EditorInChief receives the ARTICLE task and delegates a stage task to each section lead — research, then writing, then review — feeding each result into the next stage's instructions. Each lead does its own inner coordination (delegate to researchers, lead a writing team, or moderate a review panel) to fulfil its stage task, then returns a typed result. The EditorInChief synthesises the final `Article` from the returned results. The model decides the order and whether to revisit a stage; nothing scripts the pipeline. Bulky artifacts (research notes, section drafts) live in a shared workspace via `DocumentTools` and are passed by document ID, while typed task results carry the structure between agent and worker.
 
----
+**Demonstrates:** Coordination capabilities composed across a hierarchy, each in its natural role:
 
-## deepdive
+- Delegation at the top to drive the stages (each stage runs as its own held task)
+- Delegation inside the research stage for parallel investigation
+- Team leadership inside the writing stage for member self-coordination
+- Moderation inside the review stage for structured turn-taking
+- A shared workspace tool (`DocumentTools` over a Key-Value entity)
 
-*Not yet implemented.*
-
-A comprehensive demo application that exercises all coordination capabilities in a single coherent system. A user submits a technology topic and the system produces a thoroughly researched, debated, and reviewed deep-dive article — with every orchestration decision driven by LLMs, not code.
-
-15 agent types across 4 levels of nesting cover delegation, handoff, collaborative teams, emergent coordination, task dependencies, external input, and LLM-driven looping.
 
 ### Agent hierarchy
 

--- a/samples/autonomous-agent-playground/pom.xml
+++ b/samples/autonomous-agent-playground/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.akka</groupId>
     <artifactId>akka-javasdk-parent</artifactId>
-    <version>3.6.0-M3-42-e603fccb-SNAPSHOT</version>
+    <version>3.6.0-M3-74-26e469ac-SNAPSHOT</version>
   </parent>
 
   <groupId>demo</groupId>

--- a/samples/autonomous-agent-playground/specs/009-editorial/checklists/requirements.md
+++ b/samples/autonomous-agent-playground/specs/009-editorial/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Editorial — Delegation Across Coordinator Stages
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/akka.clarify` or `/akka.plan`.
+- Composes three coordination capabilities across a hierarchy: delegation at the top and in research, team leadership in writing, moderation in review.
+- Top-level delegation (not moderation) so each stage runs as a held sub-task, isolating a lead's internal team or review from the parent's processing limits.
+- Shared workspace for bulky artifacts (document references) alongside typed task results for structure.

--- a/samples/autonomous-agent-playground/specs/009-editorial/spec.md
+++ b/samples/autonomous-agent-playground/specs/009-editorial/spec.md
@@ -1,0 +1,156 @@
+# Feature Specification: Editorial — Delegation Across Coordinator Stages
+
+**Feature Branch**: `009-editorial`
+**Created**: 2026-05-22
+**Status**: Draft
+**Input**: An editor-in-chief produces a deep-dive technology article by delegating a stage task to each of three section leads — a research editor, a writing lead, and a review editor. Each section lead is itself a coordinator using a different capability internally: delegation, team leadership, and moderation respectively.
+
+## User Scenarios & Testing
+
+### User Story 1 — Submit a Topic and Receive an Article (Priority: P1)
+
+A user submits a technology topic via HTTP. The system creates an ARTICLE task assigned to an EditorInChief. The EditorInChief delegates a stage task to each section lead — research, writing, and review — feeding each result into the next stage. Each lead performs its own inner coordination to fulfil its stage task. The EditorInChief synthesises a final Article (title, body, key points) from the returned results.
+
+**Why this priority**: This is the core flow. Without it the sample produces no output.
+
+**Independent Test**: Submit a topic via HTTP POST, poll for the ARTICLE result, and verify it has a title, a body, and a non-empty key points list.
+
+**Acceptance Scenarios**:
+
+1. **Given** the system is running, **When** a user submits a topic via HTTP POST, **Then** the system accepts the request and returns an identifier for the ARTICLE task.
+2. **Given** an editorial task is in progress, **When** the user polls for the result, **Then** the system indicates the result is not yet available.
+3. **Given** the editorial task completes, **When** the user retrieves the result, **Then** the response contains a structured Article with a title, body, and key points.
+
+---
+
+### User Story 2 — Research Stage Delegates to Reporters (Priority: P2)
+
+The EditorInChief delegates a RESEARCH task to the ResearchEditor. The ResearchEditor delegates FINDINGS tasks to one or more Reporters on different angles. Reporters save their findings to the shared workspace and return ResearchFindings results. The ResearchEditor consolidates the findings into a ResearchDigest — a summary plus document references — and returns it to the EditorInChief.
+
+**Why this priority**: Demonstrates a delegation stage that is itself a delegation coordinator — the first level of nesting.
+
+**Independent Test**: Submit a topic and verify at least one FINDINGS task is created under a Reporter, and that the ResearchEditor's RESEARCH task completes with a ResearchDigest.
+
+**Acceptance Scenarios**:
+
+1. **Given** the EditorInChief processes the article, **When** it delegates the research stage, **Then** a RESEARCH task is created and assigned to a ResearchEditor.
+2. **Given** the ResearchEditor processes its task, **When** it delegates research, **Then** it creates at least one FINDINGS sub-task assigned to a Reporter.
+3. **Given** a Reporter receives a FINDINGS task, **When** it works on the task, **Then** it saves findings to the shared workspace and returns a ResearchFindings result with a document id.
+
+---
+
+### User Story 3 — Writing Stage Leads a Team (Priority: P2)
+
+The EditorInChief delegates a DRAFT task to the WritingLead, passing the research digest. The WritingLead leads a team of a SectionWriter and a CopyEditor, who claim and complete SECTION tasks from a shared backlog. The WritingLead assembles the section drafts into an ArticleDraft and returns it.
+
+**Why this priority**: Demonstrates a delegation stage that runs a team internally. Because the DRAFT task is held while the team works, the team's work does not exhaust the WritingLead's or the EditorInChief's processing limits.
+
+**Independent Test**: Submit a topic and verify a writing team is created with at least one SECTION task completed by a team member, and that the DRAFT task completes with an ArticleDraft.
+
+**Acceptance Scenarios**:
+
+1. **Given** the EditorInChief delegates the writing stage, **When** the WritingLead processes its task, **Then** it forms a writing team with at least one member.
+2. **Given** the writing team is active, **When** members process work, **Then** at least one SECTION task is claimed and completed by a team member, producing a SectionDraft result.
+
+---
+
+### User Story 4 — Review Stage Runs a Moderated Review (Priority: P2)
+
+The EditorInChief delegates a REVIEW task to the ReviewEditor, passing the draft. The ReviewEditor moderates a review between an AccuracyReviewer and a ReadabilityReviewer, collects their input, and returns a ReviewReport.
+
+**Why this priority**: Demonstrates a delegation stage that runs a moderated conversation internally — the deepest nesting in the sample.
+
+**Independent Test**: Submit a topic and verify a review conversation involves both reviewers, and that the REVIEW task completes with a ReviewReport.
+
+**Acceptance Scenarios**:
+
+1. **Given** the EditorInChief delegates the review stage, **When** the ReviewEditor processes its task, **Then** it runs a review conversation involving both the AccuracyReviewer and the ReadabilityReviewer.
+2. **Given** the review conversation completes, **When** the ReviewEditor returns its result, **Then** the ReviewReport includes notes informed by both reviewers.
+
+---
+
+### User Story 5 — Shared Workspace for Bulky Artifacts (Priority: P3)
+
+Bulky artifacts (research findings, section drafts) are saved to a shared workspace and referenced by document id across agents. Agents that need upstream work look up documents by id; agents that produce bulky content save it and pass the id forward. Typed task results carry structure and pointers; the shared workspace carries the content.
+
+**Why this priority**: Demonstrates how tools and tasks complement each other — document references for bulky content, task results for structure.
+
+**Independent Test**: After a run, the shared workspace contains at least one document created by a Reporter and at least one created by a writing-team member.
+
+**Acceptance Scenarios**:
+
+1. **Given** research is performed, **When** a Reporter completes a FINDINGS task, **Then** it has saved a document and the returned id appears in its ResearchFindings result.
+2. **Given** writing is performed, **When** a SectionWriter or CopyEditor completes a SECTION task, **Then** it has saved a document and included the id in its SectionDraft result.
+3. **Given** a reviewer needs to assess a draft, **When** it looks up a document id from the draft, **Then** it retrieves the saved content from the workspace.
+
+---
+
+### Edge Cases
+
+- What happens when the user polls for a result that does not exist (invalid identifier)? The system returns an appropriate error response.
+- What happens when a delegated stage fails (for example, a Reporter fails during research)? The stage task reflects the failure, and the EditorInChief decides whether to proceed with what it has or fail the article.
+- What happens when the EditorInChief reaches a later stage before an earlier one has produced its input? The EditorInChief is expected to sequence the stages so each has its inputs, carrying prior results forward in the stage instructions.
+- What happens when a stage produces a weak or empty result? The EditorInChief synthesises from what it has; the resulting article may be less complete.
+
+## Requirements
+
+### Functional Requirements
+
+**Endpoint**
+
+- **FR-001**: System MUST accept a topic via HTTP and create an ARTICLE task assigned to an EditorInChief, returning an identifier for the task.
+- **FR-002**: System MUST provide a polling endpoint that returns the ARTICLE task result by its identifier, and MUST indicate when the result is not yet available.
+
+**Orchestration**
+
+- **FR-003**: The EditorInChief MUST delegate work to three section leads — a ResearchEditor (research stage), a WritingLead (writing stage), and a ReviewEditor (review stage) — and synthesise their results into the final article.
+- **FR-004**: The EditorInChief MUST produce a typed Article result containing a title, a body, and a list of key points.
+- **FR-005**: The EditorInChief MUST carry each stage's result forward into the next stage's instructions. Stage ordering and any revisiting of a stage MUST be the LLM's decision, not hardcoded control flow.
+
+**Section leads**
+
+- **FR-006**: The ResearchEditor MUST process a RESEARCH task by delegating FINDINGS tasks to one or more Reporters and consolidating their findings into a ResearchDigest.
+- **FR-007**: The WritingLead MUST process a DRAFT task by leading a team of a SectionWriter and a CopyEditor and assembling their sections into an ArticleDraft.
+- **FR-008**: The ReviewEditor MUST process a REVIEW task by moderating a review between an AccuracyReviewer and a ReadabilityReviewer and consolidating their input into a ReviewReport.
+
+**Leaf workers**
+
+- **FR-009**: The Reporter MUST process FINDINGS tasks, save findings to the shared workspace, and produce a ResearchFindings result containing an angle, a summary, and a document id.
+- **FR-010**: The SectionWriter and CopyEditor MUST process SECTION tasks, reading source material from and saving sections to the shared workspace, and produce a SectionDraft result containing a section title, a summary, and a document id.
+- **FR-011**: The AccuracyReviewer and ReadabilityReviewer MUST participate in the review conversation, reading the draft from the shared workspace.
+
+**Shared workspace**
+
+- **FR-012**: The system MUST provide a shared document workspace with a tool to save a document (returning a document id) and a tool to look up a document by id, available to the agents that read and write workspace content.
+
+### Key Entities
+
+- **Topic**: User-supplied text describing the article subject.
+- **Article**: The typed result for the ARTICLE task. Contains a title, a body, and a list of key points.
+- **ResearchDigest**: The typed result for the RESEARCH task. Contains a summary and document references to the full findings.
+- **ResearchFindings**: The typed result for the FINDINGS task. Contains an angle, a one-sentence summary, and a document id.
+- **ArticleDraft**: The typed result for the DRAFT task. Contains a title, a body, and document references to the source sections.
+- **SectionDraft**: The typed result for the SECTION task. Contains a section title, a summary, and a document id.
+- **ReviewReport**: The typed result for the REVIEW task. Contains an overall assessment and a list of review notes.
+- **Document**: A stored artifact in the shared workspace. Contains a title, a summary, and the full content.
+- **Tasks (ARTICLE / RESEARCH / FINDINGS / DRAFT / SECTION / REVIEW)**: ARTICLE is the top-level task. RESEARCH, DRAFT, and REVIEW are the stage tasks the EditorInChief delegates. FINDINGS and SECTION are the worker tasks created within stages.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A user can submit a topic and retrieve a structured Article through a two-step interaction (submit, then poll).
+- **SC-002**: A run exercises delegation, team leadership, and moderation across the hierarchy — delegation at the top and in the research stage, team leadership in the writing stage, and moderation in the review stage.
+- **SC-003**: At least one document is saved to the shared workspace by a Reporter and at least one by a writing-team member, demonstrating cross-agent content sharing.
+- **SC-004**: Each stage runs as an independent sub-task, so a lead's internal team or review completes without exhausting the parent's processing limits.
+
+## Assumptions
+
+- The EditorInChief sequences the stages so each has the inputs it needs, passing prior results forward in the stage instructions. The order is the LLM's decision; the sample does not script it.
+- The editorial stages run one at a time (sequentially), since each stage depends on the previous stage's output.
+- The routing and synthesis decisions are driven by the LLM, not by hardcoded rules.
+- A single editorial run is in-flight per EditorInChief instance; concurrent runs use distinct instances.
+- No external input (human approval) gate is included; external input is covered by the `publishing` sample.
+- No authentication or authorization is required for this sample.
+- No persistence beyond the task lifecycle and the shared workspace is needed.
+- The polling model is sufficient; no push notifications or streaming are required for the core flow.

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/api/EditorialEndpoint.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/api/EditorialEndpoint.java
@@ -1,0 +1,50 @@
+package demo.editorial.api;
+
+import akka.http.javadsl.model.HttpResponse;
+import akka.javasdk.annotations.Acl;
+import akka.javasdk.annotations.http.Get;
+import akka.javasdk.annotations.http.HttpEndpoint;
+import akka.javasdk.annotations.http.Post;
+import akka.javasdk.client.ComponentClient;
+import akka.javasdk.http.AbstractHttpEndpoint;
+import akka.javasdk.http.HttpResponses;
+import demo.editorial.application.EditorInChief;
+import demo.editorial.application.EditorialTasks;
+import java.util.UUID;
+
+@Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET))
+@HttpEndpoint("/editorial")
+public class EditorialEndpoint extends AbstractHttpEndpoint {
+
+  public record TopicRequest(String topic) {}
+
+  public record TopicResponse(String taskId, String runId, String agentComponentId) {}
+
+  private final ComponentClient componentClient;
+
+  public EditorialEndpoint(ComponentClient componentClient) {
+    this.componentClient = componentClient;
+  }
+
+  @Post
+  public TopicResponse create(TopicRequest request) {
+    var agentInstanceId = requestContext()
+      .queryParams()
+      .getString("runId")
+      .filter(s -> !s.isBlank())
+      .orElseGet(() -> UUID.randomUUID().toString());
+    var taskId = componentClient
+      .forAutonomousAgent(EditorInChief.class, agentInstanceId)
+      .runSingleTask(EditorialTasks.ARTICLE.instructions(request.topic()));
+    return new TopicResponse(taskId, agentInstanceId, "editor-in-chief");
+  }
+
+  @Get("/{taskId}")
+  public HttpResponse get(String taskId) {
+    var snapshot = componentClient.forTask(taskId).get(EditorialTasks.ARTICLE);
+    return snapshot
+      .result()
+      .<HttpResponse>map(HttpResponses::ok)
+      .orElseGet(() -> HttpResponses.accepted(snapshot.status().name()));
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/AccuracyReviewer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/AccuracyReviewer.java
@@ -1,0 +1,17 @@
+package demo.editorial.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.annotations.Component;
+
+@Component(
+  id = "accuracy-reviewer",
+  description = "Reviews articles for technical accuracy, depth, and precision"
+)
+public class AccuracyReviewer extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define().tools(DocumentTools.class);
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/Article.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/Article.java
@@ -1,0 +1,5 @@
+package demo.editorial.application;
+
+import java.util.List;
+
+public record Article(String title, String body, List<String> keyPoints) {}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/ArticleDraft.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/ArticleDraft.java
@@ -1,0 +1,5 @@
+package demo.editorial.application;
+
+import java.util.List;
+
+public record ArticleDraft(String title, String body, List<String> documentIds) {}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/Bootstrap.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/Bootstrap.java
@@ -1,0 +1,31 @@
+package demo.editorial.application;
+
+import akka.javasdk.DependencyProvider;
+import akka.javasdk.ServiceSetup;
+import akka.javasdk.annotations.Setup;
+import akka.javasdk.client.ComponentClient;
+
+@Setup
+public class Bootstrap implements ServiceSetup {
+
+  private final ComponentClient componentClient;
+
+  public Bootstrap(ComponentClient componentClient) {
+    this.componentClient = componentClient;
+  }
+
+  @Override
+  public DependencyProvider createDependencyProvider() {
+    var documentTools = new DocumentTools(componentClient);
+    return new DependencyProvider() {
+      @SuppressWarnings("unchecked")
+      @Override
+      public <T> T getDependency(Class<T> clazz) {
+        if (clazz == DocumentTools.class) {
+          return (T) documentTools;
+        }
+        return null;
+      }
+    };
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/CopyEditor.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/CopyEditor.java
@@ -1,0 +1,27 @@
+package demo.editorial.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
+import akka.javasdk.annotations.Component;
+
+@Component(
+  id = "copy-editor",
+  description = "Polishes article sections for clarity, style, grammar, and consistent tone"
+)
+public class CopyEditor extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+      .instructions(
+        """
+        When a task includes document IDs, look them up in the shared workspace to read the \
+        content that needs editing. Save your polished version to the shared workspace and \
+        include the document ID in your task result. \
+        """
+      )
+      .capability(TaskAcceptance.of(EditorialTasks.SECTION))
+      .tools(DocumentTools.class);
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/Document.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/Document.java
@@ -1,0 +1,3 @@
+package demo.editorial.application;
+
+public record Document(String title, String summary, String content) {}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/DocumentStore.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/DocumentStore.java
@@ -1,0 +1,23 @@
+package demo.editorial.application;
+
+import akka.javasdk.annotations.Component;
+import akka.javasdk.keyvalueentity.KeyValueEntity;
+
+@Component(id = "editorial-document-store")
+public class DocumentStore extends KeyValueEntity<Document> {
+
+  public record SaveRequest(String title, String summary, String content) {}
+
+  public Effect<String> save(SaveRequest request) {
+    return effects()
+      .updateState(new Document(request.title(), request.summary(), request.content()))
+      .thenReply(commandContext().entityId());
+  }
+
+  public Effect<Document> get() {
+    if (currentState() == null) {
+      return effects().error("Document not found");
+    }
+    return effects().reply(currentState());
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/DocumentTools.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/DocumentTools.java
@@ -1,0 +1,54 @@
+package demo.editorial.application;
+
+import akka.javasdk.annotations.Description;
+import akka.javasdk.annotations.FunctionTool;
+import akka.javasdk.client.ComponentClient;
+import java.util.UUID;
+
+public class DocumentTools {
+
+  private final ComponentClient componentClient;
+
+  public DocumentTools(ComponentClient componentClient) {
+    this.componentClient = componentClient;
+  }
+
+  @FunctionTool(
+    description = """
+    Save a document to the shared workspace. Returns a document ID that other \
+    agents can use to look up the full content. Use this to persist research, drafts, or notes \
+    that another agent will need to read.\
+    """
+  )
+  public String saveDocument(
+    @Description("Short title for the document") String title,
+    @Description("One or two sentence summary") String summary,
+    @Description("Full document content") String content
+  ) {
+    var documentId = UUID.randomUUID().toString();
+    componentClient
+      .forKeyValueEntity(documentId)
+      .method(DocumentStore::save)
+      .invoke(new DocumentStore.SaveRequest(title, summary, content));
+    return documentId;
+  }
+
+  @FunctionTool(
+    description = """
+    Look up a document by its ID to read the full content. Use this to retrieve \
+    research findings, draft sections, or other documents saved by other agents.\
+    """
+  )
+  public Document lookupDocument(
+    @Description("The document ID to look up") String documentId
+  ) {
+    try {
+      return componentClient
+        .forKeyValueEntity(documentId)
+        .method(DocumentStore::get)
+        .invoke();
+    } catch (Exception e) {
+      return new Document("Not found", "Document " + documentId + " was not found", "");
+    }
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/EditorInChief.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/EditorInChief.java
@@ -1,0 +1,36 @@
+package demo.editorial.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.agent.autonomous.capability.Delegation;
+import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
+import akka.javasdk.annotations.Component;
+
+@Component(
+  id = "editor-in-chief",
+  description = """
+  Produces deep-dive technology articles by coordinating a research editor, a \
+  writing lead, and a review editor\
+  """
+)
+public class EditorInChief extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+      .instructions(
+        """
+        Produce a cohesive, accurate deep-dive article. Ground the writing in the research \
+        findings and fold in the reviewers' feedback before finalising. \
+        """
+      )
+      .capability(TaskAcceptance.of(EditorialTasks.ARTICLE))
+      .capability(
+        Delegation.to(
+          ResearchEditor.class,
+          WritingLead.class,
+          ReviewEditor.class
+        ).maxParallelWorkers(1) // always one stage at a time
+      );
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/EditorialTasks.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/EditorialTasks.java
@@ -1,0 +1,68 @@
+package demo.editorial.application;
+
+import akka.javasdk.agent.task.Task;
+
+public class EditorialTasks {
+
+  // prettier-ignore
+  public static final Task<Article> ARTICLE = Task
+    .name("Article")
+    .description("Produce a deep-dive article on a technology topic")
+    .resultConformsTo(Article.class);
+
+  // prettier-ignore
+  public static final Task<ResearchDigest> RESEARCH = Task
+    .name("Research")
+    .description(
+      """
+      Commission research on a technology topic from multiple angles and return a \
+      consolidated digest with document references.\
+      """
+    )
+    .resultConformsTo(ResearchDigest.class);
+
+  // prettier-ignore
+  public static final Task<ResearchFindings> FINDINGS = Task
+    .name("Findings")
+    .description(
+      """
+      Research a specific angle of a technology topic. \
+      Save findings to the shared workspace and return the document ID.\
+      """
+    )
+    .resultConformsTo(ResearchFindings.class);
+
+  // prettier-ignore
+  public static final Task<ArticleDraft> DRAFT = Task
+    .name("Draft")
+    .description(
+      """
+      Write a structured article draft from research findings. \
+      Look up any referenced documents for source material. Return the assembled draft.\
+      """
+    )
+    .resultConformsTo(ArticleDraft.class);
+
+  // prettier-ignore
+  public static final Task<SectionDraft> SECTION = Task
+    .name("Section")
+    .description(
+      """
+      Write or edit a section of an article. \
+      Look up any document IDs in the instructions for source material. \
+      Save the completed section to the shared workspace and return the document ID.\
+      """
+    )
+    .resultConformsTo(SectionDraft.class);
+
+  // prettier-ignore
+  public static final Task<ReviewReport> REVIEW = Task
+    .name("Review")
+    .description(
+      """
+      Review an article draft for technical accuracy and style, \
+      and return consolidated review notes.\
+      """
+    )
+    .resultConformsTo(ReviewReport.class);
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/ReadabilityReviewer.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/ReadabilityReviewer.java
@@ -1,0 +1,20 @@
+package demo.editorial.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.annotations.Component;
+
+@Component(
+  id = "readability-reviewer",
+  description = """
+  Reviews articles for clarity, structure, and readability for a broad \
+  professional audience\
+  """
+)
+public class ReadabilityReviewer extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define().tools(DocumentTools.class);
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/Reporter.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/Reporter.java
@@ -1,0 +1,30 @@
+package demo.editorial.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
+import akka.javasdk.annotations.Component;
+
+@Component(
+  id = "reporter",
+  description = """
+  Researches a specific angle of a technology topic. Finds key facts, technical \
+  details, and context, citing sources where possible. Saves findings to the shared workspace\
+  """
+)
+public class Reporter extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+      .instructions(
+        """
+        Save your complete findings to the shared workspace — this is how other agents \
+        access your work. Use a descriptive title and a one-sentence summary. Include the \
+        returned document ID in your task result so it can be referenced later. \
+        """
+      )
+      .capability(TaskAcceptance.of(EditorialTasks.FINDINGS))
+      .tools(DocumentTools.class);
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/ResearchDigest.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/ResearchDigest.java
@@ -1,0 +1,5 @@
+package demo.editorial.application;
+
+import java.util.List;
+
+public record ResearchDigest(String summary, List<String> documentIds) {}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/ResearchEditor.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/ResearchEditor.java
@@ -1,0 +1,24 @@
+package demo.editorial.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.agent.autonomous.capability.Delegation;
+import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
+import akka.javasdk.annotations.Component;
+
+@Component(
+  id = "research-editor",
+  description = """
+  Commissions research on a technology topic from multiple angles by delegating \
+  to reporters, and returns a consolidated research digest\
+  """
+)
+public class ResearchEditor extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+      .capability(TaskAcceptance.of(EditorialTasks.RESEARCH))
+      .capability(Delegation.to(Reporter.class).maxParallelWorkers(2));
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/ResearchFindings.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/ResearchFindings.java
@@ -1,0 +1,3 @@
+package demo.editorial.application;
+
+public record ResearchFindings(String angle, String summary, String documentId) {}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/ReviewEditor.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/ReviewEditor.java
@@ -1,0 +1,25 @@
+package demo.editorial.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.agent.autonomous.capability.Moderation;
+import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
+import akka.javasdk.annotations.Component;
+
+@Component(
+  id = "review-editor",
+  description = """
+  Reviews an article draft for technical accuracy and readability by moderating a \
+  panel of an accuracy reviewer and a readability reviewer, and returns consolidated review notes\
+  """
+)
+public class ReviewEditor extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+      .capability(TaskAcceptance.of(EditorialTasks.REVIEW))
+      .capability(Moderation.of(AccuracyReviewer.class, ReadabilityReviewer.class))
+      .tools(DocumentTools.class);
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/ReviewReport.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/ReviewReport.java
@@ -1,0 +1,5 @@
+package demo.editorial.application;
+
+import java.util.List;
+
+public record ReviewReport(String assessment, List<String> notes) {}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/SectionDraft.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/SectionDraft.java
@@ -1,0 +1,3 @@
+package demo.editorial.application;
+
+public record SectionDraft(String sectionTitle, String summary, String documentId) {}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/SectionWriter.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/SectionWriter.java
@@ -1,0 +1,30 @@
+package demo.editorial.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
+import akka.javasdk.annotations.Component;
+
+@Component(
+  id = "section-writer",
+  description = """
+  Writes article sections from research findings. Makes technical content \
+  accessible to a professional audience\
+  """
+)
+public class SectionWriter extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+      .instructions(
+        """
+        When a task includes document IDs, look them up in the shared workspace to get the \
+        full research content. Use this to write your section. Save the completed section to \
+        the shared workspace and include the document ID in your task result. \
+        """
+      )
+      .capability(TaskAcceptance.of(EditorialTasks.SECTION))
+      .tools(DocumentTools.class);
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/WritingLead.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/editorial/application/WritingLead.java
@@ -1,0 +1,37 @@
+package demo.editorial.application;
+
+import akka.javasdk.agent.autonomous.AgentDefinition;
+import akka.javasdk.agent.autonomous.AutonomousAgent;
+import akka.javasdk.agent.autonomous.capability.TaskAcceptance;
+import akka.javasdk.agent.autonomous.capability.TeamLeadership;
+import akka.javasdk.agent.autonomous.capability.TeamLeadership.TeamMember;
+import akka.javasdk.annotations.Component;
+
+@Component(
+  id = "writing-lead",
+  description = """
+  Turns research findings into a structured article draft by leading a team of \
+  a section writer and a copy editor\
+  """
+)
+public class WritingLead extends AutonomousAgent {
+
+  @Override
+  public AgentDefinition definition() {
+    return define()
+      .instructions(
+        """
+        Break the article into a few focused sections and have the team write and \
+        copy-edit each section, then assemble them into the finished draft. \
+        """
+      )
+      .capability(TaskAcceptance.of(EditorialTasks.DRAFT))
+      .capability(
+        TeamLeadership.of(
+          TeamMember.of(SectionWriter.class).maxInstances(1),
+          TeamMember.of(CopyEditor.class).maxInstances(1)
+        )
+      )
+      .tools(DocumentTools.class);
+  }
+}

--- a/samples/autonomous-agent-playground/src/main/java/demo/ui/api/SampleRegistry.java
+++ b/samples/autonomous-agent-playground/src/main/java/demo/ui/api/SampleRegistry.java
@@ -13,6 +13,15 @@ import demo.devteam.application.Developer;
 import demo.devteam.application.ProjectLead;
 import demo.docreview.application.DocumentReviewer;
 import demo.dynamic.application.DynamicAgent;
+import demo.editorial.application.AccuracyReviewer;
+import demo.editorial.application.CopyEditor;
+import demo.editorial.application.EditorInChief;
+import demo.editorial.application.ReadabilityReviewer;
+import demo.editorial.application.Reporter;
+import demo.editorial.application.ResearchEditor;
+import demo.editorial.application.ReviewEditor;
+import demo.editorial.application.SectionWriter;
+import demo.editorial.application.WritingLead;
 import demo.helloworld.application.QuestionAnswerer;
 import demo.negotiation.application.Buyer;
 import demo.negotiation.application.Facilitator;
@@ -85,7 +94,8 @@ public final class SampleRegistry {
     new SampleEntry("debate", "Debate", "debate-moderator", DebateModerator.class),
     new SampleEntry("negotiation", "Negotiation", "facilitator", Facilitator.class),
     new SampleEntry("peerreview", "Peer review", "review-moderator", ReviewModerator.class),
-    new SampleEntry("devteam", "Devteam", "project-lead", ProjectLead.class)
+    new SampleEntry("devteam", "Devteam", "project-lead", ProjectLead.class),
+    new SampleEntry("editorial", "Editorial", "editor-in-chief", EditorInChief.class)
   );
 
   private static final Map<String, SampleEntry> BY_SAMPLE_ID = ENTRIES.stream()
@@ -117,6 +127,14 @@ public final class SampleRegistry {
     map.put("style-reviewer", StyleReviewer.class);
     map.put("compliance-reviewer", ComplianceReviewer.class);
     map.put("developer", Developer.class); // devteam → team
+    map.put("research-editor", ResearchEditor.class);
+    map.put("reporter", Reporter.class);
+    map.put("writing-lead", WritingLead.class);
+    map.put("section-writer", SectionWriter.class);
+    map.put("copy-editor", CopyEditor.class);
+    map.put("review-editor", ReviewEditor.class);
+    map.put("accuracy-reviewer", AccuracyReviewer.class);
+    map.put("readability-reviewer", ReadabilityReviewer.class);
     ALL_AGENTS = Map.copyOf(map);
   }
 

--- a/samples/autonomous-agent-playground/src/main/resources/static-resources/samples/_registry.js
+++ b/samples/autonomous-agent-playground/src/main/resources/static-resources/samples/_registry.js
@@ -12,6 +12,7 @@ import { debate } from '/playground/static/samples/debate.js';
 import { negotiation } from '/playground/static/samples/negotiation.js';
 import { peerreview } from '/playground/static/samples/peerreview.js';
 import { devteam } from '/playground/static/samples/devteam.js';
+import { editorial } from '/playground/static/samples/editorial.js';
 
 export const samples = {
   helloworld,
@@ -26,4 +27,5 @@ export const samples = {
   negotiation,
   peerreview,
   devteam,
+  editorial,
 };

--- a/samples/autonomous-agent-playground/src/main/resources/static-resources/samples/editorial.js
+++ b/samples/autonomous-agent-playground/src/main/resources/static-resources/samples/editorial.js
@@ -1,0 +1,46 @@
+import { el, renderMarkdown, renderMarkdownList, postJson } from '/playground/static/samples/_helpers.js';
+
+export const editorial = {
+  id: 'editorial',
+  displayName: 'Editorial',
+  description: {
+    overview: 'An editor-in-chief coordinates a research editor, a writing lead, and a review moderator by delegating a stage task to each. Each section lead is itself a coordinator: the research editor delegates to researchers, the writing lead leads a writing team, and the review moderator runs a moderated review panel.',
+    agents: [
+      'EditorInChief — delegates research, writing, and review stages; synthesises the final article',
+      'ResearchEditor — delegates to two reporters on different angles, returns a digest',
+      'Reporter (×2) — investigates an angle, saves findings to the shared workspace',
+      'WritingLead — leads a writing team to produce the draft',
+      'SectionWriter, CopyEditor — writing-team members',
+      'ReviewEditor — moderates a review panel, returns review notes',
+      'AccuracyReviewer, ReadabilityReviewer — review-panel participants',
+    ],
+    tasks: [
+      'ARTICLE → Article(title, body, keyPoints)',
+      'RESEARCH → ResearchDigest(summary, documentIds)',
+      'FINDINGS → ResearchFindings(angle, summary, documentId)',
+      'DRAFT → ArticleDraft(title, body, documentIds)',
+      'SECTION → SectionDraft(sectionTitle, summary, documentId)',
+      'REVIEW → ReviewReport(assessment, notes)',
+    ],
+    flow: 'The EditorInChief receives an ARTICLE task and delegates a stage task to each section lead in turn — research, then writing, then review — passing each result into the next. Each lead does its own inner coordination (delegation, team leadership, or nested moderation) to fulfil its task. The editor-in-chief synthesises the final article from the returned results. The model decides the order and whether to revisit a stage.',
+    demonstrates: 'Capability mixing across a hierarchy: top-level delegation, delegation within research, team leadership within writing, and nested moderation within review. Delegation gives each stage its own held task, so a lead\'s team or panel runs without burning the parent\'s budget. Shared document workspace (DocumentTools) for bulky artifacts, with typed task results carrying structure.',
+  },
+  agentComponentId: 'editor-in-chief',
+  inputForm: {
+    fields: [{ name: 'topic', label: 'Article topic', type: 'textarea', rows: 4, placeholder: 'How autonomous AI agents coordinate in multi-agent systems' }],
+  },
+  async submit({ topic }, { runId } = {}) {
+    const url = runId ? `/editorial?runId=${encodeURIComponent(runId)}` : '/editorial';
+    const resp = await postJson(url, { topic });
+    return { runId: resp.runId, agentComponentId: resp.agentComponentId, taskId: resp.taskId };
+  },
+  renderResult(result) {
+    return el('div', { className: 'result' }, [
+      el('h3', {}, result?.title ?? 'Article'),
+      el('h4', {}, 'Body'),
+      renderMarkdown(result?.body ?? ''),
+      el('h4', {}, 'Key points'),
+      renderMarkdownList(result?.keyPoints || []),
+    ]);
+  },
+};

--- a/samples/autonomous-agent-playground/src/test/java/demo/editorial/EditorialIntegrationTest.java
+++ b/samples/autonomous-agent-playground/src/test/java/demo/editorial/EditorialIntegrationTest.java
@@ -1,0 +1,194 @@
+package demo.editorial;
+
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.completeTask;
+import static akka.javasdk.testkit.TestModelProvider.AutonomousAgentTools.delegateTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import akka.javasdk.testkit.TestKit;
+import akka.javasdk.testkit.TestKitSupport;
+import akka.javasdk.testkit.TestModelProvider;
+import demo.editorial.api.EditorialEndpoint;
+import demo.editorial.application.Article;
+import demo.editorial.application.ArticleDraft;
+import demo.editorial.application.EditorInChief;
+import demo.editorial.application.EditorialTasks;
+import demo.editorial.application.ResearchDigest;
+import demo.editorial.application.ResearchEditor;
+import demo.editorial.application.ReviewEditor;
+import demo.editorial.application.ReviewReport;
+import demo.editorial.application.WritingLead;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class EditorialIntegrationTest extends TestKitSupport {
+
+  private static final String TOPIC =
+    "How autonomous AI agents coordinate in multi-agent systems";
+
+  private final TestModelProvider editorModel = new TestModelProvider();
+  private final TestModelProvider researchEditorModel = new TestModelProvider();
+  private final TestModelProvider writingLeadModel = new TestModelProvider();
+  private final TestModelProvider reviewEditorModel = new TestModelProvider();
+
+  @Override
+  protected TestKit.Settings testKitSettings() {
+    return TestKit.Settings.DEFAULT.withAdditionalConfig(
+      "akka.javasdk.agent.openai.api-key = n/a"
+    )
+      .withModelProvider(EditorInChief.class, editorModel)
+      .withModelProvider(ResearchEditor.class, researchEditorModel)
+      .withModelProvider(WritingLead.class, writingLeadModel)
+      .withModelProvider(ReviewEditor.class, reviewEditorModel);
+  }
+
+  @BeforeEach
+  public void resetModels() {
+    editorModel.reset();
+    researchEditorModel.reset();
+    writingLeadModel.reset();
+    reviewEditorModel.reset();
+  }
+
+  // Verifies the endpoint wiring: a submitted topic creates an ARTICLE task assigned to the
+  // EditorInChief, and the task completes with a typed Article result.
+  @Test
+  public void shouldAcceptTopicAndCompleteArticle() {
+    editorModel.fixedResponse(
+      new TestModelProvider.AiResponse(
+        completeTask(
+          new Article(
+            "Coordinating Autonomous AI Agents",
+            "An overview of how autonomous agents divide and coordinate work.",
+            List.of("Delegation", "Handoff", "Moderation")
+          )
+        )
+      )
+    );
+
+    var response = httpClient
+      .POST("/editorial")
+      .withRequestBody(new EditorialEndpoint.TopicRequest(TOPIC))
+      .responseBodyAs(EditorialEndpoint.TopicResponse.class)
+      .invoke()
+      .body();
+
+    assertThat(response.taskId()).isNotBlank();
+    assertThat(response.runId()).isNotBlank();
+    assertThat(response.agentComponentId()).isEqualTo("editor-in-chief");
+
+    Awaitility.await()
+      .ignoreExceptions()
+      .atMost(10, TimeUnit.SECONDS)
+      .untilAsserted(() -> {
+        var snapshot = componentClient.forTask(response.taskId()).get(EditorialTasks.ARTICLE);
+        var article = snapshot.result().orElseThrow();
+        assertThat(article.title()).contains("Agents");
+        assertThat(article.keyPoints()).hasSize(3);
+      });
+  }
+
+  // Verifies the editorial delegation pipeline: the EditorInChief delegates the research, writing,
+  // and review stages to the three section leads and synthesises their results into the final
+  // Article. The leads complete their stage tasks directly here; their own inner coordination
+  // (delegation, team, moderation) is covered by the research, devteam, and peerreview samples.
+  @Test
+  public void shouldDelegateStagesAndSynthesizeArticle() {
+    editorModel
+      .whenMessage(msg -> msg.contains("multi-agent"))
+      .reply(
+        List.of(
+          delegateTo(
+            EditorialTasks.RESEARCH,
+            ResearchEditor.class,
+            "Commission research on coordination in multi-agent systems"
+          ),
+          delegateTo(
+            EditorialTasks.DRAFT,
+            WritingLead.class,
+            "Write the article draft from the research"
+          ),
+          delegateTo(
+            EditorialTasks.REVIEW,
+            ReviewEditor.class,
+            "Review the draft for accuracy and readability"
+          )
+        )
+      );
+
+    researchEditorModel.fixedResponse(
+      new TestModelProvider.AiResponse(
+        completeTask(
+          new ResearchDigest(
+            "Delegation, handoff, and moderation are the core coordination patterns.",
+            List.of("doc-research-1", "doc-research-2")
+          )
+        )
+      )
+    );
+
+    writingLeadModel.fixedResponse(
+      new TestModelProvider.AiResponse(
+        completeTask(
+          new ArticleDraft(
+            "Coordinating Autonomous AI Agents",
+            "A draft on delegation, handoff, and moderation across agents.",
+            List.of("doc-section-1")
+          )
+        )
+      )
+    );
+
+    reviewEditorModel.fixedResponse(
+      new TestModelProvider.AiResponse(
+        completeTask(
+          new ReviewReport(
+            "Accurate and readable; tighten the section on shared context.",
+            List.of(
+              "Accuracy: coordination patterns are described correctly",
+              "Readability: clear progression"
+            )
+          )
+        )
+      )
+    );
+
+    editorModel
+      .whenMessage(msg -> msg.contains("Continue working"))
+      .reply(
+        completeTask(
+          new Article(
+            "Coordinating Autonomous AI Agents in Production",
+            "Autonomous agents coordinate through delegation, handoff, and moderation.",
+            List.of(
+              "Delegation fans out work and synthesises results",
+              "Handoff transfers ownership between agents",
+              "Moderation structures turn-taking in a conversation"
+            )
+          )
+        )
+      );
+
+    var response = httpClient
+      .POST("/editorial")
+      .withRequestBody(new EditorialEndpoint.TopicRequest(TOPIC))
+      .responseBodyAs(EditorialEndpoint.TopicResponse.class)
+      .invoke()
+      .body();
+
+    assertThat(response.taskId()).isNotBlank();
+    assertThat(response.agentComponentId()).isEqualTo("editor-in-chief");
+
+    Awaitility.await()
+      .ignoreExceptions()
+      .atMost(30, TimeUnit.SECONDS)
+      .untilAsserted(() -> {
+        var snapshot = componentClient.forTask(response.taskId()).get(EditorialTasks.ARTICLE);
+        var article = snapshot.result().orElseThrow();
+        assertThat(article.title()).contains("Agents");
+        assertThat(article.keyPoints()).hasSize(3);
+      });
+  }
+}

--- a/samples/autonomous-agent-playground/src/test/java/demo/ui/RunControlEndpointSamplesTest.java
+++ b/samples/autonomous-agent-playground/src/test/java/demo/ui/RunControlEndpointSamplesTest.java
@@ -32,7 +32,8 @@ public class RunControlEndpointSamplesTest extends TestKitSupport {
         "debate",
         "negotiation",
         "peerreview",
-        "devteam"
+        "devteam",
+        "editorial"
       )
     );
 
@@ -43,5 +44,6 @@ public class RunControlEndpointSamplesTest extends TestKitSupport {
     assertThat(byId.get("helloworld").agentComponentId()).isEqualTo("question-answerer");
     assertThat(byId.get("debate").agentComponentId()).isEqualTo("debate-moderator");
     assertThat(byId.get("publishing").agentComponentId()).isEqualTo("content-agent");
+    assertThat(byId.get("editorial").agentComponentId()).isEqualTo("editor-in-chief");
   }
 }


### PR DESCRIPTION
This is a ported version of the editorial sample that was developed for the prototype. This combines multiple different capabilities, with coordination via delegation, team leadership, and moderation.

In the prototype, we actually used a workflow at the top level to make things more deterministic. In this example, there's an editor-in-chief that uses delegation to coordinate across different section leads for research, writing and review. This often works quite well, and if there are review notes, the editor-in-chief will redirect back to the writing team to update their drafts.

When using a smaller model such as Gemini Flash, there can be issues and I am looking at some more refinements that we can do to improve those. But the team-based coordination can still lead to more issues than the other capabilities, with agents spinning in particular. For the developer team, it can come down to the limited set of development tools, Well here, the writing generally tends to be easier for the agents to do. And this sample uses a document store to minimise the context that needs to be transferred between the agents.