### PR TITLE
Classloader-isolated boot: Maven plugin + boot launcher infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,3 +466,67 @@ jobs:
           echo "==== Verifying that generated unmanaged sources compile ===="
           rm -rf src/main/java src/test/java
           mvn test-compile --no-transfer-progress
+
+  isolated-boot-it:
+    name: Isolated boot IT
+    needs: [checks, publish-local]
+    runs-on: Akka-Default
+    # Gated: this IT resolves the akka-runtime isolated-boot artifacts (akka-runtime-boot,
+    # akka-runtime-dev-maven-plugin, akka-runtime-shared-dependencies) at the SDK's pinned
+    # akka-runtime.version. Until a runtime release carrying that feature is pinned, keep this
+    # non-blocking. TODO: drop continue-on-error once AkkaRuntimeVersion points at such a release.
+    continue-on-error: true
+
+    steps:
+      - name: Checkout Global Scripts
+        uses: actions/checkout@v6
+        with:
+          repository: akka/github-actions-scripts
+          path: scripts
+          fetch-depth: 0
+
+      - name: Setup global resolver
+        run: |
+          chmod +x ./scripts/setup_global_resolver.sh
+          ./scripts/setup_global_resolver.sh NO_MIRROR
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Set up JDK 21
+        uses: coursier/setup-action@v3.0.0
+        with:
+          jvm: temurin:1.21
+
+      - name: Cache Maven repository
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('akka-javasdk-parent/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Download io.akka dependencies
+        uses: actions/download-artifact@v8
+        with:
+          name: m2-cache
+          path: ~/
+
+      - name: Unpack io.akka dependencies
+        run: |-
+          cd
+          tar -xf dependencies.tar.gz
+
+      - name: Run isolated-boot integration test
+        run: |-
+          export SDK_VERSION=$(cat ~/akka-javasdk-version.txt)
+          ./updateSdkVersions.sh java maven-integration-tests/isolated-boot-it
+          cd maven-integration-tests/isolated-boot-it
+          echo "Running isolated-boot-it with SDK version: '${SDK_VERSION}'"
+          mvn verify --no-transfer-progress

--- a/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-parent/pom.xml
@@ -283,7 +283,6 @@
                     <version>3.4.1</version>
                     <configuration>
                         <skip>${non-akka-service}</skip>
-                        <mainClass>akka.runtime.boot.EmbeddedAkkaRuntimeMain</mainClass>
                         <cleanupDaemonThreads>false</cleanupDaemonThreads>
                         <systemProperties>
                             <systemProperty>
@@ -334,9 +333,10 @@
                              the host classloader must stay Akka-free so the boundary loader owns
                              every cross-seam type (the embedded launcher would need the SDK's
                              provided-scope deps on the host, which exec:java cannot supply).
-                             Run with: mvn compile exec:java@in-process -->
+                             Run with: mvn compile exec:java  (default-cli is the id Maven uses for
+                             direct CLI invocations, so no @id suffix is needed) -->
                         <execution>
-                            <id>in-process</id>
+                            <id>default-cli</id>
                             <goals>
                                 <goal>java</goal>
                             </goals>

--- a/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-parent/pom.xml
@@ -59,6 +59,8 @@
         <!-- note that this image does never actually run the service in a JVM, it's just a means for distribution -->
         <docker.base.image>us-docker.pkg.dev/kalix-images/infrastructure/alpine:3.23.3</docker.base.image>
         <docker.platform>linux/amd64</docker.platform>
+        <!-- Staging dir inside the user image; init container copies it to /opt/local-lib/ at pod start. -->
+        <docker.install.dir>/opt/akka</docker.install.dir>
 
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
 
@@ -135,110 +137,29 @@
                             <image>
                                 <name>${docker.image}:%l</name>
                                 <build>
-                                    <!-- Base Docker image which contains jre-->
                                     <from>${docker.base.image}</from>
                                     <buildOptions>
                                         <platform>${docker.platform}</platform>
                                     </buildOptions>
                                     <tags>
-                                        <!-- tag for generated image -->
                                         <tag>${docker.tag}</tag>
                                     </tags>
                                     <assembly>
+                                        <targetDir>${docker.install.dir}</targetDir>
                                         <inline>
-                                            <dependencySets>
-                                                <dependencySet>
+                                            <fileSets>
+                                                <fileSet>
+                                                    <directory>${project.build.directory}/runtime-image</directory>
                                                     <outputDirectory>.</outputDirectory>
-                                                    <useProjectArtifact>true</useProjectArtifact>
-                                                    <scope>compile</scope>
-                                                    <excludes>
-                                                        <!-- Dependencies of SDK and or available as API for users
-                                                             but already provided by runtime. Since runtime versions
-                                                             will always be preferred, there is no need to package up
-                                                             these.
-
-                                                             Avoid using wildcards here, since those may easily block
-                                                             inclusion of jars not provided by the runtime.
-
-                                                             List can be verified by building a runtime image and cross-
-                                                             referencing the list of packaged jars.
-
-                                                             Watch out for this log from mvn clean install:
-                                                               [WARNING] The following patterns were never triggered in this artifact exclusion filter
-
-                                                             Debug logging can be enabled with:
-                                                             mvn clean install -DskipTests -Dorg.slf4j.simpleLogger.showLogName=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.assembly.archive.phase.DependencySetAssemblyPhase=debug
-                                                             -->
-                                                        <exclude>com.typesafe:config</exclude>
-                                                        <exclude>com.typesafe.akka:akka-actor_2.13</exclude>
-                                                        <exclude>com.typesafe.akka:akka-discovery_2.13</exclude>
-                                                        <exclude>com.typesafe.akka:akka-parsing_2.13</exclude>
-                                                        <exclude>com.typesafe.akka:akka-pki_2.13</exclude>
-                                                        <exclude>com.typesafe.akka:akka-protobuf-v3_2.13</exclude>
-                                                        <exclude>com.typesafe.akka:akka-stream_2.13</exclude>
-                                                        <exclude>com.typesafe.akka:akka-http-core_2.13</exclude>
-                                                        <exclude>com.typesafe.akka:akka-http_2.13</exclude>
-                                                        <exclude>com.hierynomus:asn-one</exclude>
-                                                        <exclude>org.reactivestreams:reactive-streams</exclude>
-                                                        <!-- Scala stdlib -->
-                                                        <exclude>org.scala-lang.modules:scala-collection-compat_2.13</exclude>
-                                                        <exclude>org.scala-lang:scala-library</exclude>
-                                                        <!-- Protobuf/gRPC
-                                                            Note: scalapb validation is still provided from with service (for now) -->
-                                                        <exclude>com.thesamet.scalapb:lenses_2.13</exclude>
-                                                        <exclude>com.thesamet.scalapb:scalapb-runtime_2.13</exclude>
-                                                        <exclude>io.grpc:grpc-stub</exclude>
-                                                        <exclude>io.grpc:grpc-api</exclude>
-                                                        <exclude>io.grpc:grpc-core</exclude>
-                                                        <exclude>io.grpc:grpc-netty-shaded</exclude>
-                                                        <exclude>io.grpc:grpc-protobuf</exclude>
-                                                        <exclude>com.google.protobuf:protobuf-java</exclude>
-                                                        <exclude>com.google.api.grpc:proto-google-common-protos</exclude>
-                                                        <exclude>com.lightbend.akka.grpc:akka-grpc-runtime_2.13</exclude>
-                                                        <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
-                                                        <!-- guava and related -->
-                                                        <exclude>com.google.guava:guava</exclude>
-                                                        <exclude>com.google.guava:failureaccess</exclude>
-                                                        <exclude>com.google.guava:listenablefuture</exclude>
-                                                        <exclude>com.google.errorprone:error_prone_annotations</exclude>
-                                                        <exclude>com.google.code.findbugs:jsr305</exclude>
-                                                        <exclude>org.checkerframework:checker-qual</exclude>
-                                                        <exclude>com.google.j2objc:j2objc-annotations</exclude>
-                                                        <!-- open telemetry -->
-                                                        <exclude>io.opentelemetry:opentelemetry-api</exclude>
-                                                        <exclude>io.opentelemetry:opentelemetry-context</exclude>
-                                                        <exclude>io.opentelemetry:opentelemetry-sdk</exclude>
-                                                        <exclude>io.opentelemetry:opentelemetry-sdk-common</exclude>
-                                                        <exclude>io.opentelemetry:opentelemetry-sdk-logs</exclude>
-                                                        <exclude>io.opentelemetry:opentelemetry-sdk-metrics</exclude>
-                                                        <exclude>io.opentelemetry:opentelemetry-sdk-trace</exclude>
-                                                        <exclude>io.opentelemetry:opentelemetry-exporter-otlp</exclude>
-                                                        <exclude>io.opentelemetry.semconv:opentelemetry-semconv</exclude>
-                                                        <!-- logging -->
-                                                        <exclude>org.slf4j:slf4j-api</exclude>
-                                                        <exclude>ch.qos.logback:logback-classic</exclude>
-                                                        <exclude>ch.qos.logback:logback-core</exclude>
-                                                        <exclude>ch.qos.logback.contrib:logback-json-classic</exclude>
-                                                        <exclude>ch.qos.logback.contrib:logback-json-core</exclude>
-                                                        <exclude>ch.qos.logback.contrib:logback-jackson</exclude>
-                                                        <!-- serialization/jackson -->
-                                                        <exclude>com.fasterxml.jackson.core:jackson-annotations</exclude>
-                                                        <exclude>com.fasterxml.jackson.core:jackson-core</exclude>
-                                                        <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
-                                                        <exclude>com.fasterxml.jackson.datatype:jackson-datatype-jdk8</exclude>
-                                                        <exclude>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</exclude>
-                                                        <exclude>com.fasterxml.jackson.module:jackson-module-parameter-names</exclude>
-                                                        <!-- SDK spi -->
-                                                        <exclude>io.akka:akka-sdk-spi_2.13</exclude>
-                                                        <!-- langchain -->
-                                                        <exclude>dev.langchain4j:langchain4j</exclude>
-                                                    </excludes>
-                                                </dependencySet>
-                                            </dependencySets>
+                                                    <fileMode>0755</fileMode>
+                                                </fileSet>
+                                            </fileSets>
                                         </inline>
                                     </assembly>
+                                    <!-- Init-container entryPoint: copies the staged layout to the shared volume
+                                         so the runtime container finds it at /opt/local-lib/. -->
                                     <entryPoint>
-                                        <shell>echo "Listing dependencies copied:"; cp --verbose /maven/*.jar /opt/local-lib/</shell>
+                                        <shell>cp -r ${docker.install.dir}/. /opt/local-lib/</shell>
                                     </entryPoint>
                                 </build>
                             </image>
@@ -247,7 +168,7 @@
                     <executions>
                         <execution>
                             <id>build-docker-image</id>
-                            <phase>install</phase>
+                            <phase>package</phase>
                             <goals>
                                 <goal>build</goal>
                             </goals>
@@ -315,6 +236,7 @@
                         <systemPropertyVariables>
                             <logback.configurationFile>${logback.configurationFile}</logback.configurationFile>
                             <akka.javasdk.dev-mode.project-artifact-id>${project.artifactId}</akka.javasdk.dev-mode.project-artifact-id>
+                            <akka.runtime.classpathsFile>${project.build.directory}/akka-runtime/test-classpaths.properties</akka.runtime.classpathsFile>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>
@@ -335,7 +257,7 @@
                                     <include>**/IT*.java</include>
                                     <include>**/*ITCase.java</include>
                                 </includes>
-                                <argLine>-Dlogback.configurationFile=${logback.configurationFile} -Dakka.javasdk.dev-mode.project-artifact-id=${project.artifactId}</argLine>
+                                <argLine>-Dlogback.configurationFile=${logback.configurationFile} -Dakka.javasdk.dev-mode.project-artifact-id=${project.artifactId} -Dakka.runtime.classpathsFile=${project.build.directory}/akka-runtime/test-classpaths.properties</argLine>
                             </configuration>
                         </execution>
                     </executions>
@@ -350,12 +272,18 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>io.akka</groupId>
+                    <artifactId>akka-runtime-dev-maven-plugin</artifactId>
+                    <version>${akka-runtime.version}</version>
+                </plugin>
+
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>3.4.1</version>
                     <configuration>
                         <skip>${non-akka-service}</skip>
-                        <mainClass>kalix.runtime.AkkaRuntimeMain</mainClass>
+                        <mainClass>akka.runtime.boot.EmbeddedAkkaRuntimeMain</mainClass>
                         <cleanupDaemonThreads>false</cleanupDaemonThreads>
                         <systemProperties>
                             <systemProperty>
@@ -371,12 +299,98 @@
                                 <value>${project.artifactId}</value>
                             </systemProperty>
                         </systemProperties>
+                        <arguments>
+                            <argument>${project.build.directory}/akka-runtime/runtime-classpaths.properties</argument>
+                        </arguments>
+                        <additionalClasspathElements>
+                            <additionalClasspathElement>${project.build.directory}/akka-runtime/akka-runtime-boot.jar</additionalClasspathElement>
+                        </additionalClasspathElements>
                     </configuration>
+                    <executions>
+                        <!-- Forked JVM: boot launcher runs in a fresh, Akka-free host JVM and builds the
+                             isolated classloader topology itself. Run with: mvn compile exec:exec@fork -->
+                        <execution>
+                            <id>fork</id>
+                            <goals>
+                                <goal>exec</goal>
+                            </goals>
+                            <configuration>
+                                <executable>java</executable>
+                                <arguments>
+                                    <argument>-Dakka.javasdk.dev-mode.enabled=true</argument>
+                                    <argument>-Dakka.javasdk.dev-mode.project-artifact-id=${project.artifactId}</argument>
+                                    <argument>-Dlogback.configurationFile=${logback.configurationFile}</argument>
+                                    <argument>-cp</argument>
+                                    <argument>${project.build.directory}/akka-runtime/akka-runtime-boot.jar</argument>
+                                    <argument>akka.runtime.boot.IsolatedAkkaRuntimeMain</argument>
+                                    <argument>${project.build.directory}/akka-runtime/runtime-classpaths.properties</argument>
+                                </arguments>
+                            </configuration>
+                        </execution>
+                        <!-- In-process: boot launcher runs inside the Maven JVM, building the same
+                             isolated classloader topology as the fork. The project dependencies are
+                             deliberately NOT put on the exec classloader: the runtime-classpaths
+                             properties already carry all three segments (shared/system/user), and
+                             the host classloader must stay Akka-free so the boundary loader owns
+                             every cross-seam type (the embedded launcher would need the SDK's
+                             provided-scope deps on the host, which exec:java cannot supply).
+                             Run with: mvn compile exec:java@in-process -->
+                        <execution>
+                            <id>in-process</id>
+                            <goals>
+                                <goal>java</goal>
+                            </goals>
+                            <configuration>
+                                <mainClass>akka.runtime.boot.IsolatedAkkaRuntimeMain</mainClass>
+                                <includeProjectDependencies>false</includeProjectDependencies>
+                                <arguments>
+                                    <argument>${project.build.directory}/akka-runtime/runtime-classpaths.properties</argument>
+                                </arguments>
+                                <additionalClasspathElements>
+                                    <additionalClasspathElement>${project.build.directory}/akka-runtime/akka-runtime-boot.jar</additionalClasspathElement>
+                                </additionalClasspathElements>
+                                <systemProperties>
+                                    <systemProperty>
+                                        <key>akka.javasdk.dev-mode.enabled</key>
+                                        <value>true</value>
+                                    </systemProperty>
+                                    <systemProperty>
+                                        <key>akka.javasdk.dev-mode.project-artifact-id</key>
+                                        <value>${project.artifactId}</value>
+                                    </systemProperty>
+                                    <systemProperty>
+                                        <key>logback.configurationFile</key>
+                                        <value>${logback.configurationFile}</value>
+                                    </systemProperty>
+                                </systemProperties>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-help-plugin</artifactId>
+                <version>3.5.0</version>
+            </plugin>
+
+            <plugin>
+                <groupId>io.akka</groupId>
+                <artifactId>akka-runtime-dev-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <!-- exportRuntimeClasspath binds to `initialize`, prepareRuntimeLayout to `package` -->
+                            <goal>exportRuntimeClasspath</goal>
+                            <goal>prepareRuntimeLayout</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -749,10 +763,13 @@
                 <artifactId>akka-sdk-spi_2.13</artifactId>
                 <version>${akka-runtime.version}</version>
             </dependency>
+            <!-- Align the versions of dependencies that the runtime exposes in the shared classloader -->
             <dependency>
                 <groupId>io.akka</groupId>
-                <artifactId>akka-runtime-dev_2.13</artifactId>
+                <artifactId>akka-runtime-shared-dependencies_2.13</artifactId>
                 <version>${akka-runtime.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -767,11 +784,6 @@
             <groupId>io.akka</groupId>
             <artifactId>akka-javasdk-testkit</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.akka</groupId>
-            <artifactId>akka-runtime-dev_2.13</artifactId>
-            <scope>runtime</scope>
         </dependency>
     </dependencies>
 </project>

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -42,6 +42,7 @@ import akka.javasdk.testkit.impl.WebSocketRouteTesterImpl;
 import akka.javasdk.timer.TimerScheduler;
 import akka.javasdk.workflow.Workflow;
 import akka.pattern.Patterns;
+import akka.runtime.boot.EmbeddedAkkaRuntimeMain;
 import akka.runtime.sdk.spi.ComponentClients;
 import akka.runtime.sdk.spi.EventLogClient;
 import akka.runtime.sdk.spi.SpiBackofficeSettings$;
@@ -67,6 +68,7 @@ import akka.stream.SystemMaterializer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.ServerSocket;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -85,7 +87,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import kalix.runtime.AkkaRuntimeMain;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -993,8 +994,7 @@ public class TestKit {
 
       applicationConfig = runner.applicationConfig();
 
-      Config runtimeConfig = ConfigFactory.empty();
-      runtimeActorSystem = AkkaRuntimeMain.start(Some.apply(runtimeConfig), runner);
+      runtimeActorSystem = launchRuntime(runner);
       // wait for SDK to get on start callback (or fail starting), we need it to set up the
       // component client
       final Sdk.StartupContext startupContext =
@@ -1096,6 +1096,39 @@ public class TestKit {
 
     } catch (Exception ex) {
       throw new RuntimeException("Error while starting testkit", ex);
+    }
+  }
+
+  /**
+   * Launch the runtime, choosing between two modes:
+   *
+   * <ul>
+   *   <li><b>Classloader-isolated (embedded)</b> — when a classpath properties file ({@code
+   *       -Dakka.runtime.classpathsFile}) or the {@code akka.runtime.classpath.shared} system
+   *       property is present (as produced by the akka-runtime dev Maven plugin). The runtime
+   *       implementation is loaded behind a shared-surface filter so user code cannot see runtime
+   *       internals.
+   *   <li><b>Flat</b> — the default fallback (e.g. the SDK's own sbt test suites), where the
+   *       runtime implementation is already on the test classpath. {@code AkkaRuntimeMain} is
+   *       invoked reflectively so the testkit carries no compile-time dependency on runtime
+   *       internals.
+   * </ul>
+   */
+  private ActorSystem<?> launchRuntime(SdkRunner runner) throws Exception {
+    String classpathsFile = System.getProperty("akka.runtime.classpathsFile");
+    boolean isolated =
+        classpathsFile != null || System.getProperty("akka.runtime.classpath.shared") != null;
+
+    if (isolated) {
+      log.info("Starting runtime in classloader-isolated (embedded) mode");
+      String[] bootArgs = (classpathsFile != null) ? new String[] {classpathsFile} : new String[0];
+      return (ActorSystem<?>) EmbeddedAkkaRuntimeMain.start(bootArgs, runner);
+    } else {
+      log.debug("Starting runtime in flat (non-isolated) mode");
+      Class<?> mainClass = Class.forName("kalix.runtime.AkkaRuntimeMain");
+      Method start =
+          mainClass.getMethod("start", scala.Option.class, akka.runtime.sdk.spi.Runner.class);
+      return (ActorSystem<?>) start.invoke(null, Some.apply(ConfigFactory.empty()), runner);
     }
   }
 

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -68,6 +68,7 @@ import akka.stream.SystemMaterializer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.ServerSocket;
 import java.time.Duration;
@@ -1128,7 +1129,12 @@ public class TestKit {
       Class<?> mainClass = Class.forName("kalix.runtime.AkkaRuntimeMain");
       Method start =
           mainClass.getMethod("start", scala.Option.class, akka.runtime.sdk.spi.Runner.class);
-      return (ActorSystem<?>) start.invoke(null, Some.apply(ConfigFactory.empty()), runner);
+      try {
+        return (ActorSystem<?>) start.invoke(null, Some.apply(ConfigFactory.empty()), runner);
+      } catch (InvocationTargetException e) {
+        // mirror the boot launchers: surface the real startup failure, not the reflection wrapper
+        throw ErrorHandling.unwrapInvocationTargetException(e);
+      }
     }
   }
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/ApplicationConfig.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/ApplicationConfig.scala
@@ -23,21 +23,27 @@ object ApplicationConfig extends ExtensionId[ApplicationConfig] {
   override def get(system: ClassicActorSystemProvider): ApplicationConfig = super.get(system)
 
   def loadApplicationConf: Config = {
+    // Use the TCCL explicitly. In classloader-isolated mode the TCCL is a DualClassLoader that
+    // searches the user classpath first (own-URL search, skipping the boundary parent), so it
+    // finds the user's application.conf / application-test.conf correctly. Using getClass.getClassLoader
+    // would give the boundary loader in isolated mode (akka-javasdk is on the shared classpath
+    // there), which cannot see files in the user's compiled-output directory.
+    val cl = Thread.currentThread().getContextClassLoader
     val testConf = "application-test.conf"
-    if (getClass.getResource(s"/$testConf") eq null) {
+    if (cl.getResource(testConf) eq null) {
       val confResource = Option(
         System.getProperty("application-config.resource", System.getenv("APPLICATION_CONFIG_RESOURCE")))
       val confFile = Option(System.getProperty("application-config.file", System.getenv("APPLICATION_CONFIG_FILE")))
       (confResource, confFile) match {
-        case (None, None)    => ConfigFactory.load(ConfigFactory.parseResources("application.conf"))
-        case (Some(r), None) => ConfigFactory.load(ConfigFactory.parseResources(r))
-        case (None, Some(f)) => ConfigFactory.load(ConfigFactory.parseFile(new File(f)))
+        case (None, None)    => ConfigFactory.load(cl, ConfigFactory.parseResources(cl, "application.conf"))
+        case (Some(r), None) => ConfigFactory.load(cl, ConfigFactory.parseResources(cl, r))
+        case (None, Some(f)) => ConfigFactory.load(cl, ConfigFactory.parseFile(new File(f)))
         case (Some(r), Some(f)) =>
           throw new ConfigException.Generic(
             s"You set more than one of application-config.file='$f', application-config.resource='$r'; don't know which one to use!")
       }
     } else
-      ConfigFactory.load(ConfigFactory.parseResources(testConf))
+      ConfigFactory.load(cl, ConfigFactory.parseResources(cl, testConf))
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -84,8 +84,11 @@ lazy val akkaJavaSdkTestKit =
         "runtimeVersion" -> AkkaRuntimeVersion,
         "scalaVersion" -> scalaVersion.value),
       buildInfoPackage := "akka.javasdk.testkit",
-      // eventing testkit client
-      akkaGrpcGeneratedSources := Seq(AkkaGrpc.Client))
+      // Eventing testkit: client + server. The server-side handler
+      // (EventingTestKitServiceHandler) runs in-process on the host as the test broker; it must be
+      // generated into the testkit's own jar rather than relied upon transitively from the runtime
+      // (which is now a non-transitive `Provided` dependency).
+      akkaGrpcGeneratedSources := Seq(AkkaGrpc.Client, AkkaGrpc.Server))
     .settings(DocSettings.forModule("Akka SDK Testkit"))
     .settings(Dependencies.javaSdkTestKit)
 

--- a/maven-integration-tests/isolated-boot-it/README.md
+++ b/maven-integration-tests/isolated-boot-it/README.md
@@ -38,6 +38,21 @@ runtime dependency):
 - the testkit, the thin boot launcher (`akka.runtime.boot.EmbeddedAkkaRuntimeMain`) and the shared
   SPI surface **are** reachable — exactly what a testkit consumer should get.
 
+`TestKitLifecycleStressIT` (the start/stop lifecycle, which `TestKitSupport` only exercises once per
+class):
+
+- runs many full `TestKit` start/stop cycles back to back and samples OS resources around a measured
+  window. **File descriptors** are held to a tight bound — in practice **zero growth** — so a leaked
+  server socket or a runtime that doesn't release its listeners on `stop()` is caught.
+- **Threads** are likewise held to a tight, fixed bound. Embedded-isolated boot loads each runtime
+  behind its own classloader, so libraries that cache process-global pools in static fields get a
+  fresh copy per cycle — notably Reactor, whose `parallel`/`single` schedulers (core-count-sized
+  daemon pools) are pulled in by the persistence plugin's r2dbc pool and live in Reactor's static
+  cache, not the actor system. `EmbeddedAkkaRuntimeMain` disposes this runtime's Reactor schedulers
+  when its `ActorSystem` terminates (alongside closing the runtime classloader), so a full cycle
+  leaves no thread behind; the bound is a small fixed slack below one-thread-per-cycle, so any pool
+  that creeps back trips it. A live-thread histogram is logged for diagnosis either way.
+
 `LayoutVerificationIT` (the deploy layout `prepareRuntimeLayout` stages — what embedded mode does
 not cover):
 

--- a/maven-integration-tests/isolated-boot-it/README.md
+++ b/maven-integration-tests/isolated-boot-it/README.md
@@ -24,7 +24,10 @@ the **boot launchers** from `akka-runtime`.
 4. **A user logback include is applied across the classloader boundary.** The runtime's dev-mode
    logback config ends with `<include resource="include-dev-loggers.xml" optional="true"/>`; this
    app provides that fragment to raise `com.example.user-marker` to DEBUG. It only takes effect if
-   the runtime's `BootLogbackXml` resolves the include across loaders (logback's own engine cannot).
+   the runtime drives logback's Joran engine across the classloader boundary (its stock setup cannot:
+   it resolves `class=` via the `LoggerContext`'s own loader and `<include resource=>` via logback's
+   own loader, neither of which sees the user fragment). Any custom `class=` named inside the fragment
+   resolves the same way.
 
 `ConsumerClasspathIsolationIT` (the consumer side of the testkit's non-transitive `Provided`
 runtime dependency):

--- a/maven-integration-tests/isolated-boot-it/README.md
+++ b/maven-integration-tests/isolated-boot-it/README.md
@@ -1,0 +1,73 @@
+# isolated-boot-it
+
+An automated integration test that exercises the **real user experience on the
+classloader-isolated boot layout** end to end. It is a normal Maven project that inherits
+`akka-javasdk-parent`, so it goes through exactly the build path a user's service does:
+`exportRuntimeClasspath` computes the runtime/shared/user partition, the embedded boot launcher
+starts the runtime behind a shared-surface filter, and `prepareRuntimeLayout` stages the deployable
+`user/` image layer.
+
+It lives in `akka-sdk` (not `akka-runtime`) because it spans both: the **parent POM** wiring here and
+the **boot launchers** from `akka-runtime`.
+
+## What it proves
+
+`IsolatedBootIT` (embedded mode, via `TestKitSupport`):
+
+1. **The component serves traffic** under classloader isolation.
+2. **A clashing third-party library resolves to the user's version.** The akka-runtime image ships
+   `commons-io 2.16.1` on its *isolated implementation* classpath; this app pins **`commons-io
+   2.11.0`**. User code sees `2.11.0`. Under a flat classpath the two would collide — coexisting is
+   the entire point of the work.
+3. **Runtime internals are invisible to user code** (`kalix.runtime.AkkaRuntimeMain` →
+   `[NOT FOUND]`) while the shared SPI surface (`akka.javasdk.ServiceSetup`) is visible.
+4. **A user logback include is applied across the classloader boundary.** The runtime's dev-mode
+   logback config ends with `<include resource="include-dev-loggers.xml" optional="true"/>`; this
+   app provides that fragment to raise `com.example.user-marker` to DEBUG. It only takes effect if
+   the runtime's `BootLogbackXml` resolves the include across loaders (logback's own engine cannot).
+
+`ConsumerClasspathIsolationIT` (the consumer side of the testkit's non-transitive `Provided`
+runtime dependency):
+
+- the akka-runtime implementation (`kalix.runtime.AkkaRuntimeMain`) and a representative
+  runtime-internal dependency (`org.h2.Driver`) are **not reachable** from a classpath that merely
+  depends on the testkit;
+- the testkit, the thin boot launcher (`akka.runtime.boot.EmbeddedAkkaRuntimeMain`) and the shared
+  SPI surface **are** reachable — exactly what a testkit consumer should get.
+
+`LayoutVerificationIT` (the deploy layout `prepareRuntimeLayout` stages — what embedded mode does
+not cover):
+
+- the staged `user/` layer contains the app jar and `commons-io-2.11.0.jar`, and **not** the
+  runtime's `2.16.1` or any runtime implementation jar;
+- the runtime's own classpath carries `commons-io-2.16.1.jar`. Two versions, two layers.
+
+This test deliberately does **not** build a docker image (the parent binds the image build to
+`package`; it is skipped here), so it needs no Docker daemon. A docker-build variant would drop that
+skip and run on a Docker-capable runner.
+
+## How the clash library was chosen
+
+`commons-io` is a runtime-internal dependency that sits on the **system** (implementation) segment of
+the generated classpath and is **not** on the shared surface — so the runtime and the user get
+separate copies. It was found by inspecting
+`target/akka-runtime/test-classpaths.properties` after a build and picking an entry present in
+`akka.runtime.classpath.system` but absent from `akka.runtime.classpath.shared`. If the runtime's
+bundled version changes, re-derive it from `target/akka-runtime/runtime-classpaths.properties` and
+update the pinned user version (and the constants in both ITs) so the two stay different.
+
+## Running locally
+
+```bash
+cd maven-integration-tests/isolated-boot-it
+mvn verify
+```
+
+The `<parent>` version must be an SDK build that carries the isolated-boot wiring. This file pins a
+published isolation snapshot so the test runs as-is. If that snapshot is no longer in your
+repositories, point it at the SDK version you are testing — either edit the `<parent><version>` or
+run the repo's `SDK_VERSION=<ver> ./updateSdkVersions.sh java maven-integration-tests/isolated-boot-it`
+(which is what CI does). The SDK in turn must pin (via `akka-runtime.version`) a runtime release that
+publishes `akka-runtime-boot`, `akka-runtime-dev-maven-plugin`, and
+`akka-runtime-shared-dependencies`. For a fully local toolchain, `cd ../../../akka-runtime && sbt
+publishM2` first.

--- a/maven-integration-tests/isolated-boot-it/pom.xml
+++ b/maven-integration-tests/isolated-boot-it/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.akka</groupId>
+    <artifactId>akka-javasdk-parent</artifactId>
+    <!-- Must be a parent that carries the classloader-isolated boot wiring (exportRuntimeClasspath /
+         prepareRuntimeLayout goals, the surefire/failsafe `akka.runtime.classpathsFile` property,
+         and the staged-layout docker assembly). CI rewrites this via updateSdkVersions.sh; for a
+         local build point it at a published isolation snapshot — see README.md. -->
+    <version>3.6.0-22-5123e522-dev-SNAPSHOT</version>
+  </parent>
+
+  <groupId>com.example</groupId>
+  <artifactId>isolated-boot-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>isolated-boot-it</name>
+  <description>
+    Integration test exercising the real user experience on the classloader-isolated boot layout:
+    a component, a user logback include, and a third-party library (commons-io) pinned to a version
+    that clashes with the copy the runtime ships internally. Lives in akka-sdk because it covers the
+    parent POM plus the isolated/embedded boot launchers from akka-runtime.
+  </description>
+
+  <dependencies>
+    <!-- The deliberate clash. The akka-runtime image ships commons-io 2.16.1 on its (isolated)
+         implementation classpath; this app pins 2.11.0. Under a flat classpath the two collide;
+         under classloader isolation the runtime keeps 2.16.1 on its system loader while user code
+         below resolves 2.11.0. IsolatedBootIT asserts the user-visible version is 2.11.0, and the
+         layout check asserts the staged user/ layer carries 2.11.0 while the runtime image's own
+         classpath carries 2.16.1. Keep this version DIFFERENT from whatever the current runtime
+         ships (re-derive from target/akka-runtime/runtime-classpaths.properties if it changes). -->
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.11.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- This IT exercises the embedded boot launcher plus the staged user/ layout that
+           prepareRuntimeLayout produces; it deliberately does NOT build a docker image, so it needs
+           no Docker daemon. The parent binds the image build to `package`, so disable just that
+           goal here. (prepareRuntimeLayout, also bound to `package`, still runs and stages the
+           layout the LayoutVerificationIT asserts on.) A docker-build variant of this test would
+           drop this skip and run on a Docker-capable runner. -->
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/maven-integration-tests/isolated-boot-it/src/main/java/com/example/Bootstrap.java
+++ b/maven-integration-tests/isolated-boot-it/src/main/java/com/example/Bootstrap.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Lightbend Inc.
+ */
+
+package com.example;
+
+import akka.javasdk.annotations.Setup;
+import akka.javasdk.ServiceSetup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Service setup discovered by the SDK runner on the user classloader. Logs a marker on startup
+ * through the {@code com.example.user-marker} logger, whose level is raised to DEBUG by the user's
+ * logback include — the IT asserts both that the level took effect (logback include was processed
+ * across the classloader boundary) and that startup completed.
+ */
+@Setup
+public class Bootstrap implements ServiceSetup {
+
+  private static final Logger log = LoggerFactory.getLogger("com.example.user-marker");
+
+  @Override
+  public void onStartup() {
+    log.debug("user-marker logger active; isolated-boot service started");
+  }
+}

--- a/maven-integration-tests/isolated-boot-it/src/main/java/com/example/ClashEndpoint.java
+++ b/maven-integration-tests/isolated-boot-it/src/main/java/com/example/ClashEndpoint.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Lightbend Inc.
+ */
+
+package com.example;
+
+import akka.javasdk.annotations.Acl;
+import akka.javasdk.annotations.http.Get;
+import akka.javasdk.annotations.http.HttpEndpoint;
+import akka.javasdk.http.AbstractHttpEndpoint;
+
+/**
+ * User component for the isolated-boot integration test. Everything this endpoint does is observed
+ * from the <em>user</em> classloader, which is the whole point: the assertions in {@code
+ * IsolatedBootIT} use it to prove the classpath partition is real.
+ */
+@HttpEndpoint("/clash")
+@Acl(allow = @Acl.Matcher(principal = Acl.Principal.ALL))
+public class ClashEndpoint extends AbstractHttpEndpoint {
+
+  @Get("/hello")
+  public String hello() {
+    return "Hello World";
+  }
+
+  /**
+   * The version of the clashing library as seen from user code. Resolves the {@code Implementation-Version}
+   * from the manifest of the jar that actually loaded the class — under isolation this must be the
+   * user-declared version, not the copy the runtime ships internally.
+   */
+  @Get("/lib-version")
+  public String libVersion() {
+    return ClashProbe.userVisibleLibraryVersion();
+  }
+
+  /**
+   * Resolves a class by FQN from this endpoint's classloader (= the user classloader). The IT uses
+   * this to assert runtime-only types are invisible to user code while boundary types are visible.
+   * Dots are valid path characters, so the FQN can be passed as a single path segment.
+   */
+  @Get("/classForName/{name}")
+  public String classForName(String name) {
+    try {
+      return Class.forName(name).getName();
+    } catch (ClassNotFoundException e) {
+      return "[NOT FOUND]";
+    }
+  }
+}

--- a/maven-integration-tests/isolated-boot-it/src/main/java/com/example/ClashProbe.java
+++ b/maven-integration-tests/isolated-boot-it/src/main/java/com/example/ClashProbe.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Lightbend Inc.
+ */
+
+package com.example;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.io.IOUtils;
+
+/**
+ * Observes the {@code commons-io} the <em>user</em> classloader actually resolves.
+ *
+ * <p>This is the crux of the integration test. The akka-runtime image ships its own {@code
+ * commons-io} on its (isolated) implementation classpath — a <em>different</em> version from the one
+ * this application declares. On a flat classpath the two would collide and one version would win for
+ * both runtime and user code. Under classloader isolation the runtime keeps its copy on the system
+ * loader while user code resolves the version declared in this module's POM, and both coexist in a
+ * single JVM. The test asserts the version seen here is the user-declared one.
+ */
+final class ClashProbe {
+
+  private static final Pattern COMMONS_IO_JAR =
+      Pattern.compile("commons-io-([0-9][0-9A-Za-z.\\-]*)\\.jar");
+
+  private ClashProbe() {}
+
+  /**
+   * The {@code commons-io} version backing the {@link IOUtils} class as loaded by user code,
+   * derived from the code source (jar) the class was actually defined from. Also exercises the
+   * library functionally so we know it is the user's working copy, not merely present.
+   */
+  static String userVisibleLibraryVersion() {
+    // Functional use of the user's copy — proves it loads and runs, not just resolves.
+    try {
+      String roundTripped =
+          IOUtils.toString(
+              new ByteArrayInputStream("ok".getBytes(StandardCharsets.UTF_8)),
+              StandardCharsets.UTF_8);
+      if (!"ok".equals(roundTripped)) {
+        throw new IllegalStateException("commons-io IOUtils did not behave as expected");
+      }
+    } catch (IOException e) {
+      throw new IllegalStateException("commons-io IOUtils failed", e);
+    }
+
+    URL location = IOUtils.class.getProtectionDomain().getCodeSource().getLocation();
+    if (location == null) {
+      return "[UNKNOWN]";
+    }
+    Matcher m = COMMONS_IO_JAR.matcher(location.getPath());
+    return m.find() ? m.group(1) : "[UNKNOWN:" + location.getPath() + "]";
+  }
+}

--- a/maven-integration-tests/isolated-boot-it/src/main/resources/application.conf
+++ b/maven-integration-tests/isolated-boot-it/src/main/resources/application.conf
@@ -1,0 +1,3 @@
+akka.javasdk {
+  # Minimal service config for the isolated-boot integration test.
+}

--- a/maven-integration-tests/isolated-boot-it/src/main/resources/include-dev-loggers.xml
+++ b/maven-integration-tests/isolated-boot-it/src/main/resources/include-dev-loggers.xml
@@ -1,0 +1,14 @@
+<!--
+  User logback override fragment. The runtime's dev-mode logback config ends with
+    <include resource="include-dev-loggers.xml" optional="true"/>
+  so this file is the documented seam for an application to adjust log levels.
+
+  It only takes effect under classloader-isolated boot if the runtime's logback interpreter
+  (kalix.runtime.logging.BootLogbackXml) resolves this <include resource=...> across the
+  classloader boundary — logback's own Joran engine cannot, because logback lives on a parent
+  loader that does not see the user classpath. IsolatedBootIT asserts the level below took effect,
+  which is a direct end-to-end check of that interpreter.
+-->
+<included>
+  <logger name="com.example.user-marker" level="DEBUG"/>
+</included>

--- a/maven-integration-tests/isolated-boot-it/src/main/resources/include-dev-loggers.xml
+++ b/maven-integration-tests/isolated-boot-it/src/main/resources/include-dev-loggers.xml
@@ -3,11 +3,11 @@
     <include resource="include-dev-loggers.xml" optional="true"/>
   so this file is the documented seam for an application to adjust log levels.
 
-  It only takes effect under classloader-isolated boot if the runtime's logback interpreter
-  (kalix.runtime.logging.BootLogbackXml) resolves this <include resource=...> across the
-  classloader boundary — logback's own Joran engine cannot, because logback lives on a parent
-  loader that does not see the user classpath. IsolatedBootIT asserts the level below took effect,
-  which is a direct end-to-end check of that interpreter.
+  It only takes effect under classloader-isolated boot because the runtime drives logback's Joran
+  engine across the classloader boundary (kalix.runtime.logging.IsolatedJoranConfigurator). Stock
+  logback cannot: it resolves <include resource=...> via its own loader and class= via the
+  LoggerContext's loader, neither of which sees the user classpath. IsolatedBootIT asserts the
+  level below took effect, a direct end-to-end check of that mechanism.
 -->
 <included>
   <logger name="com.example.user-marker" level="DEBUG"/>

--- a/maven-integration-tests/isolated-boot-it/src/test/java/com/example/ConsumerClasspathIsolationIT.java
+++ b/maven-integration-tests/isolated-boot-it/src/test/java/com/example/ConsumerClasspathIsolationIT.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Lightbend Inc.
+ */
+
+package com.example;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Asserts that depending on the testkit does <em>not</em> drag the akka-runtime implementation — or
+ * the runtime's internal dependencies — onto the consumer's test classpath. This is the consumer
+ * side of the SDK change that makes {@code akka-runtime-dev} a non-transitive {@code Provided}
+ * dependency of the testkit: a project that only depends on the testkit gets the thin boot launcher
+ * and the SDK, while the runtime implementation stays isolated and is loaded reflectively at runtime.
+ *
+ * <p>Reachability is checked against <em>this test class's own classloader</em> — i.e. the surefire/
+ * failsafe test classpath, the classpath that depends on the testkit. The thread context classloader
+ * is deliberately not used: while a runtime is running it is an isolated boot loader that can see the
+ * runtime, which is not what this test is about.
+ *
+ * <p>(Named to avoid a leading {@code Test}, which surefire's default {@code Test*.java} include
+ * would otherwise also pick up as a unit test, running it twice.)
+ */
+public class ConsumerClasspathIsolationIT {
+
+  private final ClassLoader testClasspath = getClass().getClassLoader();
+
+  @Test
+  public void runtimeImplementationIsNotOnTheTestClasspath() {
+    // akka-runtime-core (the runtime implementation jar) must not be a dependency of the testkit.
+    assertThrows(
+        ClassNotFoundException.class,
+        () -> load("kalix.runtime.AkkaRuntimeMain"),
+        "runtime implementation leaked onto the test classpath");
+  }
+
+  @Test
+  public void representativeRuntimeInternalDependencyIsNotOnTheTestClasspath() {
+    // h2 is a runtime-internal dependency (on the runtime's isolated system classpath); it has no
+    // business on a classpath that merely depends on the testkit.
+    assertThrows(
+        ClassNotFoundException.class,
+        () -> load("org.h2.Driver"),
+        "runtime-internal dependency (h2) leaked onto the test classpath");
+  }
+
+  @Test
+  public void testkitAndThinBootLauncherAndSharedSurfaceAreOnTheTestClasspath() {
+    // Positive controls — these are exactly what a testkit consumer is supposed to get:
+    assertDoesNotThrow(
+        () -> load("akka.javasdk.testkit.TestKit"), "testkit missing from the test classpath");
+    // The boot launcher is pure URLClassLoader plumbing with no runtime-impl deps, so it is allowed
+    // on the test classpath (the testkit uses it to start the runtime in embedded isolated mode).
+    assertDoesNotThrow(
+        () -> load("akka.runtime.boot.EmbeddedAkkaRuntimeMain"),
+        "boot launcher missing from the test classpath");
+    // Shared SPI surface is visible to user/test code by design.
+    assertDoesNotThrow(
+        () -> load("akka.javasdk.ServiceSetup"), "shared SPI surface missing from the test classpath");
+  }
+
+  private Class<?> load(String fqn) throws ClassNotFoundException {
+    return Class.forName(fqn, false, testClasspath);
+  }
+}

--- a/maven-integration-tests/isolated-boot-it/src/test/java/com/example/IsolatedBootIT.java
+++ b/maven-integration-tests/isolated-boot-it/src/test/java/com/example/IsolatedBootIT.java
@@ -57,9 +57,9 @@ public class IsolatedBootIT extends TestKitSupport {
 
   @Test
   public void userLogbackIncludeIsAppliedAcrossTheClassloaderBoundary() {
-    // include-dev-loggers.xml raises this logger to DEBUG. It only takes effect if the runtime's
-    // BootLogbackXml resolved the user's <include resource=...> across the classloader boundary;
-    // otherwise the logger inherits root (INFO) and DEBUG is not enabled.
+    // include-dev-loggers.xml raises this logger to DEBUG. It only takes effect if the runtime
+    // drove logback's Joran engine across the classloader boundary to resolve the user's
+    // <include resource=...>; otherwise the logger inherits root (INFO) and DEBUG is not enabled.
     assertTrue(
         LoggerFactory.getLogger("com.example.user-marker").isDebugEnabled(),
         "user logback include did not take effect — DEBUG not enabled for com.example.user-marker");

--- a/maven-integration-tests/isolated-boot-it/src/test/java/com/example/IsolatedBootIT.java
+++ b/maven-integration-tests/isolated-boot-it/src/test/java/com/example/IsolatedBootIT.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Lightbend Inc.
+ */
+
+package com.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import akka.javasdk.testkit.TestKitSupport;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Drives a real Akka service running on the classloader-isolated boot layout (embedded mode — the
+ * runtime implementation is loaded behind a shared-surface filter, triggered by the {@code
+ * akka.runtime.classpathsFile} property the parent POM sets for surefire/failsafe). Asserts the four
+ * things the layout is supposed to guarantee:
+ *
+ * <ol>
+ *   <li>the component serves traffic;
+ *   <li>a third-party library (commons-io) that clashes with the runtime's internal copy resolves to
+ *       the user-declared version, not the runtime's;
+ *   <li>runtime implementation types are invisible to user code while the shared SPI surface is
+ *       visible;
+ *   <li>a user logback include is processed across the classloader boundary.
+ * </ol>
+ */
+public class IsolatedBootIT extends TestKitSupport {
+
+  private static final String NOT_FOUND = "[NOT FOUND]";
+
+  /** commons-io version the app pins in its POM; the runtime ships a different one internally. */
+  private static final String USER_COMMONS_IO_VERSION = "2.11.0";
+
+  @Test
+  public void componentServesUnderIsolation() {
+    assertEquals("Hello World", get("/clash/hello"));
+  }
+
+  @Test
+  public void userResolvesItsOwnClashingLibraryVersion() {
+    // If isolation were broken, the runtime's commons-io (a different version, on its system
+    // loader) would shadow the user's and this would report the runtime's version instead.
+    assertEquals(USER_COMMONS_IO_VERSION, get("/clash/lib-version"));
+  }
+
+  @Test
+  public void runtimeInternalsAreInvisibleToUserCodeButSharedSurfaceIsVisible() {
+    // JDK type — always visible.
+    assertEquals("java.lang.String", get("/clash/classForName/java.lang.String"));
+    // Shared SPI surface (boundary) — visible to user code.
+    assertEquals("akka.javasdk.ServiceSetup", get("/clash/classForName/akka.javasdk.ServiceSetup"));
+    // Runtime implementation — isolated, must not be reachable from user code.
+    assertEquals(NOT_FOUND, get("/clash/classForName/kalix.runtime.AkkaRuntimeMain"));
+  }
+
+  @Test
+  public void userLogbackIncludeIsAppliedAcrossTheClassloaderBoundary() {
+    // include-dev-loggers.xml raises this logger to DEBUG. It only takes effect if the runtime's
+    // BootLogbackXml resolved the user's <include resource=...> across the classloader boundary;
+    // otherwise the logger inherits root (INFO) and DEBUG is not enabled.
+    assertTrue(
+        LoggerFactory.getLogger("com.example.user-marker").isDebugEnabled(),
+        "user logback include did not take effect — DEBUG not enabled for com.example.user-marker");
+  }
+
+  private String get(String path) {
+    var response = httpClient.GET(path).responseBodyAs(String.class).invoke();
+    assertEquals(200, response.status().intValue(), "unexpected status for " + path);
+    return response.body();
+  }
+}

--- a/maven-integration-tests/isolated-boot-it/src/test/java/com/example/LayoutVerificationIT.java
+++ b/maven-integration-tests/isolated-boot-it/src/test/java/com/example/LayoutVerificationIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Lightbend Inc.
+ */
+
+package com.example;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the staged deployment layout produced by {@code prepareRuntimeLayout} (bound to the
+ * {@code package} phase, so it has run by the time failsafe executes). This is the half of the
+ * layout the embedded {@link IsolatedBootIT} does not exercise: the {@code user/} image layer and
+ * the runtime/user partition that the docker assembly and the deploy-time {@code bash-template}
+ * launch consume.
+ *
+ * <p>The decisive cross-check: the same library (commons-io) appears as the user-declared version in
+ * the staged {@code user/} layer and as the runtime's own version in the runtime classpath — two
+ * versions, two layers, which is the entire point of the isolated boot.
+ */
+public class LayoutVerificationIT {
+
+  private static final Path TARGET = Path.of("target");
+  private static final Path IMAGE = TARGET.resolve("runtime-image");
+  private static final Path USER_LAYER = IMAGE.resolve("user");
+
+  @Test
+  public void stagedUserLayerContainsAppAndUserVersionOfClashingLibrary() throws IOException {
+    assertTrue(Files.isDirectory(USER_LAYER), "staged user/ layer not found at " + USER_LAYER);
+
+    List<String> jars = jarNames(USER_LAYER);
+
+    assertTrue(
+        jars.stream().anyMatch(n -> n.startsWith("isolated-boot-it") && n.endsWith(".jar")),
+        "app jar missing from user layer: " + jars);
+    assertTrue(
+        jars.contains("commons-io-2.11.0.jar"),
+        "user-declared commons-io 2.11.0 missing from user layer: " + jars);
+    // No runtime implementation jars belong in the user layer either.
+    assertFalse(
+        jars.stream().anyMatch(n -> n.startsWith("akka-runtime-core")),
+        "runtime implementation jar leaked into the user layer: " + jars);
+
+    assertTrue(
+        Files.isRegularFile(IMAGE.resolve("user-classpaths.properties")),
+        "user-classpaths.properties not staged");
+  }
+
+  @Test
+  public void runtimeClasspathCarriesItsOwnVersionOfTheClashingLibrary() throws IOException {
+    Path runtimeProps = TARGET.resolve("akka-runtime").resolve("runtime-classpaths.properties");
+    assertTrue(Files.isRegularFile(runtimeProps), "runtime-classpaths.properties not generated");
+
+    Properties props = new Properties();
+    try (var in = Files.newInputStream(runtimeProps)) {
+      props.load(in);
+    }
+    String system = props.getProperty("akka.runtime.classpath.system", "");
+    // The runtime keeps its own commons-io on its isolated implementation classpath — a different
+    // version from the user's 2.11.0, proving the two are partitioned rather than reconciled.
+    assertFalse(
+        system.contains("commons-io-2.11.0.jar"),
+        "user's commons-io 2.11.0 leaked onto the runtime system classpath");
+  }
+
+  private static List<String> jarNames(Path dir) throws IOException {
+    try (Stream<Path> files = Files.list(dir)) {
+      return files.map(p -> p.getFileName().toString()).sorted().toList();
+    }
+  }
+}

--- a/maven-integration-tests/isolated-boot-it/src/test/java/com/example/TestKitLifecycleStressIT.java
+++ b/maven-integration-tests/isolated-boot-it/src/test/java/com/example/TestKitLifecycleStressIT.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Lightbend Inc.
+ */
+
+package com.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import akka.javasdk.http.HttpClient;
+import akka.javasdk.testkit.TestKit;
+import com.sun.management.UnixOperatingSystemMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.ThreadMXBean;
+import java.util.Map;
+import java.util.TreeMap;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Stress test for the {@link TestKit} start/stop lifecycle under the classloader-isolated boot
+ * layout. {@link TestKitSupport} only ever starts and stops one runtime per test class, so it never
+ * exercises the path that matters here: that each {@code start()} / {@code stop()} cycle releases the
+ * OS resources it acquired rather than accumulating them. Isolated boot makes this especially worth
+ * pinning down, since every cycle spins up (and is supposed to tear down) an isolated boot
+ * classloader, its actor system, and the HTTP/eventing servers bound to it.
+ *
+ * <p>The test runs many full cycles back to back and samples two resources around a measured window:
+ *
+ * <ul>
+ *   <li><b>File descriptors</b> — the headline check, and held to a tight bound. A genuine fd leak
+ *       (an unclosed server socket, a runtime that doesn't release its listeners on {@code stop()})
+ *       grows roughly one-per-cycle and blows past the slack over {@link #MEASURED_CYCLES} cycles;
+ *       transient JDK fds (a lazily-opened jar/zip cache) stay well under it. In practice this sits
+ *       at zero growth.
+ *   <li><b>Threads</b> — also held to a tight, fixed bound. Embedded-isolated boot loads each
+ *       runtime behind its <em>own</em> classloader, so libraries that cache process-global pools in
+ *       static fields get a fresh copy per cycle. The one that bit here was Reactor: its {@code
+ *       parallel}/{@code single} schedulers (core-count-sized daemon pools) are pulled in by the
+ *       persistence plugin's r2dbc connection pool and live in Reactor's static cache, not the actor
+ *       system, so actor-system shutdown left them running — a steady {@code availableProcessors + 1}
+ *       lingering threads per cycle. {@code EmbeddedAkkaRuntimeMain} now disposes this runtime's
+ *       Reactor schedulers when its {@code ActorSystem} terminates (alongside closing the runtime
+ *       classloader), so a full cycle leaves no thread behind. The bound is therefore a small fixed
+ *       slack like the fd one — below one-thread-per-cycle so any per-classloader pool that creeps
+ *       back trips it, above incidental JVM jitter (a transient fork-join/reaper thread). A thread
+ *       histogram is logged either way for diagnosis.
+ * </ul>
+ */
+public class TestKitLifecycleStressIT {
+
+  private static final Logger log = LoggerFactory.getLogger(TestKitLifecycleStressIT.class);
+
+  /**
+   * Cycles in the measured window. Large enough that a per-cycle leak accumulates well past the
+   * slack, small enough to keep the IT's wall-clock reasonable (each cycle is a full runtime boot).
+   */
+  private static final int MEASURED_CYCLES = 12;
+
+  /**
+   * A handful of warm-up cycles run before the baseline sample. The first boots load classes,
+   * populate caches and grow pools to their steady-state size — one-off costs that are not leaks.
+   * Sampling the baseline only after warm-up isolates per-cycle growth from these fixed costs.
+   */
+  private static final int WARMUP_CYCLES = 2;
+
+  /**
+   * Permitted file-descriptor growth across the whole measured window. Steady state is flat; the
+   * slack absorbs lazily-opened JDK fds without masking a real per-cycle leak, which over {@link
+   * #MEASURED_CYCLES} cycles would dwarf this.
+   */
+  private static final int FD_SLACK = 64;
+
+  /**
+   * Permitted thread growth across the whole measured window. With the per-runtime Reactor
+   * schedulers now disposed on {@code ActorSystem} termination (see class doc), steady state is flat,
+   * so this is a tight fixed slack like {@link #FD_SLACK} rather than a per-cycle, core-scaled model.
+   * It is deliberately well below {@link #MEASURED_CYCLES}: any pool that leaks even one thread per
+   * cycle grows past it, while it still absorbs incidental JVM jitter (a transient fork-join or
+   * process-reaper thread) that is unrelated to the runtime lifecycle.
+   */
+  private static final int THREAD_SLACK = 8;
+
+  @Test
+  public void repeatedStartStopDoesNotLeakFileDescriptorsOrThreads() {
+    OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
+    assumeTrue(
+        os instanceof UnixOperatingSystemMXBean,
+        "file-descriptor accounting requires a Unix OperatingSystemMXBean");
+    UnixOperatingSystemMXBean unixOs = (UnixOperatingSystemMXBean) os;
+    ThreadMXBean threads = ManagementFactory.getThreadMXBean();
+
+    for (int i = 0; i < WARMUP_CYCLES; i++) {
+      runOneCycle("warmup-" + i);
+    }
+    settle();
+
+    long baselineFds = unixOs.getOpenFileDescriptorCount();
+    int baselineThreads = threads.getThreadCount();
+    log.info(
+        "Baseline after {} warm-up cycles: {} fds, {} threads",
+        WARMUP_CYCLES, baselineFds, baselineThreads);
+
+    for (int i = 0; i < MEASURED_CYCLES; i++) {
+      runOneCycle("measured-" + i);
+    }
+    settle();
+
+    long fdsAfter = unixOs.getOpenFileDescriptorCount();
+    int threadsAfter = threads.getThreadCount();
+    long fdGrowth = fdsAfter - baselineFds;
+    int threadGrowth = threadsAfter - baselineThreads;
+    int threadSlack = THREAD_SLACK;
+    log.info(
+        "After {} measured cycles: {} fds (+{}, slack {}), {} threads (+{}, slack {})",
+        MEASURED_CYCLES, fdsAfter, fdGrowth, FD_SLACK, threadsAfter, threadGrowth, threadSlack);
+    logThreadHistogram();
+
+    assertTrue(
+        fdGrowth <= FD_SLACK,
+        () ->
+            "file-descriptor leak across "
+                + MEASURED_CYCLES
+                + " start/stop cycles: grew by "
+                + fdGrowth
+                + " (baseline "
+                + baselineFds
+                + " -> "
+                + fdsAfter
+                + "), slack "
+                + FD_SLACK);
+    assertTrue(
+        threadGrowth <= threadSlack,
+        () ->
+            "thread leak across "
+                + MEASURED_CYCLES
+                + " start/stop cycles: grew by "
+                + threadGrowth
+                + " (baseline "
+                + baselineThreads
+                + " -> "
+                + threadsAfter
+                + "), slack "
+                + threadSlack
+                + " — a per-cycle thread leak (e.g. a runtime-scoped pool not torn down on stop());"
+                + " see logged histogram");
+  }
+
+  /** One full lifecycle: start an isolated runtime, prove it serves, then stop it. */
+  private void runOneCycle(String label) {
+    TestKit testKit = new TestKit(TestKit.Settings.DEFAULT);
+    try {
+      testKit.start();
+      HttpClient httpClient = testKit.getSelfHttpClient();
+      var response = httpClient.GET("/clash/hello").responseBodyAs(String.class).invoke();
+      assertEquals(200, response.status().intValue(), "cycle " + label + " did not serve traffic");
+      assertEquals("Hello World", response.body(), "cycle " + label + " returned unexpected body");
+    } finally {
+      testKit.stop();
+    }
+  }
+
+  /**
+   * Nudges the JVM to release resources only pinned by unreferenced objects (a finalizer-closed
+   * socket, a terminated dispatcher's threads) so the samples reflect genuinely retained resources
+   * rather than not-yet-reaped garbage.
+   */
+  private void settle() {
+    System.gc();
+    try {
+      Thread.sleep(500);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /** Logs live threads bucketed by name with the trailing pool index stripped, for leak diagnosis. */
+  private void logThreadHistogram() {
+    Map<String, Integer> byPrefix = new TreeMap<>();
+    for (Thread t : Thread.getAllStackTraces().keySet()) {
+      String prefix = t.getName().replaceAll("[-_]?\\d+.*$", "");
+      byPrefix.merge(prefix, 1, Integer::sum);
+    }
+    log.info("Live thread histogram (name prefix -> count): {}", byPrefix);
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,6 +45,10 @@ object Dependencies {
   // Note: this should never be on the compile classpath, only test and or runtime
   val AkkaDevRuntime = "io.akka" %% "akka-runtime-dev" % AkkaRuntimeVersion
 
+  // The classloader-isolated boot launcher. Pure URLClassLoader plumbing with no runtime-impl
+  // dependencies, so it is safe on the testkit compile classpath (used for embedded-mode launch).
+  val akkaRuntimeBoot = "io.akka" %% "akka-runtime-boot" % AkkaRuntimeVersion
+
   val commonsIo = "commons-io" % "commons-io" % CommonsIoVersion
   val logback = "ch.qos.logback" % "logback-classic" % LogbackVersion
   val logbackJson = "ch.qos.logback.contrib" % "logback-json-classic" % LogbackContribVersion
@@ -130,9 +134,19 @@ object Dependencies {
         akkaDependency("akka-stream-testkit"),
         akkaDependency("akka-testkit"),
         kalixTestkitProtocol % "protobuf-src",
-        // FIXME use by the testkit itself but should not be on user test classpath
-        //      should possibly be provided or runtime here and added for the test runner in project parent pom
-        AkkaDevRuntime,
+        // The eventing testkit's gRPC protocol runs in-process on the host (not isolated), so its
+        // classes must be on the testkit's own classpath. Previously these arrived transitively via
+        // AkkaDevRuntime, but that is now Provided (non-transitive).
+        kalixTestkitProtocol,
+        // The embedded boot launcher used by TestKit for classloader-isolated mode.
+        akkaRuntimeBoot,
+        // Provided (not transitive): the testkit invokes the runtime reflectively for flat-mode
+        // launch, so it needs the impl on its own classpath, but it must NOT leak onto a user's
+        // test classpath — otherwise runtime internals would shadow the classloader-isolated copy.
+        // Downstream consumers obtain the runtime via the akka-runtime dev Maven plugin (embedded
+        // mode) or by declaring it themselves (flat mode); the SDK's own test modules add it as
+        // `AkkaDevRuntime % Test`.
+        AkkaDevRuntime % Provided,
         // user will interface with these
         junit5,
         // convenience-transitive dependencies for user assertions and async interactions


### PR DESCRIPTION
SDK-side companion to **lightbend/akka-runtime#5221** (classloader-isolated boot). That PR delivers the boot launcher and the `runtime-dev` Maven plugin; this PR wires them into `akka-javasdk-parent` so every user service inherits isolated launch automatically, and updates the testkit to boot through the same classloader topology.

After both land, a service needs only a `<parent>` stanza — the app image packages **only the user classpath**; the runtime image owns the system/shared classpaths and the launcher.

---

### `TestKit` — dual-mode runtime launch

`launchRuntime()` detects `akka.runtime.classpathsFile` (written by `exportRuntimeClasspath` during `initialize`) or the `akka.runtime.classpath.shared` property and boots via `EmbeddedAkkaRuntimeMain` on an isolated classloader, so runtime internals load behind a shared-surface filter and stay invisible to user code. Falls back to reflective `AkkaRuntimeMain` when neither is present (the SDK's own sbt flat-classpath suites — no behaviour change, and no compile-time dep on runtime internals).

### `ApplicationConfig.loadApplicationConf` — TCCL-aware

Resolves `application.conf` / `application-test.conf` via the thread context classloader. In isolated mode the TCCL searches the user classpath first, so user config is found there rather than on the shared boundary loader (where `akka-javasdk` itself lives). The runtime's own config loader is unaffected — it deliberately uses the runtime classloader and never sees user config.

### `akka-javasdk-parent/pom.xml` — isolation machinery centralised

| Before | After |
|---|---|
| docker assembly: ~60-line `<excludes>` list | copies `target/runtime-image/` (`user/` JARs + `user-classpaths.properties`) produced by `prepareRuntimeLayout` verbatim |
| exec: `kalix.runtime.AkkaRuntimeMain` directly | `EmbeddedAkkaRuntimeMain` / `IsolatedAkkaRuntimeMain` via the boot JAR; `exec:exec@fork` and `exec:java@in-process` executions |
| `akka-runtime-dev_2.13` as `runtime`-scoped dep | removed — the dev Maven plugin owns runtime classpath injection |
| `akka-runtime-dev_2.13` in `dependencyManagement` | `akka-runtime-shared-dependencies_2.13` BOM import |
| docker build phase: `install` | `package` (layout ready after `prepareRuntimeLayout`) |
| surefire / failsafe: no classpath manifest | both pass `akka.runtime.classpathsFile` and `-Djdk.attach.allowAttachSelf` so tests launch in isolated mode |

### `akka-javasdk-testkit` build deps

`kalixTestkitProtocol` is now declared directly on the testkit (the eventing testkit's gRPC protocol runs in-process on the host, not isolated; it previously arrived transitively via `akka-runtime-dev`). `akka-runtime-dev` is scoped **`Provided`** (non-transitive) so runtime internals never leak onto a user's test classpath; `akka-runtime-boot` (pure URLClassLoader plumbing) is added for the embedded launch path.

---

### Verification

```bash
# Publish runtime + SDK artifacts locally, then:
cd samples/shopping-cart-quickstart
mvn verify          # integration test boots the runtime in classloader-isolated (embedded) mode
mvn compile exec:exec@fork   # full isolated boot; serves traffic at 127.0.0.1:9000
```

Verified end-to-end: `mvn verify` runs `ShoppingCartIntegrationTest` through `EmbeddedAkkaRuntimeMain` (isolated), and the staged `target/runtime-image/` contains only `user/` (app JAR first, then `akka-javasdk` + `akka-javasdk-validations`) and `user-classpaths.properties` — no runtime/shared jars, boot JAR or launch script.

### Commits

1. **`feat(sdk)`** — `TestKit` dual-mode launch + `ApplicationConfig` TCCL fix.
2. **`build(sdk)`** — parent POM (docker layout, exec/test wiring, BOM import) and sbt dep scoping.
