### PR TITLE
fix: handle GenericArrayType in JsonSchema generation

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/JsonSchema.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/JsonSchema.scala
@@ -142,6 +142,12 @@ private[impl] object JsonSchema {
         try {
           val clazz = classFor(genericFieldType)
           genericFieldType match {
+            case g: GenericArrayType =>
+              (
+                new JsonSchemaArray(
+                  jsonSchemaTypeFor(g.getGenericComponentType, description, seenTypes)._1,
+                  description),
+                true)
             case _ if clazz == classOf[HttpRequest] => // for body parameter
               (emptyObject(description), false) // unknown if body is required
             case _ if clazz == classOf[HttpEntity.Strict] => // for body parameter

--- a/akka-javasdk/src/test/java/akka/javasdk/impl/SomeToolInput.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/impl/SomeToolInput.java
@@ -67,4 +67,6 @@ interface SomeToolInput {
 
   record SomeToolInputWithEnum(
       @Description("required choice") SomeEnum required, Optional<SomeEnum> optional) {}
+
+  record SomeToolInputWithClassArray(Class<?>[] classes) {}
 }

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/JsonSchemaSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/JsonSchemaSpec.scala
@@ -10,6 +10,7 @@ import akka.javasdk.impl.SomeToolInput.SomeEnum
 import akka.javasdk.impl.SomeToolInput.SomeToolInput1
 import akka.javasdk.impl.SomeToolInput.SomeToolInput2
 import akka.javasdk.impl.SomeToolInput.SomeToolInput3
+import akka.javasdk.impl.SomeToolInput.SomeToolInputWithClassArray
 import akka.javasdk.impl.SomeToolInput.SomeToolInputWithEnum
 import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaArray
 import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaBoolean
@@ -185,6 +186,12 @@ class JsonSchemaSpec extends AnyWordSpec with Matchers {
         "required" -> Schema.enumOf(Seq("ONE", "TWO", "THREE"), description = "required choice"),
         "optional" -> Schema.enumOf(Seq("ONE", "TWO", "THREE")))
       result.required shouldEqual Seq("required")
+    }
+
+    "extract schema for GenericArrayType fields such as Class[]" in {
+      val result = JsonSchema.jsonSchemaFor(classOf[SomeToolInputWithClassArray]).asInstanceOf[JsonSchemaObject]
+      result.properties("classes") shouldBe a[JsonSchemaArray]
+      result.required shouldEqual Seq("classes")
     }
 
     "use object for types causing exceptions" in {


### PR DESCRIPTION
## Summary
- Adds explicit `GenericArrayType` handling in `JsonSchema.jsonSchemaTypeFor`
- Fixes CrashLoopBackOff on voice-agent / voice-agent-trial with `MatchError: java.lang.Class<?>[]`

## Context
Runtime service setup failed when generating JSON schema for fields declared as generic array types (e.g. `Class<?>[]`), which appear as `GenericArrayType` rather than `Class.isArray`.

## Test plan
- [ ] `JsonSchemaSpec` includes new test for `Class<?>[]` field
- [ ] voice-agent workloads start successfully after runtime upgrade

Made with [Cursor](https://cursor.com)