### PR TITLE
feat(testkit): read in-memory span exporter from StartupContext

### DIFF
--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TelemetryReader.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TelemetryReader.java
@@ -9,12 +9,12 @@ import static java.util.Optional.ofNullable;
 import akka.annotation.ApiMayChange;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.workflow.Workflow;
+import akka.runtime.sdk.spi.tracing.InMemorySpanExporter;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import kalix.runtime.telemetry.tracing.TracingSetup;
 
 /**
  * A test utility for reading and inspecting telemetry data captured during test execution.
@@ -26,9 +26,9 @@ import kalix.runtime.telemetry.tracing.TracingSetup;
 @ApiMayChange
 public class TelemetryReader {
 
-  private final TracingSetup.AkkaInMemorySpanExporter inMemorySpanExporter;
+  private final InMemorySpanExporter inMemorySpanExporter;
 
-  public TelemetryReader(TracingSetup.AkkaInMemorySpanExporter inMemorySpanExporter) {
+  public TelemetryReader(InMemorySpanExporter inMemorySpanExporter) {
     this.inMemorySpanExporter = inMemorySpanExporter;
   }
 

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -61,6 +61,7 @@ import akka.runtime.sdk.spi.SpiEventingSupportSettings;
 import akka.runtime.sdk.spi.SpiMockedEventingSettings;
 import akka.runtime.sdk.spi.SpiSettings;
 import akka.runtime.sdk.spi.SpiTestSettings;
+import akka.runtime.sdk.spi.tracing.InMemorySpanExporter;
 import akka.stream.Materializer;
 import akka.stream.SystemMaterializer;
 import com.typesafe.config.Config;
@@ -85,9 +86,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import kalix.runtime.AkkaRuntimeMain;
-import kalix.runtime.telemetry.Telemetry;
-import kalix.runtime.telemetry.tracing.ActiveTracingInstrumentation;
-import kalix.runtime.telemetry.tracing.TracingSetup.AkkaInMemorySpanExporter;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -856,7 +854,7 @@ public class TestKit {
   private int eventingTestKitPort = -1;
   private Config applicationConfig;
   private String serviceName;
-  private Optional<AkkaInMemorySpanExporter> inMemorySpanExporter = Optional.empty();
+  private Optional<InMemorySpanExporter> inMemorySpanExporter = Optional.empty();
 
   /** Create a new testkit for a service descriptor with the default settings. */
   public TestKit() {
@@ -1069,15 +1067,11 @@ public class TestKit {
 
       // once runtime is started
 
-      Telemetry telemetry = (Telemetry) Telemetry.get(runtimeActorSystem);
-
-      if (telemetry.tracing()
-          instanceof ActiveTracingInstrumentation activeTracingInstrumentation) {
-        if (activeTracingInstrumentation.exporter()
-            instanceof AkkaInMemorySpanExporter inMemorySpanExporter) {
-          this.inMemorySpanExporter = Optional.of(inMemorySpanExporter);
-        }
-      }
+      // The runtime surfaces the in-memory tracing exporter (when the test tracing setup is active)
+      // through the SPI StartupContext, so the testkit reads captured spans without referencing
+      // runtime-internal telemetry types.
+      this.inMemorySpanExporter =
+          Optional.ofNullable(startupContext.inMemorySpanExporter().getOrElse(() -> null));
 
       componentClient =
           new ComponentClientImpl(
@@ -1256,7 +1250,7 @@ public class TestKit {
     return new WebSocketRouteTesterImpl(runtimeHost, runtimePort, runtimeActorSystem);
   }
 
-  public AkkaInMemorySpanExporter getInMemorySpanExporter() {
+  public InMemorySpanExporter getInMemorySpanExporter() {
     return inMemorySpanExporter.orElseThrow(
         () ->
             new IllegalStateException(

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -157,6 +157,7 @@ import akka.runtime.sdk.spi.TimedActionDescriptor
 import akka.runtime.sdk.spi.UserFunctionError
 import akka.runtime.sdk.spi.ViewDescriptor
 import akka.runtime.sdk.spi.WorkflowDescriptor
+import akka.runtime.sdk.spi.tracing.InMemorySpanExporter
 import akka.stream.Materializer
 import akka.stream.SystemMaterializer
 import com.typesafe.config.Config
@@ -393,7 +394,8 @@ class SdkRunner private (
         getSettings,
         startContext.sanitizer,
         httpMockLookup,
-        grpcMockLookup)
+        grpcMockLookup,
+        startContext.inMemorySpanExporter)
       Future.successful(app.spiComponents)
     } catch {
       case NonFatal(ex) =>
@@ -443,7 +445,8 @@ private[javasdk] object Sdk {
       agentCapabilityConverter: CapabilityConverter,
       overrideModelProvider: OverrideModelProvider,
       serializer: Serializer,
-      sanitizer: Sanitizer)
+      sanitizer: Sanitizer,
+      inMemorySpanExporter: Option[InMemorySpanExporter])
 
   private val platformManagedDependency = Set[Class[_]](
     classOf[ComponentClient],
@@ -495,7 +498,8 @@ private final class Sdk(
     runtimeSanitizer: SpiSanitizerEngine,
     httpMockLookup: String => Option[
       java.util.function.Function[akka.http.javadsl.model.HttpRequest, akka.http.javadsl.model.HttpResponse]],
-    grpcMockLookup: GrpcClientProviderImpl.ClientKey => Option[AkkaGrpcClient]) {
+    grpcMockLookup: GrpcClientProviderImpl.ClientKey => Option[AkkaGrpcClient],
+    inMemorySpanExporter: Option[InMemorySpanExporter]) {
 
   import Sdk._
 
@@ -1171,7 +1175,8 @@ private final class Sdk(
               agentCapabilityConverter,
               overrideModelProvider,
               serializer,
-              sanitizer))
+              sanitizer,
+              inMemorySpanExporter))
           Future.successful(Done)
         case Some(setup) =>
           if (dependencyProviderOpt.nonEmpty) {
@@ -1208,7 +1213,8 @@ private final class Sdk(
               agentCapabilityConverter,
               overrideModelProvider,
               serializer,
-              sanitizer))
+              sanitizer,
+              inMemorySpanExporter))
           Future.successful(Done)
       }
     }


### PR DESCRIPTION
Remove the testkit's dependency on runtime-internal telemetry types
(`kalix.runtime.telemetry.*`). The `InMemorySpanExporter` now arrives via the
SPI `StartContext`, is threaded through `Sdk.StartupContext`, and is read from
there by `TestKit` and `TelemetryReader`. Both now use the shared
`akka.runtime.sdk.spi.tracing.InMemorySpanExporter` type instead of the
previously internal one.

Also fixes how `AkkaDevRuntime` is exposed to users. The testkit needs it on
its compile classpath for protobuf-generated types from akka-runtime's
proxy-protocol and testkit-protocol sub-projects, but its transitive
dependencies need not reach users. `AkkaDevRuntime` is declared as `Provided`
in the SBT build so it is available during compilation without being propagated
via the generated pom. The parent POM then redeclares `akka-runtime-dev_2.13`
with `test` scope and a wildcard exclusion, giving users the artifact on their
test classpath while stripping all of its transitive dependencies.

`akka-persistence` is also added as an explicit compile dependency of the
testkit.

Depends on merge and release of https://github.com/lightbend/akka-runtime/pull/5260