### PR TITLE
feat: ledger client for accessing interaction records

### DIFF
--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestLedgerClient.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestLedgerClient.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.testkit;
+
+import akka.javasdk.ledger.InteractionRecord;
+import akka.javasdk.ledger.LedgerClient;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * An in-memory {@link LedgerClient} for unit tests.
+ *
+ * <p>Seed it with {@link InteractionRecord}s via {@link #seed(InteractionRecord)} and pass it to
+ * the component under test (for example an {@link akka.javasdk.evaluation.Evaluator} constructed by
+ * an {@link EvaluatorTestKit}) to assert it fetches and uses them, with no database.
+ */
+public final class TestLedgerClient implements LedgerClient {
+
+  private final ConcurrentMap<String, InteractionRecord> records = new ConcurrentHashMap<>();
+
+  /** Create an empty in-memory ledger client. */
+  public static TestLedgerClient create() {
+    return new TestLedgerClient();
+  }
+
+  /**
+   * Seed a record, keyed by its {@link InteractionRecord#interactionId()}. Replaces any existing
+   * record with the same id.
+   *
+   * @param record the record to seed
+   * @return this client, for chaining
+   */
+  public TestLedgerClient seed(InteractionRecord record) {
+    records.put(record.interactionId(), record);
+    return this;
+  }
+
+  @Override
+  public InteractionRecord getInteraction(String interactionId) {
+    var record = records.get(interactionId);
+    if (record == null) {
+      throw new NoSuchElementException("No interaction with id [" + interactionId + "]");
+    }
+    return record;
+  }
+
+  @Override
+  public CompletionStage<InteractionRecord> getInteractionAsync(String interactionId) {
+    var record = records.get(interactionId);
+    if (record == null) {
+      return CompletableFuture.failedFuture(
+          new NoSuchElementException("No interaction with id [" + interactionId + "]"));
+    }
+    return CompletableFuture.completedFuture(record);
+  }
+}

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/InteractionRecordTest.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/InteractionRecordTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.testkit.ledger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import akka.javasdk.agent.MessageContent;
+import akka.javasdk.agent.MessageContent.TextMessageContent;
+import akka.javasdk.ledger.Failure;
+import akka.javasdk.ledger.InteractionMetadata;
+import akka.javasdk.ledger.InteractionRecord;
+import akka.javasdk.ledger.ModelConfig;
+import akka.javasdk.ledger.ModelResponse;
+import akka.javasdk.ledger.ToolCall;
+import akka.javasdk.ledger.ToolCallResponse;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class InteractionRecordTest {
+
+  private static InteractionMetadata metadata() {
+    return new InteractionMetadata(
+        new ModelConfig("openai", "gpt-4", "", 0.7, 1.0, 0, 1024),
+        Map.of(),
+        Instant.EPOCH,
+        Instant.EPOCH,
+        InteractionMetadata.FinishReason.STOP);
+  }
+
+  private static InteractionRecord record(Optional<Failure> failure) {
+    var thinkingWithToolCall =
+        new ModelResponse(
+            "m1",
+            "",
+            10,
+            5,
+            "let me think",
+            List.of(new ToolCall("t1", "calc", "{\"expr\":\"2+2\"}", "4")));
+    var finalAnswer = new ModelResponse("m2", "The answer is 4.", 8, 6, "", List.of());
+    return new InteractionRecord(
+        "interaction-1",
+        "session-1",
+        "math-agent",
+        Optional.empty(),
+        metadata(),
+        "You are a calculator.",
+        List.of(TextMessageContent.from("What is 2+2?")),
+        List.of(thinkingWithToolCall, finalAnswer),
+        List.of(
+            new ToolCallResponse(
+                "t1", "calc", List.<MessageContent>of(TextMessageContent.from("4")))),
+        Optional.empty(),
+        failure,
+        Instant.EPOCH);
+  }
+
+  @Test
+  public void accessorsFlattenTheRecord() {
+    var record = record(Optional.empty());
+
+    assertEquals("What is 2+2?", record.userText());
+    assertEquals("The answer is 4.", record.finalAssistantText());
+    assertEquals(1, record.toolCalls().size());
+    assertEquals("calc", record.toolCalls().get(0).name());
+    assertEquals(18, record.totalInputTokens());
+    assertEquals(11, record.totalOutputTokens());
+    assertFalse(record.isFlowInteraction());
+    assertFalse(record.failed());
+    assertTrue(record.failureSummary().isEmpty());
+  }
+
+  @Test
+  public void finalAssistantTextSkipsResponsesWithoutContent() {
+    // the last response has content; a trailing tool-only response should not blank it out
+    var record = record(Optional.empty());
+    assertEquals("The answer is 4.", record.finalAssistantText());
+  }
+
+  @Test
+  public void failureSummaryRendersReasonAndDescription() {
+    var record = record(Optional.of(new Failure(Failure.FailureReason.TOOL_CALL, "calc exploded")));
+
+    assertTrue(record.failed());
+    assertEquals("TOOL_CALL: calc exploded", record.failureSummary().orElseThrow());
+  }
+
+  @Test
+  public void transcriptFlattensInOrder() {
+    var transcript = record(Optional.empty()).transcript();
+
+    // exact rendering: system, then user, then each model response (thinking, content, tool calls
+    // in order), then the tool call responses the model saw as input
+    var expected =
+        """
+        System: You are a calculator.
+        User: What is 2+2?
+        Assistant (thinking): let me think
+        Tool call calc({"expr":"2+2"}) -> 4
+        Assistant: The answer is 4.
+        Tool response calc: 4
+        """;
+    assertEquals(expected, transcript);
+  }
+
+  @Test
+  public void transcriptOmitsEmptySystemMessageAndRendersNonTextContent() {
+    var record =
+        new InteractionRecord(
+            "interaction-2",
+            "session-1",
+            "vision-agent",
+            Optional.empty(),
+            metadata(),
+            "", // no system message
+            List.of(
+                TextMessageContent.from("describe these"),
+                MessageContent.ImageMessageContent.fromUri("https://example.com/cat.png"),
+                MessageContent.PdfMessageContent.fromUri("https://example.com/doc.pdf")),
+            List.of(new ModelResponse("m1", "a cat and a document", 5, 4, "", List.of())),
+            List.of(),
+            Optional.empty(),
+            Optional.empty(),
+            Instant.EPOCH);
+
+    // non-text content is dropped from userText but rendered as placeholders in the transcript
+    assertEquals("describe these", record.userText());
+
+    var expected =
+        """
+        User: describe these
+        [image https://example.com/cat.png]
+        [pdf https://example.com/doc.pdf]
+        Assistant: a cat and a document
+        """;
+    assertEquals(expected, record.transcript());
+  }
+}

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/InteractionRecordTest.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/InteractionRecordTest.java
@@ -65,8 +65,8 @@ public class InteractionRecordTest {
   public void accessorsFlattenTheRecord() {
     var record = record(Optional.empty());
 
-    assertEquals("What is 2+2?", record.userText());
-    assertEquals("The answer is 4.", record.finalAssistantText());
+    assertEquals("What is 2+2?", record.inputText());
+    assertEquals("The answer is 4.", record.finalResponseText());
     assertEquals(1, record.toolCalls().size());
     assertEquals("calc", record.toolCalls().get(0).name());
     assertEquals(18, record.totalInputTokens());
@@ -77,10 +77,10 @@ public class InteractionRecordTest {
   }
 
   @Test
-  public void finalAssistantTextSkipsResponsesWithoutContent() {
+  public void finalResponseTextSkipsResponsesWithoutContent() {
     // the last response has content; a trailing tool-only response should not blank it out
     var record = record(Optional.empty());
-    assertEquals("The answer is 4.", record.finalAssistantText());
+    assertEquals("The answer is 4.", record.finalResponseText());
   }
 
   @Test
@@ -95,15 +95,15 @@ public class InteractionRecordTest {
   public void transcriptFlattensInOrder() {
     var transcript = record(Optional.empty()).transcript();
 
-    // exact rendering: system, then user, then each model response (thinking, content, tool calls
+    // exact rendering: system, then input, then each model response (thinking, content, tool calls
     // in order), then the tool call responses the model saw as input
     var expected =
         """
         System: You are a calculator.
-        User: What is 2+2?
-        Assistant (thinking): let me think
+        Input: What is 2+2?
+        Thinking: let me think
         Tool call calc({"expr":"2+2"}) -> 4
-        Assistant: The answer is 4.
+        Response: The answer is 4.
         Tool response calc: 4
         """;
     assertEquals(expected, transcript);
@@ -129,15 +129,15 @@ public class InteractionRecordTest {
             Optional.empty(),
             Instant.EPOCH);
 
-    // non-text content is dropped from userText but rendered as placeholders in the transcript
-    assertEquals("describe these", record.userText());
+    // non-text content is dropped from inputText but rendered as placeholders in the transcript
+    assertEquals("describe these", record.inputText());
 
     var expected =
         """
-        User: describe these
+        Input: describe these
         [image https://example.com/cat.png]
         [pdf https://example.com/doc.pdf]
-        Assistant: a cat and a document
+        Response: a cat and a document
         """;
     assertEquals(expected, record.transcript());
   }

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/InteractionRecordTest.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/InteractionRecordTest.java
@@ -4,9 +4,7 @@
 
 package akka.javasdk.testkit.ledger;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import akka.javasdk.agent.MessageContent;
 import akka.javasdk.agent.MessageContent.TextMessageContent;
@@ -65,30 +63,30 @@ public class InteractionRecordTest {
   public void accessorsFlattenTheRecord() {
     var record = record(Optional.empty());
 
-    assertEquals("What is 2+2?", record.inputText());
-    assertEquals("The answer is 4.", record.finalResponseText());
-    assertEquals(1, record.toolCalls().size());
-    assertEquals("calc", record.toolCalls().get(0).name());
-    assertEquals(18, record.totalInputTokens());
-    assertEquals(11, record.totalOutputTokens());
-    assertFalse(record.isFlowInteraction());
-    assertFalse(record.failed());
-    assertTrue(record.failureSummary().isEmpty());
+    assertThat(record.inputText()).isEqualTo("What is 2+2?");
+    assertThat(record.finalResponseText()).isEqualTo("The answer is 4.");
+    assertThat(record.toolCalls()).hasSize(1);
+    assertThat(record.toolCalls().get(0).name()).isEqualTo("calc");
+    assertThat(record.totalInputTokens()).isEqualTo(18);
+    assertThat(record.totalOutputTokens()).isEqualTo(11);
+    assertThat(record.isFlowInteraction()).isFalse();
+    assertThat(record.failed()).isFalse();
+    assertThat(record.failureSummary()).isEmpty();
   }
 
   @Test
   public void finalResponseTextSkipsResponsesWithoutContent() {
     // the last response has content; a trailing tool-only response should not blank it out
     var record = record(Optional.empty());
-    assertEquals("The answer is 4.", record.finalResponseText());
+    assertThat(record.finalResponseText()).isEqualTo("The answer is 4.");
   }
 
   @Test
   public void failureSummaryRendersReasonAndDescription() {
     var record = record(Optional.of(new Failure(Failure.FailureReason.TOOL_CALL, "calc exploded")));
 
-    assertTrue(record.failed());
-    assertEquals("TOOL_CALL: calc exploded", record.failureSummary().orElseThrow());
+    assertThat(record.failed()).isTrue();
+    assertThat(record.failureSummary()).contains("TOOL_CALL: calc exploded");
   }
 
   @Test
@@ -106,7 +104,7 @@ public class InteractionRecordTest {
         Response: The answer is 4.
         Tool response calc: 4
         """;
-    assertEquals(expected, transcript);
+    assertThat(transcript).isEqualTo(expected);
   }
 
   @Test
@@ -130,7 +128,7 @@ public class InteractionRecordTest {
             Instant.EPOCH);
 
     // non-text content is dropped from inputText but rendered as placeholders in the transcript
-    assertEquals("describe these", record.inputText());
+    assertThat(record.inputText()).isEqualTo("describe these");
 
     var expected =
         """
@@ -139,6 +137,6 @@ public class InteractionRecordTest {
         [pdf https://example.com/doc.pdf]
         Response: a cat and a document
         """;
-    assertEquals(expected, record.transcript());
+    assertThat(record.transcript()).isEqualTo(expected);
   }
 }

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/LedgerEvaluator.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/LedgerEvaluator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.testkit.ledger;
+
+import akka.javasdk.evaluation.Evaluation;
+import akka.javasdk.evaluation.EvaluationContext;
+import akka.javasdk.evaluation.Evaluator;
+import akka.javasdk.ledger.LedgerClient;
+
+/**
+ * An evaluator that fetches the interaction under evaluation from the ledger and passes if the
+ * assistant produced any final text. Used to exercise ledger injection into an evaluator.
+ */
+public class LedgerEvaluator extends Evaluator {
+
+  private final LedgerClient ledger;
+
+  public LedgerEvaluator(LedgerClient ledger) {
+    this.ledger = ledger;
+  }
+
+  @Override
+  public Effect evaluate(EvaluationContext context) {
+    var interaction = ledger.getInteraction(context.subject().interactionId());
+    var finalText = interaction.finalAssistantText();
+    if (finalText.isEmpty()) {
+      return effects().complete(Evaluation.failed("assistant produced no final text"));
+    }
+    return effects()
+        .complete(
+            Evaluation.passed("assistant answered")
+                .withAttribute("finalText", finalText)
+                .withAttribute("transcript", interaction.transcript()));
+  }
+}

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/LedgerEvaluator.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/LedgerEvaluator.java
@@ -11,7 +11,7 @@ import akka.javasdk.ledger.LedgerClient;
 
 /**
  * An evaluator that fetches the interaction under evaluation from the ledger and passes if the
- * assistant produced any final text. Used to exercise ledger injection into an evaluator.
+ * agent produced any final response text. Used to exercise ledger injection into an evaluator.
  */
 public class LedgerEvaluator extends Evaluator {
 
@@ -24,13 +24,13 @@ public class LedgerEvaluator extends Evaluator {
   @Override
   public Effect evaluate(EvaluationContext context) {
     var interaction = ledger.getInteraction(context.subject().interactionId());
-    var finalText = interaction.finalAssistantText();
+    var finalText = interaction.finalResponseText();
     if (finalText.isEmpty()) {
-      return effects().complete(Evaluation.failed("assistant produced no final text"));
+      return effects().complete(Evaluation.failed("agent produced no final response text"));
     }
     return effects()
         .complete(
-            Evaluation.passed("assistant answered")
+            Evaluation.passed("agent responded")
                 .withAttribute("finalText", finalText)
                 .withAttribute("transcript", interaction.transcript()));
   }

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/LedgerEvaluatorTest.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/LedgerEvaluatorTest.java
@@ -60,7 +60,7 @@ public class LedgerEvaluatorTest {
     var evaluation = result.getEvaluations().get(0);
     assertTrue(evaluation.passed());
     assertEquals("The answer is 4.", evaluation.attributes().get("finalText"));
-    assertTrue(evaluation.attributes().get("transcript").contains("Assistant: The answer is 4."));
+    assertTrue(evaluation.attributes().get("transcript").contains("Response: The answer is 4."));
   }
 
   @Test

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/LedgerEvaluatorTest.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/LedgerEvaluatorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.testkit.ledger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import akka.javasdk.agent.MessageContent.TextMessageContent;
+import akka.javasdk.evaluation.Subject;
+import akka.javasdk.ledger.InteractionMetadata;
+import akka.javasdk.ledger.InteractionRecord;
+import akka.javasdk.ledger.ModelConfig;
+import akka.javasdk.ledger.ModelResponse;
+import akka.javasdk.testkit.EvaluatorResult;
+import akka.javasdk.testkit.EvaluatorTestKit;
+import akka.javasdk.testkit.TestLedgerClient;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.Test;
+
+public class LedgerEvaluatorTest {
+
+  private static InteractionRecord answeredInteraction(String interactionId) {
+    return new InteractionRecord(
+        interactionId,
+        "session-1",
+        "math-agent",
+        Optional.empty(),
+        new InteractionMetadata(
+            new ModelConfig("openai", "gpt-4", "", 0.7, 1.0, 0, 1024),
+            Map.of(),
+            Instant.EPOCH,
+            Instant.EPOCH,
+            InteractionMetadata.FinishReason.STOP),
+        "You are a calculator.",
+        List.of(TextMessageContent.from("What is 2+2?")),
+        List.of(new ModelResponse("m1", "The answer is 4.", 8, 6, "", List.of())),
+        List.of(),
+        Optional.empty(),
+        Optional.empty(),
+        Instant.EPOCH);
+  }
+
+  @Test
+  public void evaluatorFetchesAndUsesTheSeededRecord() {
+    var ledger = TestLedgerClient.create().seed(answeredInteraction("interaction-1"));
+    var testKit = EvaluatorTestKit.of(() -> new LedgerEvaluator(ledger));
+
+    EvaluatorResult result =
+        testKit.evaluate(new Subject.AgentInteraction("math-agent", "interaction-1"));
+
+    assertTrue(result.isComplete());
+    var evaluation = result.getEvaluations().get(0);
+    assertTrue(evaluation.passed());
+    assertEquals("The answer is 4.", evaluation.attributes().get("finalText"));
+    assertTrue(evaluation.attributes().get("transcript").contains("Assistant: The answer is 4."));
+  }
+
+  @Test
+  public void missingInteractionFailsWithNoSuchElement() {
+    var ledger = TestLedgerClient.create();
+
+    assertThrows(NoSuchElementException.class, () -> ledger.getInteraction("missing"));
+
+    var async = ledger.getInteractionAsync("missing").toCompletableFuture();
+    // join wraps the failure in a CompletionException; the cause is the no-such-element error
+    var thrown = assertThrows(CompletionException.class, async::join);
+    assertTrue(thrown.getCause() instanceof NoSuchElementException);
+  }
+}

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/LedgerEvaluatorTest.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/ledger/LedgerEvaluatorTest.java
@@ -4,9 +4,8 @@
 
 package akka.javasdk.testkit.ledger;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import akka.javasdk.agent.MessageContent.TextMessageContent;
 import akka.javasdk.evaluation.Subject;
@@ -56,22 +55,24 @@ public class LedgerEvaluatorTest {
     EvaluatorResult result =
         testKit.evaluate(new Subject.AgentInteraction("math-agent", "interaction-1"));
 
-    assertTrue(result.isComplete());
+    assertThat(result.isComplete()).isTrue();
     var evaluation = result.getEvaluations().get(0);
-    assertTrue(evaluation.passed());
-    assertEquals("The answer is 4.", evaluation.attributes().get("finalText"));
-    assertTrue(evaluation.attributes().get("transcript").contains("Response: The answer is 4."));
+    assertThat(evaluation.passed()).isTrue();
+    assertThat(evaluation.attributes().get("finalText")).isEqualTo("The answer is 4.");
+    assertThat(evaluation.attributes().get("transcript")).contains("Response: The answer is 4.");
   }
 
   @Test
   public void missingInteractionFailsWithNoSuchElement() {
     var ledger = TestLedgerClient.create();
 
-    assertThrows(NoSuchElementException.class, () -> ledger.getInteraction("missing"));
+    assertThatThrownBy(() -> ledger.getInteraction("missing"))
+        .isInstanceOf(NoSuchElementException.class);
 
-    var async = ledger.getInteractionAsync("missing").toCompletableFuture();
     // join wraps the failure in a CompletionException; the cause is the no-such-element error
-    var thrown = assertThrows(CompletionException.class, async::join);
-    assertTrue(thrown.getCause() instanceof NoSuchElementException);
+    var async = ledger.getInteractionAsync("missing").toCompletableFuture();
+    assertThatThrownBy(async::join)
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(NoSuchElementException.class);
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/evaluation/LedgerBackedEvaluator.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/evaluation/LedgerBackedEvaluator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akkajavasdk.components.evaluation;
+
+import akka.javasdk.annotations.Component;
+import akka.javasdk.evaluation.Evaluation;
+import akka.javasdk.evaluation.EvaluationContext;
+import akka.javasdk.evaluation.Evaluator;
+import akka.javasdk.ledger.InteractionRecord;
+import akka.javasdk.ledger.LedgerClient;
+
+/**
+ * An evaluator that fetches the interaction under evaluation from the real {@link LedgerClient}
+ * injected by the runtime, records it into {@link LedgerEvalProbe}, and passes if the assistant
+ * produced a final answer. Bound to {@link LedgerEvalAgent} via {@code akka.javasdk.evaluation}
+ * config so the runtime triggers it for each of that agent's interactions.
+ */
+@Component(id = "ledger-eval-evaluator")
+public class LedgerBackedEvaluator extends Evaluator {
+
+  private final LedgerClient ledger;
+
+  public LedgerBackedEvaluator(LedgerClient ledger) {
+    this.ledger = ledger;
+  }
+
+  @Override
+  public Effect evaluate(EvaluationContext context) {
+    InteractionRecord interaction = ledger.getInteraction(context.subject().interactionId());
+    LedgerEvalProbe.record(interaction);
+
+    String finalText = interaction.finalAssistantText();
+    if (finalText.isEmpty()) {
+      return effects().complete(Evaluation.failed("assistant produced no final text"));
+    }
+    return effects()
+        .complete(Evaluation.passed("assistant answered").withAttribute("finalText", finalText));
+  }
+}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/evaluation/LedgerBackedEvaluator.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/evaluation/LedgerBackedEvaluator.java
@@ -13,8 +13,8 @@ import akka.javasdk.ledger.LedgerClient;
 
 /**
  * An evaluator that fetches the interaction under evaluation from the real {@link LedgerClient}
- * injected by the runtime, records it into {@link LedgerEvalProbe}, and passes if the assistant
- * produced a final answer. Bound to {@link LedgerEvalAgent} via {@code akka.javasdk.evaluation}
+ * injected by the runtime, records it into {@link LedgerEvalProbe}, and passes if the agent
+ * produced a final response. Bound to {@link LedgerEvalAgent} via {@code akka.javasdk.evaluation}
  * config so the runtime triggers it for each of that agent's interactions.
  */
 @Component(id = "ledger-eval-evaluator")
@@ -31,11 +31,11 @@ public class LedgerBackedEvaluator extends Evaluator {
     InteractionRecord interaction = ledger.getInteraction(context.subject().interactionId());
     LedgerEvalProbe.record(interaction);
 
-    String finalText = interaction.finalAssistantText();
+    String finalText = interaction.finalResponseText();
     if (finalText.isEmpty()) {
-      return effects().complete(Evaluation.failed("assistant produced no final text"));
+      return effects().complete(Evaluation.failed("agent produced no final response text"));
     }
     return effects()
-        .complete(Evaluation.passed("assistant answered").withAttribute("finalText", finalText));
+        .complete(Evaluation.passed("agent responded").withAttribute("finalText", finalText));
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/evaluation/LedgerBackedEvaluatorIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/evaluation/LedgerBackedEvaluatorIntegrationTest.java
@@ -72,10 +72,10 @@ public class LedgerBackedEvaluatorIntegrationTest extends TestKitSupport {
 
     InteractionRecord record = LedgerEvalProbe.all().iterator().next();
     assertThat(record.agentComponentId()).isEqualTo("ledger-eval-agent");
-    assertThat(record.userText()).isEqualTo("What is 2+2?");
-    assertThat(record.finalAssistantText()).isEqualTo("The answer is 4.");
+    assertThat(record.inputText()).isEqualTo("What is 2+2?");
+    assertThat(record.finalResponseText()).isEqualTo("The answer is 4.");
     assertThat(record.isFlowInteraction()).isFalse();
     assertThat(record.failed()).isFalse();
-    assertThat(record.transcript()).contains("Assistant: The answer is 4.");
+    assertThat(record.transcript()).contains("Response: The answer is 4.");
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/evaluation/LedgerBackedEvaluatorIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/evaluation/LedgerBackedEvaluatorIntegrationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akkajavasdk.components.evaluation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import akka.javasdk.ledger.InteractionRecord;
+import akka.javasdk.testkit.TestKit;
+import akka.javasdk.testkit.TestKitSupport;
+import akka.javasdk.testkit.TestModelProvider;
+import akkajavasdk.Junit5LogCapturing;
+import java.time.Duration;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Full-integration test of the ledger client: drives a real agent interaction through the embedded
+ * runtime, which records it and — because {@link LedgerBackedEvaluator} is bound to {@link
+ * LedgerEvalAgent} with {@code trigger = interaction} — samples it, enqueues an evaluation trigger,
+ * and runs the evaluator. The evaluator fetches the actual interaction via the runtime-injected
+ * {@link akka.javasdk.ledger.LedgerClient}, exercising the real ledger query end-to-end (no
+ * seeding).
+ */
+@ExtendWith(Junit5LogCapturing.class)
+public class LedgerBackedEvaluatorIntegrationTest extends TestKitSupport {
+
+  private final TestModelProvider agentModel = new TestModelProvider();
+
+  @Override
+  protected TestKit.Settings testKitSettings() {
+    return TestKit.Settings.DEFAULT.withModelProvider(LedgerEvalAgent.class, agentModel);
+  }
+
+  @BeforeEach
+  public void clearProbe() {
+    LedgerEvalProbe.clear();
+  }
+
+  @AfterEach
+  public void reset() {
+    agentModel.reset();
+    LedgerEvalProbe.clear();
+  }
+
+  @Test
+  public void triggeredEvaluatorFetchesRealInteractionFromLedger() {
+    agentModel.whenMessage(question -> question.equals("What is 2+2?")).reply("The answer is 4.");
+
+    String reply =
+        componentClient
+            .forAgent()
+            .inSession(UUID.randomUUID().toString())
+            .method(LedgerEvalAgent::ask)
+            .invoke("What is 2+2?");
+    assertThat(reply).isEqualTo("The answer is 4.");
+
+    // the runtime records the interaction, samples it, enqueues a trigger, and runs the bound
+    // evaluator, which fetches the real interaction via the injected ledger client
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(() -> assertThat(LedgerEvalProbe.all()).isNotEmpty());
+
+    // exactly one interaction was recorded and evaluated: one agent request produces one
+    // interaction, and the probe is keyed by interaction id so trigger redelivery collapses to it
+    assertThat(LedgerEvalProbe.all()).hasSize(1);
+
+    InteractionRecord record = LedgerEvalProbe.all().iterator().next();
+    assertThat(record.agentComponentId()).isEqualTo("ledger-eval-agent");
+    assertThat(record.userText()).isEqualTo("What is 2+2?");
+    assertThat(record.finalAssistantText()).isEqualTo("The answer is 4.");
+    assertThat(record.isFlowInteraction()).isFalse();
+    assertThat(record.failed()).isFalse();
+    assertThat(record.transcript()).contains("Assistant: The answer is 4.");
+  }
+}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/evaluation/LedgerEvalAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/evaluation/LedgerEvalAgent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akkajavasdk.components.evaluation;
+
+import akka.javasdk.agent.Agent;
+import akka.javasdk.annotations.Component;
+
+/**
+ * A request-based agent whose interactions are recorded to the ledger and then evaluated by {@link
+ * LedgerBackedEvaluator}, bound to it via {@code akka.javasdk.evaluation} config. Used by {@link
+ * LedgerBackedEvaluatorIntegrationTest} to drive a real interaction end-to-end.
+ */
+@Component(id = "ledger-eval-agent")
+public class LedgerEvalAgent extends Agent {
+
+  public Effect<String> ask(String question) {
+    return effects().systemMessage("You are a calculator.").userMessage(question).thenReply();
+  }
+}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/evaluation/LedgerEvalProbe.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/evaluation/LedgerEvalProbe.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akkajavasdk.components.evaluation;
+
+import akka.javasdk.ledger.InteractionRecord;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A static collector that {@link LedgerBackedEvaluator} writes the interaction it fetched from the
+ * ledger into, so {@link LedgerBackedEvaluatorIntegrationTest} can observe that the
+ * runtime-triggered evaluation ran and saw the real record. Works because the embedded runtime runs
+ * in a single JVM.
+ */
+public final class LedgerEvalProbe {
+
+  private static final ConcurrentMap<String, InteractionRecord> fetched = new ConcurrentHashMap<>();
+
+  public static void record(InteractionRecord record) {
+    fetched.put(record.interactionId(), record);
+  }
+
+  public static Collection<InteractionRecord> all() {
+    return List.copyOf(fetched.values());
+  }
+
+  public static void clear() {
+    fetched.clear();
+  }
+
+  private LedgerEvalProbe() {}
+}

--- a/akka-javasdk-tests/src/test/resources/META-INF/akka-javasdk-components_akka-javasdk-tests.conf
+++ b/akka-javasdk-tests/src/test/resources/META-INF/akka-javasdk-components_akka-javasdk-tests.conf
@@ -22,7 +22,8 @@ akka.javasdk {
       "akkajavasdk.components.agent.EventSourcedEntityAsToolIntegrationTest$CounterManagerAgent",
       "akkajavasdk.components.agent.ViewAsToolIntegrationTest$CounterQueryAgent",
       "akkajavasdk.components.agent.WorkflowAsToolIntegrationTest$WalletManagerAgent",
-      "akkajavasdk.components.evaluation.QualityJudge"
+      "akkajavasdk.components.evaluation.QualityJudge",
+      "akkajavasdk.components.evaluation.LedgerEvalAgent"
     ],
     autonomous-agent = [
       "akkajavasdk.components.agent.autonomous.TestAutonomousAgent",
@@ -41,6 +42,9 @@ akka.javasdk {
       "akkajavasdk.components.agent.autonomous.DebaterB",
       "akkajavasdk.components.agent.autonomous.ValidatedTaskAgent",
       "akkajavasdk.components.agent.autonomous.ContentLoaderTestAgent"
+    ],
+    evaluator = [
+      "akkajavasdk.components.evaluation.LedgerBackedEvaluator"
     ],
     http-endpoint = [
       "akkajavasdk.components.jwt.HelloJwtEndpoint",

--- a/akka-javasdk-tests/src/test/resources/application.conf
+++ b/akka-javasdk-tests/src/test/resources/application.conf
@@ -54,3 +54,9 @@ akka.javasdk.agent.guardrails {
 akka.javasdk.sanitization.regex-sanitizers = {
   "sanitized" = { pattern = "(sanitizesanitizesanitize)" }
 }
+
+# used in LedgerBackedEvaluatorIntegrationTest: the runtime triggers the evaluator for each
+# interaction of the bound agent, and the evaluator fetches the interaction via the ledger client
+akka.javasdk.evaluation.evaluators.ledger-eval-evaluator.agents.ledger-eval-agent {
+  trigger = interaction
+}

--- a/akka-javasdk/src/main/java/akka/javasdk/ledger/Failure.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/ledger/Failure.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.ledger;
+
+/**
+ * A failure that terminated an interaction.
+ *
+ * <p>The {@code reason} is the stored category; any finer detail (such as the specific tool that
+ * failed) is carried in the free-text {@code description}.
+ *
+ * @param reason the category of failure
+ * @param description a human-readable description of the failure
+ */
+public record Failure(FailureReason reason, String description) {
+
+  /** Why an interaction failed. */
+  public enum FailureReason {
+    /** The failure reason was not reported. */
+    UNSPECIFIED,
+    /** The model call itself failed. */
+    MODEL,
+    /** The model provider rate-limited the call. */
+    RATE_LIMIT,
+    /** The model call timed out. */
+    TIMEOUT,
+    /** The interaction used a feature the model does not support. */
+    UNSUPPORTED_FEATURE,
+    /** An internal error occurred. */
+    INTERNAL,
+    /** The model output could not be parsed into the expected result type. */
+    OUTPUT_PARSING,
+    /** A tool call failed. */
+    TOOL_CALL,
+    /** An MCP tool call failed. */
+    MCP_TOOL_CALL,
+    /** A guardrail rejected the interaction. */
+    GUARDRAIL,
+    /** Referenced content (for example an image or PDF) could not be loaded. */
+    CONTENT_LOADING
+  }
+}

--- a/akka-javasdk/src/main/java/akka/javasdk/ledger/InteractionMetadata.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/ledger/InteractionMetadata.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.ledger;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Metadata about the model call(s) of an interaction.
+ *
+ * @param modelConfig the structured model configuration used for the interaction
+ * @param modelConfigMap the raw configuration entries, including any keys not represented in the
+ *     structured {@link ModelConfig}
+ * @param callStartedAt when the model call started
+ * @param callFinishedAt when the model call finished
+ * @param finishReason why the model call finished
+ */
+public record InteractionMetadata(
+    ModelConfig modelConfig,
+    Map<String, String> modelConfigMap,
+    Instant callStartedAt,
+    Instant callFinishedAt,
+    FinishReason finishReason) {
+
+  /** Why a model call finished. */
+  public enum FinishReason {
+    /** The finish reason was not reported. */
+    UNSPECIFIED,
+    /** The model stopped at a natural stopping point. */
+    STOP,
+    /** The model stopped because it reached the maximum number of tokens. */
+    LENGTH
+  }
+}

--- a/akka-javasdk/src/main/java/akka/javasdk/ledger/InteractionRecord.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/ledger/InteractionRecord.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.ledger;
+
+import akka.javasdk.agent.MessageContent;
+import akka.javasdk.agent.MessageContent.DataMessageContent;
+import akka.javasdk.agent.MessageContent.ImageUrlMessageContent;
+import akka.javasdk.agent.MessageContent.PdfUrlMessageContent;
+import akka.javasdk.agent.MessageContent.TextMessageContent;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * The full record of a single agent interaction, as fetched from the ledger.
+ *
+ * <p>Beyond the raw fields, this type offers pure convenience accessors — {@link #userText()},
+ * {@link #finalAssistantText()}, {@link #toolCalls()}, token totals, {@link #failureSummary()} —
+ * and a flattened {@link #transcript()} rendering, for use when evaluating an interaction.
+ *
+ * @param interactionId the globally unique id of the interaction
+ * @param sessionId the id of the session the interaction belongs to
+ * @param agentComponentId the component id of the agent that produced the interaction
+ * @param flowId the id of the flow this interaction was part of, or empty for a request-based agent
+ *     interaction
+ * @param metadata metadata about the model call(s) of the interaction
+ * @param systemMessage the system message the model was given
+ * @param userMessage the user message content given to the model, in order
+ * @param modelResponses the model call(s) of the interaction, in order
+ * @param toolCallResponses tool call responses that arrived as input to a model call
+ * @param taskContext autonomous-agent task metadata, present only for flow interactions
+ * @param failure the failure that terminated the interaction, if it failed
+ * @param timestamp when the interaction was recorded
+ */
+public record InteractionRecord(
+    String interactionId,
+    String sessionId,
+    String agentComponentId,
+    Optional<String> flowId,
+    InteractionMetadata metadata,
+    String systemMessage,
+    List<MessageContent> userMessage,
+    List<ModelResponse> modelResponses,
+    List<ToolCallResponse> toolCallResponses,
+    Optional<TaskContext> taskContext,
+    Optional<Failure> failure,
+    Instant timestamp) {
+
+  /** Whether this interaction was produced by an agent running as part of a flow. */
+  public boolean isFlowInteraction() {
+    return flowId.isPresent();
+  }
+
+  /** Whether this interaction terminated in a failure. */
+  public boolean failed() {
+    return failure.isPresent();
+  }
+
+  /**
+   * The user message rendered as plain text: the text of every {@link TextMessageContent} in {@link
+   * #userMessage()}, joined by newlines. Non-text content (images, PDFs) is omitted.
+   */
+  public String userText() {
+    return userMessage.stream()
+        .filter(c -> c instanceof TextMessageContent)
+        .map(c -> ((TextMessageContent) c).text())
+        .collect(Collectors.joining("\n"));
+  }
+
+  /**
+   * The text content of the last model response that produced any, or an empty string if the model
+   * produced no text (for example an interaction that only made tool calls, or that failed).
+   */
+  public String finalAssistantText() {
+    for (int i = modelResponses.size() - 1; i >= 0; i--) {
+      var content = modelResponses.get(i).content();
+      if (content != null && !content.isEmpty()) {
+        return content;
+      }
+    }
+    return "";
+  }
+
+  /** Every tool call the model requested across all model responses, in order. */
+  public List<ToolCall> toolCalls() {
+    return modelResponses.stream()
+        .flatMap(r -> r.toolCalls().stream())
+        .collect(Collectors.toList());
+  }
+
+  /** The total number of input tokens across all model calls of the interaction. */
+  public int totalInputTokens() {
+    return modelResponses.stream().mapToInt(ModelResponse::inputTokenCount).sum();
+  }
+
+  /** The total number of output tokens across all model calls of the interaction. */
+  public int totalOutputTokens() {
+    return modelResponses.stream().mapToInt(ModelResponse::outputTokenCount).sum();
+  }
+
+  /**
+   * A human-readable summary of the failure that terminated the interaction ({@code reason:
+   * description}), or empty if the interaction did not fail.
+   */
+  public Optional<String> failureSummary() {
+    return failure.map(f -> f.reason() + ": " + f.description());
+  }
+
+  /**
+   * A flattened, ordered, readable transcript of the interaction: the system message, the user
+   * message, each model response (including any thinking and tool calls), and the tool call
+   * responses the model saw as input.
+   *
+   * <p>Pure rendering over this record; intended for feeding an interaction to an LLM-as-judge or
+   * for logging.
+   */
+  public String transcript() {
+    var sb = new StringBuilder();
+    if (systemMessage != null && !systemMessage.isEmpty()) {
+      sb.append("System: ").append(systemMessage).append("\n");
+    }
+    var user =
+        userMessage.stream().map(InteractionRecord::render).collect(Collectors.joining("\n"));
+    if (!user.isEmpty()) {
+      sb.append("User: ").append(user).append("\n");
+    }
+    for (ModelResponse response : modelResponses) {
+      if (response.thinking() != null && !response.thinking().isEmpty()) {
+        sb.append("Assistant (thinking): ").append(response.thinking()).append("\n");
+      }
+      if (response.content() != null && !response.content().isEmpty()) {
+        sb.append("Assistant: ").append(response.content()).append("\n");
+      }
+      for (ToolCall toolCall : response.toolCalls()) {
+        sb.append("Tool call ")
+            .append(toolCall.name())
+            .append("(")
+            .append(toolCall.arguments())
+            .append(") -> ")
+            .append(toolCall.response())
+            .append("\n");
+      }
+    }
+    for (ToolCallResponse toolCallResponse : toolCallResponses) {
+      var contents =
+          toolCallResponse.contents().stream()
+              .map(InteractionRecord::render)
+              .collect(Collectors.joining("\n"));
+      sb.append("Tool response ")
+          .append(toolCallResponse.name())
+          .append(": ")
+          .append(contents)
+          .append("\n");
+    }
+    return sb.toString();
+  }
+
+  private static String render(MessageContent content) {
+    if (content instanceof TextMessageContent text) {
+      return text.text();
+    } else if (content instanceof ImageUrlMessageContent image) {
+      return "[image " + image.uri() + "]";
+    } else if (content instanceof PdfUrlMessageContent pdf) {
+      return "[pdf " + pdf.uri() + "]";
+    } else if (content instanceof DataMessageContent) {
+      return "[binary content]";
+    } else {
+      return "[content]";
+    }
+  }
+}

--- a/akka-javasdk/src/main/java/akka/javasdk/ledger/InteractionRecord.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/ledger/InteractionRecord.java
@@ -17,9 +17,9 @@ import java.util.stream.Collectors;
 /**
  * The full record of a single agent interaction, as fetched from the ledger.
  *
- * <p>Beyond the raw fields, this type offers pure convenience accessors — {@link #userText()},
- * {@link #finalAssistantText()}, {@link #toolCalls()}, token totals, {@link #failureSummary()} —
- * and a flattened {@link #transcript()} rendering, for use when evaluating an interaction.
+ * <p>Beyond the raw fields, this type offers pure convenience accessors — {@link #inputText()},
+ * {@link #finalResponseText()}, {@link #toolCalls()}, token totals, {@link #failureSummary()} — and
+ * a flattened {@link #transcript()} rendering, for use when evaluating an interaction.
  *
  * @param interactionId the globally unique id of the interaction
  * @param sessionId the id of the session the interaction belongs to
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
  *     interaction
  * @param metadata metadata about the model call(s) of the interaction
  * @param systemMessage the system message the model was given
- * @param userMessage the user message content given to the model, in order
+ * @param inputMessage the input message content given to the model, in order
  * @param modelResponses the model call(s) of the interaction, in order
  * @param toolCallResponses tool call responses that arrived as input to a model call
  * @param taskContext autonomous-agent task metadata, present only for flow interactions
@@ -42,7 +42,7 @@ public record InteractionRecord(
     Optional<String> flowId,
     InteractionMetadata metadata,
     String systemMessage,
-    List<MessageContent> userMessage,
+    List<MessageContent> inputMessage,
     List<ModelResponse> modelResponses,
     List<ToolCallResponse> toolCallResponses,
     Optional<TaskContext> taskContext,
@@ -60,11 +60,11 @@ public record InteractionRecord(
   }
 
   /**
-   * The user message rendered as plain text: the text of every {@link TextMessageContent} in {@link
-   * #userMessage()}, joined by newlines. Non-text content (images, PDFs) is omitted.
+   * The input message rendered as plain text: the text of every {@link TextMessageContent} in
+   * {@link #inputMessage()}, joined by newlines. Non-text content (images, PDFs) is omitted.
    */
-  public String userText() {
-    return userMessage.stream()
+  public String inputText() {
+    return inputMessage.stream()
         .filter(c -> c instanceof TextMessageContent)
         .map(c -> ((TextMessageContent) c).text())
         .collect(Collectors.joining("\n"));
@@ -74,7 +74,7 @@ public record InteractionRecord(
    * The text content of the last model response that produced any, or an empty string if the model
    * produced no text (for example an interaction that only made tool calls, or that failed).
    */
-  public String finalAssistantText() {
+  public String finalResponseText() {
     for (int i = modelResponses.size() - 1; i >= 0; i--) {
       var content = modelResponses.get(i).content();
       if (content != null && !content.isEmpty()) {
@@ -110,7 +110,7 @@ public record InteractionRecord(
   }
 
   /**
-   * A flattened, ordered, readable transcript of the interaction: the system message, the user
+   * A flattened, ordered, readable transcript of the interaction: the system message, the input
    * message, each model response (including any thinking and tool calls), and the tool call
    * responses the model saw as input.
    *
@@ -122,17 +122,17 @@ public record InteractionRecord(
     if (systemMessage != null && !systemMessage.isEmpty()) {
       sb.append("System: ").append(systemMessage).append("\n");
     }
-    var user =
-        userMessage.stream().map(InteractionRecord::render).collect(Collectors.joining("\n"));
-    if (!user.isEmpty()) {
-      sb.append("User: ").append(user).append("\n");
+    var input =
+        inputMessage.stream().map(InteractionRecord::render).collect(Collectors.joining("\n"));
+    if (!input.isEmpty()) {
+      sb.append("Input: ").append(input).append("\n");
     }
     for (ModelResponse response : modelResponses) {
       if (response.thinking() != null && !response.thinking().isEmpty()) {
-        sb.append("Assistant (thinking): ").append(response.thinking()).append("\n");
+        sb.append("Thinking: ").append(response.thinking()).append("\n");
       }
       if (response.content() != null && !response.content().isEmpty()) {
-        sb.append("Assistant: ").append(response.content()).append("\n");
+        sb.append("Response: ").append(response.content()).append("\n");
       }
       for (ToolCall toolCall : response.toolCalls()) {
         sb.append("Tool call ")

--- a/akka-javasdk/src/main/java/akka/javasdk/ledger/LedgerClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/ledger/LedgerClient.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.ledger;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Client for fetching records from the ledger — the log of recorded agent interactions.
+ *
+ * <p>A {@code LedgerClient} can be injected into any component. An {@link
+ * akka.javasdk.evaluation.Evaluator} is the primary consumer: it fetches the interaction referenced
+ * by its {@link akka.javasdk.evaluation.Subject#interactionId()} to evaluate it.
+ *
+ * <p>Not for user extension.
+ */
+public interface LedgerClient {
+
+  /**
+   * Fetch the full record for the interaction with the given (globally unique) {@code
+   * interactionId}.
+   *
+   * <p>Blocks the calling thread until the record has been fetched. Safe to call on a Loom virtual
+   * thread. Use {@link #getInteractionAsync(String)} for the non-blocking variant.
+   *
+   * @param interactionId the globally unique id of the interaction to fetch
+   * @return the interaction record
+   * @throws NoSuchElementException if no interaction exists with that id
+   */
+  InteractionRecord getInteraction(String interactionId);
+
+  /**
+   * Async variant of {@link #getInteraction(String)}.
+   *
+   * @param interactionId the globally unique id of the interaction to fetch
+   * @return a stage that completes with the interaction record, or fails with {@link
+   *     NoSuchElementException} if no interaction exists with that id
+   */
+  CompletionStage<InteractionRecord> getInteractionAsync(String interactionId);
+}

--- a/akka-javasdk/src/main/java/akka/javasdk/ledger/ModelConfig.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/ledger/ModelConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.ledger;
+
+/**
+ * The model configuration used for an interaction.
+ *
+ * <p>The structured fields cover the settings the SDK recognises; any additional provider-specific
+ * entries are available through {@link InteractionMetadata#modelConfigMap()}.
+ *
+ * @param providerName the model provider (for example {@code openai}, {@code anthropic})
+ * @param modelName the model name as configured
+ * @param baseUrl the base URL the model was called through, or empty if not set
+ * @param temperature the sampling temperature
+ * @param topP the nucleus-sampling probability mass
+ * @param topK the top-k sampling cutoff
+ * @param maxTokens the maximum number of tokens the model was allowed to produce
+ */
+public record ModelConfig(
+    String providerName,
+    String modelName,
+    String baseUrl,
+    double temperature,
+    double topP,
+    int topK,
+    int maxTokens) {}

--- a/akka-javasdk/src/main/java/akka/javasdk/ledger/ModelResponse.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/ledger/ModelResponse.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.ledger;
+
+import java.util.List;
+
+/**
+ * A single model call within an interaction.
+ *
+ * @param id the id of this model response, a seam for correlating finer-grained records
+ * @param content the text content the model produced
+ * @param inputTokenCount the number of tokens in the input to this model call
+ * @param outputTokenCount the number of tokens the model produced
+ * @param thinking the model's reasoning/thinking output, or empty if none was recorded
+ * @param toolCalls the tool calls the model requested within this response, in order
+ */
+public record ModelResponse(
+    String id,
+    String content,
+    int inputTokenCount,
+    int outputTokenCount,
+    String thinking,
+    List<ToolCall> toolCalls) {}

--- a/akka-javasdk/src/main/java/akka/javasdk/ledger/TaskContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/ledger/TaskContext.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.ledger;
+
+/**
+ * Autonomous-agent task metadata. Present only for interactions produced by an agent running as
+ * part of a flow; absent for request-based agent interactions.
+ *
+ * @param agentInstanceId the id of the agent instance that ran the task
+ * @param taskId the id of the task
+ * @param taskName the name of the task
+ * @param taskDescription the description of the task
+ * @param taskResultType the type of the task's result
+ * @param iterationNumber the iteration of the flow this interaction belongs to
+ * @param maxIterations the maximum number of iterations configured for the flow
+ */
+public record TaskContext(
+    String agentInstanceId,
+    String taskId,
+    String taskName,
+    String taskDescription,
+    String taskResultType,
+    int iterationNumber,
+    int maxIterations) {}

--- a/akka-javasdk/src/main/java/akka/javasdk/ledger/ToolCall.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/ledger/ToolCall.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.ledger;
+
+/**
+ * A tool call the model requested within a model response, together with its recorded response.
+ *
+ * @param id the id of the tool call, correlating the request with its response
+ * @param name the name of the tool that was called
+ * @param arguments the arguments passed to the tool, as a JSON string
+ * @param response the tool's response, as a string
+ */
+public record ToolCall(String id, String name, String arguments, String response) {}

--- a/akka-javasdk/src/main/java/akka/javasdk/ledger/ToolCallResponse.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/ledger/ToolCallResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.ledger;
+
+import akka.javasdk.agent.MessageContent;
+import java.util.List;
+
+/**
+ * A tool call response that arrived as input to a model call, typically a capability-tool
+ * resolution from a prior iteration. The model saw these as input.
+ *
+ * @param id the id of the tool call this is a response to
+ * @param name the name of the tool that produced the response
+ * @param contents the content of the response, as one or more pieces of {@link MessageContent}
+ */
+public record ToolCallResponse(String id, String name, List<MessageContent> contents) {}

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -94,6 +94,7 @@ import akka.javasdk.impl.http.HttpClientProviderImpl
 import akka.javasdk.impl.http.HttpRequestContextImpl
 import akka.javasdk.impl.http.JwtClaimsImpl
 import akka.javasdk.impl.keyvalueentity.KeyValueEntityImpl
+import akka.javasdk.impl.ledger.LedgerClientImpl
 import akka.javasdk.impl.objectstorage.ObjectStorageProviderImpl
 import akka.javasdk.impl.reflection.Reflect
 import akka.javasdk.impl.reflection.Reflect.Syntax.AnnotatedElementOps
@@ -107,6 +108,7 @@ import akka.javasdk.impl.workflow.WorkflowContextImpl
 import akka.javasdk.impl.workflow.WorkflowImpl
 import akka.javasdk.keyvalueentity.KeyValueEntity
 import akka.javasdk.keyvalueentity.KeyValueEntityContext
+import akka.javasdk.ledger.LedgerClient
 import akka.javasdk.mcp.AbstractMcpEndpoint
 import akka.javasdk.mcp.McpRequestContext
 import akka.javasdk.objectstorage.ObjectStorageProvider
@@ -168,6 +170,7 @@ import akka.runtime.sdk.spi.UserFunctionError
 import akka.runtime.sdk.spi.ViewDescriptor
 import akka.runtime.sdk.spi.WorkflowDescriptor
 import akka.runtime.sdk.spi.tracing.InMemorySpanExporter
+import akka.runtime.sdk.spi.{ LedgerClient => SpiLedgerClient }
 import akka.stream.Materializer
 import akka.stream.SystemMaterializer
 import com.typesafe.config.Config
@@ -393,6 +396,7 @@ class SdkRunner private (
         startContext.materializer,
         startContext.componentClients,
         startContext.eventLogClient,
+        startContext.ledgerClient,
         startContext.remoteIdentification,
         startContext.tracerFactory,
         startContext.sdkMeter,
@@ -473,7 +477,8 @@ private[javasdk] object Sdk {
     classOf[Retries],
     classOf[AgentContext],
     classOf[AgentRegistry],
-    classOf[ObjectStorageProvider])
+    classOf[ObjectStorageProvider],
+    classOf[LedgerClient])
 
   // Run a user-supplied callback, logging any failure on the user component's own logger so it reaches the user.
   // Rethrows by default; pass rethrow = false where a failing callback must not abort the surrounding flow.
@@ -497,6 +502,7 @@ private final class Sdk(
     sdkMaterializer: Materializer,
     runtimeComponentClients: ComponentClients,
     eventLogClient: EventLogClient,
+    spiLedgerClient: SpiLedgerClient,
     remoteIdentification: Option[RemoteIdentification],
     tracerFactory: String => Tracer,
     sdkMeter: Meter,
@@ -591,6 +597,8 @@ private final class Sdk(
   }
 
   lazy private val sanitizer = SanitizerImpl(runtimeSanitizer)
+
+  private lazy val ledgerClient: LedgerClient = new LedgerClientImpl(spiLedgerClient, sdkExecutionContext)
 
   private def hasComponentId(clz: Class[_]): Boolean = {
     if (clz.hasAnnotation[Component]) {
@@ -1169,8 +1177,9 @@ private final class Sdk(
     case e if e == classOf[Executor]           =>
       // The type does not guarantee this is a Java concurrent Executor, but we know it is, since supplied from runtime
       sdkExecutionContext.asInstanceOf[Executor]
-    case s if s == classOf[Sanitizer] => sanitizer
-    case s if s == classOf[Meter]     => sdkMeter
+    case s if s == classOf[Sanitizer]    => sanitizer
+    case l if l == classOf[LedgerClient] => ledgerClient
+    case s if s == classOf[Meter]        => sdkMeter
     case o if o == classOf[ObjectStorageProvider] =>
       objectStorageProvider(telemetryContext)
   }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/ledger/LedgerClientImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/ledger/LedgerClientImpl.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl.ledger
+
+import java.net.URI
+import java.util.concurrent.CompletionException
+import java.util.concurrent.CompletionStage
+
+import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
+import scala.jdk.OptionConverters._
+
+import akka.annotation.InternalApi
+import akka.javasdk.agent.MessageContent
+import akka.javasdk.impl.ErrorHandling
+import akka.javasdk.ledger.Failure
+import akka.javasdk.ledger.InteractionMetadata
+import akka.javasdk.ledger.InteractionRecord
+import akka.javasdk.ledger.LedgerClient
+import akka.javasdk.ledger.ModelConfig
+import akka.javasdk.ledger.ModelResponse
+import akka.javasdk.ledger.TaskContext
+import akka.javasdk.ledger.ToolCall
+import akka.javasdk.ledger.ToolCallResponse
+import akka.runtime.sdk.spi.SpiLedger
+import akka.runtime.sdk.spi.{ LedgerClient => SpiLedgerClient }
+
+/**
+ * INTERNAL API
+ *
+ * The public SDK [[LedgerClient]] backed by the runtime's SPI [[SpiLedgerClient]]. Adapts the SPI record types into the
+ * SDK's public record types and the SPI `Future` into a `CompletionStage`.
+ */
+@InternalApi
+private[javasdk] final class LedgerClientImpl(spiLedgerClient: SpiLedgerClient, sdkExecutionContext: ExecutionContext)
+    extends LedgerClient {
+
+  private implicit val ec: ExecutionContext = sdkExecutionContext
+
+  override def getInteraction(interactionId: String): InteractionRecord =
+    try getInteractionAsync(interactionId).toCompletableFuture.join()
+    catch {
+      case e: CompletionException => throw ErrorHandling.unwrapCompletionException(e)
+    }
+
+  override def getInteractionAsync(interactionId: String): CompletionStage[InteractionRecord] =
+    spiLedgerClient.getInteraction(interactionId).map(LedgerClientImpl.toInteractionRecord).asJava
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[ledger] object LedgerClientImpl {
+
+  def toInteractionRecord(record: SpiLedger.InteractionRecord): InteractionRecord =
+    new InteractionRecord(
+      record.interactionId,
+      record.sessionId,
+      record.agentComponentId,
+      record.flowId.toJava,
+      toMetadata(record.metadata),
+      record.systemMessage,
+      record.userMessage.map(toMessageContent).asJava,
+      record.modelResponses.map(toModelResponse).asJava,
+      record.toolCallResponses.map(toToolCallResponse).asJava,
+      record.taskContext.map(toTaskContext).toJava,
+      record.failure.map(toFailure).toJava,
+      record.timestamp)
+
+  private def toMetadata(metadata: SpiLedger.InteractionMetadata): InteractionMetadata =
+    new InteractionMetadata(
+      toModelConfig(metadata.modelConfig),
+      metadata.modelConfigMap.asJava,
+      metadata.callStartedAt,
+      metadata.callFinishedAt,
+      toFinishReason(metadata.finishReason))
+
+  private def toModelConfig(config: SpiLedger.ModelConfig): ModelConfig =
+    new ModelConfig(
+      config.providerName,
+      config.modelName,
+      config.baseUrl,
+      config.temperature,
+      config.topP,
+      config.topK,
+      config.maxTokens)
+
+  private def toFinishReason(reason: SpiLedger.FinishReason): InteractionMetadata.FinishReason =
+    reason match {
+      case SpiLedger.FinishReason.Unspecified => InteractionMetadata.FinishReason.UNSPECIFIED
+      case SpiLedger.FinishReason.Stop        => InteractionMetadata.FinishReason.STOP
+      case SpiLedger.FinishReason.Length      => InteractionMetadata.FinishReason.LENGTH
+    }
+
+  private def toModelResponse(response: SpiLedger.ModelResponse): ModelResponse =
+    new ModelResponse(
+      response.id,
+      response.content,
+      response.inputTokenCount,
+      response.outputTokenCount,
+      response.thinking,
+      response.toolCalls.map(toToolCall).asJava)
+
+  private def toToolCall(toolCall: SpiLedger.ToolCall): ToolCall =
+    new ToolCall(toolCall.id, toolCall.name, toolCall.arguments, toolCall.response)
+
+  private def toToolCallResponse(response: SpiLedger.ToolCallResponse): ToolCallResponse =
+    new ToolCallResponse(response.id, response.name, response.contents.map(toMessageContent).asJava)
+
+  private def toMessageContent(content: SpiLedger.MessageContent): MessageContent =
+    content match {
+      case text: SpiLedger.TextContent =>
+        new MessageContent.TextMessageContent(text.text)
+      case image: SpiLedger.ImageUriContent =>
+        new MessageContent.ImageUrlMessageContent(
+          URI.create(image.uri),
+          toDetailLevel(image.detailLevel),
+          image.mimeType.toJava)
+      case pdf: SpiLedger.PdfUriContent =>
+        new MessageContent.PdfUrlMessageContent(URI.create(pdf.uri))
+    }
+
+  // Mirrors SpiAgent.ImageMessageContent.DetailLevel.render, the form stored in the ledger.
+  private def toDetailLevel(detailLevel: String): MessageContent.ImageMessageContent.DetailLevel =
+    detailLevel match {
+      case "low"        => MessageContent.ImageMessageContent.DetailLevel.LOW
+      case "medium"     => MessageContent.ImageMessageContent.DetailLevel.MEDIUM
+      case "high"       => MessageContent.ImageMessageContent.DetailLevel.HIGH
+      case "ultra high" => MessageContent.ImageMessageContent.DetailLevel.ULTRA_HIGH
+      case _            => MessageContent.ImageMessageContent.DetailLevel.AUTO
+    }
+
+  private def toTaskContext(taskContext: SpiLedger.TaskContext): TaskContext =
+    new TaskContext(
+      taskContext.agentInstanceId,
+      taskContext.taskId,
+      taskContext.taskName,
+      taskContext.taskDescription,
+      taskContext.taskResultType,
+      taskContext.iterationNumber,
+      taskContext.maxIterations)
+
+  private def toFailure(failure: SpiLedger.Failure): Failure =
+    new Failure(toFailureReason(failure.reason), failure.description)
+
+  private def toFailureReason(reason: SpiLedger.FailureReason): Failure.FailureReason =
+    reason match {
+      case SpiLedger.FailureReason.Unspecified        => Failure.FailureReason.UNSPECIFIED
+      case SpiLedger.FailureReason.Model              => Failure.FailureReason.MODEL
+      case SpiLedger.FailureReason.RateLimit          => Failure.FailureReason.RATE_LIMIT
+      case SpiLedger.FailureReason.Timeout            => Failure.FailureReason.TIMEOUT
+      case SpiLedger.FailureReason.UnsupportedFeature => Failure.FailureReason.UNSUPPORTED_FEATURE
+      case SpiLedger.FailureReason.Internal           => Failure.FailureReason.INTERNAL
+      case SpiLedger.FailureReason.OutputParsing      => Failure.FailureReason.OUTPUT_PARSING
+      case SpiLedger.FailureReason.ToolCall           => Failure.FailureReason.TOOL_CALL
+      case SpiLedger.FailureReason.McpToolCall        => Failure.FailureReason.MCP_TOOL_CALL
+      case SpiLedger.FailureReason.Guardrail          => Failure.FailureReason.GUARDRAIL
+      case SpiLedger.FailureReason.ContentLoading     => Failure.FailureReason.CONTENT_LOADING
+    }
+}

--- a/docs/src/modules/sdk/pages/setup-and-dependency-injection.adoc
+++ b/docs/src/modules/sdk/pages/setup-and-dependency-injection.adoc
@@ -117,6 +117,8 @@ The following types can be injected in Service Setup, HTTP Endpoints, gRPC Endpo
 | Utility for retrying calls
 | `java.util.concurrent.Executor`
 | An executor which runs each task in a virtual thread, and is safe to use for blocking async work, for example with `CompletableFuture.supplyAsync(() -> blocking, executor)`
+| `akka.javasdk.ledger.LedgerClient`
+| For fetching recorded agent interactions from the ledger, primarily for evaluators.
 |===
 
 Furthermore, the following component specific types can also be injected:


### PR DESCRIPTION
Refs https://github.com/lightbend/akka-runtime/issues/5330

Builds on published runtime snapshot with changes from: https://github.com/lightbend/akka-runtime/pull/5453

The SDK side interaction record includes some helpers such as accessing particular parts of the interaction, total token usage, or creating a transcript, which is useful for passing to a judge agent.

And we can now have a more end-to-end integration test for an evaluation with an evaluator that has triggered an agent's interaction, and then fetching the interaction record using the ledger client. 