### PR TITLE
feat: introduce initial version of Classifiers (#5334)

### DIFF
--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -18,6 +18,7 @@ import akka.javasdk.Sanitizer;
 import akka.javasdk.ServiceSetup;
 import akka.javasdk.agent.Agent;
 import akka.javasdk.agent.AgentRegistry;
+import akka.javasdk.agent.ClassifierClient;
 import akka.javasdk.agent.ModelProvider;
 import akka.javasdk.annotations.Component;
 import akka.javasdk.client.ComponentClient;
@@ -851,6 +852,7 @@ public class TestKit {
   private Optional<DependencyProvider> dependencyProvider;
   private AgentRegistry agentRegistry;
   private Sanitizer sanitizer;
+  private ClassifierClient classifierClient;
   private int eventingTestKitPort = -1;
   private Config applicationConfig;
   private String serviceName;
@@ -1004,6 +1006,7 @@ public class TestKit {
       dependencyProvider =
           Optional.ofNullable(startupContext.dependencyProvider().getOrElse(() -> null));
       sanitizer = startupContext.sanitizer();
+      classifierClient = startupContext.classifierClient();
 
       settings.modelProvidersByAgentId.forEach(
           (agentId, modelProvider) ->
@@ -1459,6 +1462,14 @@ public class TestKit {
    */
   public Sanitizer getSanitizer() {
     return sanitizer;
+  }
+
+  /**
+   * @return The configured classifier client for the service, for test assertions and for invoking
+   *     a configured classifier directly without going through a component.
+   */
+  public ClassifierClient getClassifierClient() {
+    return classifierClient;
   }
 
   /** Stop the testkit and local runtime. */

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKitSupport.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKitSupport.java
@@ -7,6 +7,7 @@ package akka.javasdk.testkit;
 import akka.grpc.javadsl.AkkaGrpcClient;
 import akka.javasdk.Principal;
 import akka.javasdk.Sanitizer;
+import akka.javasdk.agent.ClassifierClient;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.http.HttpClient;
 import akka.javasdk.timer.TimerScheduler;
@@ -116,5 +117,13 @@ public abstract class TestKitSupport extends AsyncCallsSupport {
    */
   public Sanitizer getSanitizer() {
     return testKit.getSanitizer();
+  }
+
+  /**
+   * @return The configured classifier client for the service, for test assertions and for invoking
+   *     a configured classifier directly without going through a component.
+   */
+  public ClassifierClient getClassifierClient() {
+    return testKit.getClassifierClient();
   }
 }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/HttpEndpointTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/HttpEndpointTest.java
@@ -224,9 +224,7 @@ public class HttpEndpointTest extends TestKitSupport {
     assertThat(response.body()).isEqualTo("toxic");
 
     var directUsageResult =
-        getClassifierClient()
-            .classifier("toxicity-test-classifier")
-            .classify("a perfectly fine message");
+        getClassifierClient().classify("toxicity-test-classifier", "a perfectly fine message");
     assertThat(directUsageResult.label()).contains("clean");
   }
 
@@ -236,10 +234,7 @@ public class HttpEndpointTest extends TestKitSupport {
     // TestGrpcServiceClient constructor param resolvable only via
     // Bootstrap.createDependencyProvider(), not via any platform-managed inject -- proves
     // classifier construction runs after Bootstrap.createDependencyProvider().
-    var result =
-        getClassifierClient()
-            .classifier("dependency-provided-test-classifier")
-            .classify("anything");
+    var result = getClassifierClient().classify("dependency-provided-test-classifier", "anything");
     assertThat(result.label()).contains("resolved");
   }
 

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/HttpEndpointTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/HttpEndpointTest.java
@@ -216,6 +216,34 @@ public class HttpEndpointTest extends TestKitSupport {
   }
 
   @Test
+  public void injectableClassifierClientWorks() {
+    // depends on the "toxicity-test-classifier" config, see test application.conf
+    var response =
+        httpClient.GET("/classify/totally-toxic-content").responseBodyAs(String.class).invoke();
+    assertThat(response.status()).isEqualTo(StatusCodes.OK);
+    assertThat(response.body()).isEqualTo("toxic");
+
+    var directUsageResult =
+        getClassifierClient()
+            .classifier("toxicity-test-classifier")
+            .classify("a perfectly fine message");
+    assertThat(directUsageResult.label()).contains("clean");
+  }
+
+  @Test
+  public void classifierConstructorCanResolveADependencyProviderSuppliedDependency() {
+    // "dependency-provided-test-classifier" (see test application.conf) takes a
+    // TestGrpcServiceClient constructor param resolvable only via
+    // Bootstrap.createDependencyProvider(), not via any platform-managed inject -- proves
+    // classifier construction runs after Bootstrap.createDependencyProvider().
+    var result =
+        getClassifierClient()
+            .classifier("dependency-provided-test-classifier")
+            .classify("anything");
+    assertThat(result.label()).contains("resolved");
+  }
+
+  @Test
   public void shouldHandleBigDecimalOutOfTheBox() {
     var bigDecimal = new java.math.BigDecimal("12345678901234567890.12345678901234567890");
     var response =

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/AgentIntegrationTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/AgentIntegrationTest.java
@@ -70,6 +70,7 @@ public class AgentIntegrationTest extends TestKitSupport {
         .withModelProvider(ProtobufAgentWithConformsTo.class, testModelProvider)
         .withModelProvider(ProtobufAgentWithResponseAs.class, testModelProvider)
         .withModelProvider(ModelGuardrailTestAgent.class, testModelProvider)
+        .withModelProvider(ClassifierBackedGuardrailTestAgent.class, testModelProvider)
         .withDependencyProvider(depsProvider);
   }
 
@@ -619,6 +620,44 @@ public class AgentIntegrationTest extends TestKitSupport {
     // then
     // the GuardrailException still reaches onFailure even for the new ModelGuardrail
     assertThat(result.response()).contains("blocked by test model guard");
+  }
+
+  @Test
+  public void shouldAllowResponseWhenClassifierBackedGuardrailDoesNotFlagIt() {
+    // given
+    // classifier-backed-guardrail-test-agent is configured to use ClassifierBackedModelGuard,
+    // which delegates to the "toxicity-test-classifier" resolved via
+    // GuardrailContext.classifierClient()
+    testModelProvider.whenMessage(s -> s.equals("hello")).reply("a perfectly fine response");
+
+    // when
+    ClassifierBackedGuardrailTestAgent.SomeResponse result =
+        componentClient
+            .forAgent()
+            .inSession(newSessionId())
+            .method(ClassifierBackedGuardrailTestAgent::mapLlmResponse)
+            .invoke("hello");
+
+    // then
+    assertThat(result.response()).isEqualTo("a perfectly fine response");
+  }
+
+  @Test
+  public void shouldBlockResponseWhenClassifierBackedGuardrailFlagsIt() {
+    // given
+    testModelProvider.whenMessage(s -> s.equals("hello")).reply("this response is toxic");
+
+    // when
+    ClassifierBackedGuardrailTestAgent.SomeResponse result =
+        componentClient
+            .forAgent()
+            .inSession(newSessionId())
+            .method(ClassifierBackedGuardrailTestAgent::mapLlmResponse)
+            .invoke("hello");
+
+    // then
+    // the guardrail's Decision.Deny reason surfaces through the GuardrailException
+    assertThat(result.response()).contains("blocked by classifier: toxic");
   }
 
   @Test

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/ClassifierBackedGuardrailTestAgent.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/ClassifierBackedGuardrailTestAgent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akkajavasdk.components.agent;
+
+import akka.javasdk.agent.Agent;
+import akka.javasdk.agent.Guardrail;
+import akka.javasdk.annotations.Component;
+
+@Component(id = "classifier-backed-guardrail-test-agent")
+public class ClassifierBackedGuardrailTestAgent extends Agent {
+  public record SomeResponse(String response) {}
+
+  public Effect<SomeResponse> mapLlmResponse(String question) {
+    return effects()
+        .systemMessage("You are a helpful...")
+        .userMessage(question)
+        .map(SomeResponse::new)
+        .onFailure(
+            cause -> {
+              return switch (cause) {
+                case Guardrail.GuardrailException e -> new SomeResponse(e.getMessage());
+                case RuntimeException e -> throw e;
+                default -> throw new RuntimeException(cause);
+              };
+            })
+        .thenReply();
+  }
+}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/ClassifierBackedModelGuard.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/ClassifierBackedModelGuard.java
@@ -17,9 +17,8 @@ import akka.javasdk.agent.ModelGuardrail;
  * rather than a string literal, so the guardrail-to-classifier binding can be re-pointed at
  * deployment time without rebuilding -- the canonical pattern for governance-owned names.
  *
- * <p>decide(...) is still synchronous (a known limitation, see ToolGuardrail's FIXME), so this uses
- * the blocking {@link ClassifierClient#classify}, which itself completes asynchronously, exercising
- * that combination.
+ * <p>decide(...) is synchronous, so this uses the blocking {@link ClassifierClient#classify}, which
+ * itself completes asynchronously, exercising that combination.
  */
 public class ClassifierBackedModelGuard implements ModelGuardrail {
   private final ClassifierClient classifierClient;

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/ClassifierBackedModelGuard.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/ClassifierBackedModelGuard.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akkajavasdk.components.agent;
+
+import akka.javasdk.agent.Classifier;
+import akka.javasdk.agent.Decision;
+import akka.javasdk.agent.GuardrailContext;
+import akka.javasdk.agent.ModelGuardrail;
+
+/**
+ * A ModelGuardrail that delegates the decision to a configured classifier, resolved via {@link
+ * GuardrailContext#classifierClient()}. Demonstrates the "used inline from a guardrail" scenario.
+ *
+ * <p>The classifier name comes from the guardrail's own config section ({@code classifier = ...})
+ * rather than a string literal, so the guardrail-to-classifier binding can be re-pointed at
+ * deployment time without rebuilding -- the canonical pattern for governance-owned names.
+ *
+ * <p>decide(...) is still synchronous (a known limitation, see ToolGuardrail's FIXME), so this uses
+ * the blocking {@link Classifier#classify}, which itself completes asynchronously, exercising that
+ * combination.
+ */
+public class ClassifierBackedModelGuard implements ModelGuardrail {
+  private final Classifier classifier;
+
+  public ClassifierBackedModelGuard(GuardrailContext context) {
+    this.classifier =
+        context.classifierClient().classifier(context.config().getString("classifier"));
+  }
+
+  @Override
+  public Decision decide(CallContext ctx) {
+    try {
+      var classification = classifier.classify(ctx.text());
+      if (classification.label().map(l -> l.equals("toxic")).orElse(false)) {
+        return new Decision.Deny("blocked by classifier: " + classification.label().get());
+      }
+      return new Decision.Allow();
+    } catch (RuntimeException e) {
+      return new Decision.Fail("classifier invocation failed", e);
+    }
+  }
+}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/ClassifierBackedModelGuard.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/ClassifierBackedModelGuard.java
@@ -4,7 +4,7 @@
 
 package akkajavasdk.components.agent;
 
-import akka.javasdk.agent.Classifier;
+import akka.javasdk.agent.ClassifierClient;
 import akka.javasdk.agent.Decision;
 import akka.javasdk.agent.GuardrailContext;
 import akka.javasdk.agent.ModelGuardrail;
@@ -18,21 +18,22 @@ import akka.javasdk.agent.ModelGuardrail;
  * deployment time without rebuilding -- the canonical pattern for governance-owned names.
  *
  * <p>decide(...) is still synchronous (a known limitation, see ToolGuardrail's FIXME), so this uses
- * the blocking {@link Classifier#classify}, which itself completes asynchronously, exercising that
- * combination.
+ * the blocking {@link ClassifierClient#classify}, which itself completes asynchronously, exercising
+ * that combination.
  */
 public class ClassifierBackedModelGuard implements ModelGuardrail {
-  private final Classifier classifier;
+  private final ClassifierClient classifierClient;
+  private final String classifierName;
 
   public ClassifierBackedModelGuard(GuardrailContext context) {
-    this.classifier =
-        context.classifierClient().classifier(context.config().getString("classifier"));
+    this.classifierClient = context.classifierClient();
+    this.classifierName = context.config().getString("classifier");
   }
 
   @Override
   public Decision decide(CallContext ctx) {
     try {
-      var classification = classifier.classify(ctx.text());
+      var classification = classifierClient.classify(classifierName, ctx.text());
       if (classification.label().map(l -> l.equals("toxic")).orElse(false)) {
         return new Decision.Deny("blocked by classifier: " + classification.label().get());
       }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/DependencyProvidedClassifier.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/DependencyProvidedClassifier.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akkajavasdk.components.agent;
+
+import akka.javasdk.agent.Classification;
+import akka.javasdk.agent.Classifier;
+import akka.javasdk.agent.ClassifierContext;
+import akkajavasdk.protocol.TestGrpcServiceClient;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Test classifier whose constructor takes a dependency resolvable only via the service's {@code
+ * DependencyProvider} ({@link akkajavasdk.components.Bootstrap#createDependencyProvider()}), not
+ * via any platform-managed inject. Proves classifier construction happens after {@code
+ * ServiceSetup.createDependencyProvider()} has run.
+ */
+public class DependencyProvidedClassifier implements Classifier {
+  private final TestGrpcServiceClient dependencyProvidedClient;
+
+  public DependencyProvidedClassifier(
+      ClassifierContext context, TestGrpcServiceClient dependencyProvidedClient) {
+    this.dependencyProvidedClient = dependencyProvidedClient;
+  }
+
+  @Override
+  public CompletionStage<Classification> classifyAsync(String input) {
+    return CompletableFuture.completedFuture(
+        Classification.label(dependencyProvidedClient != null ? "resolved" : "missing"));
+  }
+}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/DependencyProvidedClassifier.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/DependencyProvidedClassifier.java
@@ -26,7 +26,7 @@ public class DependencyProvidedClassifier implements Classifier {
   }
 
   @Override
-  public CompletionStage<Classification> classifyAsync(String input) {
+  public CompletionStage<Classification> classify(String input) {
     return CompletableFuture.completedFuture(
         Classification.label(dependencyProvidedClient != null ? "resolved" : "missing"));
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/ThresholdClassifier.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/ThresholdClassifier.java
@@ -27,7 +27,7 @@ public class ThresholdClassifier implements Classifier {
   }
 
   @Override
-  public CompletionStage<Classification> classifyAsync(String input) {
+  public CompletionStage<Classification> classify(String input) {
     return CompletableFuture.supplyAsync(
         () -> {
           boolean toxic = input.toLowerCase().contains("toxic");

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/ThresholdClassifier.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/ThresholdClassifier.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akkajavasdk.components.agent;
+
+import akka.javasdk.agent.Classification;
+import akka.javasdk.agent.Classifier;
+import akka.javasdk.agent.ClassifierContext;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Test classifier: labels input containing "toxic" as toxic with score 1.0, everything else as
+ * clean with score 0.0. Completes on a separate thread (rather than the calling thread) to exercise
+ * the case of an async classifier invoked from a still-synchronous guardrail.
+ */
+public class ThresholdClassifier implements Classifier {
+  private final double threshold;
+
+  public ThresholdClassifier(ClassifierContext context) {
+    this.threshold = context.config().getDouble("threshold");
+  }
+
+  public double threshold() {
+    return threshold;
+  }
+
+  @Override
+  public CompletionStage<Classification> classifyAsync(String input) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          boolean toxic = input.toLowerCase().contains("toxic");
+          return toxic ? Classification.of(1.0, "toxic") : Classification.of(0.0, "clean");
+        });
+  }
+}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/http/TestEndpoint.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/http/TestEndpoint.java
@@ -10,6 +10,7 @@ import akka.http.javadsl.model.HttpEntity.Strict;
 import akka.http.javadsl.model.HttpResponse;
 import akka.http.javadsl.model.StatusCodes;
 import akka.javasdk.Sanitizer;
+import akka.javasdk.agent.ClassifierClient;
 import akka.javasdk.annotations.Acl;
 import akka.javasdk.annotations.http.Get;
 import akka.javasdk.annotations.http.HttpEndpoint;
@@ -33,14 +34,17 @@ import java.util.List;
 public class TestEndpoint extends AbstractHttpEndpoint {
 
   private final Sanitizer sanitizer;
+  private final ClassifierClient classifierClient;
   private final ComponentClient componentClient;
   private final ObjectStorageProvider objectStorageProvider;
 
   public TestEndpoint(
       Sanitizer sanitizer,
+      ClassifierClient classifierClient,
       ComponentClient componentClient,
       ObjectStorageProvider objectStorageProvider) {
     this.sanitizer = sanitizer;
+    this.classifierClient = classifierClient;
     this.componentClient = componentClient;
     this.objectStorageProvider = objectStorageProvider;
   }
@@ -71,6 +75,15 @@ public class TestEndpoint extends AbstractHttpEndpoint {
   @Get("/sanitized")
   public String sanitized() {
     return sanitizer.sanitize("Here's a string to sanitize: sanitizesanitizesanitize");
+  }
+
+  @Get("/classify/{text}")
+  public String classify(String text) {
+    return classifierClient
+        .classifier("toxicity-test-classifier")
+        .classify(text)
+        .label()
+        .orElse("no label");
   }
 
   public record BigDecimalRequest(BigDecimal value) {}

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/http/TestEndpoint.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/http/TestEndpoint.java
@@ -79,11 +79,7 @@ public class TestEndpoint extends AbstractHttpEndpoint {
 
   @Get("/classify/{text}")
   public String classify(String text) {
-    return classifierClient
-        .classifier("toxicity-test-classifier")
-        .classify(text)
-        .label()
-        .orElse("no label");
+    return classifierClient.classify("toxicity-test-classifier", text).label().orElse("no label");
   }
 
   public record BigDecimalRequest(BigDecimal value) {}

--- a/akka-javasdk-tests/src/test/resources/META-INF/akka-javasdk-components_akka-javasdk-tests.conf
+++ b/akka-javasdk-tests/src/test/resources/META-INF/akka-javasdk-components_akka-javasdk-tests.conf
@@ -18,6 +18,7 @@ akka.javasdk {
       "akkajavasdk.components.agent.ProtobufAgentWithConformsTo",
       "akkajavasdk.components.agent.ProtobufAgentWithResponseAs",
       "akkajavasdk.components.agent.ModelGuardrailTestAgent",
+      "akkajavasdk.components.agent.ClassifierBackedGuardrailTestAgent",
       "akkajavasdk.components.agent.KeyValueEntityAsToolIntegrationTest$UserManagerAgent",
       "akkajavasdk.components.agent.EventSourcedEntityAsToolIntegrationTest$CounterManagerAgent",
       "akkajavasdk.components.agent.ViewAsToolIntegrationTest$CounterQueryAgent",

--- a/akka-javasdk-tests/src/test/resources/application.conf
+++ b/akka-javasdk-tests/src/test/resources/application.conf
@@ -49,6 +49,26 @@ akka.javasdk.agent.guardrails {
     report-only = false
     block-reason = "blocked by test model guard"
   }
+
+  "classifier backed model guard" {
+    class = "akkajavasdk.components.agent.ClassifierBackedModelGuard"
+    agents = ["classifier-backed-guardrail-test-agent"]
+    category = TOXIC
+    use-for = ["model-response"]
+    report-only = false
+    # governance-owned binding: which configured classifier this guardrail consults
+    classifier = "toxicity-test-classifier"
+  }
+}
+
+akka.javasdk.agent.classifiers {
+  "toxicity-test-classifier" {
+    class = "akkajavasdk.components.agent.ThresholdClassifier"
+    threshold = 0.5
+  }
+  "dependency-provided-test-classifier" {
+    class = "akkajavasdk.components.agent.DependencyProvidedClassifier"
+  }
 }
 
 akka.javasdk.sanitization.regex-sanitizers = {

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/Classification.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/Classification.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.agent;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * The result of a {@link Classifier}: a score and/or label, with optional confidence and
+ * attributes.
+ *
+ * @param score a numeric score, if the classifier produces one
+ * @param label a categorical label, if the classifier produces one (may be derived from the score)
+ * @param confidence the classifier's confidence in its own result, if available
+ * @param attributes any extra key-value detail the classifier wants to attach
+ */
+public record Classification(
+    Optional<Double> score,
+    Optional<String> label,
+    Optional<Double> confidence,
+    Map<String, String> attributes) {
+
+  /** Creates a {@link Classification} with only a score. */
+  public static Classification score(double score) {
+    return new Classification(Optional.of(score), Optional.empty(), Optional.empty(), Map.of());
+  }
+
+  /** Creates a {@link Classification} with only a label. */
+  public static Classification label(String label) {
+    return new Classification(Optional.empty(), Optional.of(label), Optional.empty(), Map.of());
+  }
+
+  /** Creates a {@link Classification} with both a score and a label. */
+  public static Classification of(double score, String label) {
+    return new Classification(Optional.of(score), Optional.of(label), Optional.empty(), Map.of());
+  }
+}

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/Classification.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/Classification.java
@@ -22,6 +22,10 @@ public record Classification(
     Optional<Double> confidence,
     Map<String, String> attributes) {
 
+  public Classification {
+    attributes = Map.copyOf(attributes); // defensive, unmodifiable copy
+  }
+
   /** Creates a {@link Classification} with only a score. */
   public static Classification score(double score) {
     return new Classification(Optional.of(score), Optional.empty(), Optional.empty(), Map.of());

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/Classifier.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/Classifier.java
@@ -14,14 +14,14 @@ import java.util.concurrent.CompletionStage;
  * small specialised model, a prompted or fine-tuned LLM, or an external classification API — the
  * implementation is just user code calling out to whatever it needs.
  *
- * <p>An implementation has a public constructor, optionally taking a {@link ClassifierContext}
- * parameter, which gives access to the classifier's configured name, its config section, and a
- * {@link ClassifierClient} for composing other configured classifiers (for example, an ensemble
- * classifier combining several underlying classifiers).
+ * <p>An implementation has a public constructor into which the platform's managed dependencies can
+ * be injected — including a {@link ClassifierClient}, for composing other configured classifiers
+ * (for example, an ensemble classifier combining several underlying ones), or a {@link
+ * ClassifierContext} for the classifier's configured name and config section.
  *
  * <p>Unlike a {@link Guardrail}, a classifier is never bound to a call boundary and is never
  * dispatched by the runtime. It is invoked inline, wherever a guardrail, an evaluator, or
- * application code needs it, by looking it up from an injected {@link ClassifierClient}.
+ * application code needs it, through an injected {@link ClassifierClient} by name.
  *
  * <p>Classifiers are enabled with configuration; see agent documentation.
  */

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/Classifier.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/Classifier.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.agent;
+
+import akka.javasdk.impl.ErrorHandling;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * A classifier maps an input to a {@link Classification} — a score and/or label, with optional
+ * confidence and metadata. Can be implemented with rules or regex, embeddings, traditional ML, a
+ * small specialised model, a prompted or fine-tuned LLM, or an external classification API — the
+ * implementation is just user code calling out to whatever it needs.
+ *
+ * <p>An implementation has a public constructor, optionally taking a {@link ClassifierContext}
+ * parameter, which gives access to the classifier's configured name, its config section, and a
+ * {@link ClassifierClient} for composing other configured classifiers (for example, an ensemble
+ * classifier combining several underlying classifiers).
+ *
+ * <p>Unlike a {@link Guardrail}, a classifier is never bound to a call boundary and is never
+ * dispatched by the runtime. It is invoked inline, wherever a guardrail, an evaluator, or
+ * application code needs it, by looking it up from an injected {@link ClassifierClient}.
+ *
+ * <p>Classifiers are enabled with configuration; see agent documentation.
+ */
+public interface Classifier {
+
+  /**
+   * Classifies {@code input} and returns the resulting {@link Classification}.
+   *
+   * @return the classification
+   */
+  default Classification classify(String input) {
+    try {
+      return classifyAsync(input).toCompletableFuture().join();
+    } catch (CompletionException e) {
+      throw ErrorHandling.unwrapCompletionException(e);
+    }
+  }
+
+  /**
+   * Async variant of {@link #classify}.
+   *
+   * @return a CompletionStage with the classification
+   */
+  CompletionStage<Classification> classifyAsync(String input);
+}

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/Classifier.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/Classifier.java
@@ -4,8 +4,6 @@
 
 package akka.javasdk.agent;
 
-import akka.javasdk.impl.ErrorHandling;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -16,7 +14,7 @@ import java.util.concurrent.CompletionStage;
  *
  * <p>An implementation has a public constructor into which the platform's managed dependencies can
  * be injected — including a {@link ClassifierClient}, for composing other configured classifiers
- * (for example, an ensemble classifier combining several underlying ones), or a {@link
+ * (for example, an ensemble classifier combining several underlying ones), and a {@link
  * ClassifierContext} for the classifier's configured name and config section.
  *
  * <p>Unlike a {@link Guardrail}, a classifier is never bound to a call boundary and is never
@@ -30,20 +28,7 @@ public interface Classifier {
   /**
    * Classifies {@code input} and returns the resulting {@link Classification}.
    *
-   * @return the classification
-   */
-  default Classification classify(String input) {
-    try {
-      return classifyAsync(input).toCompletableFuture().join();
-    } catch (CompletionException e) {
-      throw ErrorHandling.unwrapCompletionException(e);
-    }
-  }
-
-  /**
-   * Async variant of {@link #classify}.
-   *
    * @return a CompletionStage with the classification
    */
-  CompletionStage<Classification> classifyAsync(String input);
+  CompletionStage<Classification> classify(String input);
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/ClassifierClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/ClassifierClient.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.agent;
+
+import akka.annotation.DoNotInherit;
+
+/**
+ * Injectable client for looking up configured classifiers by name.
+ *
+ * <p>Can be injected in agents, guardrails, evaluators, and application code, to invoke a
+ * configured {@link Classifier} inline wherever it's needed.
+ *
+ * <p>Not for user extension, implementation provided by the SDK.
+ */
+@DoNotInherit
+public interface ClassifierClient {
+
+  /**
+   * Looks up the classifier configured under {@code name}.
+   *
+   * @throws IllegalArgumentException if no classifier is configured with that name
+   */
+  Classifier classifier(String name);
+}

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/ClassifierClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/ClassifierClient.java
@@ -12,10 +12,6 @@ import java.util.concurrent.CompletionStage;
  *
  * <p>Can be injected in agents, guardrails, evaluators, and application code — including into
  * another classifier's constructor, to compose an ensemble out of several configured classifiers.
- * Unlike the classifiers themselves, which the user implements, the client is how they are
- * <em>called</em>: it never hands back a {@link Classifier} instance, only classifies through one
- * by name, the same way the rest of the SDK talks to a component through a client rather than
- * returning the component.
  *
  * <p>Not for user extension, implementation provided by the SDK.
  */

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/ClassifierClient.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/ClassifierClient.java
@@ -5,12 +5,17 @@
 package akka.javasdk.agent;
 
 import akka.annotation.DoNotInherit;
+import java.util.concurrent.CompletionStage;
 
 /**
- * Injectable client for looking up configured classifiers by name.
+ * Client for invoking a configured {@link Classifier} by name.
  *
- * <p>Can be injected in agents, guardrails, evaluators, and application code, to invoke a
- * configured {@link Classifier} inline wherever it's needed.
+ * <p>Can be injected in agents, guardrails, evaluators, and application code — including into
+ * another classifier's constructor, to compose an ensemble out of several configured classifiers.
+ * Unlike the classifiers themselves, which the user implements, the client is how they are
+ * <em>called</em>: it never hands back a {@link Classifier} instance, only classifies through one
+ * by name, the same way the rest of the SDK talks to a component through a client rather than
+ * returning the component.
  *
  * <p>Not for user extension, implementation provided by the SDK.
  */
@@ -18,9 +23,17 @@ import akka.annotation.DoNotInherit;
 public interface ClassifierClient {
 
   /**
-   * Looks up the classifier configured under {@code name}.
+   * Classifies {@code input} with the classifier configured under {@code name}, blocking for the
+   * result.
    *
    * @throws IllegalArgumentException if no classifier is configured with that name
    */
-  Classifier classifier(String name);
+  Classification classify(String name, String input);
+
+  /**
+   * Async variant of {@link #classify}.
+   *
+   * @throws IllegalArgumentException if no classifier is configured with that name
+   */
+  CompletionStage<Classification> classifyAsync(String name, String input);
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/ClassifierContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/ClassifierContext.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.agent;
+
+import com.typesafe.config.Config;
+
+/**
+ * Context information available to a classifier constructor. Gives access to the classifier's name,
+ * its configuration, and a client for looking up other configured classifiers.
+ */
+public interface ClassifierContext {
+
+  /** The name of the classifier. */
+  String name();
+
+  /** The config section for the specific classifier. */
+  Config config();
+
+  /**
+   * A client for looking up other configured classifiers, for composing e.g. an ensemble classifier
+   * out of several underlying ones.
+   */
+  ClassifierClient classifierClient();
+}

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/ClassifierContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/ClassifierContext.java
@@ -7,8 +7,11 @@ package akka.javasdk.agent;
 import com.typesafe.config.Config;
 
 /**
- * Context information available to a classifier constructor. Gives access to the classifier's name,
- * its configuration, and a client for looking up other configured classifiers.
+ * Context information available to a classifier constructor. Gives access to the classifier's name
+ * and its configuration.
+ *
+ * <p>To invoke other configured classifiers — for example, to compose an ensemble out of several
+ * underlying ones — inject a {@link ClassifierClient} into the constructor.
  */
 public interface ClassifierContext {
 
@@ -17,11 +20,4 @@ public interface ClassifierContext {
 
   /** The config section for the specific classifier. */
   Config config();
-
-  /**
-   * A client for invoking other configured classifiers by name, for composing e.g. an ensemble
-   * classifier out of several underlying ones. Equivalent to injecting a {@link ClassifierClient}
-   * directly into the constructor, which is the preferred style.
-   */
-  ClassifierClient classifierClient();
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/ClassifierContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/ClassifierContext.java
@@ -19,8 +19,9 @@ public interface ClassifierContext {
   Config config();
 
   /**
-   * A client for looking up other configured classifiers, for composing e.g. an ensemble classifier
-   * out of several underlying ones.
+   * A client for invoking other configured classifiers by name, for composing e.g. an ensemble
+   * classifier out of several underlying ones. Equivalent to injecting a {@link ClassifierClient}
+   * directly into the constructor, which is the preferred style.
    */
   ClassifierClient classifierClient();
 }

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/GuardrailContext.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/GuardrailContext.java
@@ -18,4 +18,7 @@ public interface GuardrailContext {
 
   /** The config section for the specific guardrail. */
   Config config();
+
+  /** A client for invoking a configured {@link Classifier}, e.g. to inform the decision. */
+  ClassifierClient classifierClient();
 }

--- a/akka-javasdk/src/main/resources/reference.conf
+++ b/akka-javasdk/src/main/resources/reference.conf
@@ -199,6 +199,17 @@ akka.javasdk {
 
     }
 
+    # Classifiers map an input to a Classification (a score and/or label, with optional
+    # confidence and metadata). Unlike guardrails, a classifier has no boundary binding and is
+    # never dispatched by the runtime -- it is looked up by name from an injected
+    # ClassifierClient and invoked inline wherever a guardrail, an evaluator, or application code
+    # needs it.
+    #
+    # A classifier implementation can have additional configuration properties.
+    classifiers {
+
+    }
+
     evaluators {
       toxicity-evaluator {
         model-provider = ${akka.javasdk.agent.model-provider}

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -836,7 +836,6 @@ private final class Sdk(
                 // remember to update component type API doc and docs if changing the set of injectables
                 case p if p == classOf[EventSourcedEntityContext] => context
                 case s if s == classOf[Sanitizer]                 => sanitizer
-                case c if c == classOf[ClassifierClient]          => classifierClient
                 case r if r == classOf[AgentRegistry]             => agentRegistry
                 case p if p == classOf[NotificationPublisher[_]] =>
                   new NotificationPublisher[Any] {
@@ -890,7 +889,6 @@ private final class Sdk(
                 // remember to update component type API doc and docs if changing the set of injectables
                 case p if p == classOf[KeyValueEntityContext] => context
                 case s if s == classOf[Sanitizer]             => sanitizer
-                case c if c == classOf[ClassifierClient]      => classifierClient
                 case r if r == classOf[AgentRegistry]         => agentRegistry
                 case p if p == classOf[NotificationPublisher[_]] =>
                   new NotificationPublisher[Any] {

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -49,6 +49,9 @@ import akka.javasdk.UnhandledExceptionHandler
 import akka.javasdk.agent.Agent
 import akka.javasdk.agent.AgentContext
 import akka.javasdk.agent.AgentRegistry
+import akka.javasdk.agent.Classifier
+import akka.javasdk.agent.ClassifierClient
+import akka.javasdk.agent.ClassifierContext
 import akka.javasdk.agent.ModelProvider
 import akka.javasdk.agent.autonomous.AutonomousAgent
 import akka.javasdk.annotations.Component
@@ -75,6 +78,7 @@ import akka.javasdk.impl.agent.AgentImpl
 import akka.javasdk.impl.agent.AgentImpl.AgentContextImpl
 import akka.javasdk.impl.agent.AgentRegistryImpl
 import akka.javasdk.impl.agent.AutonomousAgentImpl
+import akka.javasdk.impl.agent.ClassifierProvider
 import akka.javasdk.impl.agent.FunctionTools
 import akka.javasdk.impl.agent.GuardrailProvider
 import akka.javasdk.impl.agent.OverrideModelProvider
@@ -136,6 +140,8 @@ import akka.runtime.sdk.spi.RegionInfo
 import akka.runtime.sdk.spi.RemoteIdentification
 import akka.runtime.sdk.spi.SpiAgent
 import akka.runtime.sdk.spi.SpiAutonomousAgent
+import akka.runtime.sdk.spi.SpiClassifierClient
+import akka.runtime.sdk.spi.SpiClassifierSetup
 import akka.runtime.sdk.spi.SpiComponents
 import akka.runtime.sdk.spi.SpiConfiguredGuardrail
 import akka.runtime.sdk.spi.SpiConsumer
@@ -407,6 +413,7 @@ class SdkRunner private (
         startedPromise,
         getSettings,
         startContext.sanitizer,
+        startContext.classifierClient,
         httpMockLookup,
         grpcMockLookup,
         startContext.inMemorySpanExporter)
@@ -461,6 +468,7 @@ private[javasdk] object Sdk {
       overrideModelProvider: OverrideModelProvider,
       serializer: Serializer,
       sanitizer: Sanitizer,
+      classifierClient: ClassifierClient,
       inMemorySpanExporter: Option[InMemorySpanExporter])
 
   private val platformManagedDependency = Set[Class[_]](
@@ -513,6 +521,7 @@ private final class Sdk(
     startedPromise: Promise[StartupContext],
     spiSettings: SpiSettings,
     runtimeSanitizer: SpiSanitizerEngine,
+    runtimeClassifierClient: SpiClassifierClient,
     httpMockLookup: String => Option[
       java.util.function.Function[akka.http.javadsl.model.HttpRequest, akka.http.javadsl.model.HttpResponse]],
     grpcMockLookup: GrpcClientProviderImpl.ClientKey => Option[AkkaGrpcClient],
@@ -587,7 +596,18 @@ private final class Sdk(
       invalid.throwFailureSummary()
   }
 
-  private val guardrailProvider = new GuardrailProvider(system, applicationConfig, sdkTracerFactory)
+  // Constructed before the GuardrailProvider, whose guardrails may need to invoke a classifier.
+  // Deliberately NOT validated here: validateClassifiers() runs from preStart instead (see below),
+  // after ServiceSetup's createDependencyProvider(), so a classifier constructor can depend on the
+  // user's DependencyProvider. Guardrail construction stays eager (agent descriptor building needs
+  // concrete bindings from guardrailProvider.agentGuardrails(...) below), so a classifier reached
+  // only from inside a guardrail's constructor is still constructed here, early -- guardrails
+  // themselves are out of scope for this deferral.
+  private val classifierProvider =
+    new ClassifierProvider(system, applicationConfig, runtimeClassifierClient, wireClassifier)
+
+  private val guardrailProvider =
+    new GuardrailProvider(system, applicationConfig, sdkTracerFactory, classifierProvider.client)
   try {
     guardrailProvider.validate()
   } catch {
@@ -596,7 +616,38 @@ private final class Sdk(
       throw exc
   }
 
+  // Routes classifier construction through the general DI mechanism (classifiers only --
+  // guardrails are left to the separate enhanced-guardrail work), so a classifier's constructor
+  // can declare any of the platform-managed dependencies (HttpClientProvider, ComponentClient,
+  // ...) alongside/instead of ClassifierContext.
+  private def wireClassifier(clz: Class[Classifier], context: ClassifierContext): Classifier =
+    wiredInstance[Classifier]("Classifier", clz) {
+      sideEffectingComponentInjects(None, callerSpiffe = None).orElse {
+        case c if c == classOf[ClassifierContext] =>
+          context
+      }
+    }
+
+  // Called from preStart, after dependencyProviderOpt is finalized for this service, so a
+  // classifier constructor needing a user-DependencyProvider-supplied dependency can resolve it.
+  private def validateClassifiers(): Unit =
+    try classifierProvider.validate()
+    catch {
+      case NonFatal(exc) =>
+        logger.error("Invalid classifiers: {}", exc.getMessage, exc)
+        throw exc
+    }
+
   lazy private val sanitizer = SanitizerImpl(runtimeSanitizer)
+  // Root-context handle for callers with no per-call telemetryContext (StartupContext/testkit);
+  // components get a per-injection handle via classifierClient(telemetryContext) below.
+  lazy private val classifierClient: ClassifierClient = classifierProvider.client
+
+  private def classifierClient(telemetryContext: Option[OtelContext]): ClassifierClient =
+    telemetryContext match {
+      case None          => classifierClient
+      case Some(context) => classifierProvider.clientFor(context)
+    }
 
   private lazy val ledgerClient: LedgerClient = new LedgerClientImpl(spiLedgerClient, sdkExecutionContext)
 
@@ -785,6 +836,7 @@ private final class Sdk(
                 // remember to update component type API doc and docs if changing the set of injectables
                 case p if p == classOf[EventSourcedEntityContext] => context
                 case s if s == classOf[Sanitizer]                 => sanitizer
+                case c if c == classOf[ClassifierClient]          => classifierClient
                 case r if r == classOf[AgentRegistry]             => agentRegistry
                 case p if p == classOf[NotificationPublisher[_]] =>
                   new NotificationPublisher[Any] {
@@ -838,6 +890,7 @@ private final class Sdk(
                 // remember to update component type API doc and docs if changing the set of injectables
                 case p if p == classOf[KeyValueEntityContext] => context
                 case s if s == classOf[Sanitizer]             => sanitizer
+                case c if c == classOf[ClassifierClient]      => classifierClient
                 case r if r == classOf[AgentRegistry]         => agentRegistry
                 case p if p == classOf[NotificationPublisher[_]] =>
                   new NotificationPublisher[Any] {
@@ -1177,9 +1230,10 @@ private final class Sdk(
     case e if e == classOf[Executor]           =>
       // The type does not guarantee this is a Java concurrent Executor, but we know it is, since supplied from runtime
       sdkExecutionContext.asInstanceOf[Executor]
-    case s if s == classOf[Sanitizer]    => sanitizer
-    case l if l == classOf[LedgerClient] => ledgerClient
-    case s if s == classOf[Meter]        => sdkMeter
+    case s if s == classOf[Sanitizer]        => sanitizer
+    case c if c == classOf[ClassifierClient] => classifierClient(telemetryContext)
+    case l if l == classOf[LedgerClient]     => ledgerClient
+    case s if s == classOf[Meter]            => sdkMeter
     case o if o == classOf[ObjectStorageProvider] =>
       objectStorageProvider(telemetryContext)
   }
@@ -1238,6 +1292,7 @@ private final class Sdk(
     val preStart = { (system: ActorSystem[_]) =>
       serviceSetup match {
         case None =>
+          validateClassifiers()
           startedPromise.trySuccess(
             StartupContext(
               runtimeComponentClients,
@@ -1250,6 +1305,7 @@ private final class Sdk(
               overrideModelProvider,
               serializer,
               sanitizer,
+              classifierClient,
               inMemorySpanExporter))
           Future.successful(Done)
         case Some(setup) =>
@@ -1261,6 +1317,7 @@ private final class Sdk(
               dependencyProviderOpt.foreach(_ => logger.info("Service configured with DependencyProvider"))
             }
           }
+          validateClassifiers()
           // Only register the shutdown task if the user actually overrode onShutdown,
           // otherwise we'd add a no-op task to coordinated shutdown for every service.
           val onShutdownOverridden =
@@ -1288,6 +1345,7 @@ private final class Sdk(
               overrideModelProvider,
               serializer,
               sanitizer,
+              classifierClient,
               inMemorySpanExporter))
           Future.successful(Done)
       }
@@ -1353,6 +1411,8 @@ private final class Sdk(
         config = g.config)
     })
 
+    val classifierSetup = new SpiClassifierSetup(classifierProvider.spiConfiguredClassifiers)
+
     val serviceNameOverride = sdkSettings.devModeSettings.map(_.serviceName)
 
     new SpiComponents(
@@ -1363,12 +1423,13 @@ private final class Sdk(
         protocolMajorVersion = BuildInfo.protocolMajorVersion,
         protocolMinorVersion = BuildInfo.protocolMinorVersion),
       componentDescriptors = descriptors,
-      guardrailSetup,
+      guardrailSetup = guardrailSetup,
+      classifierSetup = classifierSetup,
       preStart = preStart,
       onStart = onStart,
       reportError = reportError,
-      healthCheck = () => SdkRunner.FutureDone,
-      onUnhandledException = onUnhandledException)
+      onUnhandledException = onUnhandledException,
+      healthCheck = () => SdkRunner.FutureDone)
   }
 
   private lazy val agentRegistry =

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierContextImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierContextImpl.scala
@@ -6,14 +6,14 @@ package akka.javasdk.impl.agent
 
 import akka.annotation.InternalApi
 import akka.javasdk.agent.ClassifierClient
-import akka.javasdk.agent.GuardrailContext
+import akka.javasdk.agent.ClassifierContext
 import com.typesafe.config.Config
 
 /**
  * INTERNAL API
  */
-@InternalApi private[javasdk] final class GuardrailContextImpl(
+@InternalApi private[javasdk] final class ClassifierContextImpl(
     override val name: String,
     override val config: Config,
     override val classifierClient: ClassifierClient)
-    extends GuardrailContext
+    extends ClassifierContext

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierContextImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierContextImpl.scala
@@ -5,15 +5,11 @@
 package akka.javasdk.impl.agent
 
 import akka.annotation.InternalApi
-import akka.javasdk.agent.ClassifierClient
 import akka.javasdk.agent.ClassifierContext
 import com.typesafe.config.Config
 
 /**
  * INTERNAL API
  */
-@InternalApi private[javasdk] final class ClassifierContextImpl(
-    override val name: String,
-    override val config: Config,
-    override val classifierClient: ClassifierClient)
+@InternalApi private[javasdk] final class ClassifierContextImpl(override val name: String, override val config: Config)
     extends ClassifierContext

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierProvider.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierProvider.scala
@@ -34,20 +34,14 @@ import io.opentelemetry.context.{ Context => TelemetryContext }
  * per-agent/per-boundary selection here -- just construction, validation, and a [[ClassifierClient]] that classifies
  * through them by name.
  *
- * The [[ClassifierClient]] never returns a [[Classifier]] instance -- it exposes `classify(name, input)`, delegating
- * through the runtime's [[SpiClassifierClient]] -- so, like the rest of the SDK, callers talk to a classifier through a
- * client rather than holding a reference to it. An ensemble composes by having a [[ClassifierClient]] injected into its
- * constructor and calling other classifiers by name.
+ * The [[ClassifierClient]] exposes `classify(name, input)` rather than returning a [[Classifier]] instance. An ensemble
+ * composes by having a [[ClassifierClient]] injected into its constructor and calling other classifiers by name.
+ * Construction does not resolve sibling instances, so it cannot form a dependency graph: each classifier is built once
+ * and memoized.
  *
- * Because composition no longer resolves sibling instances at construction time, construction cannot form a dependency
- * graph, and there is no construction-time cycle to guard against: each classifier is built once and memoized. A cycle
- * is now only possible at invocation (A calls B calls A), which would need call-context propagation to detect -- a
- * follow-up, ideally with the chain carried on [[SpiClassifier.Content]].
- *
- * Invocation delegates through the runtime's [[SpiClassifierClient]], not a local call. The runtime is the single choke
- * point for observability, context propagation, and ledger recording; a thrown exception surfaces as a failed
- * `CompletionStage` because the runtime's own dispatch already normalizes synchronous throws into a failed `Future`
- * -- this class deliberately does not duplicate that translation.
+ * Invocation delegates through the runtime's [[SpiClassifierClient]], the single choke point for observability, context
+ * propagation, and ledger recording. A synchronous throw from a classifier surfaces as a failed `CompletionStage`,
+ * since the runtime's dispatch normalizes it into a failed `Future`.
  */
 @InternalApi private[javasdk] final class ClassifierProvider(
     system: ActorSystem[_],
@@ -67,9 +61,8 @@ import io.opentelemetry.context.{ Context => TelemetryContext }
   private val cache = mutable.Map.empty[String, Classifier]
 
   /**
-   * The client handed out where no per-call `telemetryContext` is available yet -- to a guardrail's `GuardrailContext`,
-   * to another classifier's `ClassifierContext` for ensemble composition, and via the testkit. Known v1 gap: those
-   * classifications ride a root OTel context rather than the caller's (#5383).
+   * The client for call sites with no per-call `telemetryContext` -- a guardrail's `GuardrailContext`, another
+   * classifier's `ClassifierContext`, and the testkit. Its invocations carry a root OTel context.
    */
   val client: ClassifierClient = clientFor(TelemetryContext.root())
 
@@ -130,12 +123,10 @@ import io.opentelemetry.context.{ Context => TelemetryContext }
   /**
    * The classifiers to register with the runtime, so [[SpiClassifierClient]] calls have something to invoke.
    *
-   * Deliberately does not call `getOrCreate` here: this is built while assembling `SpiComponents`, which the runtime
-   * handshake requires synchronously, before `preStart` runs `validate()` (see `SdkRunner`'s `validateClassifiers`)
-   * -- i.e. before a user `DependencyProvider` may exist yet. Each adapter instead resolves its classifier lazily, on
-   * first `classify(...)` call, which is guaranteed to be after `preStart` completes (nothing can call `classify()`
-   * before the service has started); `validate()` still forces and caches every instance eagerly at that point, so bad
-   * config/classes still fail at startup, just from `preStart` rather than from this constructor.
+   * Each adapter resolves its classifier lazily, on first `classify(...)` call, rather than here: this runs while
+   * assembling `SpiComponents` (required synchronously for the runtime handshake), before `preStart` runs `validate()`
+   * and before a user `DependencyProvider` exists. `validate()` forces and caches every instance at startup, so bad
+   * config or classes fail there.
    */
   def spiConfiguredClassifiers: Seq[SpiConfiguredClassifier] =
     configuredClassifiers.map { c =>
@@ -164,11 +155,9 @@ import io.opentelemetry.context.{ Context => TelemetryContext }
       c.attributes.asScala.toMap)
 
   /**
-   * Wraps a user classifier so the runtime can invoke it once registered. `resolve` is called on every invocation
-   * rather than once at adapter-construction time, so registration (`spiConfiguredClassifiers`) can happen before the
-   * classifier itself is safe to construct (see the scaladoc there); `getOrCreate` memoizes, so this is cheap after the
-   * first real resolution. Only [[SpiClassifier.TextContent]] exists in v1; the public `classify(String)` has no
-   * per-call context parameter, so the content's `telemetryContext` isn't surfaced to the user's classifier.
+   * Wraps a user classifier so the runtime can invoke it once registered. `resolve` runs on every invocation rather
+   * than at construction, so registration (`spiConfiguredClassifiers`) can happen before the classifier is safe to
+   * construct; `getOrCreate` memoizes, so it is cheap after the first resolution.
    */
   private final class SpiClassifierAdapter(resolve: () => Classifier) extends SpiClassifier {
     override def classify(content: SpiClassifier.Content): Future[SpiClassifier.Classification] =

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierProvider.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierProvider.scala
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl.agent
+
+import java.util.concurrent.CompletionStage
+
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
+import scala.jdk.OptionConverters._
+
+import akka.actor.typed.ActorSystem
+import akka.annotation.InternalApi
+import akka.javasdk.agent.Classification
+import akka.javasdk.agent.Classifier
+import akka.javasdk.agent.ClassifierClient
+import akka.javasdk.agent.ClassifierContext
+import akka.runtime.sdk.spi.SpiClassifier
+import akka.runtime.sdk.spi.SpiClassifierClient
+import akka.runtime.sdk.spi.SpiConfiguredClassifier
+import com.typesafe.config.Config
+import io.opentelemetry.context.{ Context => TelemetryContext }
+
+/**
+ * INTERNAL API
+ *
+ * Classifiers are looked up by name (never dispatched by the runtime), so unlike [[GuardrailProvider]] there's no
+ * per-agent/per-boundary selection here -- just construction, validation, and a [[ClassifierClient]] handing out
+ * runtime-backed handles by name.
+ *
+ * Construction (via `wireClassifier`, routed through the SDK's general `wiredInstance` DI mechanism so any component
+ * dependency -- not just [[ClassifierContext]] -- can be injected; the class must have a single public constructor, per
+ * the component convention `wiredInstance` enforces) is lazy and memoized, guarded against cycles: a classifier's
+ * constructor may pull in another configured classifier (through
+ * [[akka.javasdk.agent.ClassifierContext.classifierClient]]) to build an ensemble, and resolving such a dependency
+ * chain that loops back on itself fails with a clear error rather than a `StackOverflowError`.
+ *
+ * Invocation is different from construction: every `classify(...)` call -- direct, from a guardrail, or from ensemble
+ * composition -- delegates through the runtime's [[SpiClassifierClient]], not a local call. The runtime is the single
+ * choke point for observability, context propagation, and ledger recording; a thrown exception surfaces as a failed
+ * `CompletionStage` because the runtime's own dispatch already normalizes synchronous throws into a failed `Future`
+ * -- this class deliberately does not duplicate that translation.
+ */
+@InternalApi private[javasdk] final class ClassifierProvider(
+    system: ActorSystem[_],
+    applicationConfig: Config,
+    runtimeClassifierClient: SpiClassifierClient,
+    wireClassifier: (Class[Classifier], ClassifierContext) => Classifier) {
+
+  lazy val configuredClassifiers: Seq[ConfiguredClassifier] = {
+    ClassifierSettings(applicationConfig.getConfig("akka.javasdk.agent.classifiers")).configuredClassifiers
+  }
+
+  private lazy val byName: Map[String, ConfiguredClassifier] =
+    configuredClassifiers.map(c => c.name -> c).toMap
+
+  // Guarded by this provider's monitor. Construction happens once per name (at validate() time,
+  // or lazily on first lookup), so contention is not a concern; the monitor is reentrant, which is
+  // what allows a classifier's own construction to recursively resolve another one by name.
+  private val cache = mutable.Map.empty[String, Classifier]
+  private val inProgress = mutable.LinkedHashSet.empty[String]
+
+  /**
+   * The client handed out at construction time -- to a guardrail's `GuardrailContext`, to another classifier's
+   * `ClassifierContext` for ensemble composition, and via the testkit -- where no per-call `telemetryContext` is
+   * available yet. Known v1 gap: those classifications ride a root OTel context rather than the caller's (#5383).
+   */
+  val client: ClassifierClient = clientFor(TelemetryContext.root())
+
+  /** A `ClassifierClient` whose invocations carry `telemetryContext` -- one per component injection. */
+  def clientFor(telemetryContext: TelemetryContext): ClassifierClient = new ClassifierClient {
+    private val handles = mutable.Map.empty[String, Classifier]
+
+    override def classifier(name: String): Classifier = {
+      // Construct (validating existence and detecting cycles eagerly) before taking this client's
+      // monitor: construction can recurse into another client's classifier(...) (ensemble
+      // constructors), which nests provider-monitor -> client-monitor -- so this lookup must not
+      // nest them in the opposite order.
+      getOrCreate(name)
+      synchronized {
+        handles.getOrElseUpdate(
+          name,
+          new Classifier {
+            override def classifyAsync(input: String): CompletionStage[Classification] =
+              runtimeClassifierClient
+                .classify(name, new SpiClassifier.TextContent(input, telemetryContext))
+                .map(ClassifierProvider.toClassification)(ExecutionContext.parasitic)
+                .asJava
+          })
+      }
+    }
+  }
+
+  private def getOrCreate(name: String): Classifier = synchronized {
+    cache.get(name) match {
+      case Some(instance) => instance
+      case None =>
+        if (inProgress.contains(name))
+          throw new IllegalStateException(
+            s"Cyclic classifier dependency detected: ${(inProgress.toSeq :+ name).mkString(" -> ")}")
+
+        val configured = byName.getOrElse(
+          name,
+          throw new IllegalArgumentException(
+            s"No classifier configured with name [$name]. Configured classifiers: [${byName.keys.mkString(", ")}]"))
+
+        inProgress += name
+        try {
+          val instance = createClassifier(configured)
+          cache(name) = instance
+          instance
+        } finally {
+          inProgress -= name
+        }
+    }
+  }
+
+  private def createClassifier(c: ConfiguredClassifier): Classifier = {
+    val clz =
+      try system.dynamicAccess.classLoader.loadClass(c.implementationClass)
+      catch {
+        case _: ClassNotFoundException =>
+          throw new IllegalArgumentException(
+            s"Classifier [${c.name}] implementation class " +
+            s"[${c.implementationClass}] not found")
+      }
+    if (!classOf[Classifier].isAssignableFrom(clz))
+      throw new IllegalArgumentException(
+        s"Classifier [${c.name}] must implement [${classOf[Classifier].getName}], " +
+        s"but [${c.implementationClass}] does not")
+
+    val context = new ClassifierContextImpl(c.name, c.config, client)
+    wireClassifier(clz.asInstanceOf[Class[Classifier]], context)
+  }
+
+  /** Eagerly constructs every configured classifier, so bad config/classes fail at startup. */
+  def validate(): Unit = configuredClassifiers.foreach(c => getOrCreate(c.name))
+
+  /**
+   * The classifiers to register with the runtime, so [[SpiClassifierClient]] calls have something to invoke.
+   *
+   * Deliberately does not call `getOrCreate` here: this is built while assembling `SpiComponents`, which the runtime
+   * handshake requires synchronously, before `preStart` runs `validate()` (see `SdkRunner`'s `validateClassifiers`)
+   * -- i.e. before a user `DependencyProvider` may exist yet. Each adapter instead resolves its classifier lazily, on
+   * first `classify(...)` call, which is guaranteed to be after `preStart` completes (nothing can call `classify()`
+   * before the service has started); `validate()` still forces and caches every instance eagerly at that point, so bad
+   * config/classes still fail at startup, just from `preStart` rather than from this constructor.
+   */
+  def spiConfiguredClassifiers: Seq[SpiConfiguredClassifier] =
+    configuredClassifiers.map { c =>
+      new SpiConfiguredClassifier(
+        name = c.name,
+        implementationClass = c.implementationClass,
+        config = c.config,
+        instance = new ClassifierProvider.SpiClassifierAdapter(() => getOrCreate(c.name)))
+    }
+}
+
+@InternalApi private[javasdk] object ClassifierProvider {
+
+  private def toClassification(r: SpiClassifier.Result): Classification =
+    new Classification(
+      r.score.map(Double.box).toJava,
+      r.label.toJava,
+      r.confidence.map(Double.box).toJava,
+      r.attributes.asJava)
+
+  private def fromClassification(c: Classification): SpiClassifier.Result =
+    new SpiClassifier.Result(
+      c.score.toScala.map(Double.unbox),
+      c.label.toScala,
+      c.confidence.toScala.map(Double.unbox),
+      c.attributes.asScala.toMap)
+
+  /**
+   * Wraps a user classifier so the runtime can invoke it once registered. `resolve` is called on every invocation
+   * rather than once at adapter-construction time, so registration (`spiConfiguredClassifiers`) can happen before the
+   * classifier itself is safe to construct (see the scaladoc there); `getOrCreate` memoizes, so this is cheap after the
+   * first real resolution. Only [[SpiClassifier.TextContent]] exists in v1; the public `classify(String)` has no
+   * per-call context parameter, so the content's `telemetryContext` isn't surfaced to the user's classifier.
+   */
+  private final class SpiClassifierAdapter(resolve: () => Classifier) extends SpiClassifier {
+    override def classify(content: SpiClassifier.Content): Future[SpiClassifier.Result] =
+      content match {
+        case text: SpiClassifier.TextContent =>
+          resolve().classifyAsync(text.text).asScala.map(fromClassification)(ExecutionContext.parasitic)
+      }
+  }
+}

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierProvider.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierProvider.scala
@@ -4,6 +4,7 @@
 
 package akka.javasdk.impl.agent
 
+import java.util.concurrent.CompletionException
 import java.util.concurrent.CompletionStage
 
 import scala.collection.mutable
@@ -19,6 +20,7 @@ import akka.javasdk.agent.Classification
 import akka.javasdk.agent.Classifier
 import akka.javasdk.agent.ClassifierClient
 import akka.javasdk.agent.ClassifierContext
+import akka.javasdk.impl.ErrorHandling
 import akka.runtime.sdk.spi.SpiClassifier
 import akka.runtime.sdk.spi.SpiClassifierClient
 import akka.runtime.sdk.spi.SpiConfiguredClassifier
@@ -29,19 +31,21 @@ import io.opentelemetry.context.{ Context => TelemetryContext }
  * INTERNAL API
  *
  * Classifiers are looked up by name (never dispatched by the runtime), so unlike [[GuardrailProvider]] there's no
- * per-agent/per-boundary selection here -- just construction, validation, and a [[ClassifierClient]] handing out
- * runtime-backed handles by name.
+ * per-agent/per-boundary selection here -- just construction, validation, and a [[ClassifierClient]] that classifies
+ * through them by name.
  *
- * Construction (via `wireClassifier`, routed through the SDK's general `wiredInstance` DI mechanism so any component
- * dependency -- not just [[ClassifierContext]] -- can be injected; the class must have a single public constructor, per
- * the component convention `wiredInstance` enforces) is lazy and memoized, guarded against cycles: a classifier's
- * constructor may pull in another configured classifier (through
- * [[akka.javasdk.agent.ClassifierContext.classifierClient]]) to build an ensemble, and resolving such a dependency
- * chain that loops back on itself fails with a clear error rather than a `StackOverflowError`.
+ * The [[ClassifierClient]] never returns a [[Classifier]] instance -- it exposes `classify(name, input)`, delegating
+ * through the runtime's [[SpiClassifierClient]] -- so, like the rest of the SDK, callers talk to a classifier through a
+ * client rather than holding a reference to it. An ensemble composes by having a [[ClassifierClient]] injected into its
+ * constructor and calling other classifiers by name.
  *
- * Invocation is different from construction: every `classify(...)` call -- direct, from a guardrail, or from ensemble
- * composition -- delegates through the runtime's [[SpiClassifierClient]], not a local call. The runtime is the single
- * choke point for observability, context propagation, and ledger recording; a thrown exception surfaces as a failed
+ * Because composition no longer resolves sibling instances at construction time, construction cannot form a dependency
+ * graph, and there is no construction-time cycle to guard against: each classifier is built once and memoized. A cycle
+ * is now only possible at invocation (A calls B calls A), which would need call-context propagation to detect -- a
+ * follow-up, ideally with the chain carried on [[SpiClassifier.Content]].
+ *
+ * Invocation delegates through the runtime's [[SpiClassifierClient]], not a local call. The runtime is the single choke
+ * point for observability, context propagation, and ledger recording; a thrown exception surfaces as a failed
  * `CompletionStage` because the runtime's own dispatch already normalizes synchronous throws into a failed `Future`
  * -- this class deliberately does not duplicate that translation.
  */
@@ -58,64 +62,47 @@ import io.opentelemetry.context.{ Context => TelemetryContext }
   private lazy val byName: Map[String, ConfiguredClassifier] =
     configuredClassifiers.map(c => c.name -> c).toMap
 
-  // Guarded by this provider's monitor. Construction happens once per name (at validate() time,
-  // or lazily on first lookup), so contention is not a concern; the monitor is reentrant, which is
-  // what allows a classifier's own construction to recursively resolve another one by name.
+  // Guarded by this provider's monitor. Each classifier is constructed once (at validate() time, or
+  // lazily on first invocation via the SPI adapter) and memoized.
   private val cache = mutable.Map.empty[String, Classifier]
-  private val inProgress = mutable.LinkedHashSet.empty[String]
 
   /**
-   * The client handed out at construction time -- to a guardrail's `GuardrailContext`, to another classifier's
-   * `ClassifierContext` for ensemble composition, and via the testkit -- where no per-call `telemetryContext` is
-   * available yet. Known v1 gap: those classifications ride a root OTel context rather than the caller's (#5383).
+   * The client handed out where no per-call `telemetryContext` is available yet -- to a guardrail's `GuardrailContext`,
+   * to another classifier's `ClassifierContext` for ensemble composition, and via the testkit. Known v1 gap: those
+   * classifications ride a root OTel context rather than the caller's (#5383).
    */
   val client: ClassifierClient = clientFor(TelemetryContext.root())
 
   /** A `ClassifierClient` whose invocations carry `telemetryContext` -- one per component injection. */
   def clientFor(telemetryContext: TelemetryContext): ClassifierClient = new ClassifierClient {
-    private val handles = mutable.Map.empty[String, Classifier]
-
-    override def classifier(name: String): Classifier = {
-      // Construct (validating existence and detecting cycles eagerly) before taking this client's
-      // monitor: construction can recurse into another client's classifier(...) (ensemble
-      // constructors), which nests provider-monitor -> client-monitor -- so this lookup must not
-      // nest them in the opposite order.
-      getOrCreate(name)
-      synchronized {
-        handles.getOrElseUpdate(
-          name,
-          new Classifier {
-            override def classifyAsync(input: String): CompletionStage[Classification] =
-              runtimeClassifierClient
-                .classify(name, new SpiClassifier.TextContent(input, telemetryContext))
-                .map(ClassifierProvider.toClassification)(ExecutionContext.parasitic)
-                .asJava
-          })
-      }
+    override def classifyAsync(name: String, input: String): CompletionStage[Classification] = {
+      requireConfigured(name)
+      runtimeClassifierClient
+        .classify(name, new SpiClassifier.TextContent(input, telemetryContext))
+        .map(ClassifierProvider.toClassification)(ExecutionContext.parasitic)
+        .asJava
     }
+
+    override def classify(name: String, input: String): Classification =
+      try classifyAsync(name, input).toCompletableFuture.join()
+      catch {
+        case e: CompletionException => throw ErrorHandling.unwrapCompletionException(e)
+      }
   }
+
+  private def requireConfigured(name: String): Unit =
+    if (!byName.contains(name))
+      throw new IllegalArgumentException(
+        s"No classifier configured with name [$name]. Configured classifiers: [${byName.keys.mkString(", ")}]")
 
   private def getOrCreate(name: String): Classifier = synchronized {
     cache.get(name) match {
       case Some(instance) => instance
       case None =>
-        if (inProgress.contains(name))
-          throw new IllegalStateException(
-            s"Cyclic classifier dependency detected: ${(inProgress.toSeq :+ name).mkString(" -> ")}")
-
-        val configured = byName.getOrElse(
-          name,
-          throw new IllegalArgumentException(
-            s"No classifier configured with name [$name]. Configured classifiers: [${byName.keys.mkString(", ")}]"))
-
-        inProgress += name
-        try {
-          val instance = createClassifier(configured)
-          cache(name) = instance
-          instance
-        } finally {
-          inProgress -= name
-        }
+        requireConfigured(name)
+        val instance = createClassifier(byName(name))
+        cache(name) = instance
+        instance
     }
   }
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierProvider.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierProvider.scala
@@ -113,7 +113,7 @@ import io.opentelemetry.context.{ Context => TelemetryContext }
         s"Classifier [${c.name}] must implement [${classOf[Classifier].getName}], " +
         s"but [${c.implementationClass}] does not")
 
-    val context = new ClassifierContextImpl(c.name, c.config, client)
+    val context = new ClassifierContextImpl(c.name, c.config)
     wireClassifier(clz.asInstanceOf[Class[Classifier]], context)
   }
 
@@ -163,7 +163,7 @@ import io.opentelemetry.context.{ Context => TelemetryContext }
     override def classify(content: SpiClassifier.Content): Future[SpiClassifier.Classification] =
       content match {
         case text: SpiClassifier.TextContent =>
-          resolve().classifyAsync(text.text).asScala.map(fromClassification)(ExecutionContext.parasitic)
+          resolve().classify(text.text).asScala.map(fromClassification)(ExecutionContext.parasitic)
       }
   }
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierProvider.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierProvider.scala
@@ -162,15 +162,15 @@ import io.opentelemetry.context.{ Context => TelemetryContext }
 
 @InternalApi private[javasdk] object ClassifierProvider {
 
-  private def toClassification(r: SpiClassifier.Result): Classification =
+  private def toClassification(r: SpiClassifier.Classification): Classification =
     new Classification(
       r.score.map(Double.box).toJava,
       r.label.toJava,
       r.confidence.map(Double.box).toJava,
       r.attributes.asJava)
 
-  private def fromClassification(c: Classification): SpiClassifier.Result =
-    new SpiClassifier.Result(
+  private def fromClassification(c: Classification): SpiClassifier.Classification =
+    new SpiClassifier.Classification(
       c.score.toScala.map(Double.unbox),
       c.label.toScala,
       c.confidence.toScala.map(Double.unbox),
@@ -184,7 +184,7 @@ import io.opentelemetry.context.{ Context => TelemetryContext }
    * per-call context parameter, so the content's `telemetryContext` isn't surfaced to the user's classifier.
    */
   private final class SpiClassifierAdapter(resolve: () => Classifier) extends SpiClassifier {
-    override def classify(content: SpiClassifier.Content): Future[SpiClassifier.Result] =
+    override def classify(content: SpiClassifier.Content): Future[SpiClassifier.Classification] =
       content match {
         case text: SpiClassifier.TextContent =>
           resolve().classifyAsync(text.text).asScala.map(fromClassification)(ExecutionContext.parasitic)

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierSettings.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierSettings.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl.agent
+
+import scala.jdk.CollectionConverters._
+
+import akka.annotation.InternalApi
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigObject
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[javasdk] object ClassifierSettings {
+  def apply(config: Config): ClassifierSettings = {
+    val configuredClassifiers =
+      config.root.asScala.iterator.collect { case (key, value: ConfigObject) =>
+        ConfiguredClassifier(key, value.toConfig)
+      }.toSeq
+    new ClassifierSettings(configuredClassifiers)
+  }
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[javasdk] final case class ClassifierSettings(configuredClassifiers: Seq[ConfiguredClassifier]) {}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[javasdk] object ConfiguredClassifier {
+  def apply(name: String, config: Config): ConfiguredClassifier =
+    new ConfiguredClassifier(name = name, implementationClass = config.getString("class"), config = config)
+}
+
+/**
+ * INTERNAL API
+ *
+ * Unlike [[ConfiguredGuardrail]], a classifier has no boundary binding (no `use-for`/`agents`) -- it is looked up by
+ * name, not dispatched by the runtime.
+ */
+@InternalApi private[javasdk] final case class ConfiguredClassifier(
+    name: String,
+    implementationClass: String,
+    config: Config) {
+  require(!name.isBlank, s"name must be defined for classifier")
+  require(!implementationClass.isBlank, s"implementation-class must be defined for classifier [$name]")
+}

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierSettings.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/ClassifierSettings.scala
@@ -16,8 +16,11 @@ import com.typesafe.config.ConfigObject
 @InternalApi private[javasdk] object ClassifierSettings {
   def apply(config: Config): ClassifierSettings = {
     val configuredClassifiers =
-      config.root.asScala.iterator.collect { case (key, value: ConfigObject) =>
-        ConfiguredClassifier(key, value.toConfig)
+      config.root.asScala.iterator.map {
+        case (key, value: ConfigObject) =>
+          ConfiguredClassifier(key, value.toConfig)
+        case (key, value) =>
+          throw new IllegalArgumentException(s"Classifier [$key] must be a config object, but was [${value.valueType}]")
       }.toSeq
     new ClassifierSettings(configuredClassifiers)
   }
@@ -32,8 +35,11 @@ import com.typesafe.config.ConfigObject
  * INTERNAL API
  */
 @InternalApi private[javasdk] object ConfiguredClassifier {
-  def apply(name: String, config: Config): ConfiguredClassifier =
+  def apply(name: String, config: Config): ConfiguredClassifier = {
+    if (!config.hasPath("class"))
+      throw new IllegalArgumentException(s"Classifier [$name] must define [class]")
     new ConfiguredClassifier(name = name, implementationClass = config.getString("class"), config = config)
+  }
 }
 
 /**

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/GuardrailProvider.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/GuardrailProvider.scala
@@ -12,6 +12,8 @@ import scala.util.control.NonFatal
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.javasdk.Tracing
+import akka.javasdk.agent.Classifier
+import akka.javasdk.agent.ClassifierClient
 import akka.javasdk.agent.Decision
 import akka.javasdk.agent.Decision.Allow
 import akka.javasdk.agent.Decision.Deny
@@ -206,6 +208,13 @@ import io.opentelemetry.context.{ Context => OtelContext }
   // McpToolRequest/McpToolResponse.
   private val ToolSideUseFor: Set[UseFor] = Set(UseFor.BeforeToolCall)
   private val ModelSideUseFor: Set[UseFor] = Set(UseFor.ModelRequest, UseFor.ModelResponse)
+
+  // Default classifierClient for call sites (and tests) that don't supply one; any lookup fails
+  // descriptively instead of silently returning something.
+  private val NoClassifiersConfigured: ClassifierClient = new ClassifierClient {
+    override def classifier(name: String): Classifier =
+      throw new IllegalArgumentException(s"No classifier configured with name [$name] (no ClassifierClient available)")
+  }
 }
 
 /**
@@ -214,7 +223,10 @@ import io.opentelemetry.context.{ Context => OtelContext }
 @InternalApi private[javasdk] final class GuardrailProvider(
     system: ActorSystem[_],
     applicationConfig: Config,
-    tracerFactory: () => Tracer) {
+    tracerFactory: () => Tracer,
+    // Defaulted so existing call sites (and tests) that don't care about classifiers are unaffected;
+    // SdkRunner always passes the real ClassifierClient.
+    classifierClient: ClassifierClient = GuardrailProvider.NoClassifiersConfigured) {
   import GuardrailProvider._
 
   lazy val configuredGuardrails: Seq[ConfiguredGuardrail] = {
@@ -244,7 +256,7 @@ import io.opentelemetry.context.{ Context => OtelContext }
   }
 
   private def createGuardrail(c: ConfiguredGuardrail): Guardrail = {
-    val guardrailContext = new GuardrailContextImpl(c.name, c.config)
+    val guardrailContext = new GuardrailContextImpl(c.name, c.config, classifierClient)
     val instance = system.dynamicAccess
       .createInstanceFor[Guardrail](c.implementationClass, (classOf[GuardrailContext] -> guardrailContext) :: Nil)
       .recoverWith { case _: ClassNotFoundException | _: NoSuchMethodException =>

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/GuardrailProvider.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/GuardrailProvider.scala
@@ -4,6 +4,8 @@
 
 package akka.javasdk.impl.agent
 
+import java.util.concurrent.CompletionStage
+
 import scala.annotation.nowarn
 import scala.concurrent.Future
 import scala.util.Failure
@@ -12,7 +14,7 @@ import scala.util.control.NonFatal
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.javasdk.Tracing
-import akka.javasdk.agent.Classifier
+import akka.javasdk.agent.Classification
 import akka.javasdk.agent.ClassifierClient
 import akka.javasdk.agent.Decision
 import akka.javasdk.agent.Decision.Allow
@@ -209,10 +211,12 @@ import io.opentelemetry.context.{ Context => OtelContext }
   private val ToolSideUseFor: Set[UseFor] = Set(UseFor.BeforeToolCall)
   private val ModelSideUseFor: Set[UseFor] = Set(UseFor.ModelRequest, UseFor.ModelResponse)
 
-  // Default classifierClient for call sites (and tests) that don't supply one; any lookup fails
+  // Default classifierClient for call sites (and tests) that don't supply one; any call fails
   // descriptively instead of silently returning something.
   private val NoClassifiersConfigured: ClassifierClient = new ClassifierClient {
-    override def classifier(name: String): Classifier =
+    override def classify(name: String, input: String): Classification =
+      throw new IllegalArgumentException(s"No classifier configured with name [$name] (no ClassifierClient available)")
+    override def classifyAsync(name: String, input: String): CompletionStage[Classification] =
       throw new IllegalArgumentException(s"No classifier configured with name [$name] (no ClassifierClient available)")
   }
 }

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ClassifierProviderSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ClassifierProviderSpec.scala
@@ -1,0 +1,339 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl.agent
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.javasdk.agent.Classification
+import akka.javasdk.agent.Classifier
+import akka.javasdk.agent.ClassifierContext
+import akka.javasdk.agent.Decision
+import akka.javasdk.agent.ModelGuardrail
+import akka.runtime.sdk.spi.SpiClassifier
+import akka.runtime.sdk.spi.SpiClassifierClient
+import akka.runtime.sdk.spi.SpiConfiguredClassifier
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigException
+import com.typesafe.config.ConfigFactory
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.trace.Tracer
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+object ClassifierProviderSpec {
+  private val testTracerFactory: () => Tracer = () => OpenTelemetry.noop().getTracer("test")
+
+  private val config = ConfigFactory.parseString(s"""
+    akka.javasdk.agent.classifiers {
+      "toxicity" {
+        class = "akka.javasdk.impl.agent.ClassifierProviderSpec$$ToxicityClassifier"
+        threshold = 0.8
+      }
+      "no-context" {
+        class = "akka.javasdk.impl.agent.ClassifierProviderSpec$$NoContextClassifier"
+      }
+    }
+    """)
+
+  class ToxicityClassifier(context: ClassifierContext) extends Classifier {
+    private val threshold = context.config().getDouble("threshold")
+    override def classifyAsync(input: String): CompletionStage[Classification] =
+      CompletableFuture.completedFuture(Classification.of(threshold, s"classified:$input"))
+  }
+
+  class NoContextClassifier extends Classifier {
+    override def classifyAsync(input: String): CompletionStage[Classification] =
+      CompletableFuture.completedFuture(Classification.label("ok"))
+  }
+
+  class ThrowingClassifier extends Classifier {
+    override def classifyAsync(input: String): CompletionStage[Classification] =
+      throw new IllegalStateException("kaboom")
+  }
+
+  class WrongClassifier
+
+  // Resolves another named classifier from its own constructor, to compose an ensemble.
+  class EnsembleClassifier(context: ClassifierContext) extends Classifier {
+    private val delegate = context.classifierClient().classifier("toxicity")
+    override def classifyAsync(input: String): CompletionStage[Classification] = delegate.classifyAsync(input)
+  }
+
+  class CyclicA(context: ClassifierContext) extends Classifier {
+    context.classifierClient().classifier("cyclic-b")
+    override def classifyAsync(input: String): CompletionStage[Classification] =
+      CompletableFuture.completedFuture(Classification.label("a"))
+  }
+
+  class CyclicB(context: ClassifierContext) extends Classifier {
+    context.classifierClient().classifier("cyclic-a")
+    override def classifyAsync(input: String): CompletionStage[Classification] =
+      CompletableFuture.completedFuture(Classification.label("b"))
+  }
+
+  val ConcurrentCallCount = new AtomicInteger(0)
+
+  // Tracks how many calls are in flight concurrently, to check the shared singleton instance
+  // doesn't corrupt state across parallel classify() calls.
+  class ConcurrentClassifier extends Classifier {
+    override def classifyAsync(input: String): CompletionStage[Classification] = {
+      val inFlight = ConcurrentCallCount.incrementAndGet()
+      try CompletableFuture.completedFuture(Classification.score(inFlight.toDouble))
+      finally ConcurrentCallCount.decrementAndGet()
+    }
+  }
+
+  // Implements both ModelGuardrail and Classifier -- allowed, since a classifier is looked up by
+  // name rather than dispatched, so there's no ambiguity with the guardrail's boundary dispatch.
+  // Zero-arg constructor is the only shape a dual-purpose class can have: classifier construction
+  // goes through the SDK's wiredInstance (which requires a single public constructor), while
+  // guardrail construction only matches (GuardrailContext) or (), and neither path matches the
+  // other's context type.
+  class DualPurpose extends ModelGuardrail with Classifier {
+    override def decide(ctx: ModelGuardrail.CallContext): Decision = new Decision.Allow()
+    override def classifyAsync(input: String): CompletionStage[Classification] =
+      CompletableFuture.completedFuture(Classification.label(s"dual:$input"))
+  }
+
+  // Test-only stand-in for the runtime's classifier dispatch (akka-runtime's
+  // RuntimeClassifierClient + Classifier wrapper + EmbeddedSdkDispatch.wrapClassifier): looks a
+  // registered classifier up by name and invokes it, wrapping the call in Future(...).flatten so a
+  // synchronous throw becomes a failed Future -- exactly the normalization the real runtime
+  // provides. The SDK side itself does not double-translate.
+  final class LoopbackSpiClassifierClient extends SpiClassifierClient {
+    @volatile private var byName: Map[String, SpiConfiguredClassifier] = Map.empty
+
+    def register(configured: Seq[SpiConfiguredClassifier]): Unit = byName = configured.map(c => c.name -> c).toMap
+
+    override def classify(name: String, content: SpiClassifier.Content): Future[SpiClassifier.Result] =
+      byName.get(name) match {
+        case Some(c) => Future(c.instance.classify(content))(ExecutionContext.parasitic).flatten
+        case None    => Future.failed(new IllegalArgumentException(s"No classifier registered with name [$name]"))
+      }
+  }
+
+  // Mirrors Sdk.wiredInstance's unwrapping of InvocationTargetException, so a classifier
+  // constructor's own exceptions (e.g. missing config, cyclic dependency) surface as themselves
+  // rather than wrapped -- matching production wiring. Does NOT mirror wiredInstance's
+  // single-public-constructor requirement or general dependency injection; those live in
+  // Sdk.wireClassifier and are out of this spec's reach.
+  private def wireClassifier(clz: Class[Classifier], context: ClassifierContext): Classifier =
+    try {
+      try clz.getConstructor(classOf[ClassifierContext]).newInstance(context)
+      catch {
+        case _: NoSuchMethodException => clz.getConstructor().newInstance()
+      }
+    } catch {
+      case exc: java.lang.reflect.InvocationTargetException if exc.getCause != null => throw exc.getCause
+    }
+
+  /** Builds a provider wired to a fresh loopback runtime client, registered with whatever's configured. */
+  private def newProvider(system: akka.actor.typed.ActorSystem[_], config: Config): ClassifierProvider = {
+    val runtimeClient = new LoopbackSpiClassifierClient
+    val provider = new ClassifierProvider(system, config, runtimeClient, wireClassifier)
+    runtimeClient.register(provider.spiConfiguredClassifiers)
+    provider
+  }
+}
+
+class ClassifierProviderSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with Matchers with LogCapturing {
+  import ClassifierProviderSpec._
+
+  "The ClassifierProvider" should {
+    "validate" in {
+      val provider = newProvider(system, config)
+      provider.validate()
+    }
+
+    "throw from validate when the configured class doesn't implement Classifier" in {
+      val faultyConfig =
+        ConfigFactory
+          .parseString(s"""
+          akka.javasdk.agent.classifiers {
+            "bad" {
+              class = "akka.javasdk.impl.agent.ClassifierProviderSpec$$WrongClassifier"
+            }
+          }
+          """)
+          .withFallback(config)
+      val provider = new ClassifierProvider(system, faultyConfig, new LoopbackSpiClassifierClient, wireClassifier)
+      intercept[IllegalArgumentException] {
+        provider.validate()
+      }.getMessage should include("must implement [akka.javasdk.agent.Classifier]")
+    }
+
+    "throw from validate when required config is missing" in {
+      val faultyConfig =
+        ConfigFactory
+          .parseString(s"""
+          akka.javasdk.agent.classifiers {
+            "toxicity" {
+              class = "akka.javasdk.impl.agent.ClassifierProviderSpec$$ToxicityClassifier"
+            }
+          }
+          """)
+      val provider = new ClassifierProvider(system, faultyConfig, new LoopbackSpiClassifierClient, wireClassifier)
+      intercept[ConfigException] {
+        provider.validate()
+      }
+    }
+
+    "construct with and without a ClassifierContext constructor" in {
+      val provider = newProvider(system, config)
+
+      val toxicity = provider.client.classifier("toxicity")
+      val result = toxicity.classifyAsync("some text").toCompletableFuture.get(3, TimeUnit.SECONDS)
+      result.score() shouldBe java.util.Optional.of(0.8)
+      result.label() shouldBe java.util.Optional.of("classified:some text")
+
+      val noContext = provider.client.classifier("no-context")
+      val result2 = noContext.classifyAsync("anything").toCompletableFuture.get(3, TimeUnit.SECONDS)
+      result2.label() shouldBe java.util.Optional.of("ok")
+    }
+
+    "support the blocking classify(...) alongside classifyAsync(...)" in {
+      val provider = newProvider(system, config)
+      val result = provider.client.classifier("toxicity").classify("some text")
+      result.label() shouldBe java.util.Optional.of("classified:some text")
+    }
+
+    "throw a descriptive IllegalArgumentException for an unknown classifier name" in {
+      val provider = newProvider(system, config)
+      val ex = intercept[IllegalArgumentException] {
+        provider.client.classifier("does-not-exist")
+      }
+      ex.getMessage should include("No classifier configured with name [does-not-exist]")
+      ex.getMessage should include("toxicity")
+    }
+
+    "return the same instance across repeated lookups" in {
+      val provider = newProvider(system, config)
+      (provider.client.classifier("toxicity") should be).theSameInstanceAs(provider.client.classifier("toxicity"))
+    }
+
+    "convert a thrown exception from classify(...) into a failed CompletionStage rather than propagating it" in {
+      val cfg = ConfigFactory
+        .parseString(s"""
+          akka.javasdk.agent.classifiers {
+            "throwing" {
+              class = "akka.javasdk.impl.agent.ClassifierProviderSpec$$ThrowingClassifier"
+            }
+          }
+          """)
+      val provider = newProvider(system, cfg)
+      val classifier = provider.client.classifier("throwing")
+
+      // must not throw synchronously
+      val stage = classifier.classifyAsync("anything")
+      val failure = intercept[java.util.concurrent.ExecutionException] {
+        stage.toCompletableFuture.get(3, TimeUnit.SECONDS)
+      }
+      failure.getCause shouldBe a[IllegalStateException]
+      failure.getCause.getMessage shouldBe "kaboom"
+    }
+
+    "let a classifier compose another configured classifier via ClassifierContext.classifierClient" in {
+      val cfg = ConfigFactory
+        .parseString(s"""
+          akka.javasdk.agent.classifiers {
+            "ensemble" {
+              class = "akka.javasdk.impl.agent.ClassifierProviderSpec$$EnsembleClassifier"
+            }
+          }
+          """)
+        .withFallback(config)
+      val provider = newProvider(system, cfg)
+      val ensemble = provider.client.classifier("ensemble")
+      val result = ensemble.classifyAsync("hi").toCompletableFuture.get(3, TimeUnit.SECONDS)
+      result.label() shouldBe java.util.Optional.of("classified:hi")
+    }
+
+    "throw a descriptive error instead of overflowing the stack on a cyclic classifier dependency" in {
+      val cfg = ConfigFactory.parseString(s"""
+        akka.javasdk.agent.classifiers {
+          "cyclic-a" {
+            class = "akka.javasdk.impl.agent.ClassifierProviderSpec$$CyclicA"
+          }
+          "cyclic-b" {
+            class = "akka.javasdk.impl.agent.ClassifierProviderSpec$$CyclicB"
+          }
+        }
+        """)
+      // Not newProvider: that eagerly forces spiConfiguredClassifiers for registration, which would
+      // hit the same cycle outside this intercept block.
+      val provider = new ClassifierProvider(system, cfg, new LoopbackSpiClassifierClient, wireClassifier)
+      val ex = intercept[IllegalStateException] {
+        provider.client.classifier("cyclic-a")
+      }
+      ex.getMessage should include("Cyclic classifier dependency detected")
+      ex.getMessage should include("cyclic-a")
+      ex.getMessage should include("cyclic-b")
+    }
+
+    "handle concurrent classify(...) calls against the shared singleton instance safely" in {
+      val cfg = ConfigFactory.parseString(s"""
+        akka.javasdk.agent.classifiers {
+          "concurrent" {
+            class = "akka.javasdk.impl.agent.ClassifierProviderSpec$$ConcurrentClassifier"
+          }
+        }
+        """)
+      val provider = newProvider(system, cfg)
+      val classifier = provider.client.classifier("concurrent")
+
+      val pool = Executors.newFixedThreadPool(8)
+      try {
+        val latch = new CountDownLatch(50)
+        val results = (1 to 50).map { _ =>
+          val f = pool.submit(() => classifier.classifyAsync("x").toCompletableFuture.get(3, TimeUnit.SECONDS))
+          latch.countDown()
+          f
+        }
+        latch.await(5, TimeUnit.SECONDS) shouldBe true
+        results.foreach(_.get(3, TimeUnit.SECONDS))
+        ConcurrentCallCount.get() shouldBe 0
+      } finally pool.shutdown()
+    }
+
+    "accept a class implementing both ModelGuardrail and Classifier" in {
+      val classifierCfg = ConfigFactory.parseString(s"""
+        akka.javasdk.agent.classifiers {
+          "dual" {
+            class = "akka.javasdk.impl.agent.ClassifierProviderSpec$$DualPurpose"
+          }
+        }
+        """)
+      val classifierProvider = newProvider(system, classifierCfg)
+      classifierProvider.validate()
+      val result =
+        classifierProvider.client.classifier("dual").classifyAsync("x").toCompletableFuture.get(3, TimeUnit.SECONDS)
+      result.label() shouldBe java.util.Optional.of("dual:x")
+
+      val guardrailCfg = ConfigFactory.parseString(s"""
+        akka.javasdk.agent.guardrails {
+          "dual" {
+            class = "akka.javasdk.impl.agent.ClassifierProviderSpec$$DualPurpose"
+            agents = ["some-agent"]
+            category = TOXIC
+            use-for = ["model-response"]
+          }
+        }
+        """)
+      val guardrailProvider = new GuardrailProvider(system, guardrailCfg, testTracerFactory)
+      guardrailProvider.validate()
+      guardrailProvider.agentGuardrails("some-agent", role = None).modelResponseGuardrails.size shouldBe 1
+    }
+  }
+}

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ClassifierProviderSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ClassifierProviderSpec.scala
@@ -18,6 +18,7 @@ import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.javasdk.agent.Classification
 import akka.javasdk.agent.Classifier
+import akka.javasdk.agent.ClassifierClient
 import akka.javasdk.agent.ClassifierContext
 import akka.javasdk.agent.Decision
 import akka.javasdk.agent.ModelGuardrail
@@ -49,27 +50,26 @@ object ClassifierProviderSpec {
 
   class ToxicityClassifier(context: ClassifierContext) extends Classifier {
     private val threshold = context.config().getDouble("threshold")
-    override def classifyAsync(input: String): CompletionStage[Classification] =
+    override def classify(input: String): CompletionStage[Classification] =
       CompletableFuture.completedFuture(Classification.of(threshold, s"classified:$input"))
   }
 
   class NoContextClassifier extends Classifier {
-    override def classifyAsync(input: String): CompletionStage[Classification] =
+    override def classify(input: String): CompletionStage[Classification] =
       CompletableFuture.completedFuture(Classification.label("ok"))
   }
 
   class ThrowingClassifier extends Classifier {
-    override def classifyAsync(input: String): CompletionStage[Classification] =
+    override def classify(input: String): CompletionStage[Classification] =
       throw new IllegalStateException("kaboom")
   }
 
   class WrongClassifier
 
-  // Composes another configured classifier by calling it through the client, never holding a
-  // reference to the classifier itself.
-  class EnsembleClassifier(context: ClassifierContext) extends Classifier {
-    private val client = context.classifierClient()
-    override def classifyAsync(input: String): CompletionStage[Classification] =
+  // Composes another configured classifier by calling it through the injected client, never holding
+  // a reference to the classifier itself.
+  class EnsembleClassifier(client: ClassifierClient) extends Classifier {
+    override def classify(input: String): CompletionStage[Classification] =
       client.classifyAsync("toxicity", input)
   }
 
@@ -78,7 +78,7 @@ object ClassifierProviderSpec {
   // Tracks how many calls are in flight concurrently, to check the shared singleton instance
   // doesn't corrupt state across parallel classify() calls.
   class ConcurrentClassifier extends Classifier {
-    override def classifyAsync(input: String): CompletionStage[Classification] = {
+    override def classify(input: String): CompletionStage[Classification] = {
       val inFlight = ConcurrentCallCount.incrementAndGet()
       try CompletableFuture.completedFuture(Classification.score(inFlight.toDouble))
       finally ConcurrentCallCount.decrementAndGet()
@@ -93,7 +93,7 @@ object ClassifierProviderSpec {
   // other's context type.
   class DualPurpose extends ModelGuardrail with Classifier {
     override def decide(ctx: ModelGuardrail.CallContext): Decision = new Decision.Allow()
-    override def classifyAsync(input: String): CompletionStage[Classification] =
+    override def classify(input: String): CompletionStage[Classification] =
       CompletableFuture.completedFuture(Classification.label(s"dual:$input"))
   }
 
@@ -112,14 +112,20 @@ object ClassifierProviderSpec {
       }
   }
 
-  // Simplified stand-in for Sdk.wiredInstance: unwraps InvocationTargetException so a classifier
-  // constructor's own exceptions (e.g. missing config) surface as themselves. Does not do the
-  // dependency injection or single-public-constructor enforcement that production wiring adds.
-  private def wireClassifier(clz: Class[Classifier], context: ClassifierContext): Classifier =
+  // Simplified stand-in for Sdk.wiredInstance: injects a ClassifierClient or ClassifierContext by
+  // constructor shape and unwraps InvocationTargetException so a classifier constructor's own
+  // exceptions (e.g. missing config) surface as themselves. Does not do the full dependency
+  // injection or single-public-constructor enforcement that production wiring adds.
+  private def wireClassifier(
+      client: => ClassifierClient)(clz: Class[Classifier], context: ClassifierContext): Classifier =
     try {
-      try clz.getConstructor(classOf[ClassifierContext]).newInstance(context)
+      try clz.getConstructor(classOf[ClassifierClient]).newInstance(client)
       catch {
-        case _: NoSuchMethodException => clz.getConstructor().newInstance()
+        case _: NoSuchMethodException =>
+          try clz.getConstructor(classOf[ClassifierContext]).newInstance(context)
+          catch {
+            case _: NoSuchMethodException => clz.getConstructor().newInstance()
+          }
       }
     } catch {
       case exc: java.lang.reflect.InvocationTargetException if exc.getCause != null => throw exc.getCause
@@ -128,7 +134,8 @@ object ClassifierProviderSpec {
   /** Builds a provider wired to a fresh loopback runtime client, registered with whatever's configured. */
   private def newProvider(system: akka.actor.typed.ActorSystem[_], config: Config): ClassifierProvider = {
     val runtimeClient = new LoopbackSpiClassifierClient
-    val provider = new ClassifierProvider(system, config, runtimeClient, wireClassifier)
+    var provider: ClassifierProvider = null
+    provider = new ClassifierProvider(system, config, runtimeClient, wireClassifier(provider.client))
     runtimeClient.register(provider.spiConfiguredClassifiers)
     provider
   }
@@ -154,7 +161,11 @@ class ClassifierProviderSpec extends ScalaTestWithActorTestKit with AnyWordSpecL
           }
           """)
           .withFallback(config)
-      val provider = new ClassifierProvider(system, faultyConfig, new LoopbackSpiClassifierClient, wireClassifier)
+      val provider = new ClassifierProvider(
+        system,
+        faultyConfig,
+        new LoopbackSpiClassifierClient,
+        wireClassifier(sys.error("no ClassifierClient in this test")))
       intercept[IllegalArgumentException] {
         provider.validate()
       }.getMessage should include("must implement [akka.javasdk.agent.Classifier]")
@@ -170,7 +181,11 @@ class ClassifierProviderSpec extends ScalaTestWithActorTestKit with AnyWordSpecL
             }
           }
           """)
-      val provider = new ClassifierProvider(system, faultyConfig, new LoopbackSpiClassifierClient, wireClassifier)
+      val provider = new ClassifierProvider(
+        system,
+        faultyConfig,
+        new LoopbackSpiClassifierClient,
+        wireClassifier(sys.error("no ClassifierClient in this test")))
       intercept[ConfigException] {
         provider.validate()
       }

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ClassifierProviderSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ClassifierProviderSpec.scala
@@ -97,11 +97,9 @@ object ClassifierProviderSpec {
       CompletableFuture.completedFuture(Classification.label(s"dual:$input"))
   }
 
-  // Test-only stand-in for the runtime's classifier dispatch (akka-runtime's
-  // RuntimeClassifierClient + Classifier wrapper + EmbeddedSdkDispatch.wrapClassifier): looks a
-  // registered classifier up by name and invokes it, wrapping the call in Future(...).flatten so a
-  // synchronous throw becomes a failed Future -- exactly the normalization the real runtime
-  // provides. The SDK side itself does not double-translate.
+  // Test-only stand-in for the runtime's classifier dispatch: looks a registered classifier up by
+  // name and invokes it, wrapping the call in Future(...).flatten so a synchronous throw becomes a
+  // failed Future, as the runtime does.
   final class LoopbackSpiClassifierClient extends SpiClassifierClient {
     @volatile private var byName: Map[String, SpiConfiguredClassifier] = Map.empty
 
@@ -114,11 +112,9 @@ object ClassifierProviderSpec {
       }
   }
 
-  // Mirrors Sdk.wiredInstance's unwrapping of InvocationTargetException, so a classifier
-  // constructor's own exceptions (e.g. missing config, cyclic dependency) surface as themselves
-  // rather than wrapped -- matching production wiring. Does NOT mirror wiredInstance's
-  // single-public-constructor requirement or general dependency injection; those live in
-  // Sdk.wireClassifier and are out of this spec's reach.
+  // Simplified stand-in for Sdk.wiredInstance: unwraps InvocationTargetException so a classifier
+  // constructor's own exceptions (e.g. missing config) surface as themselves. Does not do the
+  // dependency injection or single-public-constructor enforcement that production wiring adds.
   private def wireClassifier(clz: Class[Classifier], context: ClassifierContext): Classifier =
     try {
       try clz.getConstructor(classOf[ClassifierContext]).newInstance(context)

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ClassifierProviderSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ClassifierProviderSpec.scala
@@ -117,7 +117,7 @@ object ClassifierProviderSpec {
 
     def register(configured: Seq[SpiConfiguredClassifier]): Unit = byName = configured.map(c => c.name -> c).toMap
 
-    override def classify(name: String, content: SpiClassifier.Content): Future[SpiClassifier.Result] =
+    override def classify(name: String, content: SpiClassifier.Content): Future[SpiClassifier.Classification] =
       byName.get(name) match {
         case Some(c) => Future(c.instance.classify(content))(ExecutionContext.parasitic).flatten
         case None    => Future.failed(new IllegalArgumentException(s"No classifier registered with name [$name]"))

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ClassifierProviderSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ClassifierProviderSpec.scala
@@ -65,22 +65,12 @@ object ClassifierProviderSpec {
 
   class WrongClassifier
 
-  // Resolves another named classifier from its own constructor, to compose an ensemble.
+  // Composes another configured classifier by calling it through the client, never holding a
+  // reference to the classifier itself.
   class EnsembleClassifier(context: ClassifierContext) extends Classifier {
-    private val delegate = context.classifierClient().classifier("toxicity")
-    override def classifyAsync(input: String): CompletionStage[Classification] = delegate.classifyAsync(input)
-  }
-
-  class CyclicA(context: ClassifierContext) extends Classifier {
-    context.classifierClient().classifier("cyclic-b")
+    private val client = context.classifierClient()
     override def classifyAsync(input: String): CompletionStage[Classification] =
-      CompletableFuture.completedFuture(Classification.label("a"))
-  }
-
-  class CyclicB(context: ClassifierContext) extends Classifier {
-    context.classifierClient().classifier("cyclic-a")
-    override def classifyAsync(input: String): CompletionStage[Classification] =
-      CompletableFuture.completedFuture(Classification.label("b"))
+      client.classifyAsync("toxicity", input)
   }
 
   val ConcurrentCallCount = new AtomicInteger(0)
@@ -193,34 +183,27 @@ class ClassifierProviderSpec extends ScalaTestWithActorTestKit with AnyWordSpecL
     "construct with and without a ClassifierContext constructor" in {
       val provider = newProvider(system, config)
 
-      val toxicity = provider.client.classifier("toxicity")
-      val result = toxicity.classifyAsync("some text").toCompletableFuture.get(3, TimeUnit.SECONDS)
+      val result = provider.client.classifyAsync("toxicity", "some text").toCompletableFuture.get(3, TimeUnit.SECONDS)
       result.score() shouldBe java.util.Optional.of(0.8)
       result.label() shouldBe java.util.Optional.of("classified:some text")
 
-      val noContext = provider.client.classifier("no-context")
-      val result2 = noContext.classifyAsync("anything").toCompletableFuture.get(3, TimeUnit.SECONDS)
+      val result2 = provider.client.classifyAsync("no-context", "anything").toCompletableFuture.get(3, TimeUnit.SECONDS)
       result2.label() shouldBe java.util.Optional.of("ok")
     }
 
     "support the blocking classify(...) alongside classifyAsync(...)" in {
       val provider = newProvider(system, config)
-      val result = provider.client.classifier("toxicity").classify("some text")
+      val result = provider.client.classify("toxicity", "some text")
       result.label() shouldBe java.util.Optional.of("classified:some text")
     }
 
     "throw a descriptive IllegalArgumentException for an unknown classifier name" in {
       val provider = newProvider(system, config)
       val ex = intercept[IllegalArgumentException] {
-        provider.client.classifier("does-not-exist")
+        provider.client.classifyAsync("does-not-exist", "x")
       }
       ex.getMessage should include("No classifier configured with name [does-not-exist]")
       ex.getMessage should include("toxicity")
-    }
-
-    "return the same instance across repeated lookups" in {
-      val provider = newProvider(system, config)
-      (provider.client.classifier("toxicity") should be).theSameInstanceAs(provider.client.classifier("toxicity"))
     }
 
     "convert a thrown exception from classify(...) into a failed CompletionStage rather than propagating it" in {
@@ -233,10 +216,9 @@ class ClassifierProviderSpec extends ScalaTestWithActorTestKit with AnyWordSpecL
           }
           """)
       val provider = newProvider(system, cfg)
-      val classifier = provider.client.classifier("throwing")
 
       // must not throw synchronously
-      val stage = classifier.classifyAsync("anything")
+      val stage = provider.client.classifyAsync("throwing", "anything")
       val failure = intercept[java.util.concurrent.ExecutionException] {
         stage.toCompletableFuture.get(3, TimeUnit.SECONDS)
       }
@@ -244,7 +226,7 @@ class ClassifierProviderSpec extends ScalaTestWithActorTestKit with AnyWordSpecL
       failure.getCause.getMessage shouldBe "kaboom"
     }
 
-    "let a classifier compose another configured classifier via ClassifierContext.classifierClient" in {
+    "let a classifier compose another configured classifier through the client" in {
       val cfg = ConfigFactory
         .parseString(s"""
           akka.javasdk.agent.classifiers {
@@ -255,31 +237,8 @@ class ClassifierProviderSpec extends ScalaTestWithActorTestKit with AnyWordSpecL
           """)
         .withFallback(config)
       val provider = newProvider(system, cfg)
-      val ensemble = provider.client.classifier("ensemble")
-      val result = ensemble.classifyAsync("hi").toCompletableFuture.get(3, TimeUnit.SECONDS)
+      val result = provider.client.classifyAsync("ensemble", "hi").toCompletableFuture.get(3, TimeUnit.SECONDS)
       result.label() shouldBe java.util.Optional.of("classified:hi")
-    }
-
-    "throw a descriptive error instead of overflowing the stack on a cyclic classifier dependency" in {
-      val cfg = ConfigFactory.parseString(s"""
-        akka.javasdk.agent.classifiers {
-          "cyclic-a" {
-            class = "akka.javasdk.impl.agent.ClassifierProviderSpec$$CyclicA"
-          }
-          "cyclic-b" {
-            class = "akka.javasdk.impl.agent.ClassifierProviderSpec$$CyclicB"
-          }
-        }
-        """)
-      // Not newProvider: that eagerly forces spiConfiguredClassifiers for registration, which would
-      // hit the same cycle outside this intercept block.
-      val provider = new ClassifierProvider(system, cfg, new LoopbackSpiClassifierClient, wireClassifier)
-      val ex = intercept[IllegalStateException] {
-        provider.client.classifier("cyclic-a")
-      }
-      ex.getMessage should include("Cyclic classifier dependency detected")
-      ex.getMessage should include("cyclic-a")
-      ex.getMessage should include("cyclic-b")
     }
 
     "handle concurrent classify(...) calls against the shared singleton instance safely" in {
@@ -291,13 +250,14 @@ class ClassifierProviderSpec extends ScalaTestWithActorTestKit with AnyWordSpecL
         }
         """)
       val provider = newProvider(system, cfg)
-      val classifier = provider.client.classifier("concurrent")
 
       val pool = Executors.newFixedThreadPool(8)
       try {
         val latch = new CountDownLatch(50)
         val results = (1 to 50).map { _ =>
-          val f = pool.submit(() => classifier.classifyAsync("x").toCompletableFuture.get(3, TimeUnit.SECONDS))
+          val f =
+            pool.submit(() =>
+              provider.client.classifyAsync("concurrent", "x").toCompletableFuture.get(3, TimeUnit.SECONDS))
           latch.countDown()
           f
         }
@@ -318,7 +278,7 @@ class ClassifierProviderSpec extends ScalaTestWithActorTestKit with AnyWordSpecL
       val classifierProvider = newProvider(system, classifierCfg)
       classifierProvider.validate()
       val result =
-        classifierProvider.client.classifier("dual").classifyAsync("x").toCompletableFuture.get(3, TimeUnit.SECONDS)
+        classifierProvider.client.classifyAsync("dual", "x").toCompletableFuture.get(3, TimeUnit.SECONDS)
       result.label() shouldBe java.util.Optional.of("dual:x")
 
       val guardrailCfg = ConfigFactory.parseString(s"""

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ClassifierSettingsSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ClassifierSettingsSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl.agent
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+object ClassifierSettingsSpec {
+  private val config = ConfigFactory.parseString(s"""
+    akka.javasdk.agent.classifiers {
+      "toxicity" {
+        class = "test.ToxicityClassifier"
+        threshold = 0.8
+      }
+
+      "bias" {
+        class = "test.BiasClassifier"
+      }
+    }
+    """)
+}
+
+class ClassifierSettingsSpec extends AnyWordSpec with Matchers {
+  import ClassifierSettingsSpec._
+
+  "The ClassifierSettings" should {
+    "load from config" in {
+      val settings = ClassifierSettings(config.getConfig("akka.javasdk.agent.classifiers"))
+      settings.configuredClassifiers.size shouldBe 2
+
+      val toxicity = settings.configuredClassifiers.find(_.name == "toxicity").get
+      toxicity.implementationClass shouldBe "test.ToxicityClassifier"
+      toxicity.config.getDouble("threshold") shouldBe 0.8
+
+      val bias = settings.configuredClassifiers.find(_.name == "bias").get
+      bias.implementationClass shouldBe "test.BiasClassifier"
+    }
+
+    "accept an empty classifiers section" in {
+      val settings = ClassifierSettings(ConfigFactory.parseString("""{}"""))
+      settings.configuredClassifiers shouldBe empty
+    }
+
+    "reject a configured classifier missing the class key" in {
+      val faulty = ConfigFactory.parseString("""
+        "no class" {
+          threshold = 0.5
+        }
+        """)
+      intercept[com.typesafe.config.ConfigException] {
+        ClassifierSettings(faulty)
+      }
+    }
+  }
+}

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ClassifierSettingsSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/agent/ClassifierSettingsSpec.scala
@@ -50,9 +50,22 @@ class ClassifierSettingsSpec extends AnyWordSpec with Matchers {
           threshold = 0.5
         }
         """)
-      intercept[com.typesafe.config.ConfigException] {
+      val ex = intercept[IllegalArgumentException] {
         ClassifierSettings(faulty)
       }
+      ex.getMessage should include("no class")
+      ex.getMessage should include("class")
+    }
+
+    "reject a classifier entry that is not a config object" in {
+      val faulty = ConfigFactory.parseString("""
+        "not an object" = 42
+        """)
+      val ex = intercept[IllegalArgumentException] {
+        ClassifierSettings(faulty)
+      }
+      ex.getMessage should include("not an object")
+      ex.getMessage should include("config object")
     }
   }
 }

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/view/ViewDescriptorFactorySpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/view/ViewDescriptorFactorySpec.scala
@@ -13,12 +13,12 @@ import akka.runtime.sdk.spi.ConsumerSource
 import akka.runtime.sdk.spi.Principal
 import akka.runtime.sdk.spi.RegionInfo
 import akka.runtime.sdk.spi.ServiceNamePattern
-import akka.runtime.sdk.spi.SpiffePattern
 import akka.runtime.sdk.spi.SpiSchema.SpiClass
 import akka.runtime.sdk.spi.SpiSchema.SpiInteger
 import akka.runtime.sdk.spi.SpiSchema.SpiList
 import akka.runtime.sdk.spi.SpiSchema.SpiString
 import akka.runtime.sdk.spi.SpiSchema.SpiTimestamp
+import akka.runtime.sdk.spi.SpiffePattern
 import akka.runtime.sdk.spi.ViewDescriptor
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/view/ViewDescriptorFactorySpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/view/ViewDescriptorFactorySpec.scala
@@ -13,12 +13,12 @@ import akka.runtime.sdk.spi.ConsumerSource
 import akka.runtime.sdk.spi.Principal
 import akka.runtime.sdk.spi.RegionInfo
 import akka.runtime.sdk.spi.ServiceNamePattern
+import akka.runtime.sdk.spi.SpiffePattern
 import akka.runtime.sdk.spi.SpiSchema.SpiClass
 import akka.runtime.sdk.spi.SpiSchema.SpiInteger
 import akka.runtime.sdk.spi.SpiSchema.SpiList
 import akka.runtime.sdk.spi.SpiSchema.SpiString
 import akka.runtime.sdk.spi.SpiSchema.SpiTimestamp
-import akka.runtime.sdk.spi.SpiffePattern
 import akka.runtime.sdk.spi.ViewDescriptor
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val ProtocolVersionMinor = 1
   }
 
-  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.10-25-93dfc135-SNAPSHOT")
+  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.10-31-e7f1b261-SNAPSHOT")
 
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned


### PR DESCRIPTION
Companion to the runtime-side PR lightbend/akka-runtime#5468. Design log: [`5334.md`](https://github.com/retronym/akka-sdk/blob/design-doc-5334-snapshot/5334.md) (kept out of this branch, see note below).

Supersedes retronym/akka-sdk#5 (moved here to target the real upstream instead of my fork).

## Classifiers in three snippets

```java
public class ToxicityClassifier implements Classifier {
  private final double threshold;

  public ToxicityClassifier(ClassifierContext ctx) {
    this.threshold = ctx.config().getDouble("threshold");
  }

  @Override
  public CompletionStage<Classification> classifyAsync(String input) {
    return callModel(input)
        .thenApply(score -> Classification.of(score, score > threshold ? "toxic" : "clean"));
  }
}
```

```hocon
akka.javasdk.agent.classifiers {
  "toxicity" {
    class = "com.example.ToxicityClassifier"
    threshold = 0.8
  }
}
```

```java
// anywhere: agent, guardrail, evaluator, plain app code
Classification result = classifierClient.classifier("toxicity").classify(input); // blocking
// or classifierClient.classifier("toxicity").classifyAsync(input)
```

A `Classifier` is a lightweight, guardrail-like governance control — config-driven, resolved by name through an injectable `ClassifierClient`, usable directly, from a guardrail (`GuardrailContext.classifierClient()`), or composed into an ensemble classifier. Every `classify` call crosses the SPI to the runtime, which owns dispatch isolation, instrumentation, and recording. Classifier construction goes through the normal DI mechanism (`HttpClientProvider`, `ComponentClient`, etc. injectable alongside `ClassifierContext`) and is deferred to `preStart`, so a classifier can depend on a `DependencyProvider`-supplied dependency.

**Known v1 gap**: guardrail-/ensemble-invoked classifications ride a root OTel context rather than the caller's, revisited with the async-guardrail migration (#5383).

Single commit. Depends on `lightbend/akka-runtime#5468`; this branch doesn't build against the default `1.6.10` pin — run locally with `-Dakka-runtime.version=<runtime snapshot version>`.

---
**Note on `5334.md`**: per review, the design-doc log isn't tracked in this branch. Still readable at the [`design-doc-5334-snapshot`](https://github.com/retronym/akka-sdk/tree/design-doc-5334-snapshot) tag.
