### PR TITLE
docs: Akka Runtime version in release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ attributes: prepare
 		> "${managed_partials}/attributes.adoc"
 	docs/bin/version.sh | xargs -0  printf ":akka-javasdk-version: %s" \
 		> "${managed_partials}/attributes.adoc"
-	echo "" >> "${managed_partials}/attributes.adoc"
 	echo ":akka-runtime-version: $$(docs/bin/runtime-version-from-sbt.sh)" \
 		>> "${managed_partials}/attributes.adoc"
 	echo ":akka-cli-version: 3.0.65" >> "${managed_partials}/attributes.adoc"

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ attributes: prepare
 		> "${managed_partials}/attributes.adoc"
 	docs/bin/version.sh | xargs -0  printf ":akka-javasdk-version: %s" \
 		> "${managed_partials}/attributes.adoc"
+	echo "" >> "${managed_partials}/attributes.adoc"
+	echo ":akka-runtime-version: $$(docs/bin/runtime-version-from-sbt.sh)" \
+		>> "${managed_partials}/attributes.adoc"
 	echo ":akka-cli-version: 3.0.65" >> "${managed_partials}/attributes.adoc"
 	echo ":akka-cli-min-version: 3.0.4" >> "${managed_partials}/attributes.adoc"
 	# see https://adoptium.net/marketplace/

--- a/build.sbt
+++ b/build.sbt
@@ -217,3 +217,8 @@ def updatePomVersion(
 }
 
 addCommandAlias("formatAll", "scalafmtAll; javafmtAll")
+
+// extract Akka Runtime version for tooling with
+// print akka-javasdk / akkaRuntimeVersion
+val akkaRuntimeVersion = settingKey[String]("Akka Runtime version")
+ThisBuild / akkaRuntimeVersion := Dependencies.AkkaRuntimeVersion

--- a/docs/bin/runtime-version-from-sbt.sh
+++ b/docs/bin/runtime-version-from-sbt.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# deliberately not using `--client`
+sbt --no-colors "print akka-javasdk/akkaRuntimeVersion" | tail -n 1 | tr -d '[:space:]'

--- a/docs/src/modules/reference/pages/release-notes.adoc
+++ b/docs/src/modules/reference/pages/release-notes.adoc
@@ -6,7 +6,7 @@ Akka constantly gets updates and improvements enabling new features and expandin
 
 Current versions
 
-* xref:sdk:index.adoc[Akka SDK {akka-javasdk-version}]
+* xref:sdk:index.adoc[Akka SDK {akka-javasdk-version}] (relies on Akka Runtime {akka-runtime-version})
 * Akka CLI {akka-cli-version}
 * A glance of all Akka libraries and their current versions is presented at https://doc.akka.io/libraries/akka-dependencies/current[Akka library versions].
 

--- a/docs/src/modules/sdk/pages/spec-driven-development.adoc
+++ b/docs/src/modules/sdk/pages/spec-driven-development.adoc
@@ -34,7 +34,7 @@ In Claude Code, install the Akka plugin from the AI Marketplace:
 [source]
 ----
 /plugin marketplace add akka/ai-marketplace
-/plugin install akka@ai-marketplace
+/plugin install akka@akka-ai-marketplace
 /reload-plugins
 ----
 
@@ -48,7 +48,7 @@ TIP: If you are unable to add the marketplace, clone the Akka plugin repository 
 ----
 /akka:setup
 ----
-+
+
 This configures your environment — ensuring the Akka CLI is installed, Java and Maven are available, and your Akka download token is properly configured. Once setup completes, you are ready to start building.
 
 [TIP.manual]


### PR DESCRIPTION
Show the Akka Runtime version an SDK was release with on the [release notes page](https://doc.akka.io/reference/release-notes.html).

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References
- https://github.com/lightbend/kalix/issues/15348