### PR TITLE
fix: catch FileNotFoundException when reading existing component descriptor

### DIFF
--- a/akka-javasdk-annotation-processor/src/main/java/akka/javasdk/tooling/processor/ComponentAnnotationProcessor.java
+++ b/akka-javasdk-annotation-processor/src/main/java/akka/javasdk/tooling/processor/ComponentAnnotationProcessor.java
@@ -9,6 +9,7 @@ import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.NoSuchFileException;
@@ -299,8 +300,11 @@ public class ComponentAnnotationProcessor extends BaseAkkaProcessor {
         }
       }
       existingDescriptorResource.delete();
-    } catch (NoSuchFileException ex) {
-      // no existing file
+    } catch (NoSuchFileException | FileNotFoundException ex) {
+      // No existing descriptor — expected on a clean build or first compile in IntelliJ.
+      // Standard javac (Maven/Gradle) throws NoSuchFileException via PathFileObject.openReader(),
+      // while IntelliJ's JPS build system uses JpsFileObject/OutputFileObject backed by
+      // FileInputStream, which throws FileNotFoundException instead.
       debug("No existing Akka component descriptor found");
       existingConfig = ConfigFactory.empty();
     }


### PR DESCRIPTION
When building with IntelliJ (via JPS), filer.getResource() returns
a JpsFileObject/OutputFileObject backed by java.io.FileInputStream
rather than javac's standard PathFileObject (which uses
Files.newInputStream).

When the descriptor does not yet exist — typically on a clean build
or the first incremental build after clearing the output directory —
JpsFileObject.openReader() throws FileNotFoundException, while standard
javac/Maven/Gradle throw NoSuchFileException. Catch both so the
processor handles the "no existing descriptor" case correctly in both
environments.

Before:

```
java.io.FileNotFoundException: /Users/jz/code/akka-sdk/samples/shopping-cart-quickstart/target/classes/META-INF/akka-javasdk-components_com.example_shopping-cart-quickstart.conf (No such file or directory)
  	at java.base/java.io.FileInputStream.open0(Native Method)
  	at java.base/java.io.FileInputStream.open(FileInputStream.java:213)
  	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:152)
  	at org.jetbrains.jps.javac.JpsFileObject.loadCharContent(JpsFileObject.java:67)
  	at org.jetbrains.jps.javac.OutputFileObject.getCharContent(OutputFileObject.java:142)
  	at org.jetbrains.jps.javac.JpsFileObject.openReader(JpsFileObject.java:50)
  	at jdk.compiler/com.sun.tools.javac.api.ClientCodeWrapper$WrappedFileObject.openReader(ClientCo
  	```

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
