### PR TITLE
docs: alerts baseline page

### DIFF
--- a/docs/src/modules/operations/nav.adoc
+++ b/docs/src/modules/operations/nav.adoc
@@ -43,6 +43,7 @@
 ***** xref:operations:observability-and-monitoring/metrics.adoc[]
 ***** xref:operations:observability-and-monitoring/traces.adoc[]
 ***** xref:operations:observability-and-monitoring/observability-exports.adoc[]
+***** xref:operations:observability-and-monitoring/alerting-baselines.adoc[]
 
 **** xref:operations:integrating-cicd/index.adoc[]
 ***** xref:operations:integrating-cicd/github-actions.adoc[]

--- a/docs/src/modules/operations/pages/observability-and-monitoring/alerting-baselines.adoc
+++ b/docs/src/modules/operations/pages/observability-and-monitoring/alerting-baselines.adoc
@@ -56,7 +56,7 @@ NOTE: For gRPC streaming calls, the duration metric measures the full stream lif
 
 | Content load duration p99
 | `akka.agent.content_load.duration` (p99)
-| > 2 s
+| > 2 s (depends on content source)
 |===
 
 == Event Sourced Entities
@@ -109,9 +109,9 @@ TIP: Key Value Entity metrics use `akka.component.type="key-value-entity"` to di
 | `akka.workflow.step.duration` (filter where `error.type` attribute is present)
 | > 1 req/s
 
-| Active workflow count spike
+| Active workflow count
 | `akka.workflow.active`
-| Alert on unexpected spikes (may indicate stuck workflows)
+| Set a reasonable max for your workload (sustained counts above the expected maximum may indicate stuck workflows)
 
 | Recovery duration p99
 | `akka.workflow.recovery.duration` (p99)

--- a/docs/src/modules/operations/pages/observability-and-monitoring/alerting-baselines.adoc
+++ b/docs/src/modules/operations/pages/observability-and-monitoring/alerting-baselines.adoc
@@ -2,7 +2,7 @@
 
 Setting up alerts on key metrics helps detect issues before they impact users. The following are suggested baselines for common Akka components.
 
-WARNING: These thresholds are starting points — tune them based on your workload characteristics and operational experience.
+NOTE: These thresholds are starting points — tune them based on your workload characteristics and operational experience.
 
 TIP: For a full list of available metrics and their attributes, see the xref:reference:telemetry/metrics.adoc[Telemetry metrics reference]. To set up metric exports to your monitoring system, see xref:operations:observability-and-monitoring/observability-exports.adoc[].
 

--- a/docs/src/modules/operations/pages/observability-and-monitoring/alerting-baselines.adoc
+++ b/docs/src/modules/operations/pages/observability-and-monitoring/alerting-baselines.adoc
@@ -1,0 +1,181 @@
+= Alerting baselines
+
+Setting up alerts on key metrics helps detect issues before they impact users. The following are suggested baselines for common Akka components.
+
+WARNING: These thresholds are starting points — tune them based on your workload characteristics and operational experience.
+
+TIP: For a full list of available metrics and their attributes, see the xref:reference:telemetry/metrics.adoc[Telemetry metrics reference]. To set up metric exports to your monitoring system, see xref:operations:observability-and-monitoring/observability-exports.adoc[].
+
+== HTTP Endpoints
+
+[cols="2,2,1"]
+|===
+| Alert condition | Metric | Suggested threshold
+
+| Failing requests rate
+| `http.server.request.duration` (filter where `error.type` attribute is present)
+| > 1 req/s
+
+| Processing time p99
+| `http.server.request.duration` (p99)
+| > 200 ms
+|===
+
+NOTE: For streaming HTTP endpoints, the duration metric measures the full stream lifetime, so the p99 threshold above may not be meaningful. Focus on the failing requests rate for streaming endpoints instead.
+
+== gRPC Endpoints
+
+[cols="2,2,1"]
+|===
+| Alert condition | Metric | Suggested threshold
+
+| Failing requests rate
+| `rpc.server.call.duration` (filter where `error.type` attribute is present)
+| > 1 req/s
+
+| Call duration p99
+| `rpc.server.call.duration` (p99)
+| > 200 ms
+|===
+
+NOTE: For gRPC streaming calls, the duration metric measures the full stream lifetime, so the p99 threshold above may not be meaningful. Focus on the failing requests rate for streaming endpoints instead.
+
+== Agent components
+
+[cols="2,2,1"]
+|===
+| Alert condition | Metric | Suggested threshold
+
+| Commands failed rate
+| `akka.agent.command.duration` (filter where `error.type` attribute is present)
+| > 1 cmd/s
+
+| Tools failed rate
+| `gen_ai.client.operation.duration` (filter where `gen_ai.operation.name="execute_tool"` and `error.type` is present)
+| > 1 cmd/s
+
+| Content load duration p99
+| `akka.agent.content_load.duration` (p99)
+| > 2 s
+|===
+
+== Event Sourced Entities
+
+TIP: Event Sourced Entity metrics use `akka.component.type="event-sourced-entity"` to distinguish them from Key Value Entity metrics, which share the same metric names.
+
+[cols="2,2,1"]
+|===
+| Alert condition | Metric | Suggested threshold
+
+| Persist time p99
+| `akka.entity.persist.duration` (p99, filter `akka.component.type="event-sourced-entity"`)
+| > 100 ms (average over 60s)
+
+| Processing time p99
+| `akka.entity.command.processing.duration` (p99, filter `akka.component.type="event-sourced-entity"`)
+| > 100 ms (average over 60s)
+|===
+
+NOTE: For Event Sourced Entities, occasional spikes in persist or processing time are expected (for example, during snapshot creation). Using a 60-second averaging window helps filter out these transient peaks.
+
+== Key Value Entities
+
+TIP: Key Value Entity metrics use `akka.component.type="key-value-entity"` to distinguish them from Event Sourced Entity metrics, which share the same metric names.
+
+[cols="2,2,1"]
+|===
+| Alert condition | Metric | Suggested threshold
+
+| Persist time p99
+| `akka.entity.persist.duration` (p99, filter `akka.component.type="key-value-entity"`)
+| > 100 ms (average over 60s)
+
+| Processing time p99
+| `akka.entity.command.processing.duration` (p99, filter `akka.component.type="key-value-entity"`)
+| > 100 ms (average over 60s)
+|===
+
+== Workflows
+
+[cols="2,2,1"]
+|===
+| Alert condition | Metric | Suggested threshold
+
+| Commands failed rate
+| `akka.workflow.command.duration` (filter where `error.type` attribute is present)
+| > 1 req/s
+
+| Steps failed rate
+| `akka.workflow.step.duration` (filter where `error.type` attribute is present)
+| > 1 req/s
+
+| Active workflow count spike
+| `akka.workflow.active`
+| Alert on unexpected spikes (may indicate stuck workflows)
+
+| Recovery duration p99
+| `akka.workflow.recovery.duration` (p99)
+| > 1 s
+|===
+
+== Views
+
+[cols="2,2,1"]
+|===
+| Alert condition | Metric | Suggested threshold
+
+| Query duration p99
+| `akka.view.query.duration` (p99)
+| > 500 ms
+
+| Update duration p99
+| `akka.view.update.duration` (p99)
+| > 500 ms
+|===
+
+== Consumers
+
+[cols="2,2,1"]
+|===
+| Alert condition | Metric | Suggested threshold
+
+| Events consumption lag (max)
+| `akka.projection.consumer.lag` (max)
+| > 1 min
+
+| Events processing time (avg)
+| `akka.consumer.message.duration` (average)
+| > 1 s
+
+| Subscriptions failed
+| `akka.eventing.stream.failed` (counter)
+| > 0
+|===
+
+== Replication
+
+NOTE: These metrics are only applicable to multi-region deployments.
+
+[cols="2,2,1"]
+|===
+| Alert condition | Metric | Suggested threshold
+
+| Replication lag (avg)
+| `akka.projection.consumer.lag` (average, filter `akka.projection.type="replicated-event-sourced-projection"`)
+| > 10 s
+|===
+
+== Timers and Timed Actions
+
+[cols="2,2,1"]
+|===
+| Alert condition | Metric | Suggested threshold
+
+| Timer call failures
+| `akka.timer.call.duration` (filter where `error.type` attribute is present)
+| > 0
+
+| Timed action failures
+| `akka.timed_action.message.duration` (filter where `error.type` attribute is present)
+| > 0
+|===

--- a/docs/src/modules/operations/pages/observability-and-monitoring/metrics.adoc
+++ b/docs/src/modules/operations/pages/observability-and-monitoring/metrics.adoc
@@ -89,3 +89,5 @@ image:operations:dashboard-control-tower-metrics-screenshot.png[]
 **Replication lag - average:** Average lag for multi-region event replication.
 
 **Replication failures:** Failure rate for multi-region replication.
+
+TIP: For suggested alerting thresholds on these metrics, see xref:operations:observability-and-monitoring/alerting-baselines.adoc[].

--- a/docs/src/modules/operations/pages/operator-best-practices.adoc
+++ b/docs/src/modules/operations/pages/operator-best-practices.adoc
@@ -22,4 +22,8 @@ Workflows handle writes, reads and forwarding of requests in a similar way as Ev
 Changing primary regions is a serious operation and should be thought out carefully. Ideally you plan this ahead of time and synchronize the regions by allowing the replication lag to drop to zero. You can put the project into a read only mode that will stop any writes from happening if you want to be sure that there will be zero data collisions when you change the primary.
 
 === Container registries
-Container registries are regional in Akka. If you decide to use xref:operations:projects/external-container-registries.adoc[] be aware that you should have container registries in or near each of the regions in your project. If you only have your container images in one place and that place becomes unavailable your services will not be able to start new instances. 
+Container registries are regional in Akka. If you decide to use xref:operations:projects/external-container-registries.adoc[] be aware that you should have container registries in or near each of the regions in your project. If you only have your container images in one place and that place becomes unavailable your services will not be able to start new instances.
+
+== Alerting
+
+Setting up alerts on key metrics is an important part of operating Akka services. For suggested alerting thresholds across endpoints, entities, workflows, consumers, and replication, see xref:operations:observability-and-monitoring/alerting-baselines.adoc[].

--- a/docs/src/modules/sdk/pages/ai-coding-assistant-guidelines.adoc
+++ b/docs/src/modules/sdk/pages/ai-coding-assistant-guidelines.adoc
@@ -61,7 +61,6 @@ These guidelines apply only to the Akka SDK and do not cover usage of the lower-
 * State of a workflow can be defined as a record inside the workflow, but if it contains much business logic it should be in the `domain` package, also know as domain object.
 * Use methods returning `StepEffect` for each step of the workflow. Don't use the old deprecated `definition` method. Prefer defining a `StepName` annotation to the step methods to give them a stable identifier.
 * Workflows should be explicit about timeouts and retries whenever appropriate. When calling agents the step timeout must be rather long (60 seconds) since LLM response times can be long. A workflow that orchestrates agents should define `defaultStepRecover` in the `WorkflowSettings` with limited number of retries, to avoid too many (costly) retries to the LLM.
-* Long-running workflows should have a safety-net mechanism (e.g., an overall timeout or a monitor step) to detect and handle stuck executions rather than running indefinitely.
 
 == Agents
 
@@ -71,9 +70,6 @@ These guidelines apply only to the Akka SDK and do not cover usage of the lower-
 * Agent classes should be stateless and not have mutable state in itself.
 * The agent session id is typically a UUID to guarantee uniqueness for new agent interactions, but it can be shared between different agents that participate in the same session.
 * Prefer to use a default model defined in config.
-* For structured responses, prefer `responseConformsTo(Class)` which uses the model's structured output support.
-* Agents that parse JSON responses or call tools should include `.onFailure(ex -> fallback)` error handling to gracefully handle model failures.
-* Configure `MemoryProvider` intentionally per agent — use `.none()` for stateless interactions, `.limitedWindow()` for conversational agents, or `.limitedWindow().readLast(N)` to control context size.
 
 == Views
 
@@ -115,5 +111,5 @@ These guidelines apply only to the Akka SDK and do not cover usage of the lower-
 * Use Junit 5+ annotations (`@Test` etc).
 * Use `assertThat` from `assertj`.
 * Use `componentClient` from the `TestKitSupport` for testing components (there is no “mock” component client).
-* Use `TestModelProvider` to mock responses from AI model when testing agents. Use `JsonSupport.encodeToString(mockObject)` to serialize mock responses rather than writing raw JSON strings, to ensure the mock matches the actual serialization format.
+* Use `TestModelProvider` to mock responses from AI model when testing agents.
 

--- a/docs/src/modules/sdk/pages/ai-coding-assistant-guidelines.adoc
+++ b/docs/src/modules/sdk/pages/ai-coding-assistant-guidelines.adoc
@@ -61,6 +61,7 @@ These guidelines apply only to the Akka SDK and do not cover usage of the lower-
 * State of a workflow can be defined as a record inside the workflow, but if it contains much business logic it should be in the `domain` package, also know as domain object.
 * Use methods returning `StepEffect` for each step of the workflow. Don't use the old deprecated `definition` method. Prefer defining a `StepName` annotation to the step methods to give them a stable identifier.
 * Workflows should be explicit about timeouts and retries whenever appropriate. When calling agents the step timeout must be rather long (60 seconds) since LLM response times can be long. A workflow that orchestrates agents should define `defaultStepRecover` in the `WorkflowSettings` with limited number of retries, to avoid too many (costly) retries to the LLM.
+* Long-running workflows should have a safety-net mechanism (e.g., an overall timeout or a monitor step) to detect and handle stuck executions rather than running indefinitely.
 
 == Agents
 
@@ -70,6 +71,9 @@ These guidelines apply only to the Akka SDK and do not cover usage of the lower-
 * Agent classes should be stateless and not have mutable state in itself.
 * The agent session id is typically a UUID to guarantee uniqueness for new agent interactions, but it can be shared between different agents that participate in the same session.
 * Prefer to use a default model defined in config.
+* For structured responses, prefer `responseConformsTo(Class)` which uses the model's structured output support.
+* Agents that parse JSON responses or call tools should include `.onFailure(ex -> fallback)` error handling to gracefully handle model failures.
+* Configure `MemoryProvider` intentionally per agent — use `.none()` for stateless interactions, `.limitedWindow()` for conversational agents, or `.limitedWindow().readLast(N)` to control context size.
 
 == Views
 
@@ -111,5 +115,5 @@ These guidelines apply only to the Akka SDK and do not cover usage of the lower-
 * Use Junit 5+ annotations (`@Test` etc).
 * Use `assertThat` from `assertj`.
 * Use `componentClient` from the `TestKitSupport` for testing components (there is no “mock” component client).
-* Use `TestModelProvider` to mock responses from AI model when testing agents.
+* Use `TestModelProvider` to mock responses from AI model when testing agents. Use `JsonSupport.encodeToString(mockObject)` to serialize mock responses rather than writing raw JSON strings, to ensure the mock matches the actual serialization format.
 


### PR DESCRIPTION
Adding a page for the recommended baseline for alerting for akka services.

Renders like this

<img width="878" height="1157" alt="Screenshot 2026-06-25 at 21 55 55" src="https://github.com/user-attachments/assets/d3d5e7c7-dd18-4efb-81d5-23331089c268" />
