### PR TITLE
chore: remove unused opentelemetry-exporter-otlp dependency from build configuration

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,7 +71,6 @@ object Dependencies {
 
   val opentelemetryApi = "io.opentelemetry" % "opentelemetry-api" % OpenTelemetryVersion
   val opentelemetrySdk = "io.opentelemetry" % "opentelemetry-sdk" % OpenTelemetryVersion
-  val opentelemetryExporterOtlp = "io.opentelemetry" % "opentelemetry-exporter-otlp" % OpenTelemetryVersion
   val opentelemetryContext = "io.opentelemetry" % "opentelemetry-context" % OpenTelemetryVersion
   val opentelemetrySemConv = "io.opentelemetry.semconv" % "opentelemetry-semconv" % OpenTelemetrySemConv
 
@@ -83,7 +82,6 @@ object Dependencies {
   private val sdkDeps = Seq(
     opentelemetryApi,
     opentelemetrySdk,
-    opentelemetryExporterOtlp,
     opentelemetryContext,
     opentelemetrySemConv,
     // akka-http is pulling akka-pki and akka-discovery, we need to force it to be same version


### PR DESCRIPTION
This removes these from the transitive dependencies:

```
io/opentelemetry/opentelemetry-exporter-otlp/1.57.0/opentelemetry-exporter-otlp-1.57.0.jar
io/opentelemetry/opentelemetry-exporter-otlp-common/1.57.0/opentelemetry-exporter-otlp-common-1.57.0.jar
io/opentelemetry/opentelemetry-exporter-sender-okhttp/1.57.0/opentelemetry-exporter-sender-okhttp-1.57.0.jar
io/opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi/1.57.0/opentelemetry-sdk-extension-autoconfigure-spi-1.57.0.jar
io/opentelemetry/opentelemetry-exporter-common/1.57.0/opentelemetry-exporter-common-1.57.0.jar
com/squareup/okhttp3/okhttp-jvm/5.3.2/okhttp-jvm-5.3.2.jar
com/squareup/okio/okio-jvm/3.16.4/okio-jvm-3.16.4.jar
org/jetbrains/kotlin/kotlin-stdlib/2.2.21/kotlin-stdlib-2.2.21.jar
org/jetbrains/annotations/13.0/annotations-13.0.jar
```

Once we support classloader isolation of the runtime's internals, this will benefit users by reducing the size of the SDK mandated dependencies, for example by allowing them to use a binary incompatible version of `okhttp`.