### PR TITLE
feat: support for multi-content tool response

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SessionMemoryEntityTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SessionMemoryEntityTest.java
@@ -20,6 +20,7 @@ import akka.javasdk.agent.SessionMessage;
 import akka.javasdk.agent.SessionMessage.AiMessage;
 import akka.javasdk.agent.SessionMessage.MessageContent.ImageUriMessageContent;
 import akka.javasdk.agent.SessionMessage.MessageContent.TextMessageContent;
+import akka.javasdk.agent.SessionMessage.MultimodalToolCallResponse;
 import akka.javasdk.agent.SessionMessage.MultimodalUserMessage;
 import akka.javasdk.agent.SessionMessage.TokenUsage;
 import akka.javasdk.agent.SessionMessage.UserMessage;
@@ -178,6 +179,53 @@ public class SessionMemoryEntityTest {
 
     // then
     assertThat(historyResult.getReply().messages()).containsExactly(userMessage, aiMessage);
+  }
+
+  @Test
+  public void shouldAddMultimodalToolResponseToHistory() {
+    // given
+    var testKit =
+        EventSourcedTestKit.of(
+            (context) -> new SessionMemoryEntity(config, context, agentRegistryEmpty));
+    var timestamp = Instant.now();
+    UserMessage userMessage = new UserMessage(timestamp, "show me the chart", COMPONENT_ID);
+    SessionMessage.MessageContent text = new TextMessageContent("here is the chart");
+    SessionMessage.MessageContent image =
+        new ImageUriMessageContent(
+            "object://charts/q1.png",
+            MessageContent.ImageMessageContent.DetailLevel.AUTO,
+            Optional.of("image/png"));
+    var contents = List.of(text, image);
+    var toolResponse =
+        new MultimodalToolCallResponse(timestamp, COMPONENT_ID, "call-1", "renderChart", contents);
+
+    // when
+    EventSourcedResult<Done> result =
+        testKit
+            .method(SessionMemoryEntity::addInteraction)
+            .invoke(new AddInteractionCmd(userMessage, List.of(toolResponse)));
+
+    // then
+    assertThat(result.getReply()).isEqualTo(done());
+
+    var events = result.getAllEvents();
+    assertThat(events).hasSize(2);
+    assertThat(events.getFirst()).isInstanceOf(SessionMemoryEntity.Event.UserMessageAdded.class);
+    assertThat(events.get(1))
+        .isInstanceOf(SessionMemoryEntity.Event.MultimodalToolResponseMessageAdded.class);
+    var toolEvent = (SessionMemoryEntity.Event.MultimodalToolResponseMessageAdded) events.get(1);
+    assertThat(toolEvent.componentId()).isEqualTo(COMPONENT_ID);
+    assertThat(toolEvent.id()).isEqualTo("call-1");
+    assertThat(toolEvent.name()).isEqualTo("renderChart");
+    assertThat(toolEvent.contents()).isEqualTo(contents);
+    assertThat(toolEvent.sizeInBytes()).isEqualTo(toolResponse.size());
+
+    // when retrieving history
+    EventSourcedResult<SessionHistory> historyResult =
+        testKit.method(SessionMemoryEntity::getHistory).invoke(emptyGetHistory);
+
+    // then the multimodal tool response round-trips faithfully (URI preserved)
+    assertThat(historyResult.getReply().messages()).containsExactly(userMessage, toolResponse);
   }
 
   @Test

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMemoryEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMemoryEntity.java
@@ -10,6 +10,7 @@ import akka.Done;
 import akka.javasdk.agent.SessionMemoryEntity.Event;
 import akka.javasdk.agent.SessionMemoryEntity.State;
 import akka.javasdk.agent.SessionMessage.AiMessage;
+import akka.javasdk.agent.SessionMessage.MultimodalToolCallResponse;
 import akka.javasdk.agent.SessionMessage.MultimodalUserMessage;
 import akka.javasdk.agent.SessionMessage.TokenUsage;
 import akka.javasdk.agent.SessionMessage.ToolCallResponse;
@@ -274,6 +275,16 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
         String content,
         int sizeInBytes)
         implements Event, Message {}
+
+    @TypeName("akka-memory-multimodal-tool-response-message-added")
+    record MultimodalToolResponseMessageAdded(
+        Instant timestamp,
+        String componentId,
+        String id,
+        String name,
+        List<SessionMessage.MessageContent> contents,
+        int sizeInBytes)
+        implements Event, Message {}
   }
 
   // Request commands
@@ -381,6 +392,15 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
                               toolCallResponse.name(),
                               toolCallResponse.text(),
                               toolCallResponse.size());
+
+                      case MultimodalToolCallResponse multimodalToolCallResponse ->
+                          new Event.MultimodalToolResponseMessageAdded(
+                              multimodalToolCallResponse.timestamp(),
+                              multimodalToolCallResponse.componentId(),
+                              multimodalToolCallResponse.id(),
+                              multimodalToolCallResponse.name(),
+                              multimodalToolCallResponse.contents(),
+                              multimodalToolCallResponse.size());
 
                       default -> throw new IllegalArgumentException("Unsupported message: " + msg);
                     })
@@ -552,6 +572,16 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
                               multimodalUserMessage.componentId(),
                               multimodalUserMessage.contents(),
                               multimodalUserMessage.size()));
+
+                  case MultimodalToolCallResponse multimodalToolCallResponse ->
+                      events.add(
+                          new Event.MultimodalToolResponseMessageAdded(
+                              multimodalToolCallResponse.timestamp(),
+                              multimodalToolCallResponse.componentId(),
+                              multimodalToolCallResponse.id(),
+                              multimodalToolCallResponse.name(),
+                              multimodalToolCallResponse.contents(),
+                              multimodalToolCallResponse.size()));
                 }
               });
     }
@@ -582,6 +612,10 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
           result.add(evt);
         }
         case Event.ToolResponseMessageAdded evt -> {
+          size += evt.sizeInBytes();
+          result.add(evt);
+        }
+        case Event.MultimodalToolResponseMessageAdded evt -> {
           size += evt.sizeInBytes();
           result.add(evt);
         }
@@ -626,6 +660,9 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
 
       case Event.ToolResponseMessageAdded toolMsg ->
           currentState().addMessage(SessionMessageConverter.apply(toolMsg));
+
+      case Event.MultimodalToolResponseMessageAdded multimodalToolMsg ->
+          currentState().addMessage(SessionMessageConverter.apply(multimodalToolMsg));
 
       case Event.HistoryCleared __ -> currentState().compact(eventContext().sequenceNumber());
 

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMemoryInterceptor.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMemoryInterceptor.java
@@ -12,10 +12,10 @@ package akka.javasdk.agent;
  * implementations only need to override the variant(s) they want to transform.
  *
  * <p>Hooks are provided for each top-level {@link SessionMessage} variant: user messages (text and
- * multimodal), AI replies, and tool call responses. Tool requests are nested inside {@link
- * SessionMessage.AiMessage} and are not exposed as a dedicated hook; rewrite them by overriding
- * {@link #beforeWrite(String, SessionMessage.AiMessage)} and rebuilding the message with the
- * transformed list.
+ * multimodal), AI replies, and tool call responses (text and multimodal). Tool requests are nested
+ * inside {@link SessionMessage.AiMessage} and are not exposed as a dedicated hook; rewrite them by
+ * overriding {@link #beforeWrite(String, SessionMessage.AiMessage)} and rebuilding the message with
+ * the transformed list.
  *
  * <p>Read-side behavior (history limit, filters, read/write toggles) is configured through {@link
  * MemoryProvider} and is not exposed here.
@@ -102,6 +102,20 @@ public interface SessionMemoryInterceptor {
    */
   default SessionMessage.ToolCallResponse beforeWrite(
       String sessionId, SessionMessage.ToolCallResponse toolCallResponse) {
+    return toolCallResponse;
+  }
+
+  /**
+   * Called immediately before a {@link SessionMessage.MultimodalToolCallResponse} is persisted to
+   * session memory. The returned message is what gets written. The default implementation returns
+   * the input unchanged.
+   *
+   * @param sessionId The unique identifier for the contextual session
+   * @param toolCallResponse The multimodal tool call response about to be persisted
+   * @return The (possibly transformed) message to persist; must not be {@code null}
+   */
+  default SessionMessage.MultimodalToolCallResponse beforeWrite(
+      String sessionId, SessionMessage.MultimodalToolCallResponse toolCallResponse) {
     return toolCallResponse;
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMessage.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMessage.java
@@ -5,6 +5,7 @@
 package akka.javasdk.agent;
 
 import akka.javasdk.agent.SessionMessage.AiMessage;
+import akka.javasdk.agent.SessionMessage.MultimodalToolCallResponse;
 import akka.javasdk.agent.SessionMessage.MultimodalUserMessage;
 import akka.javasdk.agent.SessionMessage.ToolCallResponse;
 import akka.javasdk.agent.SessionMessage.UserMessage;
@@ -23,11 +24,27 @@ import java.util.Optional;
   @JsonSubTypes.Type(value = UserMessage.class, name = "UM"),
   @JsonSubTypes.Type(value = AiMessage.class, name = "AIM"),
   @JsonSubTypes.Type(value = ToolCallResponse.class, name = "TCR"),
-  @JsonSubTypes.Type(value = MultimodalUserMessage.class, name = "MUM")
+  @JsonSubTypes.Type(value = MultimodalUserMessage.class, name = "MUM"),
+  @JsonSubTypes.Type(value = MultimodalToolCallResponse.class, name = "MTCR")
 })
 public sealed interface SessionMessage {
   static int sizeInBytes(String text) {
     return text.length(); // simple implementation, but not correct for all encodings
+  }
+
+  static int sizeInBytes(List<MessageContent> contents) {
+    return contents.stream()
+        .mapToInt(
+            content ->
+                switch (content) {
+                  case MessageContent.TextMessageContent text -> sizeInBytes(text.text());
+                  case MessageContent.ImageUriMessageContent image ->
+                      sizeInBytes(image.uri())
+                          + sizeInBytes(image.detailLevel().toString())
+                          + image.mimeType().map(SessionMessage::sizeInBytes).orElse(0);
+                  case MessageContent.PdfUriMessageContent pdf -> sizeInBytes(pdf.uri());
+                })
+        .sum();
   }
 
   int size();
@@ -56,7 +73,6 @@ public sealed interface SessionMessage {
     record PdfUriMessageContent(String uri) implements MessageContent {}
   }
 
-  // need to introduce new message to keep backward compatibility
   record MultimodalUserMessage(Instant timestamp, List<MessageContent> contents, String componentId)
       implements SessionMessage {
 
@@ -176,6 +192,16 @@ public sealed interface SessionMessage {
     @Override
     public int size() {
       return SessionMessage.sizeInBytes(text);
+    }
+  }
+
+  record MultimodalToolCallResponse(
+      Instant timestamp, String componentId, String id, String name, List<MessageContent> contents)
+      implements SessionMessage {
+
+    @Override
+    public int size() {
+      return SessionMessage.sizeInBytes(contents);
     }
   }
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMessageConverter.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMessageConverter.java
@@ -31,6 +31,12 @@ public class SessionMessageConverter {
         event.timestamp(), event.componentId(), event.id(), event.name(), event.content());
   }
 
+  public static SessionMessage apply(
+      SessionMemoryEntity.Event.MultimodalToolResponseMessageAdded event) {
+    return new SessionMessage.MultimodalToolCallResponse(
+        event.timestamp(), event.componentId(), event.id(), event.name(), event.contents());
+  }
+
   public static SessionMessage apply(SessionMemoryEntity.Event.Message event) {
     return switch (event) {
       case SessionMemoryEntity.Event.UserMessageAdded userMsg -> apply(userMsg);
@@ -41,6 +47,9 @@ public class SessionMessageConverter {
       case SessionMemoryEntity.Event.AiMessageAdded aiMsg -> apply(aiMsg);
 
       case SessionMemoryEntity.Event.ToolResponseMessageAdded toolMsg -> apply(toolMsg);
+
+      case SessionMemoryEntity.Event.MultimodalToolResponseMessageAdded multimodalToolMsg ->
+          apply(multimodalToolMsg);
     };
   }
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
@@ -414,17 +414,21 @@ private[impl] object AgentImpl {
     messageContent match {
       case content: MessageContent.TextMessageContent =>
         new SpiAgent.TextMessageContent(content.text())
+
       case content: MessageContent.ImageUrlMessageContent =>
         new SpiAgent.ImageUriMessageContent(
           content.uri,
           toSpiDetailLevel(content.detailLevel()),
           content.mimeType().toScala)
+
       case content: MessageContent.PdfUrlMessageContent =>
         new SpiAgent.PdfUriMessageContent(content.uri)
+
       case _: MessageContent.ImageDataMessageContent =>
         throw new UnsupportedOperationException(
           "Inline image data message content cannot be sent as input. Upload to object storage and " +
           "reference it via an object:// URI, or use a URI-referenced content type.")
+
       case _: MessageContent.PdfDataMessageContent =>
         throw new UnsupportedOperationException(
           "Inline PDF data message content cannot be sent as input. Upload to object storage and " +

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
@@ -486,6 +486,57 @@ private[impl] object AgentImpl {
       new MessageContent.PdfBytesMessageContent(pdf.bytes.toArrayUnsafe())
   }
 
+  /** SPI message content → session-memory content; inline bytes degrade to a placeholder. */
+  private[agent] def toSessionMemoryContent(mc: SpiAgent.MessageContent): SessionMessage.MessageContent =
+    mc match {
+      case t: SpiAgent.TextMessageContent =>
+        new SessionMessage.MessageContent.TextMessageContent(t.text)
+      case img: SpiAgent.ImageUriMessageContent =>
+        new SessionMessage.MessageContent.ImageUriMessageContent(
+          img.uri.toString,
+          fromSpiDetailLevel(img.detailLevel),
+          img.mimeType.toJava)
+      case pdf: SpiAgent.PdfUriMessageContent =>
+        new SessionMessage.MessageContent.PdfUriMessageContent(pdf.uri.toString)
+      case _: SpiAgent.ImageBytesMessageContent =>
+        new SessionMessage.MessageContent.TextMessageContent(SessionMessage.MessageContent.IMAGE_PLACEHOLDER)
+      case _: SpiAgent.PdfBytesMessageContent =>
+        new SessionMessage.MessageContent.TextMessageContent(SessionMessage.MessageContent.PDF_PLACEHOLDER)
+    }
+
+  /** Session-memory content → SPI message content. */
+  private[agent] def toSpiSessionContent(content: SessionMessage.MessageContent): SpiAgent.MessageContent =
+    content match {
+      case c: SessionMessage.MessageContent.TextMessageContent =>
+        new SpiAgent.TextMessageContent(c.text())
+      case c: SessionMessage.MessageContent.ImageUriMessageContent =>
+        new SpiAgent.ImageUriMessageContent(
+          URI.create(c.uri()),
+          toSpiDetailLevel(c.detailLevel()),
+          c.mimeType().toScala)
+      case c: SessionMessage.MessageContent.PdfUriMessageContent =>
+        new SpiAgent.PdfUriMessageContent(URI.create(c.uri()))
+    }
+
+  /**
+   * A single text content yields a [[SessionMessage.ToolCallResponse]]; otherwise a
+   * [[SessionMessage.MultimodalToolCallResponse]].
+   */
+  private[agent] def toSessionToolCallResponse(
+      timestamp: Instant,
+      componentId: String,
+      id: String,
+      name: String,
+      spiContents: Seq[SpiAgent.MessageContent]): SessionMessage = {
+    val contents = spiContents.map(toSessionMemoryContent)
+    contents match {
+      case Seq(t: SessionMessage.MessageContent.TextMessageContent) =>
+        new SessionMessage.ToolCallResponse(timestamp, componentId, id, name, t.text())
+      case _ =>
+        new SessionMessage.MultimodalToolCallResponse(timestamp, componentId, id, name, contents.asJava)
+    }
+  }
+
   private[agent] def toSpiContentLoader(
       javaContentLoader: ContentLoader,
       ec: ExecutionContext): SpiAgent.SpiContentLoader =
@@ -531,24 +582,13 @@ private[impl] object AgentImpl {
         case m: UserMessage =>
           new SpiAgent.ContextMessage.UserMessage(m.text())
         case m: MultimodalUserMessage =>
-          val contents = m
-            .contents()
-            .asScala
-            .map {
-              case content: SessionMessage.MessageContent.TextMessageContent =>
-                new SpiAgent.TextMessageContent(content.text())
-              case content: SessionMessage.MessageContent.ImageUriMessageContent =>
-                new SpiAgent.ImageUriMessageContent(
-                  URI.create(content.uri()),
-                  toSpiDetailLevel(content.detailLevel()),
-                  content.mimeType().toScala)
-              case content: SessionMessage.MessageContent.PdfUriMessageContent =>
-                new SpiAgent.PdfUriMessageContent(URI.create(content.uri()))
-            }
-            .toSeq
+          val contents = m.contents().asScala.map(toSpiSessionContent).toSeq
           new SpiAgent.ContextMessage.UserMessage(contents)
         case m: ToolCallResponse =>
           new ContextMessage.ToolCallResponseMessage(m.id(), m.name(), m.text())
+        case m: SessionMessage.MultimodalToolCallResponse =>
+          val contents = m.contents().asScala.map(toSpiSessionContent).toSeq
+          new ContextMessage.ToolCallResponseMessage(m.id(), m.name(), contents)
         case m =>
           throw new IllegalStateException("Unsupported message type " + m.getClass.getName)
       }
@@ -816,7 +856,7 @@ private[impl] final class AgentImpl(
             res.attributes.asJava)
 
         case res: SpiAgent.ToolCallResponse =>
-          new ToolCallResponse(res.timestamp, componentId, res.id, res.name, res.content)
+          AgentImpl.toSessionToolCallResponse(res.timestamp, componentId, res.id, res.name, res.contents)
       }
 
     if (userMessage.isTextOnly) {

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AutonomousAgentImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AutonomousAgentImpl.scala
@@ -24,7 +24,6 @@ import akka.javasdk.agent.SessionMessage.AiMessage
 import akka.javasdk.agent.SessionMessage.MultimodalUserMessage
 import akka.javasdk.agent.SessionMessage.TokenUsage
 import akka.javasdk.agent.SessionMessage.ToolCallRequest
-import akka.javasdk.agent.SessionMessage.ToolCallResponse
 import akka.javasdk.agent.SessionMessage.UserMessage
 import akka.javasdk.agent._
 import akka.javasdk.agent.task.TaskAttachment
@@ -514,11 +513,7 @@ private[impl] final class AutonomousAgentImpl(
         new AiMessage(now, m.content, componentId, toolCallRequests, m.thinking.toJava, tokenUsage, m.attributes.asJava)
 
       case m: SpiAgent.ContextMessage.ToolCallResponseMessage =>
-        val content =
-          m.contents.collect { case t: SpiAgent.TextMessageContent =>
-            t.text
-          }.mkString
-        new ToolCallResponse(now, componentId, m.id, m.name, content)
+        AgentImpl.toSessionToolCallResponse(now, componentId, m.id, m.name, m.contents)
     }
 
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/FunctionTools.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/FunctionTools.scala
@@ -44,6 +44,9 @@ object FunctionTools {
     def invoke(args: Array[Any]): Any
 
     def returnType: Class[_]
+
+    /** Defaults to returnType */
+    def genericReturnType: Type = returnType
   }
 
   /**
@@ -71,6 +74,9 @@ object FunctionTools {
 
     override def returnType: Class[_] =
       method.getReturnType
+
+    override def genericReturnType: Type =
+      method.getGenericReturnType
   }
 
   private val uniqueId = "uniqueId"

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/InterceptingSessionMemory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/InterceptingSessionMemory.scala
@@ -48,6 +48,8 @@ final class InterceptingSessionMemory(delegate: SessionMemory, interceptor: Sess
       requireNonNullResult(interceptor.beforeWrite(sessionId, ai), "AiMessage")
     case tcr: SessionMessage.ToolCallResponse =>
       requireNonNullResult(interceptor.beforeWrite(sessionId, tcr), "ToolCallResponse")
+    case mtcr: SessionMessage.MultimodalToolCallResponse =>
+      requireNonNullResult(interceptor.beforeWrite(sessionId, mtcr), "MultimodalToolCallResponse")
     // UserMessage and MultimodalUserMessage are never present in the messages list — the user
     // message is passed as a separate argument to addInteraction. These cases exist only to
     // satisfy exhaustiveness on the sealed SessionMessage interface; pass through unchanged.

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ToolExecutor.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ToolExecutor.scala
@@ -4,7 +4,13 @@
 
 package akka.javasdk.impl.agent
 
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.lang.reflect.TypeVariable
+import java.lang.reflect.WildcardType
 import java.util.Optional
+
+import scala.jdk.CollectionConverters.ListHasAsScala
 
 import akka.annotation.InternalApi
 import akka.javasdk.agent.MessageContent
@@ -28,16 +34,25 @@ class ToolExecutor(functionTools: Map[String, FunctionToolInvoker], serializer: 
 
   /**
    * Executes a tool call command synchronously, returning its result as a sequence of message contents.
-   *
-   * A tool that declares a [[MessageContent]] return type produces multimodal content (text, an image/PDF URI
-   * reference, or inline image/PDF bytes) sent back to the model. Any other return type keeps the existing behaviour:
-   * text as-is, or JSON serialization, wrapped as a single text content.
    */
   def executeMultimodal(request: SpiAgent.ToolCallCommand): Seq[SpiAgent.MessageContent] = {
     val (toolInvoker, toolResult) = invoke(request)
-    // Dispatch on the declared return type, not the runtime value: a MessageContent-returning tool is
-    // multimodal; anything else is text/JSON. This keeps empty and element-type handling unambiguous.
-    if (classOf[MessageContent].isAssignableFrom(toolInvoker.returnType)) {
+    if (isListOfMessageContent(toolInvoker.genericReturnType)) {
+      if (toolResult == null)
+        throw new IllegalArgumentException(
+          s"Tool [${request.name}] declares a List<${classOf[MessageContent].getSimpleName}> return type but returned null. " +
+          "A multimodal tool must return a non-null list with at least one non-null MessageContent.")
+      val contents = toolResult
+        .asInstanceOf[java.util.List[MessageContent]]
+        .asScala
+        .collect { case msg if msg != null => AgentImpl.toSpiToolResultContent(msg) }
+        .toSeq
+      if (contents.isEmpty)
+        throw new IllegalArgumentException(
+          s"Tool [${request.name}] declares a List<${classOf[MessageContent].getSimpleName}> return type but returned no content. " +
+          "A multimodal tool must return a non-null list with at least one non-null MessageContent.")
+      contents
+    } else if (classOf[MessageContent].isAssignableFrom(toolInvoker.returnType)) {
       if (toolResult == null)
         throw new IllegalArgumentException(
           s"Tool [${request.name}] declares a ${classOf[MessageContent].getSimpleName} return type but returned null. " +
@@ -45,6 +60,27 @@ class ToolExecutor(functionTools: Map[String, FunctionToolInvoker], serializer: 
       Seq(AgentImpl.toSpiToolResultContent(toolResult.asInstanceOf[MessageContent]))
     } else
       Seq(new SpiAgent.TextMessageContent(textResult(toolInvoker, toolResult)))
+  }
+
+  private def isListOfMessageContent(tpe: Type): Boolean = tpe match {
+    case pt: ParameterizedType if pt.getRawType == classOf[java.util.List[_]] =>
+      pt.getActualTypeArguments match {
+        case Array(arg) => elementClass(arg).exists(classOf[MessageContent].isAssignableFrom)
+        case _          => false
+      }
+    case _ => false
+  }
+
+  /**
+   * Resolve the element type to a raw class so that `List<MessageContent>`, a subtype `List<ImageMessageContent>`, a
+   * bounded wildcard `List<? extends MessageContent>`, and a bounded type variable `<T extends MessageContent>` are all
+   * recognized as content lists. Unbounded element types (e.g. `List<?>`) resolve to `Object` and fall through to JSON.
+   */
+  private def elementClass(tpe: Type): Option[Class[_]] = tpe match {
+    case c: Class[_]         => Some(c)
+    case wt: WildcardType    => wt.getUpperBounds.collectFirst { case c: Class[_] => c }
+    case tv: TypeVariable[_] => tv.getBounds.collectFirst { case c: Class[_] => c }
+    case _                   => None
   }
 
   /** Resolve the tool invoker, deserialize the JSON arguments, and invoke the tool. */

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/AgentImplToolResponseSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/AgentImplToolResponseSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl.agent
+
+import java.net.URI
+import java.time.Instant
+
+import scala.jdk.CollectionConverters._
+
+import akka.javasdk.agent.SessionMessage
+import akka.runtime.sdk.spi.SpiAgent
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class AgentImplToolResponseSpec extends AnyWordSpec with Matchers {
+
+  private def toSessionMessage(contents: Seq[SpiAgent.MessageContent]): SessionMessage =
+    AgentImpl.toSessionToolCallResponse(Instant.EPOCH, "agent", "id1", "render_chart", contents)
+
+  "AgentImpl.toSessionToolCallResponse" should {
+
+    "collapse a single text content to a legacy ToolCallResponse" in {
+      toSessionMessage(Seq(new SpiAgent.TextMessageContent("just text"))) match {
+        case tcr: SessionMessage.ToolCallResponse =>
+          tcr.id() shouldBe "id1"
+          tcr.name() shouldBe "render_chart"
+          tcr.text() shouldBe "just text"
+        case other => fail(s"expected a legacy ToolCallResponse, got [${other.getClass.getSimpleName}]")
+      }
+    }
+
+    "keep a single image-URI content as a MultimodalToolCallResponse" in {
+      val image = new SpiAgent.ImageUriMessageContent(
+        URI.create("object://bucket/chart.png"),
+        SpiAgent.ImageMessageContent.Auto,
+        Some("image/png"))
+
+      toSessionMessage(Seq(image)) match {
+        case mtcr: SessionMessage.MultimodalToolCallResponse =>
+          mtcr.contents().asScala.toList match {
+            case (img: SessionMessage.MessageContent.ImageUriMessageContent) :: Nil =>
+              img.uri() shouldBe "object://bucket/chart.png"
+            case other => fail(s"unexpected contents: $other")
+          }
+        case other => fail(s"expected a MultimodalToolCallResponse, got [${other.getClass.getSimpleName}]")
+      }
+    }
+
+    "keep a text + image content list as a MultimodalToolCallResponse in order" in {
+      val text = new SpiAgent.TextMessageContent("caption")
+      val image = new SpiAgent.ImageUriMessageContent(
+        URI.create("object://bucket/chart.png"),
+        SpiAgent.ImageMessageContent.Auto,
+        Some("image/png"))
+
+      toSessionMessage(Seq(text, image)) match {
+        case mtcr: SessionMessage.MultimodalToolCallResponse =>
+          mtcr.contents().asScala.toList match {
+            case (t: SessionMessage.MessageContent.TextMessageContent) ::
+                (img: SessionMessage.MessageContent.ImageUriMessageContent) :: Nil =>
+              t.text() shouldBe "caption"
+              img.uri() shouldBe "object://bucket/chart.png"
+            case other => fail(s"unexpected contents: $other")
+          }
+        case other => fail(s"expected a MultimodalToolCallResponse, got [${other.getClass.getSimpleName}]")
+      }
+    }
+  }
+}

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/InterceptingSessionMemorySpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/InterceptingSessionMemorySpec.scala
@@ -17,6 +17,7 @@ import akka.javasdk.agent.SessionMemoryInterceptor
 import akka.javasdk.agent.SessionMessage
 import akka.javasdk.agent.SessionMessage.AiMessage
 import akka.javasdk.agent.SessionMessage.MessageContent.TextMessageContent
+import akka.javasdk.agent.SessionMessage.MultimodalToolCallResponse
 import akka.javasdk.agent.SessionMessage.MultimodalUserMessage
 import akka.javasdk.agent.SessionMessage.ToolCallResponse
 import akka.javasdk.agent.SessionMessage.UserMessage
@@ -147,6 +148,32 @@ class InterceptingSessionMemorySpec extends AnyWordSpec with Matchers {
       delegate.lastMessages.size() shouldBe 1
       val seen = delegate.lastMessages.get(0).asInstanceOf[ToolCallResponse]
       seen.text() shouldBe "this is a short one"
+    }
+
+    "reflect multimodal tool call response transform in messages list" in {
+      val delegate = new RecordingSessionMemory
+      val interceptor = new SessionMemoryInterceptor {
+        override def beforeWrite(sessionId: String, mtcr: MultimodalToolCallResponse): MultimodalToolCallResponse =
+          new MultimodalToolCallResponse(
+            mtcr.timestamp(),
+            mtcr.componentId(),
+            mtcr.id(),
+            mtcr.name(),
+            util.List.of(new TextMessageContent("redacted")))
+      }
+      val memory = new InterceptingSessionMemory(delegate, interceptor)
+
+      val mtcr = new MultimodalToolCallResponse(
+        Instant.EPOCH,
+        "agent",
+        "id1",
+        "render_chart",
+        util.List.of(new TextMessageContent("caption"), new TextMessageContent("more")))
+      memory.addInteraction("s1", userMessage("hi"), util.List.of(mtcr))
+
+      delegate.lastMessages.size() shouldBe 1
+      val seen = delegate.lastMessages.get(0).asInstanceOf[MultimodalToolCallResponse]
+      seen.contents().asScala.map(_.asInstanceOf[TextMessageContent].text()).toList shouldBe List("redacted")
     }
   }
 }

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ToolExecutorSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ToolExecutorSpec.scala
@@ -44,6 +44,7 @@ class ToolExecutorSpec extends AnyWordSpecLike with TestSuite with Matchers {
       override def types: Array[Type] = method.getGenericParameterTypes
       override def invoke(args: Array[Any]): Any = method.invoke(any, args: _*)
       override def returnType: Class[_] = method.getReturnType
+      override def genericReturnType: Type = method.getGenericReturnType
     }
   }
 
@@ -345,6 +346,162 @@ class ToolExecutorSpec extends AnyWordSpecLike with TestSuite with Matchers {
       result match {
         case Seq(txt: SpiAgent.TextMessageContent) =>
           serializer.objectMapper.readTree(txt.text) shouldBe serializer.objectMapper.readTree("""{"name":"bar"}""")
+        case other => fail(s"unexpected result: $other")
+      }
+    }
+
+    "executeMultimodal returns every element when a tool returns a List<MessageContent>" in {
+      val png = "fake png bytes".getBytes
+      class TestClass {
+        def method(value: String): java.util.List[MessageContent] =
+          java.util.List.of(
+            MessageContent.TextMessageContent.from("caption: " + value),
+            MessageContent.ImageMessageContent.fromBytes(png, "image/png"))
+      }
+      val executor = new ToolExecutor(Map("method" -> functionToolFor(new TestClass)), serializer)
+
+      val result = executor.executeMultimodal(toolRequest("method", """{ "value": "sunset" }"""))
+
+      result match {
+        case Seq(txt: SpiAgent.TextMessageContent, img: SpiAgent.ImageBytesMessageContent) =>
+          txt.text shouldBe "caption: sunset"
+          img.bytes.toArrayUnsafe() shouldBe png
+          img.mimeType shouldBe "image/png"
+        case other => fail(s"unexpected result: $other")
+      }
+    }
+
+    "executeMultimodal treats a List of a MessageContent subtype as a content list" in {
+      val png = "fake png bytes".getBytes
+      class TestClass {
+        def method(value: String): java.util.List[MessageContent.ImageBytesMessageContent] =
+          java.util.List.of(MessageContent.ImageMessageContent.fromBytes(png, "image/png"))
+      }
+      val executor = new ToolExecutor(Map("method" -> functionToolFor(new TestClass)), serializer)
+
+      val result = executor.executeMultimodal(toolRequest("method", """{ "value": "x" }"""))
+
+      result match {
+        case Seq(img: SpiAgent.ImageBytesMessageContent) =>
+          img.bytes.toArrayUnsafe() shouldBe png
+        case other => fail(s"unexpected result: $other")
+      }
+    }
+
+    "executeMultimodal treats a List<? extends MessageContent> as a content list" in {
+      val png = "fake png bytes".getBytes
+      class TestClass {
+        def method(value: String): java.util.List[_ <: MessageContent] =
+          java.util.List.of(MessageContent.ImageMessageContent.fromBytes(png, "image/png"))
+      }
+      val executor = new ToolExecutor(Map("method" -> functionToolFor(new TestClass)), serializer)
+
+      val result = executor.executeMultimodal(toolRequest("method", """{ "value": "x" }"""))
+
+      result match {
+        case Seq(img: SpiAgent.ImageBytesMessageContent) =>
+          img.bytes.toArrayUnsafe() shouldBe png
+        case other => fail(s"unexpected result: $other")
+      }
+    }
+
+    "executeMultimodal preserves order for a text + image + pdf list" in {
+      val png = "fake png bytes".getBytes
+      val pdf = "fake pdf bytes".getBytes
+      class TestClass {
+        def method(value: String): java.util.List[MessageContent] =
+          java.util.List.of(
+            MessageContent.TextMessageContent.from(value),
+            MessageContent.ImageMessageContent.fromBytes(png, "image/png"),
+            MessageContent.PdfMessageContent.fromBytes(pdf))
+      }
+      val executor = new ToolExecutor(Map("method" -> functionToolFor(new TestClass)), serializer)
+
+      val result = executor.executeMultimodal(toolRequest("method", """{ "value": "hi" }"""))
+
+      result match {
+        case Seq(
+              t: SpiAgent.TextMessageContent,
+              i: SpiAgent.ImageBytesMessageContent,
+              p: SpiAgent.PdfBytesMessageContent) =>
+          t.text shouldBe "hi"
+          i.bytes.toArrayUnsafe() shouldBe png
+          p.bytes.toArrayUnsafe() shouldBe pdf
+        case other => fail(s"unexpected result: $other")
+      }
+    }
+
+    "executeMultimodal filters out null elements from a List<MessageContent>" in {
+      class TestClass {
+        def method(value: String): java.util.List[MessageContent] =
+          java.util.Arrays.asList(
+            MessageContent.TextMessageContent.from("a"),
+            null,
+            MessageContent.TextMessageContent.from("b"))
+      }
+      val executor = new ToolExecutor(Map("method" -> functionToolFor(new TestClass)), serializer)
+
+      val result = executor.executeMultimodal(toolRequest("method", """{ "value": "x" }"""))
+
+      result match {
+        case Seq(a: SpiAgent.TextMessageContent, b: SpiAgent.TextMessageContent) =>
+          a.text shouldBe "a"
+          b.text shouldBe "b"
+        case other => fail(s"unexpected result: $other")
+      }
+    }
+
+    "executeMultimodal throws for an empty List<MessageContent>" in {
+      class TestClass {
+        def method(value: String): java.util.List[MessageContent] =
+          java.util.Collections.emptyList()
+      }
+      val executor = new ToolExecutor(Map("method" -> functionToolFor(new TestClass)), serializer)
+
+      val ex = intercept[IllegalArgumentException] {
+        executor.executeMultimodal(toolRequest("method", """{ "value": "x" }"""))
+      }
+      ex.getMessage should include("returned no content")
+    }
+
+    "executeMultimodal throws for a null List<MessageContent>" in {
+      class TestClass {
+        def method(value: String): java.util.List[MessageContent] = null
+      }
+      val executor = new ToolExecutor(Map("method" -> functionToolFor(new TestClass)), serializer)
+
+      val ex = intercept[IllegalArgumentException] {
+        executor.executeMultimodal(toolRequest("method", """{ "value": "x" }"""))
+      }
+      ex.getMessage should include("returned null")
+    }
+
+    "executeMultimodal throws for a List<MessageContent> containing only nulls" in {
+      class TestClass {
+        def method(value: String): java.util.List[MessageContent] =
+          java.util.Arrays.asList(null, null)
+      }
+      val executor = new ToolExecutor(Map("method" -> functionToolFor(new TestClass)), serializer)
+
+      val ex = intercept[IllegalArgumentException] {
+        executor.executeMultimodal(toolRequest("method", """{ "value": "x" }"""))
+      }
+      ex.getMessage should include("returned no content")
+    }
+
+    "executeMultimodal does not treat a List of a non-MessageContent type as a content list" in {
+      class TestClass {
+        def method(value: String): java.util.List[Foo] =
+          java.util.List.of(Foo(value))
+      }
+      val executor = new ToolExecutor(Map("method" -> functionToolFor(new TestClass)), serializer)
+
+      val result = executor.executeMultimodal(toolRequest("method", """{ "value": "bar" }"""))
+
+      result match {
+        case Seq(txt: SpiAgent.TextMessageContent) =>
+          serializer.objectMapper.readTree(txt.text) shouldBe
+            serializer.objectMapper.readTree("""[{"name":"bar"}]""")
         case other => fail(s"unexpected result: $other")
       }
     }

--- a/docs/src/modules/sdk/pages/agents/extending.adoc
+++ b/docs/src/modules/sdk/pages/agents/extending.adoc
@@ -159,7 +159,23 @@ include::example$doc-snippets/src/main/java/com/example/application/StreetViewAg
 
 The model receives the image directly, with no need to upload it to object storage first.
 
-A tool that declares a `MessageContent` return type must always return a non-null value; returning `null` results in an `IllegalArgumentException`. If the tool has no media to return, return a `TextMessageContent` instead.
+A tool that declares a single `MessageContent` return type must always return a non-null value; returning `null` results in an `IllegalArgumentException`. If the tool has no media to return, return a `TextMessageContent` instead.
+
+[#returning_a_list_of_contents]
+=== Returning multiple contents
+
+A tool can also declare its return type as `List<MessageContent>` to send several pieces of content in one tool result — for example a caption plus an image, or text plus a PDF. Every element is delivered to the model in list order. A subtype element (`List<ImageMessageContent>`) or a bounded wildcard (`List<? extends MessageContent>`) is accepted as well; any other element type makes the result a plain JSON tool response.
+
+[source,java,indent=0]
+.{sample-base-url}/doc-snippets/src/main/java/com/example/application/ChartAgent.java[ChartAgent.java]
+----
+include::example$doc-snippets/src/main/java/com/example/application/ChartAgent.java[tag=class]
+----
+<1> Declare the return type as `List<MessageContent>`.
+<2> The first element — a text caption.
+<3> The second element — the rendered image, delivered right after the caption.
+
+Individual `null` elements are filtered out, but the tool must return at least one non-null `MessageContent`: returning `null`, an empty list, or a list containing only `null` elements results in an `IllegalArgumentException`, just like the single-`MessageContent` form. Each element follows the same persistence rules described below: text and URI-referenced contents are kept in session memory, while inline bytes become a `[image]`/`[pdf]` placeholder.
 
 [IMPORTANT]
 ====

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val ProtocolVersionMinor = 1
   }
 
-  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.8")
+  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.9")
 
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned

--- a/samples/doc-snippets/src/main/java/com/example/application/ChartAgent.java
+++ b/samples/doc-snippets/src/main/java/com/example/application/ChartAgent.java
@@ -1,0 +1,38 @@
+package com.example.application;
+
+import akka.javasdk.agent.Agent;
+import akka.javasdk.agent.MessageContent;
+import akka.javasdk.annotations.Component;
+import akka.javasdk.annotations.FunctionTool;
+import java.util.List;
+
+// tag::class[]
+@Component(id = "chart-agent")
+public class ChartAgent extends Agent {
+
+  public static class ChartService {
+
+    @FunctionTool(description = "Renders a chart for the given metric, with a caption")
+    public List<MessageContent> renderChart(String metric) { // <1>
+      byte[] image = renderChartImage(metric);
+      return List.of(
+        MessageContent.TextMessageContent.from("Chart for " + metric), // <2>
+        MessageContent.ImageMessageContent.fromBytes(image, "image/png")
+      ); // <3>
+    }
+
+    private byte[] renderChartImage(String metric) {
+      // render the chart and return the raw image bytes
+      return new byte[0];
+    }
+  }
+
+  public Effect<String> ask(String question) {
+    return effects()
+      .systemMessage("You can render charts to help answer questions about metrics.")
+      .tools(new ChartService())
+      .userMessage(question)
+      .thenReply();
+  }
+}
+// end::class[]

--- a/samples/doc-snippets/src/main/java/com/example/application/CompactionAgent.java
+++ b/samples/doc-snippets/src/main/java/com/example/application/CompactionAgent.java
@@ -89,6 +89,19 @@ public class CompactionAgent extends Agent {
           }
           case SessionMessage.ToolCallResponse toolRes -> "\n\nTOOL_CALL_RESPONSE:\n" +
           toolRes.text();
+          // end::compaction[]
+          case SessionMessage.MultimodalToolCallResponse multimodalToolRes -> multimodalToolRes
+            .contents()
+            .stream()
+            .map(content ->
+              switch (content) {
+                case MessageContent.ImageUriMessageContent image -> "image from " +
+                image.uri();
+                case MessageContent.PdfUriMessageContent pdf -> "pdf from " + pdf.uri();
+                case MessageContent.TextMessageContent text -> text.text();
+              })
+            .reduce("", (acc, text) -> "\n\nTOOL_CALL_RESPONSE:\n" + text, String::concat);
+          // tag::compaction[]
         };
       })
       .collect(Collectors.joining()); // <3>


### PR DESCRIPTION
This PR extends tool-call results to carry multiple, multimodal content parts (text + images + PDFs) instead of a single text string,

Depends on https://github.com/lightbend/akka-runtime/pull/5315