### PR TITLE
chore: Support inherited command handlers and queries

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/EntityDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/EntityDescriptorFactory.scala
@@ -19,18 +19,19 @@ private[impl] object EntityDescriptorFactory extends ComponentDescriptorFactory 
 
   override def buildDescriptorFor(component: Class[_], serializer: Serializer): ComponentDescriptor = {
     //TODO remove capitalization of method name, can't be done per component, because component client reuse the same logic for all
+    // getMethods (not getDeclaredMethods) so command handlers inherited from a base class are included
     val commandHandlerMethods = if (classOf[EventSourcedEntity[_, _]].isAssignableFrom(component)) {
-      component.getDeclaredMethods.collect {
+      component.getMethods.collect {
         case method if isCommandHandlerCandidate[EventSourcedEntity.Effect[_]](method) =>
           method.getName.capitalize -> MethodInvoker(method)
       }
     } else if (classOf[KeyValueEntity[_]].isAssignableFrom(component)) {
-      component.getDeclaredMethods.collect {
+      component.getMethods.collect {
         case method if isCommandHandlerCandidate[KeyValueEntity.Effect[_]](method) =>
           method.getName.capitalize -> MethodInvoker(method)
       }
     } else if (classOf[Workflow[_]].isAssignableFrom(component)) {
-      component.getDeclaredMethods.collect {
+      component.getMethods.collect {
         case method if isCommandHandlerCandidate[Workflow.Effect[_]](method) =>
           method.getName.capitalize -> MethodInvoker(method)
       }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -720,7 +720,7 @@ private final class Sdk(
         val componentId = Reflect.readComponentId(clz)
 
         val readOnlyCommandNames =
-          clz.getDeclaredMethods.collect {
+          clz.getMethods.collect {
             case method
                 if isCommandHandlerCandidate[EventSourcedEntity.Effect[_]](method) && method.getReturnType == classOf[
                   EventSourcedEntity.ReadOnlyEffect[_]] =>
@@ -786,7 +786,7 @@ private final class Sdk(
         val componentId = Reflect.readComponentId(clz)
 
         val readOnlyCommandNames =
-          clz.getDeclaredMethods.collect {
+          clz.getMethods.collect {
             case method
                 if isCommandHandlerCandidate[KeyValueEntity.Effect[_]](method) && method.getReturnType == classOf[
                   KeyValueEntity.ReadOnlyEffect[_]] =>
@@ -847,7 +847,7 @@ private final class Sdk(
           clz.asInstanceOf[Class[Workflow[_]]])
 
         val readOnlyCommandNames =
-          clz.getDeclaredMethods.collect {
+          clz.getMethods.collect {
             case method
                 if isCommandHandlerCandidate[Workflow.Effect[_]](method) && method.getReturnType == classOf[
                   Workflow.ReadOnlyEffect[_]] =>

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/TimedActionDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/TimedActionDescriptorFactory.scala
@@ -17,7 +17,8 @@ private[impl] object TimedActionDescriptorFactory extends ComponentDescriptorFac
 
   override def buildDescriptorFor(component: Class[_], serializer: Serializer): ComponentDescriptor = {
     //TODO remove capitalization of method name, can't be done per component, because component client reuse the same logic for all
-    val invokers = component.getDeclaredMethods.collect {
+    // getMethods (not getDeclaredMethods) so command handlers inherited from a base class are included
+    val invokers = component.getMethods.collect {
       case method if isCommandHandlerCandidate[TimedAction.Effect](method) =>
         method.getName.capitalize -> MethodInvoker(method)
     }.toMap

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentDescriptorFactory.scala
@@ -20,8 +20,9 @@ private[impl] object AgentDescriptorFactory extends ComponentDescriptorFactory {
 
   override def buildDescriptorFor(component: Class[_], serializer: Serializer): ComponentDescriptor = {
     //TODO remove capitalization of method name, can't be done per component, because component client reuse the same logic for all
+    // getMethods (not getDeclaredMethods) so a command handler inherited from a base class is included
     val commandHandlerMethods = if (classOf[Agent].isAssignableFrom(component)) {
-      component.getDeclaredMethods.collect {
+      component.getMethods.collect {
         case method
             if isCommandHandlerCandidate[Agent.Effect[_]](method) || isCommandHandlerCandidate[Agent.StreamEffect](
               method) =>

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/autonomous/CapabilityConverter.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/autonomous/CapabilityConverter.scala
@@ -146,7 +146,7 @@ private[javasdk] class CapabilityConverter(
     sdkTargets.map { agentClass =>
       val componentId = Reflect.readComponentId(agentClass)
       val effectMethod =
-        agentClass.getDeclaredMethods
+        agentClass.getMethods
           .find { method =>
             Reflect.isCommandHandlerCandidate[Agent.Effect[_]](method) ||
             Reflect.isCommandHandlerCandidate[Agent.StreamEffect](method)

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AgentClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AgentClientImpl.scala
@@ -196,7 +196,7 @@ private[javasdk] final case class AgentClientImpl(
         "The agent id is defined with the @Component annotation."))
 
     val effectMethod =
-      agentClass.getDeclaredMethods
+      agentClass.getMethods
         .find { method =>
           isCommandHandlerCandidate[Agent.Effect[_]](method) || isCommandHandlerCandidate[Agent.StreamEffect](method)
         }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/reflection/Reflect.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/reflection/Reflect.scala
@@ -176,7 +176,7 @@ private[impl] object Reflect {
   def isEvaluatorAgent(cls: Class[_]): Boolean = {
     isAgent(cls) && {
       val effectMethod =
-        cls.getDeclaredMethods
+        cls.getMethods
           .find { method =>
             isCommandHandlerCandidate[Agent.Effect[_]](method)
           }
@@ -198,7 +198,10 @@ private[impl] object Reflect {
     effectType.runtimeClass.isAssignableFrom(method.getReturnType) &&
     method.getParameterTypes.length <= 1 &&
     // Workflow will have lambdas returning Effect, we want to filter them out
-    !method.getName.startsWith("lambda$")
+    !method.getName.startsWith("lambda$") &&
+    // skip synthetic/bridge methods, e.g. the erased-signature bridge generated for an overridden
+    // generic command handler, which would otherwise be picked up as a duplicate candidate
+    !method.isSynthetic
   }
 
   def getReturnClass[T](declaringClass: Class[_], method: Method): Class[T] =
@@ -290,9 +293,14 @@ private[impl] object Reflect {
 
   def workflowKnownInputTypes(clz: Class[_]): List[Class[_]] = {
 
-    // register all inputs for methods returning StepEffect
+    // register all inputs for methods returning StepEffect, including steps inherited from a base
+    // class - traverse the hierarchy the same way as WorkflowDescriptor discovers step methods
+    def allMethods(c: Class[_]): Seq[Method] =
+      if (c == null || c == classOf[Object]) Seq.empty
+      else c.getDeclaredMethods.toSeq ++ allMethods(c.getSuperclass) ++ c.getInterfaces.flatMap(allMethods)
+
     val stepEffectClass = classOf[Workflow.StepEffect]
-    val methods = clz.getDeclaredMethods.filter { m =>
+    val methods = allMethods(clz).filter { m =>
       m.getParameterTypes.length == 1 && stepEffectClass.isAssignableFrom(m.getReturnType)
     }
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewDescriptorFactory.scala
@@ -152,7 +152,8 @@ private[impl] object ViewDescriptorFactory {
       View.QueryEffect[_]] || method.getReturnType == classOf[View.QueryStreamEffect[_]])
 
   private def extractQueryMethods(component: Class[_]): Seq[QueryMethod] = {
-    val annotatedQueryMethods = component.getDeclaredMethods.toIndexedSeq.filter(validQueryMethod)
+    // getMethods (not getDeclaredMethods) so @Query methods inherited from a base class are included
+    val annotatedQueryMethods = component.getMethods.toIndexedSeq.filter(validQueryMethod)
     annotatedQueryMethods.map(method =>
       try {
         extractQueryMethod(method)

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/inheritance/InheritedHandlerModels.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/inheritance/InheritedHandlerModels.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.testmodels.inheritance;
+
+import akka.javasdk.agent.Agent;
+import akka.javasdk.annotations.Component;
+import akka.javasdk.eventsourcedentity.EventSourcedEntity;
+import akka.javasdk.keyvalueentity.KeyValueEntity;
+import akka.javasdk.timedaction.TimedAction;
+import akka.javasdk.workflow.Workflow;
+
+/**
+ * Components whose command handlers (and a workflow step) are declared on a base class, to verify
+ * the descriptor factories discover handlers inherited from a super class. Method bodies return
+ * null since the descriptors are only built, never invoked, in these tests.
+ */
+public class InheritedHandlerModels {
+
+  // --- Event Sourced Entity ---
+
+  public abstract static class BaseEsEntity extends EventSourcedEntity<Integer, String> {
+    public Effect<String> inheritedIncrease(Integer value) {
+      return null;
+    }
+
+    public ReadOnlyEffect<Integer> inheritedGet() {
+      return null;
+    }
+  }
+
+  @Component(id = "inheriting-es")
+  public static class InheritingEsEntity extends BaseEsEntity {
+    public Effect<String> ownCommand(String cmd) {
+      return null;
+    }
+
+    public Integer applyEvent(String event) {
+      return 0;
+    }
+  }
+
+  // --- Key Value Entity ---
+
+  public abstract static class BaseKvEntity extends KeyValueEntity<Integer> {
+    public Effect<String> inheritedSet(Integer value) {
+      return null;
+    }
+
+    public ReadOnlyEffect<Integer> inheritedGet() {
+      return null;
+    }
+  }
+
+  @Component(id = "inheriting-kv")
+  public static class InheritingKvEntity extends BaseKvEntity {
+    public Effect<String> ownSet(Integer value) {
+      return null;
+    }
+  }
+
+  // --- Timed Action ---
+
+  public abstract static class BaseTimedAction extends TimedAction {
+    public Effect inheritedCommand(String msg) {
+      return null;
+    }
+  }
+
+  @Component(id = "inheriting-action")
+  public static class InheritingTimedAction extends BaseTimedAction {
+    public Effect ownCommand() {
+      return null;
+    }
+  }
+
+  // --- Agent (must have exactly one command handler, here only the inherited one) ---
+
+  public abstract static class BaseAgent extends Agent {
+    public Effect<String> inheritedQuery(String question) {
+      return null;
+    }
+  }
+
+  @Component(id = "inheriting-agent")
+  public static class InheritingAgent extends BaseAgent {}
+
+  // --- Workflow (command handlers and a step declared on the base class) ---
+
+  public record StepInput(String value) {}
+
+  public abstract static class BaseWorkflow extends Workflow<String> {
+    public Effect<String> inheritedStart(String cmd) {
+      return null;
+    }
+
+    public ReadOnlyEffect<String> inheritedGet() {
+      return null;
+    }
+
+    public StepEffect inheritedStep(StepInput input) {
+      return null;
+    }
+  }
+
+  @Component(id = "inheriting-workflow")
+  public static class InheritingWorkflow extends BaseWorkflow {
+    public Effect<String> ownCommand(String cmd) {
+      return null;
+    }
+  }
+}

--- a/akka-javasdk/src/test/java/akka/javasdk/testmodels/view/ViewTestModels.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/testmodels/view/ViewTestModels.java
@@ -78,6 +78,26 @@ public class ViewTestModels {
     }
   }
 
+  // Base class declaring a @Query method that a concrete View subclass inherits.
+  public abstract static class BaseQueryView extends View {
+    @Query("SELECT * FROM users WHERE email = :email")
+    public QueryEffect<User> inheritedQuery(ByEmail byEmail) {
+      return queryResult();
+    }
+  }
+
+  @Component(id = "users_view")
+  public static class ViewWithInheritedQuery extends BaseQueryView {
+
+    @Consume.FromKeyValueEntity(UserEntity.class)
+    public static class UserUpdater extends TableUpdater<User> {}
+
+    @Query("SELECT * FROM users WHERE email = :email")
+    public QueryEffect<User> ownQuery(ByEmail byEmail) {
+      return queryResult();
+    }
+  }
+
   @Component(id = "users_view")
   public static class ViewWithLowerCaseQuery extends View {
 

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/InheritedCommandHandlerSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/InheritedCommandHandlerSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl
+
+import akka.javasdk.impl.reflection.Reflect
+import akka.javasdk.impl.serialization.Serializer
+import akka.javasdk.impl.workflow.WorkflowDescriptor
+import akka.javasdk.testmodels.inheritance.InheritedHandlerModels
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class InheritedCommandHandlerSpec extends AnyWordSpec with OptionValues with Matchers {
+
+  private val serializer = new Serializer()
+
+  private def invokerNames(component: Class[_]): Set[String] =
+    ComponentDescriptor.descriptorFor(component, serializer).methodInvokers.keySet
+
+  "Command handler discovery" should {
+
+    "pick up Event Sourced Entity command handlers inherited from a base class" in {
+      invokerNames(classOf[InheritedHandlerModels.InheritingEsEntity]) should ===(
+        Set("InheritedIncrease", "InheritedGet", "OwnCommand"))
+    }
+
+    "pick up Key Value Entity command handlers inherited from a base class" in {
+      invokerNames(classOf[InheritedHandlerModels.InheritingKvEntity]) should ===(
+        Set("InheritedSet", "InheritedGet", "OwnSet"))
+    }
+
+    "pick up Timed Action command handlers inherited from a base class" in {
+      invokerNames(classOf[InheritedHandlerModels.InheritingTimedAction]) should ===(
+        Set("InheritedCommand", "OwnCommand"))
+    }
+
+    "pick up the Agent command handler inherited from a base class" in {
+      invokerNames(classOf[InheritedHandlerModels.InheritingAgent]) should ===(Set("InheritedQuery"))
+    }
+
+    "pick up Workflow command handlers inherited from a base class" in {
+      invokerNames(classOf[InheritedHandlerModels.InheritingWorkflow]) should ===(
+        Set("InheritedStart", "InheritedGet", "OwnCommand"))
+    }
+
+    "register input types for Workflow steps inherited from a base class" in {
+      Reflect.workflowKnownInputTypes(classOf[InheritedHandlerModels.InheritingWorkflow]) should contain(
+        classOf[InheritedHandlerModels.StepInput])
+    }
+
+    "find a Workflow step method inherited from a base class" in {
+      val descriptor = new WorkflowDescriptor(new InheritedHandlerModels.InheritingWorkflow())
+      descriptor.findStepMethodByName("inheritedStep") shouldBe defined
+    }
+  }
+}

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/view/ViewDescriptorFactorySpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/view/ViewDescriptorFactorySpec.scala
@@ -40,6 +40,12 @@ class ViewDescriptorFactorySpec extends AnyWordSpec with Matchers {
       }
     }
 
+    "pick up a @Query method inherited from a base class" in {
+      assertDescriptor[ViewWithInheritedQuery] { desc =>
+        desc.queries.map(_.name).toSet shouldBe Set("inheritedQuery", "ownQuery")
+      }
+    }
+
     "allow View query with quoted table name" in {
       assertDescriptor[ViewWithQuotedTableName] { desc =>
         desc.tables.map(_.tableName) shouldBe Seq("üsérs tåble")


### PR DESCRIPTION
This allows, in a superclass, to define, command handlers in KVE and ES entities, Workflows (was partially supported but did not quite work), and agents (probably not very useful but for consistency), and queries on views.