### PR TITLE
chore: build hygiene — sbt dependency-tree plugin + antrun clean fix

### DIFF
--- a/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-parent/pom.xml
@@ -551,7 +551,7 @@
                                                          erroronmissingdir="false"/>
                                             </resourcecount>
                                         </condition>
-                                        <delete dir="target" if:set="descriptor.missing"/>
+                                        <delete dir="target/classes" if:set="descriptor.missing"/>
                                     </target>
                                 </configuration>
                             </execution>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,6 +12,7 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
 addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.11.0")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.3")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
+addDependencyTreePlugin
 
 // align guava version between sbt-akka-grpc and sbt-java-formatter
 libraryDependencies += "com.google.guava" % "guava" % "33.3.1-jre"


### PR DESCRIPTION
## Summary

Two build-hygiene precursors carved out of the classloader-isolation work so they can land independently.

### `chore: enable sbt dependency-tree plugin`

Adds `addDependencyTreePlugin`, making `dependencyTree` / `whatDependsOn` available for inspecting the build's dependency graph. Tooling-only; no effect on published artifacts.

### `fix(maven-parent): clean target/classes, not target/, on missing descriptor`

The antrun guard in `akka-javasdk-parent` deletes generated component-descriptor output when no descriptor is present, but it was deleting the entire `target/` directory — which on a `clean package` also wipes sibling plugin output produced earlier in the same build. Scoping the delete to `target/classes` removes only the stale descriptor tree. This is a standalone correctness fix, independent of the isolation work it was discovered alongside.

