### PR TITLE
chore: Support generic arrays in JSON schema

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/JsonSchema.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/JsonSchema.scala
@@ -152,6 +152,8 @@ private[impl] object JsonSchema {
               (new JsonSchemaString(description), true)
             case _ if clazz.isArray =>
               (new JsonSchemaArray(jsonSchemaTypeFor(clazz.getComponentType, None, seenTypes)._1, None), true)
+            case g: GenericArrayType =>
+              (new JsonSchemaArray(jsonSchemaTypeFor(g.getGenericComponentType, None, seenTypes)._1, description), true)
             case p: ParameterizedType if clazz == classOf[Optional[_]] =>
               val (jsonFieldType, _) = jsonSchemaTypeFor(p.getActualTypeArguments.head, description, seenTypes)
               (jsonFieldType, false)

--- a/akka-javasdk/src/test/java/akka/javasdk/impl/SomeToolInput.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/impl/SomeToolInput.java
@@ -36,6 +36,10 @@ interface SomeToolInput {
       Set<String> setOfStrings,
       Map<String, String> mapOfStrings) {}
 
+  // List<String>[] reflects as a GenericArrayType (component type is parameterized)
+  record SomeToolInputWithGenericArray(
+      @Description("array of lists") List<String>[] genericArray, NestedObject[] objectArray) {}
+
   record SomeToolInput3(@Description("a nested object") NestedObject nestedObject) {}
 
   record NestedObject(@Description("a value in the nested object") String someString) {}

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/JsonSchemaSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/JsonSchemaSpec.scala
@@ -11,6 +11,7 @@ import akka.javasdk.impl.SomeToolInput.SomeToolInput1
 import akka.javasdk.impl.SomeToolInput.SomeToolInput2
 import akka.javasdk.impl.SomeToolInput.SomeToolInput3
 import akka.javasdk.impl.SomeToolInput.SomeToolInputWithEnum
+import akka.javasdk.impl.SomeToolInput.SomeToolInputWithGenericArray
 import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaArray
 import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaBoolean
 import akka.runtime.sdk.spi.SpiJsonSchema.JsonSchemaDataType
@@ -107,6 +108,19 @@ class JsonSchemaSpec extends AnyWordSpec with Matchers {
         "setOfStrings" -> Schema.array(items = Schema.string()),
         // semi-supported - no map type in json, but can be represented as object
         "mapOfStrings" -> Schema.jsonObject())
+    }
+
+    "extract schema with generic array" in {
+      val result =
+        JsonSchema.jsonSchemaFor(classOf[SomeToolInputWithGenericArray]).asInstanceOf[JsonSchemaObject]
+
+      result.properties shouldEqual Map(
+        "genericArray" -> Schema.array(items = Schema.array(items = Schema.string()), description = "array of lists"),
+        "objectArray" -> Schema.array(items = Schema.jsonObject(
+          properties = Map("someString" -> Schema.string(description = "a value in the nested object")),
+          required = Seq("someString"))))
+
+      result.required.toSet shouldEqual Set("genericArray", "objectArray")
     }
 
     "extract schema with nested object" in {


### PR DESCRIPTION
Previously fell back to nondescript `object` in schema, this should pass along more type details whenever possible.