### PR TITLE
feat: support Scala TableUpdater discovery in View descriptor factories

### DIFF
--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/invalid/ViewWithPrivateUpdater.java
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/invalid/ViewWithPrivateUpdater.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.example;
+
+import akka.javasdk.annotations.Component;
+import akka.javasdk.annotations.Consume;
+import akka.javasdk.annotations.Query;
+import akka.javasdk.view.TableUpdater;
+import akka.javasdk.view.View;
+
+// A private updater must still be rejected even after the isStatic guard is removed.
+@Component(id = "private-updater-view")
+public class ViewWithPrivateUpdater extends View {
+
+  public static class Row {
+    public String id;
+    public String value;
+  }
+
+  @Query("SELECT * FROM rows")
+  public QueryEffect<Row> getAll() {
+    return queryResult();
+  }
+
+  @Consume.FromTopic("test-topic")
+  private class Updater extends TableUpdater<Row> {
+    public Effect<Row> onEvent(Row r) {
+      return effects().updateRow(r);
+    }
+  }
+}

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/valid/ViewWithNonStaticUpdater.java
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/valid/ViewWithNonStaticUpdater.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.example;
+
+import akka.javasdk.annotations.Component;
+import akka.javasdk.annotations.Consume;
+import akka.javasdk.annotations.Query;
+import akka.javasdk.view.TableUpdater;
+import akka.javasdk.view.View;
+
+// A public non-static (inner) updater must be accepted now that the isStatic guard is dropped.
+@Component(id = "non-static-updater-view")
+public class ViewWithNonStaticUpdater extends View {
+
+  public static class Row {
+    public String id;
+    public String value;
+  }
+
+  @Query("SELECT * FROM rows")
+  public QueryEffect<Row> getAll() {
+    return queryResult();
+  }
+
+  @Consume.FromTopic("test-topic")
+  public class Updater extends TableUpdater<Row> {
+    public Effect<Row> onEvent(Row r) {
+      return effects().updateRow(r);
+    }
+  }
+}

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/scala/com/example/ScalaLikeView.scala
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/scala/com/example/ScalaLikeView.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.example
+
+import akka.javasdk.annotations.{ Component, Consume, Query }
+import akka.javasdk.view.{ TableUpdater, View }
+
+/**
+ * Scala-idiomatic View fixture: the TableUpdater lives in the companion object, not in the primary class. At the JVM
+ * level `Updater` ends up in `ScalaLikeView$.getDeclaredClasses()`, not in `ScalaLikeView.getDeclaredClasses()`.
+ *
+ * RuntimeTypeDef.getNestedTypes() must search the companion class to find it.
+ */
+object ScalaLikeView {
+  case class Row(id: String, value: String)
+
+  @Consume.FromTopic("test-topic")
+  class Updater extends TableUpdater[Row] {
+    def onEvent(r: Row): TableUpdater.Effect[Row] = effects().updateRow(r)
+  }
+}
+
+@Component(id = "scala-like-view")
+class ScalaLikeView extends View {
+  @Query("SELECT * FROM scala_rows")
+  def getAll(): View.QueryEffect[ScalaLikeView.Row] = queryResult()
+}

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/scala/com/example/ViewValidationSpec.scala
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/scala/com/example/ViewValidationSpec.scala
@@ -4,6 +4,8 @@
 
 package com.example
 
+import akka.javasdk.tooling.validation.Validation
+import akka.javasdk.validation.ast.runtime.RuntimeTypeDef
 import com.example.CompilationTestSupport.CompileTimeValidation
 import com.example.CompilationTestSupport.RuntimeValidation
 import com.example.CompilationTestSupport.ValidationMode
@@ -272,6 +274,36 @@ abstract class AbstractViewValidationSpec(val validationMode: ValidationMode)
       assertInvalid(
         "invalid/ViewWithMultipleSnapshotHandlers.java",
         "Only one method can be annotated with @SnapshotHandler")
+    }
+
+    "accept View with public non-static (inner class) TableUpdater" in {
+      assertValid("valid/ViewWithNonStaticUpdater.java")
+    }
+
+    "reject View with private TableUpdater even without static guard" in {
+      assertInvalid(
+        "invalid/ViewWithPrivateUpdater.java",
+        "A view must contain at least one public static TableUpdater subclass")
+    }
+
+    "accept Scala-style View whose TableUpdater is in the companion object" in {
+      // Only meaningful for runtime validation: the Scala fixture is already compiled
+      // on the test classpath; compile-time validation does not process Scala sources.
+      if (validationMode == RuntimeValidation) {
+        val typeDef = new RuntimeTypeDef(classOf[ScalaLikeView])
+        val result = akka.javasdk.tooling.validation.Validations.validate(typeDef)
+        result shouldBe a[Validation.Valid]
+      }
+    }
+
+    "find nested types in the companion object via RuntimeTypeDef.getNestedTypes" in {
+      if (validationMode == RuntimeValidation) {
+        val typeDef = new RuntimeTypeDef(classOf[ScalaLikeView])
+        val nestedNames = typeDef.getNestedTypes
+        nestedNames.stream
+          .map[String](_.getSimpleName)
+          .anyMatch(_ == "Updater") shouldBe true
+      }
     }
   }
 }

--- a/akka-javasdk-validations/src/main/java/akka/javasdk/tooling/validation/ViewValidations.java
+++ b/akka-javasdk-validations/src/main/java/akka/javasdk/tooling/validation/ViewValidations.java
@@ -103,7 +103,7 @@ public class ViewValidations {
    * @return true if it extends View.TableUpdater
    */
   private static boolean isViewTableUpdater(TypeDef typeDef) {
-    if (!typeDef.isPublic() || !typeDef.isStatic()) {
+    if (!typeDef.isPublic()) {
       return false;
     }
     return typeDef.extendsType("akka.javasdk.view.TableUpdater");

--- a/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/runtime/RuntimeTypeDef.java
+++ b/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/runtime/RuntimeTypeDef.java
@@ -166,10 +166,15 @@ public record RuntimeTypeDef(Class<?> clazz) implements TypeDef {
 
   @Override
   public List<TypeDef> getNestedTypes() {
-    return Arrays.stream(clazz.getDeclaredClasses())
-        .map(RuntimeTypeDef::new)
-        .map(t -> (TypeDef) t)
-        .toList();
+    List<TypeDef> nested = new java.util.ArrayList<>();
+    Arrays.stream(clazz.getDeclaredClasses()).map(RuntimeTypeDef::new).forEach(nested::add);
+    // Also include types declared in the Scala companion object (e.g. FooView$).
+    try {
+      Class<?> companion = Class.forName(clazz.getName() + "$", false, clazz.getClassLoader());
+      Arrays.stream(companion.getDeclaredClasses()).map(RuntimeTypeDef::new).forEach(nested::add);
+    } catch (ClassNotFoundException ignored) {
+    }
+    return java.util.Collections.unmodifiableList(nested);
   }
 
   @Override

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/reflection/Reflect.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/reflection/Reflect.scala
@@ -284,7 +284,6 @@ private[impl] object Reflect {
 
   def isViewTableUpdater(component: Class[_]): Boolean =
     classOf[TableUpdater[_]].isAssignableFrom(component) &&
-    Modifier.isStatic(component.getModifiers) &&
     Modifier.isPublic(component.getModifiers)
 
   def workflowStateType(component: Class[_]): Class[_] = {

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/view/ViewDescriptorFactory.scala
@@ -59,6 +59,13 @@ private[impl] object ViewDescriptorFactory {
 
   val TableNamePattern: Regex = """(?i)FROM(?-i)\s+(?:`([^`]+)`|([A-Za-z][A-Za-z0-9_]*))""".r
 
+  private def companionDeclaredClasses(cls: Class[_]): Seq[Class[_]] =
+    try {
+      Class.forName(cls.getName + "$", false, cls.getClassLoader).getDeclaredClasses.toSeq
+    } catch {
+      case _: ClassNotFoundException => Seq.empty
+    }
+
   def apply(
       viewClass: Class[_],
       serializer: Serializer,
@@ -67,7 +74,8 @@ private[impl] object ViewDescriptorFactory {
     val componentId = ComponentDescriptorFactory.readComponentIdValue(viewClass)
 
     val tableUpdaters =
-      viewClass.getDeclaredClasses.toSeq.filter(Reflect.isViewTableUpdater)
+      (viewClass.getDeclaredClasses.toSeq ++ companionDeclaredClasses(viewClass))
+        .filter(Reflect.isViewTableUpdater)
 
     val allQueryMethods = extractQueryMethods(viewClass)
     val allQueryStrings = allQueryMethods.map(_.queryString)

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/reflection/ReflectSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/reflection/ReflectSpec.scala
@@ -17,6 +17,9 @@ import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels
 import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.ProtoConsumerWithAnnotation
 import akka.javasdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.ValidProtoEventSourcedEntity
 import akka.javasdk.testmodels.subscriptions.PubSubTestModels.CircularProtoConsumer
+import akka.javasdk.testmodels.view.ScalaViewWithCompanionUpdater
+import akka.javasdk.testmodels.view.ScalaViewWithInnerUpdater
+import akka.javasdk.testmodels.view.ViewTestModels
 import akka.javasdk.testmodels.workflow.WorkflowState
 import akka.javasdk.testmodels.workflow.WorkflowTestModels.TransferWorkflow
 import akka.javasdk.testmodels.workflow.WorkflowTestModels.TransferWorkflowAnnotatedAbstractClass
@@ -195,6 +198,37 @@ class ReflectSpec extends AnyWordSpec with Matchers {
       val desc = ComponentDescriptor.descriptorFor(classOf[CircularProtoConsumer], serializer)
       val result = Reflect.protoCommandHandlerInputOutput(desc)
       result.map(_.getName) should contain allOf ("CircularParent", "CircularChild")
+    }
+
+    "Reflect.isViewTableUpdater" must {
+
+      "accept a public static nested TableUpdater (Java shape)" in {
+        val updater = classOf[ViewTestModels.UserByEmailWithGet].getDeclaredClasses
+          .find(classOf[akka.javasdk.view.TableUpdater[_]].isAssignableFrom(_))
+          .get
+        Reflect.isViewTableUpdater(updater) shouldBe true
+      }
+
+      "accept a public non-static inner TableUpdater (Scala inner-class shape)" in {
+        val updater = classOf[ScalaViewWithInnerUpdater].getDeclaredClasses
+          .find(classOf[akka.javasdk.view.TableUpdater[_]].isAssignableFrom(_))
+          .get
+        Reflect.isViewTableUpdater(updater) shouldBe true
+      }
+
+      "accept a TableUpdater declared in the Scala companion object" in {
+        // In compiled Scala 2, classes defined inside `object Foo` appear in
+        // classOf[Foo].getDeclaredClasses() as ACC_STATIC nested classes — the JVM
+        // InnerClasses attribute attributes them to the primary class, not to Foo$.
+        val updater = classOf[ScalaViewWithCompanionUpdater].getDeclaredClasses
+          .find(classOf[akka.javasdk.view.TableUpdater[_]].isAssignableFrom(_))
+          .get
+        Reflect.isViewTableUpdater(updater) shouldBe true
+      }
+
+      "reject a class that does not extend TableUpdater" in {
+        Reflect.isViewTableUpdater(classOf[String]) shouldBe false
+      }
     }
   }
 }

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/view/ViewDescriptorFactorySpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/view/ViewDescriptorFactorySpec.scala
@@ -8,6 +8,8 @@ import scala.reflect.ClassTag
 
 import akka.dispatch.ExecutionContexts
 import akka.javasdk.impl.serialization.Serializer
+import akka.javasdk.testmodels.view.ScalaViewWithCompanionUpdater
+import akka.javasdk.testmodels.view.ScalaViewWithInnerUpdater
 import akka.javasdk.testmodels.view.ViewTestModels
 import akka.runtime.sdk.spi.ConsumerSource
 import akka.runtime.sdk.spi.Principal
@@ -126,6 +128,27 @@ class ViewDescriptorFactorySpec extends AnyWordSpec with Matchers {
           case Some(tableName) => tableName shouldBe expectedTableName
           case None            => fail(s"pattern does not match [$query]")
         }
+      }
+    }
+
+    "create a descriptor for a Scala View whose TableUpdater is in the companion object" in {
+      assertDescriptor[ScalaViewWithCompanionUpdater] { desc =>
+        desc.tables should have size 1
+        desc.tables.head.tableName shouldBe "scala_companion_rows"
+      }
+    }
+
+    "create a descriptor for a Scala View whose TableUpdater is a non-static inner class" in {
+      assertDescriptor[ScalaViewWithInnerUpdater] { desc =>
+        desc.tables should have size 1
+        desc.tables.head.tableName shouldBe "scala_inner_rows"
+      }
+    }
+
+    "not duplicate table updaters when companion class has no nested classes" in {
+      // Java static-nested shape: only getDeclaredClasses() finds it; no Scala companion exists.
+      assertDescriptor[ViewWithLowerCaseQuery] { desc =>
+        desc.tables should have size 1
       }
     }
 

--- a/akka-javasdk/src/test/scala/akka/javasdk/testmodels/view/ScalaViewTestModels.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/testmodels/view/ScalaViewTestModels.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.testmodels.view
+
+import akka.javasdk.annotations.{ Component, Consume, Query }
+import akka.javasdk.view.{ TableUpdater, View }
+
+/**
+ * Scala-idiomatic View (Option B): the TableUpdater lives in the companion object. In compiled Scala 2, the JVM
+ * InnerClasses attribute lists `Updater` as a static nested class of the primary class (`ScalaViewWithCompanionUpdater`),
+ * so it appears in `classOf[ScalaViewWithCompanionUpdater].getDeclaredClasses()` with ACC_STATIC set.
+ *
+ * ViewDescriptorFactory discovers it via the normal `viewClass.getDeclaredClasses` scan after the ACC_STATIC guard
+ * was removed from `Reflect.isViewTableUpdater`.
+ */
+object ScalaViewWithCompanionUpdater {
+  case class Row(id: String)
+
+  @Consume.FromTopic("test-topic")
+  class Updater extends TableUpdater[Row] {
+    def onEvent(r: Row): TableUpdater.Effect[Row] = effects().updateRow(r)
+  }
+}
+
+@Component(id = "scala-view-companion")
+class ScalaViewWithCompanionUpdater extends View {
+  @Query("SELECT * FROM scala_companion_rows")
+  def getAll(): View.QueryEffect[ScalaViewWithCompanionUpdater.Row] = queryResult()
+}
+
+/**
+ * Scala View (Option A): the TableUpdater is a non-static inner class of the primary class. The `Updater` appears in
+ * `ScalaViewWithInnerUpdater.getDeclaredClasses()` but is not ACC_STATIC.
+ *
+ * ViewDescriptorFactory must accept it after the isStatic guard is removed from Reflect.isViewTableUpdater.
+ *
+ * Row is placed in the companion object so it is a regular top-level-ish class and not itself a non-static inner class
+ * (which would complicate schema reflection).
+ */
+object ScalaViewWithInnerUpdater {
+  case class Row(id: String)
+}
+
+@Component(id = "scala-view-inner")
+class ScalaViewWithInnerUpdater extends View {
+
+  @Consume.FromTopic("test-topic")
+  class Updater extends TableUpdater[ScalaViewWithInnerUpdater.Row] {
+    def onEvent(r: ScalaViewWithInnerUpdater.Row): TableUpdater.Effect[ScalaViewWithInnerUpdater.Row] =
+      effects().updateRow(r)
+  }
+
+  @Query("SELECT * FROM scala_inner_rows")
+  def getAll(): View.QueryEffect[ScalaViewWithInnerUpdater.Row] = queryResult()
+}


### PR DESCRIPTION
## Summary

- **Problem**: Scala 2 cannot produce `public static` nested `TableUpdater` classes. Two Scala-idiomatic patterns were silently ignored:
  - **Option A** – `TableUpdater` as a non-static inner class of the `View` class (fails the old `Modifier.isStatic` guard)
  - **Option B** – `TableUpdater` defined in the companion `object` (classes appear in `classOf[FooView].getDeclaredClasses()` as `ACC_STATIC`, so this actually worked already once the `isStatic` guard is removed)

- Drop `Modifier.isStatic` guard from `Reflect.isViewTableUpdater` and `ViewValidations.isViewTableUpdater` (annotation-processor path)
- Add defensive companion-class search in `ViewDescriptorFactory` and `RuntimeTypeDef.getNestedTypes()` for future-proofing

### Key insight
In **compiled** Scala 2, companion object members are listed in the JVM `InnerClasses` attribute as static nested classes of the **primary** class (`FooView`), not inside the module class (`FooView$`). This differs from Scala REPL behavior.

## Test plan

- [ ] `ReflectSpec` – new `Reflect.isViewTableUpdater` block: Java static, Scala inner, Scala companion, non-`TableUpdater` cases
- [ ] `ViewDescriptorFactorySpec` – new tests for `ScalaViewWithCompanionUpdater`, `ScalaViewWithInnerUpdater`, and no-duplicate guard
- [ ] `ViewValidationSpec` – `ViewWithNonStaticUpdater.java` accepted; `ViewWithPrivateUpdater.java` rejected; Scala companion roundtrip via `RuntimeTypeDef`
- [ ] All 390 annotation-processor tests pass
- [ ] All 46 descriptor/reflect tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)