### PR TITLE
chore: pin akka-sdk-spi to akka-runtime.version

### DIFF
--- a/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-parent/pom.xml
@@ -740,6 +740,15 @@
                 <artifactId>akka-javasdk-testkit</artifactId>
                 <version>${akka-javasdk.version}</version>
             </dependency>
+            <!-- Align the SPI with the runtime version rather than the one the SDK was built against.
+                 In production the runtime provides the SPI (it is excluded from the service image above),
+                 so pinning it here makes -Dakka-runtime.version reproduce that binding locally and surface
+                 SPI incompatibilities during development. -->
+            <dependency>
+                <groupId>io.akka</groupId>
+                <artifactId>akka-sdk-spi_2.13</artifactId>
+                <version>${akka-runtime.version}</version>
+            </dependency>
             <dependency>
                 <groupId>io.akka</groupId>
                 <artifactId>akka-runtime-dev_2.13</artifactId>


### PR DESCRIPTION
When testing SPI changes on samples, it's useful to force it to compile and run with the same SPI as in prod. This is not what happens today because the SPI stays pinned by the SDK version. 

Forcing a different runtime version produces this deps tree that is not exactly what happens in production. 

The SPI is a SDK dependencies and do now follow the runtime version. 
```
mvn dependency:tree -Dakka-runtime.version=1.6.3-2-0bf3b1c3-SNAPSHOT 
[INFO] +- io.akka:akka-javasdk:jar:3.6.0:compile
[INFO] |  +- io.akka:akka-sdk-spi_2.13:jar:1.6.3:compile
[INFO] \- io.akka:akka-runtime-dev_2.13:jar:1.6.3-2-0bf3b1c3-SNAPSHOT:runtime
```

With this PR, we get: 

```
mvn dependency:tree -Dakka-runtime.version=1.6.3-2-0bf3b1c3-SNAPSHOT 
[INFO] +- io.akka:akka-javasdk:jar:3.6.0-5-0cceab02-SNAPSHOT:compile
[INFO] |  +- io.akka:akka-sdk-spi_2.13:jar:1.6.3-2-0bf3b1c3-SNAPSHOT:compile
[INFO] \- io.akka:akka-runtime-dev_2.13:jar:1.6.3-2-0bf3b1c3-SNAPSHOT:runtime
```

This is closer to what happens in production. In production we exclude the one provided by the SDK and we use the runtime version. 