### PR TITLE
feat: resolve Scala lambdas in MethodRefResolver via ASM bytecode inspection

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/MethodRefResolver.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/MethodRefResolver.scala
@@ -4,13 +4,25 @@
 
 package akka.javasdk.impl.client
 
+import java.io.InputStream
 import java.lang.invoke.SerializedLambda
 import java.lang.reflect.Method
+
+import scala.jdk.CollectionConverters._
+
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.MethodInsnNode
 
 private[impl] object MethodRefResolver {
 
   /**
    * Resolve the method ref for a lambda.
+   *
+   * Java method references resolve directly via SerializedLambda. Scala lambdas always wrap the call in a synthetic
+   * $anonfun$ method; in that case we read the bytecode of that method to locate the single delegated call and return
+   * the real target method.
    */
   def resolveMethodRef(lambda: Any): Method = {
     val lambdaType = lambda.getClass
@@ -45,8 +57,60 @@ private[impl] object MethodRefResolver {
     val argumentClasses = getArgumentClasses(lambdaType.getClassLoader, serializedLambda.getImplMethodSignature)
     if (serializedLambda.getImplClass.equals("<init>")) {
       throw new IllegalArgumentException("Passed in method ref is a constructor.")
+    } else if (serializedLambda.getImplMethodName.startsWith("$anonfun$")) {
+      // Scala lambda: the impl method is a synthetic $anonfun$ wrapper in the enclosing class.
+      // We inspect its bytecode to find the single delegated method call.
+      resolveScalaLambdaDelegate(
+        lambdaType.getClassLoader,
+        serializedLambda.getImplClass,
+        serializedLambda.getImplMethodName)
     } else {
       ownerClass.getDeclaredMethod(serializedLambda.getImplMethodName, argumentClasses: _*)
+    }
+  }
+
+  // Reads the bytecode of the synthetic $anonfun$ method and finds the single INVOKEVIRTUAL /
+  // INVOKEINTERFACE instruction that represents the real target method.
+  private def resolveScalaLambdaDelegate(
+      classLoader: ClassLoader,
+      implClass: String,
+      implMethodName: String): Method = {
+    val stream: InputStream = classLoader.getResourceAsStream(implClass + ".class")
+    if (stream == null)
+      throw new IllegalArgumentException(s"Cannot load bytecode for $implClass to resolve Scala lambda")
+
+    val classBytes =
+      try stream.readAllBytes()
+      finally stream.close()
+
+    val classNode = new ClassNode()
+    new ClassReader(classBytes).accept(classNode, ClassReader.SKIP_FRAMES | ClassReader.SKIP_DEBUG)
+
+    val lambdaMethod = classNode.methods.asScala
+      .find(_.name == implMethodName)
+      .getOrElse(throw new IllegalArgumentException(
+        s"Cannot find synthetic lambda method '$implMethodName' in class $implClass"))
+
+    val delegateCalls = lambdaMethod.instructions.toArray.collect {
+      case insn: MethodInsnNode
+          if (insn.getOpcode == Opcodes.INVOKEVIRTUAL || insn.getOpcode == Opcodes.INVOKEINTERFACE)
+            && insn.owner != "java/lang/Object" =>
+        insn
+    }
+
+    if (delegateCalls.length != 1)
+      throw new IllegalArgumentException(
+        s"Scala lambda body must contain exactly one virtual method call to be resolved as a method " +
+        s"reference, found ${delegateCalls.length}. Use a simple method reference: entity => entity.someMethod()")
+
+    val target = delegateCalls.head
+    val targetClass = loadClass(classLoader, target.owner)
+    val targetArgClasses = getArgumentClasses(classLoader, target.desc)
+    try {
+      targetClass.getDeclaredMethod(target.name, targetArgClasses: _*)
+    } catch {
+      case e: NoSuchMethodException =>
+        throw new IllegalArgumentException(s"Could not find method '${target.name}' in ${targetClass.getName}", e)
     }
   }
 

--- a/akka-javasdk/src/test/java/akka/javasdk/impl/client/MethodRefResolverTest.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/impl/client/MethodRefResolverTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import akka.japi.function.Function;
+import akka.japi.function.Function2;
+import org.junit.jupiter.api.Test;
+
+class MethodRefResolverTest {
+
+  static class SomeEntity {
+    public String getState() {
+      return "state";
+    }
+
+    public String processCommand(String cmd) {
+      return cmd;
+    }
+  }
+
+  @Test
+  void resolveNoArgJavaMethodRef() throws Exception {
+    // Java method reference: SerializedLambda.implMethodName = "getState" (no $anonfun$ wrapper)
+    Function<SomeEntity, String> ref = SomeEntity::getState;
+    var method = MethodRefResolver.resolveMethodRef(ref);
+    assertThat(method.getName()).isEqualTo("getState");
+    assertThat(method.getDeclaringClass()).isEqualTo(SomeEntity.class);
+    assertThat(method.getParameterCount()).isEqualTo(0);
+  }
+
+  @Test
+  void resolveOneArgJavaMethodRef() throws Exception {
+    // Java method reference with the entity as first arg and a command as second arg
+    Function2<SomeEntity, String, String> ref = SomeEntity::processCommand;
+    var method = MethodRefResolver.resolveMethodRef(ref);
+    assertThat(method.getName()).isEqualTo("processCommand");
+    assertThat(method.getDeclaringClass()).isEqualTo(SomeEntity.class);
+    assertThat(method.getParameterTypes()).containsExactly(String.class);
+  }
+
+  @Test
+  void rejectNonSerializable() {
+    // java.util.function.Function is not Serializable
+    assertThatThrownBy(
+            () ->
+                MethodRefResolver.resolveMethodRef(
+                    (java.util.function.Function<SomeEntity, String>) SomeEntity::getState))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("serializable");
+  }
+}

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/client/MethodRefResolverSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/client/MethodRefResolverSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl.client
+
+import akka.japi.{ function => jfn }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+object MethodRefResolverSpec {
+  class SomeEntity {
+    def getState: String = "state"
+    def processCommand(cmd: String): String = cmd
+  }
+}
+
+class MethodRefResolverSpec extends AnyWordSpec with Matchers {
+  import MethodRefResolverSpec._
+
+  "MethodRefResolver" should {
+
+    "resolve a Scala lambda with no args to the underlying method" in {
+      // Scala always wraps the call in a synthetic $anonfun$ method; we read the bytecode to find
+      // the real target.
+      val ref: jfn.Function[SomeEntity, String] = _.getState
+      val method = MethodRefResolver.resolveMethodRef(ref)
+      method.getName shouldBe "getState"
+      method.getDeclaringClass shouldBe classOf[SomeEntity]
+      method.getParameterCount shouldBe 0
+    }
+
+    "resolve a Scala lambda with one arg to the underlying method" in {
+      val ref: jfn.Function2[SomeEntity, String, String] = _.processCommand(_)
+      val method = MethodRefResolver.resolveMethodRef(ref)
+      method.getName shouldBe "processCommand"
+      method.getDeclaringClass shouldBe classOf[SomeEntity]
+      method.getParameterTypes shouldBe Array(classOf[String])
+    }
+
+    "reject a Scala lambda with multiple method calls" in {
+      val ref: jfn.Function[SomeEntity, String] = e => e.getState + e.processCommand("x")
+      an[IllegalArgumentException] should be thrownBy MethodRefResolver.resolveMethodRef(ref)
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,6 +36,8 @@ object Dependencies {
   val OpenTelemetryVersion = "1.57.0"
   val OpenTelemetrySemConv = "1.34.0"
 
+  val AsmVersion = "9.7"
+
   val CommonsIoVersion = "2.11.0"
   val MunitVersion = "0.7.29"
 
@@ -76,6 +78,8 @@ object Dependencies {
 
   val typesafeConfig = "com.typesafe" % "config" % "1.4.6"
   val protobufJavaUtil = "com.google.protobuf" % "protobuf-java-util" % GoogleProtobufVersion
+  val asm = "org.ow2.asm" % "asm" % AsmVersion
+  val asmTree = "org.ow2.asm" % "asm-tree" % AsmVersion
 
   private val deps = libraryDependencies
 
@@ -118,6 +122,8 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-http-core" % AkkaHttpVersion,
     akkaDependency("akka-stream"),
     akkaDependency("akka-actor-typed") % Provided,
+    asm,
+    asmTree,
     "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,
     junit5 % Test,
     "org.assertj" % "assertj-core" % "3.24.2" % Test)


### PR DESCRIPTION
Scala lambdas always wrap the target call in a synthetic `anonfun` method,
so `SerializedLambda.getImplMethodName` points to that wrapper rather than the
real method. We now detect this case and use ASM to read the enclosing class's
bytecode, find the single `INVOKEVIRTUAL`/`INVOKEINTERFACE` in the wrapper, and
return the real target Method.

- Add org.ow2.asm:asm + asm-tree 9.7 to akka-javasdk dependencies
- Extend MethodRefResolver with Scala lambda unwrapping via resolveScalaLambdaDelegate
- Add Java unit tests for existing method-reference behaviour (MethodRefResolverTest)
- Add Scala unit tests for the new Scala lambda resolution (MethodRefResolverSpec)

References #1560

