### PR TITLE
feat: SPIFFE id ACLs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,6 +40,10 @@ jobs:
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
         uses: coursier/cache-action@v8.1.0
+        with:
+          # enables invalidating stale caches (bump extraKey)
+          extraKey: "v2"
+          disableFallback: true
 
       - name: Set up JDK 21
         # https://github.com/coursier/setup-action/releases

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/invalid/GrpcEndpointAclSpiffeWildcardNotLast.java
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/invalid/GrpcEndpointAclSpiffeWildcardNotLast.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.example;
+
+import akka.javasdk.annotations.Acl;
+import akka.javasdk.annotations.GrpcEndpoint;
+
+@GrpcEndpoint
+// ** is only allowed as the final token
+@Acl(allow = @Acl.Matcher(spiffe = "svc/**/agent"))
+public class GrpcEndpointAclSpiffeWildcardNotLast {
+
+  public String someMethod() {
+    return "ok";
+  }
+}

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/invalid/HttpEndpointAclSpiffeWildcardNotLast.java
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/invalid/HttpEndpointAclSpiffeWildcardNotLast.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.example;
+
+import akka.javasdk.annotations.Acl;
+import akka.javasdk.annotations.http.Get;
+import akka.javasdk.annotations.http.HttpEndpoint;
+
+@HttpEndpoint("/api")
+public class HttpEndpointAclSpiffeWildcardNotLast {
+
+  // ** is only allowed as the final token
+  @Acl(allow = @Acl.Matcher(spiffe = "svc/**/agent"))
+  @Get("/")
+  public String list() {
+    return "list";
+  }
+}

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/valid/ValidHttpEndpointWithSpiffeAcl.java
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/resources/test-sources/valid/ValidHttpEndpointWithSpiffeAcl.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.example;
+
+import akka.javasdk.annotations.Acl;
+import akka.javasdk.annotations.http.Get;
+import akka.javasdk.annotations.http.HttpEndpoint;
+import akka.javasdk.annotations.http.Post;
+
+@HttpEndpoint("/api")
+// trailing ** is valid: matches all components of the checkout service
+@Acl(allow = @Acl.Matcher(spiffe = "svc/checkout/**"))
+public class ValidHttpEndpointWithSpiffeAcl {
+
+  @Get("/")
+  public String list() {
+    return "list";
+  }
+
+  // single-segment wildcards are valid anywhere
+  @Acl(allow = @Acl.Matcher(spiffe = "svc/*/agent/*"))
+  @Post("/")
+  public String create(String body) {
+    return "create";
+  }
+}

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/scala/com/example/AclAnnotationValidationSpec.scala
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/scala/com/example/AclAnnotationValidationSpec.scala
@@ -38,6 +38,22 @@ abstract class AbstractAclAnnotationValidationSpec(val validationMode: Validatio
       assertValid("valid/ValidConsumerWithServiceStreamAndMethodAcl.java")
     }
 
+    "accept a SPIFFE @Acl pattern with a trailing ** and single-segment wildcards" in {
+      assertValid("valid/ValidHttpEndpointWithSpiffeAcl.java")
+    }
+
+    "reject a SPIFFE @Acl pattern with a non-final ** on an HttpEndpoint" in {
+      assertInvalid(
+        "invalid/HttpEndpointAclSpiffeWildcardNotLast.java",
+        "`**` is only allowed as the final token")
+    }
+
+    "reject a SPIFFE @Acl pattern with a non-final ** on a GrpcEndpoint" in {
+      assertInvalid(
+        "invalid/GrpcEndpointAclSpiffeWildcardNotLast.java",
+        "`**` is only allowed as the final token")
+    }
+
     "reject @Acl on a Consumer without @Produce.ServiceStream" in {
       assertInvalid(
         "invalid/AclOnConsumer.java",

--- a/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/scala/com/example/AclAnnotationValidationSpec.scala
+++ b/akka-javasdk-annotation-processor-tests/component-validation-descriptors/src/test/scala/com/example/AclAnnotationValidationSpec.scala
@@ -43,15 +43,11 @@ abstract class AbstractAclAnnotationValidationSpec(val validationMode: Validatio
     }
 
     "reject a SPIFFE @Acl pattern with a non-final ** on an HttpEndpoint" in {
-      assertInvalid(
-        "invalid/HttpEndpointAclSpiffeWildcardNotLast.java",
-        "`**` is only allowed as the final token")
+      assertInvalid("invalid/HttpEndpointAclSpiffeWildcardNotLast.java", "`**` is only allowed as the final token")
     }
 
     "reject a SPIFFE @Acl pattern with a non-final ** on a GrpcEndpoint" in {
-      assertInvalid(
-        "invalid/GrpcEndpointAclSpiffeWildcardNotLast.java",
-        "`**` is only allowed as the final token")
+      assertInvalid("invalid/GrpcEndpointAclSpiffeWildcardNotLast.java", "`**` is only allowed as the final token")
     }
 
     "reject @Acl on a Consumer without @Produce.ServiceStream" in {

--- a/akka-javasdk-validations/src/main/java/akka/javasdk/tooling/validation/Validations.java
+++ b/akka-javasdk-validations/src/main/java/akka/javasdk/tooling/validation/Validations.java
@@ -37,17 +37,87 @@ public class Validations {
    * @return a Validation result indicating success or failure with error messages
    */
   public static Validation validate(TypeDef typeDef) {
+    // @Acl (with its SPIFFE patterns) can appear on any endpoint kind and on @Produce.ServiceStream
+    // consumers, so validate its patterns regardless of which branch handles the rest.
+    Validation aclPatterns = spiffeAclPatternValidation(typeDef);
     if (typeDef.hasAnnotation(HTTP_ENDPOINT_ANNOTATION)) {
-      return HttpEndpointValidations.validate(typeDef);
+      return HttpEndpointValidations.validate(typeDef).combine(aclPatterns);
     } else if (typeDef.hasAnnotation(GRPC_ENDPOINT_ANNOTATION)) {
-      // no specific validations for grpc endpoint
-      return Validation.Valid.instance();
+      // no specific validations for grpc endpoint beyond ACL patterns
+      return aclPatterns;
     } else if (typeDef.hasAnnotation(MCP_ENDPOINT_ANNOTATION)) {
-      // no specific validations for mcp endpoint
-      return Validation.Valid.instance();
+      // no specific validations for mcp endpoint beyond ACL patterns
+      return aclPatterns;
     } else {
-      return validateComponent(typeDef);
+      return validateComponent(typeDef).combine(aclPatterns);
     }
+  }
+
+  /**
+   * Validates the SPIFFE glob patterns of any {@code @Acl} matchers on the class and its methods. A
+   * {@code **} (cross-segment wildcard) is only valid as the final token of a pattern; mirrors the
+   * runtime glob compiler in akka-runtime's {@code PrincipalMatcher.compileSegmentGlob}.
+   *
+   * @param typeDef the class to validate
+   * @return a Validation result indicating success or failure
+   */
+  public static Validation spiffeAclPatternValidation(TypeDef typeDef) {
+    List<String> errors = new ArrayList<>();
+
+    typeDef
+        .findAnnotation(ACL_ANNOTATION)
+        .ifPresent(
+            acl ->
+                invalidSpiffePatterns(acl)
+                    .forEach(bad -> errors.add(errorMessage(typeDef, badSpiffePatternMessage(bad)))));
+
+    for (MethodDef method : typeDef.getMethods()) {
+      method
+          .findAnnotation(ACL_ANNOTATION)
+          .ifPresent(
+              acl ->
+                  invalidSpiffePatterns(acl)
+                      .forEach(
+                          bad -> errors.add(errorMessage(method, badSpiffePatternMessage(bad)))));
+    }
+
+    return Validation.of(errors);
+  }
+
+  private static List<String> invalidSpiffePatterns(AnnotationDef aclAnnotation) {
+    List<String> invalid = new ArrayList<>();
+    List<AnnotationDef> matchers = new ArrayList<>();
+    matchers.addAll(aclAnnotation.getAnnotationArrayValue("allow"));
+    matchers.addAll(aclAnnotation.getAnnotationArrayValue("deny"));
+    for (AnnotationDef matcher : matchers) {
+      String spiffe = matcher.getStringValue("spiffe").orElse("");
+      if (!spiffe.isEmpty() && !isValidSpiffePattern(spiffe)) {
+        invalid.add(spiffe);
+      }
+    }
+    return invalid;
+  }
+
+  /** A {@code **} (cross-segment wildcard) is only valid as the final token of the pattern. */
+  static boolean isValidSpiffePattern(String pattern) {
+    int i = 0;
+    while (i < pattern.length()) {
+      if (pattern.charAt(i) == '*' && i + 1 < pattern.length() && pattern.charAt(i + 1) == '*') {
+        if (i + 2 != pattern.length()) {
+          return false;
+        }
+        i += 2;
+      } else {
+        i++;
+      }
+    }
+    return true;
+  }
+
+  private static String badSpiffePatternMessage(String pattern) {
+    return "Invalid SPIFFE ACL pattern ["
+        + pattern
+        + "]: `**` is only allowed as the final token (matches everything below).";
   }
 
   private static Validation validateComponent(TypeDef typeDef) {

--- a/akka-javasdk-validations/src/main/java/akka/javasdk/tooling/validation/Validations.java
+++ b/akka-javasdk-validations/src/main/java/akka/javasdk/tooling/validation/Validations.java
@@ -69,7 +69,8 @@ public class Validations {
         .ifPresent(
             acl ->
                 invalidSpiffePatterns(acl)
-                    .forEach(bad -> errors.add(errorMessage(typeDef, badSpiffePatternMessage(bad)))));
+                    .forEach(
+                        bad -> errors.add(errorMessage(typeDef, badSpiffePatternMessage(bad)))));
 
     for (MethodDef method : typeDef.getMethods()) {
       method
@@ -99,7 +100,7 @@ public class Validations {
   }
 
   /** A {@code **} (cross-segment wildcard) is only valid as the final token of the pattern. */
-  static boolean isValidSpiffePattern(String pattern) {
+  public static boolean isValidSpiffePattern(String pattern) {
     int i = 0;
     while (i < pattern.length()) {
       if (pattern.charAt(i) == '*' && i + 1 < pattern.length() && pattern.charAt(i + 1) == '*') {

--- a/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/AnnotationDef.java
+++ b/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/AnnotationDef.java
@@ -4,6 +4,7 @@
 
 package akka.javasdk.validation.ast;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -48,4 +49,15 @@ public interface AnnotationDef {
    * @return the type reference, or empty if not found or not a class value
    */
   Optional<TypeRefDef> getClassValue(String attributeName);
+
+  /**
+   * Gets an array of nested annotations from an annotation attribute.
+   *
+   * <p>For example, for {@code @Acl(allow = {@Acl.Matcher(...), @Acl.Matcher(...)})}, calling {@code
+   * getAnnotationArrayValue("allow")} returns one AnnotationDef per matcher.
+   *
+   * @param attributeName the name of the attribute
+   * @return the nested annotations, or an empty list if not found or not an annotation array
+   */
+  List<AnnotationDef> getAnnotationArrayValue(String attributeName);
 }

--- a/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/AnnotationDef.java
+++ b/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/AnnotationDef.java
@@ -53,8 +53,8 @@ public interface AnnotationDef {
   /**
    * Gets an array of nested annotations from an annotation attribute.
    *
-   * <p>For example, for {@code @Acl(allow = {@Acl.Matcher(...), @Acl.Matcher(...)})}, calling {@code
-   * getAnnotationArrayValue("allow")} returns one AnnotationDef per matcher.
+   * <p>For example, for {@code @Acl(allow = {@Acl.Matcher(...), @Acl.Matcher(...)})}, calling
+   * {@code getAnnotationArrayValue("allow")} returns one AnnotationDef per matcher.
    *
    * @param attributeName the name of the attribute
    * @return the nested annotations, or an empty list if not found or not an annotation array

--- a/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/compiletime/CompileTimeAnnotationDef.java
+++ b/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/compiletime/CompileTimeAnnotationDef.java
@@ -63,7 +63,8 @@ public record CompileTimeAnnotationDef(AnnotationMirror annotationMirror) implem
                     .filter(e -> e instanceof AnnotationValue)
                     .map(e -> ((AnnotationValue) e).getValue())
                     .filter(val -> val instanceof AnnotationMirror)
-                    .map(val -> (AnnotationDef) new CompileTimeAnnotationDef((AnnotationMirror) val))
+                    .map(
+                        val -> (AnnotationDef) new CompileTimeAnnotationDef((AnnotationMirror) val))
                     .toList())
         .orElse(List.of());
   }

--- a/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/compiletime/CompileTimeAnnotationDef.java
+++ b/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/compiletime/CompileTimeAnnotationDef.java
@@ -6,6 +6,7 @@ package akka.javasdk.validation.ast.compiletime;
 
 import akka.javasdk.validation.ast.AnnotationDef;
 import akka.javasdk.validation.ast.TypeRefDef;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.lang.model.element.AnnotationMirror;
@@ -48,6 +49,23 @@ public record CompileTimeAnnotationDef(AnnotationMirror annotationMirror) implem
         .filter(v -> v instanceof TypeMirror)
         .map(v -> (TypeMirror) v)
         .map(CompileTimeTypeRefDef::new);
+  }
+
+  @Override
+  public List<AnnotationDef> getAnnotationArrayValue(String attributeName) {
+    return getAttributeValue(attributeName)
+        .map(AnnotationValue::getValue)
+        .filter(v -> v instanceof List)
+        .map(v -> (List<?>) v)
+        .map(
+            list ->
+                list.stream()
+                    .filter(e -> e instanceof AnnotationValue)
+                    .map(e -> ((AnnotationValue) e).getValue())
+                    .filter(val -> val instanceof AnnotationMirror)
+                    .map(val -> (AnnotationDef) new CompileTimeAnnotationDef((AnnotationMirror) val))
+                    .toList())
+        .orElse(List.of());
   }
 
   /**

--- a/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/runtime/RuntimeAnnotationDef.java
+++ b/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/runtime/RuntimeAnnotationDef.java
@@ -9,6 +9,8 @@ import akka.javasdk.validation.ast.TypeRefDef;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -57,6 +59,19 @@ public record RuntimeAnnotationDef(Annotation annotation) implements AnnotationD
         .filter(v -> v instanceof Class)
         .map(v -> (Class<?>) v)
         .map(RuntimeTypeRefDef::new);
+  }
+
+  @Override
+  public List<AnnotationDef> getAnnotationArrayValue(String attributeName) {
+    return getAttributeValue(attributeName)
+        .filter(v -> v instanceof Annotation[])
+        .map(v -> (Annotation[]) v)
+        .map(
+            arr ->
+                Arrays.stream(arr)
+                    .map(a -> (AnnotationDef) new RuntimeAnnotationDef(a))
+                    .toList())
+        .orElse(List.of());
   }
 
   /**

--- a/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/runtime/RuntimeAnnotationDef.java
+++ b/akka-javasdk-validations/src/main/java/akka/javasdk/validation/ast/runtime/RuntimeAnnotationDef.java
@@ -68,9 +68,7 @@ public record RuntimeAnnotationDef(Annotation annotation) implements AnnotationD
         .map(v -> (Annotation[]) v)
         .map(
             arr ->
-                Arrays.stream(arr)
-                    .map(a -> (AnnotationDef) new RuntimeAnnotationDef(a))
-                    .toList())
+                Arrays.stream(arr).map(a -> (AnnotationDef) new RuntimeAnnotationDef(a)).toList())
         .orElse(List.of());
   }
 

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/Acl.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/Acl.java
@@ -50,7 +50,7 @@ public @interface Acl {
    * When a matcher is applied to the request, the request is considered to match if at least one of
    * the principals attached to the request matches.
    *
-   * <p>Each Matcher can be configured either with a 'service' or a 'principal', but not both.
+   * <p>Each Matcher can be configured with exactly one of 'service', 'spiffe' or 'principal'.
    */
   @Target({ElementType.TYPE, ElementType.METHOD})
   @Retention(RetentionPolicy.RUNTIME)
@@ -65,6 +65,22 @@ public @interface Acl {
      * <p>Supports glob matching, that is, * means all services in this project.
      */
     String service() default "";
+
+    /**
+     * Match a calling component by its SPIFFE identity, allowing component-level rules such as all
+     * components of a service, all components of a given type, or one specific component.
+     *
+     * <p>Supports glob matching, where {@code *} matches any sequence of characters. The pattern is
+     * matched against the component-path suffix of the caller's SPIFFE id, i.e. {@code
+     * svc/<service>/<component-type>/<component-id>}. For example {@code
+     * svc/shopping-cart/event-sourced-entity/cart} for a single component, or a leading-{@code *}
+     * glob to match all event-sourced-entities of any service.
+     *
+     * <p>Only requests from in-mesh peers carry a SPIFFE identity (internet/ingress callers never
+     * match). The {@code svc/<service>} part is authenticated; the {@code
+     * <component-type>/<component-id>} part is self-asserted by the calling service.
+     */
+    String spiffe() default "";
 
     /** A principal matcher that can be specified with no additional configuration. */
     Principal principal() default Principal.UNSPECIFIED;

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/Acl.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/Acl.java
@@ -73,8 +73,9 @@ public @interface Acl {
      * <p>Supports glob matching, where {@code *} matches any sequence of characters. The pattern is
      * matched against the component-path suffix of the caller's SPIFFE id, i.e. {@code
      * svc/<service>/<component-type>/<component-id>}. For example {@code
-     * svc/shopping-cart/event-sourced-entity/cart} for a single component, or a leading-{@code *}
-     * glob to match all event-sourced-entities of any service.
+     * svc/shopping-cart/workflow/checkout} for a single component, or a leading-{@code *} glob to
+     * match all agents of any service. Only components that make outbound calls (such as workflows
+     * and agents) appear as callers.
      *
      * <p>Only requests from in-mesh peers carry a SPIFFE identity (internet/ingress callers never
      * match). The {@code svc/<service>} part is authenticated; the {@code

--- a/akka-javasdk/src/main/java/akka/javasdk/annotations/Acl.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/annotations/Acl.java
@@ -70,12 +70,13 @@ public @interface Acl {
      * Match a calling component by its SPIFFE identity, allowing component-level rules such as all
      * components of a service, all components of a given type, or one specific component.
      *
-     * <p>Supports glob matching, where {@code *} matches any sequence of characters. The pattern is
-     * matched against the component-path suffix of the caller's SPIFFE id, i.e. {@code
-     * svc/<service>/<component-type>/<component-id>}. For example {@code
-     * svc/shopping-cart/workflow/checkout} for a single component, or a leading-{@code *} glob to
-     * match all agents of any service. Only components that make outbound calls (such as workflows
-     * and agents) appear as callers.
+     * <p>Supports segment-aware glob matching over the {@code /}-separated path: {@code *} matches
+     * within a single path segment, and {@code **} (only allowed as the final token) matches across
+     * segments. The pattern is matched against the component-path suffix of the caller's SPIFFE id,
+     * i.e. {@code svc/<service>/<component-type>/<component-id>}. For example {@code
+     * svc/shopping-cart/workflow/checkout} for a single component, {@code svc/shopping-cart/**} for
+     * all components of a service, or {@code svc/*}{@code /agent/*} for all agents of any service.
+     * Only components that make outbound calls (such as workflows and agents) appear as callers.
      *
      * <p>Only requests from in-mesh peers carry a SPIFFE identity (internet/ingress callers never
      * match). The {@code svc/<service>} part is authenticated; the {@code

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/AclDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/AclDescriptorFactory.scala
@@ -13,6 +13,7 @@ import akka.runtime.sdk.spi.All
 import akka.runtime.sdk.spi.Internet
 import akka.runtime.sdk.spi.PrincipalMatcher
 import akka.runtime.sdk.spi.ServiceNamePattern
+import akka.runtime.sdk.spi.SpiffePattern
 import com.google.rpc.Code
 
 /**
@@ -22,11 +23,14 @@ import com.google.rpc.Code
 private[impl] object AclDescriptorFactory {
 
   val invalidAnnotationUsage: String =
-    "Invalid annotation usage. Matcher has both 'principal' and 'service' defined. " +
-    "Only one is allowed."
+    "Invalid annotation usage. Matcher must have exactly one of 'principal', 'service' or 'spiffe' defined."
 
   def validateMatcher(matcher: Acl.Matcher): Unit = {
-    if (matcher.principal() != Acl.Principal.UNSPECIFIED && matcher.service().nonEmpty)
+    val definedCount =
+      (if (matcher.principal() != Acl.Principal.UNSPECIFIED) 1 else 0) +
+      (if (matcher.service().nonEmpty) 1 else 0) +
+      (if (matcher.spiffe().nonEmpty) 1 else 0)
+    if (definedCount > 1)
       throw new IllegalArgumentException(invalidAnnotationUsage)
   }
 
@@ -47,9 +51,11 @@ private[impl] object AclDescriptorFactory {
   private def toPrincipalMatcher(matchers: Array[Acl.Matcher]): List[PrincipalMatcher] =
     matchers.map { m =>
       m.principal match {
-        case Acl.Principal.ALL         => All
-        case Acl.Principal.INTERNET    => Internet
-        case Acl.Principal.UNSPECIFIED => new ServiceNamePattern(m.service())
+        case Acl.Principal.ALL      => All
+        case Acl.Principal.INTERNET => Internet
+        case Acl.Principal.UNSPECIFIED =>
+          if (m.spiffe().nonEmpty) new SpiffePattern(m.spiffe())
+          else new ServiceNamePattern(m.service())
       }
     }.toList
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/AclDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/AclDescriptorFactory.scala
@@ -8,6 +8,7 @@ import akka.annotation.InternalApi
 import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.model.StatusCodes.Forbidden
 import akka.javasdk.annotations.Acl
+import akka.javasdk.tooling.validation.Validations
 import akka.runtime.sdk.spi.ACL
 import akka.runtime.sdk.spi.All
 import akka.runtime.sdk.spi.Internet
@@ -32,24 +33,12 @@ private[impl] object AclDescriptorFactory {
       (if (matcher.spiffe().nonEmpty) 1 else 0)
     if (definedCount > 1)
       throw new IllegalArgumentException(invalidAnnotationUsage)
-    if (matcher.spiffe().nonEmpty)
-      validateSpiffePattern(matcher.spiffe())
-  }
-
-  // Mirrors the runtime glob compiler (akka-runtime PrincipalMatcher.compileSegmentGlob): in a SPIFFE ACL glob
-  // `*` matches within a single path segment and `**` matches across segments, but `**` is only valid as the final
-  // token of the pattern. Reject a non-final `**` (or `***`) here so the mistake surfaces when the service is built
-  // rather than only when the runtime compiles the pattern.
-  def validateSpiffePattern(pattern: String): Unit = {
-    var i = 0
-    while (i < pattern.length) {
-      if (pattern.charAt(i) == '*' && i + 1 < pattern.length && pattern.charAt(i + 1) == '*') {
-        if (i + 2 != pattern.length)
-          throw new IllegalArgumentException(
-            s"Invalid SPIFFE ACL pattern [$pattern]: `**` is only allowed as the final token (matches everything below)")
-        i += 2
-      } else i += 1
-    }
+    // Same rule the compile-time/runtime validation framework applies (Validations.isValidSpiffePattern) and that
+    // the runtime glob compiler enforces: `**` is only valid as the final token. Checked here too so a pattern that
+    // somehow slipped past validation still fails when the service descriptor is built.
+    if (matcher.spiffe().nonEmpty && !Validations.isValidSpiffePattern(matcher.spiffe()))
+      throw new IllegalArgumentException(
+        s"Invalid SPIFFE ACL pattern [${matcher.spiffe()}]: `**` is only allowed as the final token (matches everything below)")
   }
 
   // receives the method, checks if it is annotated with @Acl and if so,

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/AclDescriptorFactory.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/AclDescriptorFactory.scala
@@ -32,6 +32,24 @@ private[impl] object AclDescriptorFactory {
       (if (matcher.spiffe().nonEmpty) 1 else 0)
     if (definedCount > 1)
       throw new IllegalArgumentException(invalidAnnotationUsage)
+    if (matcher.spiffe().nonEmpty)
+      validateSpiffePattern(matcher.spiffe())
+  }
+
+  // Mirrors the runtime glob compiler (akka-runtime PrincipalMatcher.compileSegmentGlob): in a SPIFFE ACL glob
+  // `*` matches within a single path segment and `**` matches across segments, but `**` is only valid as the final
+  // token of the pattern. Reject a non-final `**` (or `***`) here so the mistake surfaces when the service is built
+  // rather than only when the runtime compiles the pattern.
+  def validateSpiffePattern(pattern: String): Unit = {
+    var i = 0
+    while (i < pattern.length) {
+      if (pattern.charAt(i) == '*' && i + 1 < pattern.length && pattern.charAt(i + 1) == '*') {
+        if (i + 2 != pattern.length)
+          throw new IllegalArgumentException(
+            s"Invalid SPIFFE ACL pattern [$pattern]: `**` is only allowed as the final token (matches everything below)")
+        i += 2
+      } else i += 1
+    }
   }
 
   // receives the method, checks if it is annotated with @Acl and if so,

--- a/akka-javasdk/src/test/java/akka/javasdk/impl/http/TestEndpoints.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/impl/http/TestEndpoints.java
@@ -147,6 +147,21 @@ public class TestEndpoints {
     public String thisAndThat() {
       return "this-and-that";
     }
+
+    @Get("/spiffe")
+    @Acl(allow = @Acl.Matcher(spiffe = "svc/checkout/*"))
+    public String spiffe() {
+      return "spiffe";
+    }
+  }
+
+  @HttpEndpoint("invalid-acl-spiffe")
+  public static class TestEndpointInvalidAclSpiffe {
+    @Get("/invalid")
+    @Acl(allow = @Acl.Matcher(service = "*", spiffe = "svc/checkout/*"))
+    public String invalid() {
+      return "invalid matcher";
+    }
   }
 
   @HttpEndpoint("invalid-acl")

--- a/akka-javasdk/src/test/java/akka/javasdk/impl/http/TestEndpoints.java
+++ b/akka-javasdk/src/test/java/akka/javasdk/impl/http/TestEndpoints.java
@@ -164,6 +164,15 @@ public class TestEndpoints {
     }
   }
 
+  @HttpEndpoint("invalid-acl-spiffe-pattern")
+  public static class TestEndpointInvalidAclSpiffePattern {
+    @Get("/invalid")
+    @Acl(allow = @Acl.Matcher(spiffe = "svc/**/agent"))
+    public String invalid() {
+      return "invalid spiffe pattern";
+    }
+  }
+
   @HttpEndpoint("invalid-acl")
   public static class TestEndpointInvalidAcl {
     @Get("/invalid")

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/HttpEndpointDescriptorFactorySpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/HttpEndpointDescriptorFactorySpec.scala
@@ -16,6 +16,7 @@ import akka.runtime.sdk.spi.ClaimValues
 import akka.runtime.sdk.spi.HttpEndpointMethodSpec
 import akka.runtime.sdk.spi.Internet
 import akka.runtime.sdk.spi.ServiceNamePattern
+import akka.runtime.sdk.spi.SpiffePattern
 import akka.runtime.sdk.spi.SpiJsonSchema
 import akka.runtime.sdk.spi.StaticClaim
 import org.scalatest.matchers.should.Matchers
@@ -203,7 +204,7 @@ class HttpEndpointDescriptorFactorySpec extends AnyWordSpec with Matchers {
       val descriptor = HttpEndpointDescriptorFactory(classOf[http.TestEndpoints.TestEndpointAcls], _ => null)
 
       descriptor.mainPath should ===(Some("/acls/"))
-      descriptor.methods should have size 3
+      descriptor.methods should have size 4
 
       descriptor.componentOptions.aclOpt should not be empty
       descriptor.componentOptions.aclOpt.get.deny shouldBe List(All)
@@ -228,11 +229,19 @@ class HttpEndpointDescriptorFactorySpec extends AnyWordSpec with Matchers {
         "that")
       thisAndThat.methodOptions.acl.get.deny shouldBe empty
       thisAndThat.methodOptions.acl.get.denyHttpCode should contain(Forbidden)
+
+      val spiffe = byMethodName("spiffe")
+      spiffe.methodOptions.acl should not be empty
+      spiffe.methodOptions.acl.get.allow.collect { case p: SpiffePattern => p.pattern } shouldBe Seq("svc/checkout/*")
     }
 
     "throw error if annotations are not valid" in {
       assertThrows[IllegalArgumentException] {
         HttpEndpointDescriptorFactory(classOf[http.TestEndpoints.TestEndpointInvalidAcl], _ => null)
+      }
+
+      assertThrows[IllegalArgumentException] {
+        HttpEndpointDescriptorFactory(classOf[http.TestEndpoints.TestEndpointInvalidAclSpiffe], _ => null)
       }
 
       val caught = intercept[IllegalArgumentException] {

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/HttpEndpointDescriptorFactorySpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/HttpEndpointDescriptorFactorySpec.scala
@@ -16,8 +16,8 @@ import akka.runtime.sdk.spi.ClaimValues
 import akka.runtime.sdk.spi.HttpEndpointMethodSpec
 import akka.runtime.sdk.spi.Internet
 import akka.runtime.sdk.spi.ServiceNamePattern
-import akka.runtime.sdk.spi.SpiffePattern
 import akka.runtime.sdk.spi.SpiJsonSchema
+import akka.runtime.sdk.spi.SpiffePattern
 import akka.runtime.sdk.spi.StaticClaim
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/HttpEndpointDescriptorFactorySpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/HttpEndpointDescriptorFactorySpec.scala
@@ -248,6 +248,11 @@ class HttpEndpointDescriptorFactorySpec extends AnyWordSpec with Matchers {
         HttpEndpointDescriptorFactory(classOf[http.TestEndpoints.TestEndpointInvalidAclDenyCode], _ => null)
       }
       caught.getMessage should include("Invalid HTTP status code: 123123")
+
+      val spiffeCaught = intercept[IllegalArgumentException] {
+        HttpEndpointDescriptorFactory(classOf[http.TestEndpoints.TestEndpointInvalidAclSpiffePattern], _ => null)
+      }
+      spiffeCaught.getMessage should include("`**` is only allowed as the final token")
     }
 
     //Utility to compare StaticClaim to avoid creating `equals` in the original.

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/view/ViewDescriptorFactorySpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/view/ViewDescriptorFactorySpec.scala
@@ -58,8 +58,7 @@ class ViewDescriptorFactorySpec extends AnyWordSpec with Matchers {
         val options = desc.componentOptions
         val acl = options.aclOpt.get
         acl.allow.head match {
-          case _: Principal => fail()
-          // TODO: SpiffePattern is handled in the SPIFFE ACL PR stacked on top of this one
+          case _: Principal     => fail()
           case _: SpiffePattern => fail()
           case pattern: ServiceNamePattern =>
             pattern.pattern shouldBe "test"
@@ -72,8 +71,7 @@ class ViewDescriptorFactorySpec extends AnyWordSpec with Matchers {
         val query = desc.queries.find(_.name == "getEmployeeByEmail").get
         val acl = query.methodOptions.acl.get
         acl.allow.head match {
-          case _: Principal => fail()
-          // TODO: SpiffePattern is handled in the SPIFFE ACL PR stacked on top of this one
+          case _: Principal     => fail()
           case _: SpiffePattern => fail()
           case pattern: ServiceNamePattern =>
             pattern.pattern shouldBe "test"

--- a/docs/src/modules/concepts/pages/acls.adoc
+++ b/docs/src/modules/concepts/pages/acls.adoc
@@ -24,6 +24,7 @@ In Akka, a principal is an abstract entity that represents the origin or source 
 * *Service Principals*: Represent Akka services, allowing you to configure ACLs to permit access only to requests originating from specific services within the project.
 * *Internet Principal*: Represents external requests coming from the internet. Akka identifies these requests as originating from the Akka ingress (according to a configured route). Note that:
 ** Requests labeled with the *internet principal* are validated by mTLS, but this does not imply that mTLS was used to connect to the ingress from the internet client itself. To enforce mTLS on connections from internet clients, refer to xref:operations:tls-certificates.adoc[].
+* *Component identity (SPIFFE)*: For finer granularity than a whole service, you can match on the calling component's SPIFFE identity, which encodes the calling service, component type and component id. This allows rules such as "only the `checkout` workflow" or "any agent". See xref:sdk:access-control.adoc[] for details.
 
 == Configuring ACLs
 To configure ACLs and secure your Akka services effectively, follow these steps:

--- a/docs/src/modules/sdk/pages/access-control.adoc
+++ b/docs/src/modules/sdk/pages/access-control.adoc
@@ -92,6 +92,41 @@ include::example$doc-snippets/src/main/java/com/example/acl/UserEndpoint.java[ta
 ----
 
 
+== Component-level access with SPIFFE
+
+The `service` matcher controls access at the granularity of a whole service. To express finer-grained rules — for
+example "only the `checkout` workflow may call this endpoint", or "any agent may call this endpoint" — use the `spiffe`
+matcher. It matches on the calling component's https://spiffe.io[SPIFFE] identity, which encodes the calling service,
+the component type, and the component id.
+
+The pattern is matched against the component-path suffix of the caller's SPIFFE id, of the form
+`svc/<service>/<component-type>/<component-id>`. It supports glob matching where `*` matches any sequence of characters,
+so an exact value matches a single component and wildcards match groups of components:
+
+[source,java,indent=0]
+----
+// a single specific component
+@Acl(allow = @Acl.Matcher(spiffe = "svc/checkout/workflow/order"))
+
+// all components of the checkout service
+@Acl(allow = @Acl.Matcher(spiffe = "svc/checkout/*"))
+
+// all agents of any service
+@Acl(allow = @Acl.Matcher(spiffe = "*/agent/*"))
+----
+
+Component types that can appear as a caller are the ones that make outbound calls, such as workflows and agents. A
+`Matcher` may set exactly one of `service`, `spiffe` or `principal`.
+
+[NOTE]
+====
+Only requests from in-mesh peers carry a SPIFFE identity; internet and ingress requests never match a `spiffe` rule.
+The `svc/<service>` part of the identity is authenticated and cannot be spoofed, while the
+`<component-type>/<component-id>` part is asserted by the calling service. Matching by service is therefore fully
+authenticated; matching a specific component additionally trusts the calling service to report its own component path
+honestly.
+====
+
 == Default ACL
 
 If no ACLs are defined at all, Akka will deny requests from both other services and the internet to all components of

--- a/docs/src/modules/sdk/pages/access-control.adoc
+++ b/docs/src/modules/sdk/pages/access-control.adoc
@@ -101,9 +101,9 @@ the component type, and the component id.
 
 The pattern is matched against the component-path suffix of the caller's SPIFFE id, of the form
 `svc/<service>/<component-type>/<component-id>`. It supports segment-aware glob matching over the `/`-separated path:
-`*` matches within a single path segment, while `**` (only allowed as the final token) matches across segments. So an
-exact value matches a single component, a single `*` matches one path segment, and a trailing `**` matches everything
-below a prefix:
+`*` matches within a single path segment, while `**` (only allowed as the final token) matches across segments. An
+exact value therefore matches a single component, a single `*` matches one path segment, and a trailing `**` matches
+everything below a prefix:
 
 [source,java,indent=0]
 ----

--- a/docs/src/modules/sdk/pages/access-control.adoc
+++ b/docs/src/modules/sdk/pages/access-control.adoc
@@ -100,8 +100,10 @@ matcher. It matches on the calling component's https://spiffe.io[SPIFFE] identit
 the component type, and the component id.
 
 The pattern is matched against the component-path suffix of the caller's SPIFFE id, of the form
-`svc/<service>/<component-type>/<component-id>`. It supports glob matching where `*` matches any sequence of characters,
-so an exact value matches a single component and wildcards match groups of components:
+`svc/<service>/<component-type>/<component-id>`. It supports segment-aware glob matching over the `/`-separated path:
+`*` matches within a single path segment, while `**` (only allowed as the final token) matches across segments. So an
+exact value matches a single component, a single `*` matches one path segment, and a trailing `**` matches everything
+below a prefix:
 
 [source,java,indent=0]
 ----
@@ -109,10 +111,10 @@ so an exact value matches a single component and wildcards match groups of compo
 @Acl(allow = @Acl.Matcher(spiffe = "svc/checkout/workflow/order"))
 
 // all components of the checkout service
-@Acl(allow = @Acl.Matcher(spiffe = "svc/checkout/*"))
+@Acl(allow = @Acl.Matcher(spiffe = "svc/checkout/**"))
 
 // all agents of any service
-@Acl(allow = @Acl.Matcher(spiffe = "*/agent/*"))
+@Acl(allow = @Acl.Matcher(spiffe = "svc/*/agent/*"))
 ----
 
 Component types that can appear as a caller are the ones that make outbound calls, such as workflows and agents. A


### PR DESCRIPTION
Exact acl pattern/id match still to be decided. This is a draft where only the svc part of the path is matched but doubting that is how it should be.

References:
 - https://github.com/lightbend/kalix/issues/16111

On top of PR https://github.com/akka/akka-sdk/pull/1681
Depends on upstream https://github.com/lightbend/akka-runtime/pull/5419
