### PR TITLE
chore: discover HTTP endpoint methods from base classes

### DIFF
--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/invalid/HttpEndpointInheritedWrongParamName.java
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/invalid/HttpEndpointInheritedWrongParamName.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import akka.javasdk.annotations.http.HttpEndpoint;
+import akka.javasdk.annotations.http.Get;
+
+abstract class BaseHttpEndpointWrongParamName {
+
+  // Parameter name 'bob' doesn't match path variable 'id', and the route is inherited
+  // by the concrete endpoint below, so the error must be reported for the subclass too.
+  @Get("/{id}")
+  public String inherited(String bob) {
+    return "inherited";
+  }
+}
+
+@HttpEndpoint("/my-endpoint")
+public class HttpEndpointInheritedWrongParamName extends BaseHttpEndpointWrongParamName {
+}

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/valid/ValidHttpEndpointWithInheritedMethods.java
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/valid/ValidHttpEndpointWithInheritedMethods.java
@@ -1,0 +1,27 @@
+package com.example;
+
+import akka.javasdk.annotations.http.HttpEndpoint;
+import akka.javasdk.annotations.http.Get;
+import akka.javasdk.annotations.http.Post;
+
+abstract class BaseHttpEndpoint {
+
+  @Get("/inherited/{id}")
+  public String inherited(String id) {
+    return "inherited " + id;
+  }
+
+  @Post("/inherited")
+  public String inheritedCreate(String body) {
+    return "created";
+  }
+}
+
+@HttpEndpoint("/api/inheriting")
+public class ValidHttpEndpointWithInheritedMethods extends BaseHttpEndpoint {
+
+  @Get("/own/{id}")
+  public String own(String id) {
+    return "own " + id;
+  }
+}

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/scala/com/example/HttpEndpointValidationSpec.scala
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/scala/com/example/HttpEndpointValidationSpec.scala
@@ -64,6 +64,10 @@ abstract class AbstractHttpEndpointValidationSpec(val validationMode: Validation
       assertValid("valid/ValidHttpEndpointAllMethods.java")
     }
 
+    "accept valid HTTP endpoint with routes inherited from a base class" in {
+      assertValid("valid/ValidHttpEndpointWithInheritedMethods.java")
+    }
+
     // ==================== Public Modifier Validation ====================
 
     "reject non-public HTTP endpoint" in {
@@ -103,6 +107,14 @@ abstract class AbstractHttpEndpointValidationSpec(val validationMode: Validation
         "The parameter [bob]",
         "does not match the method parameter name [value]",
         "HttpEndpointWrongSecondParamName.list3")
+    }
+
+    "reject HTTP endpoint with wrong parameter name on an inherited method" in {
+      assertInvalid(
+        "invalid/HttpEndpointInheritedWrongParamName.java",
+        "The parameter [id]",
+        "does not match the method parameter name [bob]",
+        "inherited")
     }
 
     "reject HTTP endpoint with too many parameters" in {

--- a/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/runtime/RuntimeTypeDef.java
+++ b/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/runtime/RuntimeTypeDef.java
@@ -72,11 +72,25 @@ public record RuntimeTypeDef(Class<?> clazz) implements TypeDef {
 
   @Override
   public List<MethodDef> getMethods() {
-    return Arrays.stream(clazz.getDeclaredMethods())
+    List<MethodDef> methods = new java.util.ArrayList<>();
+    // Methods declared in this type. Synthetic/bridge methods are skipped so the result matches
+    // the source-level view of CompileTimeTypeDef (e.g. erased-signature bridges for an inherited
+    // generic method would otherwise be counted as separate handlers).
+    Arrays.stream(clazz.getDeclaredMethods())
+        .filter(m -> !m.isSynthetic())
         .map(RuntimeMethodDef::new)
-        .map(m -> (MethodDef) m)
-        .sorted() // sorted to ensure predictable output in tests
-        .toList();
+        .forEach(methods::add);
+
+    // Methods inherited from the superclass hierarchy, matching CompileTimeTypeDef. Stops at
+    // Object so e.g. an inherited @Get/@Post endpoint method is discovered the same way in both
+    // modes.
+    Class<?> superclass = clazz.getSuperclass();
+    if (superclass != null && !superclass.equals(Object.class)) {
+      methods.addAll(new RuntimeTypeDef(superclass).getMethods());
+    }
+
+    // sorted to ensure predictable output in tests
+    return methods.stream().sorted().toList();
   }
 
   @Override

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/HttpEndpointDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/HttpEndpointDescriptorFactory.scala
@@ -66,8 +66,11 @@ private[javasdk] object HttpEndpointDescriptorFactory {
     }
 
     // Note: validation is now done at compile-time by HttpEndpointValidations
+    // getMethods rather than getDeclaredMethods so that @Get/@Post/etc. annotated methods
+    // inherited from a base class are also picked up. Java does not propagate annotations
+    // to subclass overrides, so an unannotated override transparently opts the route out.
     val methods: Vector[HttpEndpointMethodDescriptor] =
-      endpointClass.getDeclaredMethods.toVector.flatMap { method =>
+      endpointClass.getMethods.toVector.flatMap { method =>
 
         val maybePathMethod = if (method.getAnnotation(classOf[Get]) != null) {
           val path = method.getAnnotation(classOf[Get]).value()

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/HttpEndpointDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/HttpEndpointDescriptorFactory.scala
@@ -66,9 +66,6 @@ private[javasdk] object HttpEndpointDescriptorFactory {
     }
 
     // Note: validation is now done at compile-time by HttpEndpointValidations
-    // getMethods rather than getDeclaredMethods so that @Get/@Post/etc. annotated methods
-    // inherited from a base class are also picked up. Java does not propagate annotations
-    // to subclass overrides, so an unannotated override transparently opts the route out.
     val methods: Vector[HttpEndpointMethodDescriptor] =
       endpointClass.getMethods.toVector.flatMap { method =>
 

--- a/akka-javasdk/src/test/java/akka/javasdk/impl/http/TestEndpoints.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/impl/http/TestEndpoints.java
@@ -273,6 +273,52 @@ public class TestEndpoints {
     public void b() {}
   }
 
+  // Base class declaring @Get/@Post methods that a concrete @HttpEndpoint subclass inherits.
+  public abstract static class BaseEndpoint {
+
+    @Get("/inherited")
+    public String inherited() {
+      return "inherited";
+    }
+
+    @Post("/inherited-post")
+    public String inheritedPost(AThing theBody) {
+      return "inherited-post";
+    }
+
+    @Get("/overridden")
+    public String overridden() {
+      return "base";
+    }
+
+    @Get("/dropped")
+    public String dropped() {
+      return "base";
+    }
+  }
+
+  @HttpEndpoint("inheriting")
+  public static class InheritingEndpoint extends BaseEndpoint {
+
+    @Get("/own")
+    public String own() {
+      return "own";
+    }
+
+    // Re-declares @Get — should keep the inherited route binding with the override implementation.
+    @Override
+    @Get("/overridden")
+    public String overridden() {
+      return "override";
+    }
+
+    // No annotation on the override — the route from the base class is opted out.
+    @Override
+    public String dropped() {
+      return "override";
+    }
+  }
+
   // Valid WebSocket endpoints for positive testing
   @HttpEndpoint("websocket")
   public static class ValidWebSocketEndpoints {

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/HttpEndpointDescriptorFactorySpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/HttpEndpointDescriptorFactorySpec.scala
@@ -170,6 +170,29 @@ class HttpEndpointDescriptorFactorySpec extends AnyWordSpec with Matchers {
       lowLevelBodyOnly.methodSpec shouldBe Spec(requestBody = Spec.lowLevelBody())
     }
 
+    "pick up routes inherited from a base class" in {
+      val descriptor = HttpEndpointDescriptorFactory(classOf[http.TestEndpoints.InheritingEndpoint], _ => null)
+      val byMethodName = descriptor.methods.map(md => md.userMethod.getName -> md).toMap
+
+      descriptor.mainPath should ===(Some("/inheriting/"))
+      // inherited @Get and @Post, the subclass's own @Get, and the override that re-declares @Get.
+      // The override without annotation drops the base class route.
+      byMethodName.keySet should ===(Set("inherited", "inheritedPost", "own", "overridden"))
+
+      val inherited = byMethodName("inherited")
+      inherited.pathExpression should ===("inherited")
+      inherited.httpMethod should ===(HttpMethods.GET)
+
+      val inheritedPost = byMethodName("inheritedPost")
+      inheritedPost.pathExpression should ===("inherited-post")
+      inheritedPost.httpMethod should ===(HttpMethods.POST)
+
+      val overridden = byMethodName("overridden")
+      overridden.pathExpression should ===("overridden")
+      overridden.httpMethod should ===(HttpMethods.GET)
+      overridden.userMethod.getDeclaringClass should ===(classOf[http.TestEndpoints.InheritingEndpoint])
+    }
+
     "hide double slash when combining prefix with method path" in {
       val descriptor = HttpEndpointDescriptorFactory(classOf[http.TestEndpoints.WithRootPrefix], _ => null)
       val byMethodName = descriptor.methods.map(md => md.userMethod.getName -> md).toMap

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/HttpEndpointDescriptorFactorySpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/HttpEndpointDescriptorFactorySpec.scala
@@ -175,8 +175,6 @@ class HttpEndpointDescriptorFactorySpec extends AnyWordSpec with Matchers {
       val byMethodName = descriptor.methods.map(md => md.userMethod.getName -> md).toMap
 
       descriptor.mainPath should ===(Some("/inheriting/"))
-      // inherited @Get and @Post, the subclass's own @Get, and the override that re-declares @Get.
-      // The override without annotation drops the base class route.
       byMethodName.keySet should ===(Set("inherited", "inheritedPost", "own", "overridden"))
 
       val inherited = byMethodName("inherited")


### PR DESCRIPTION
Seems unintentional that we didn't support this previously.