### PR TITLE
docs: governance APIs (guardrails, classifiers, evaluators, ledger, SPIFFE)

### DIFF
--- a/docs/src/modules/concepts/pages/acls.adoc
+++ b/docs/src/modules/concepts/pages/acls.adoc
@@ -26,6 +26,13 @@ In Akka, a principal is an abstract entity that represents the origin or source 
 ** Requests labeled with the *internet principal* are validated by mTLS, but this does not imply that mTLS was used to connect to the ingress from the internet client itself. To enforce mTLS on connections from internet clients, refer to xref:operations:tls-certificates.adoc[].
 * *Component identity (SPIFFE)*: For finer granularity than a whole service, you can match on the calling component's SPIFFE identity, which encodes the calling service, component type and component id. This allows rules such as "only the `checkout` workflow" or "any agent". See xref:sdk:access-control.adoc[] for details.
 
+When one component in a service calls another service, the caller's component identity is propagated across the service
+boundary, so the receiving service can both match it in an `@Acl` and read it programmatically. The service-level part
+of that identity is attested by the service mesh and cannot be spoofed; the component-level part is asserted by the
+calling service. Requests that originate from the internet carry no component identity. See
+xref:sdk:access-control.adoc#_inspecting_the_callers_identity[Inspecting the caller's identity] for how to read it in
+an endpoint.
+
 == Configuring ACLs
 To configure ACLs and secure your Akka services effectively, follow these steps:
 

--- a/docs/src/modules/concepts/pages/governance-and-the-runtime.adoc
+++ b/docs/src/modules/concepts/pages/governance-and-the-runtime.adoc
@@ -30,11 +30,18 @@ PII must be scrubbed, but decisions must still be explainable. If an AI rejects 
 
 Akka's governance is not a separate product or integration. It is a property of every deployment.
 
-* **Runtime policy enforcement** — Guardrails, policies, LLMs-as-a-judge, and sanitizers are fully embedded within the runtime. Bad requests get stopped before they consume tokens, not after.
+* **Runtime policy enforcement** — Guardrails, classifiers, evaluators, LLMs-as-a-judge, and sanitizers are fully embedded within the runtime. Bad requests get stopped before they consume tokens, not after.
 * **Self-explanation** — Every decision can be traced and explained, satisfying regulatory requirements for transparency.
 * **Self-containment** — Failures are contained at the point of origin. A misbehaving agent cannot cascade into other parts of your system.
-* **Interaction logging** — Every interaction is recorded immutably by the runtime that executed it.
+* **Interaction logging** — Every interaction is recorded immutably by the runtime that executed it, in the interaction ledger.
 * **Causal analysis** — Trace the chain of decisions that led to any outcome.
+
+These capabilities play distinct roles, and they compose:
+
+* **Guardrails** *enforce* — they run at a call boundary and can stop an interaction. See xref:sdk:agents/guardrails.adoc[].
+* **Classifiers** *score* — they map text to a score or label, and are consulted by guardrails, evaluators, or application code rather than dispatched by the runtime. See xref:sdk:agents/classifiers.adoc[].
+* **Evaluators** *assess* — the runtime triggers them per interaction to record a verdict, out of band. See xref:sdk:evaluators.adoc[].
+* **The interaction ledger** *audits* — it records every interaction immutably, and evaluators read from it. See xref:sdk:evaluators.adoc#_the_ledger_client[The ledger client].
 
 == Compliance Certifications
 
@@ -48,8 +55,10 @@ Akka holds more than 19 compliance certifications including:
 == Related Documentation
 
 * xref:sdk:agents/guardrails.adoc[Guardrails] — Configure runtime policy enforcement
+* xref:sdk:agents/classifiers.adoc[Classifiers] — Score or label text for guardrails, evaluators, and application code
+* xref:sdk:evaluators.adoc[Evaluators] — Assess agent interactions per interaction, and read the interaction ledger
 * xref:sdk:sanitization.adoc[Data sanitization] — PII scrubbing implementation
-* xref:sdk:access-control.adoc[Access Control] — Service-level access control lists
+* xref:sdk:access-control.adoc[Access Control] — Service-level and component-level access control lists
 
 == See Also
 

--- a/docs/src/modules/concepts/pages/governance-and-the-runtime.adoc
+++ b/docs/src/modules/concepts/pages/governance-and-the-runtime.adoc
@@ -36,12 +36,12 @@ Akka's governance is not a separate product or integration. It is a property of 
 * **Interaction logging** — Every interaction is recorded immutably by the runtime that executed it, in the ledger.
 * **Causal analysis** — Trace the chain of decisions that led to any outcome.
 
-These capabilities play distinct roles, and they compose:
+These pieces play different roles and work together:
 
-* **Guardrails** *enforce* — they run at a call boundary and can stop an interaction. See xref:sdk:agents/guardrails.adoc[].
-* **Classifiers** *score* — they map text to a score or label, consulted by guardrails, evaluators, or application code. See xref:sdk:agents/classifiers.adoc[].
-* **Evaluators** *assess* — the runtime triggers them per interaction to record a verdict, out of band. See xref:sdk:evaluators.adoc[].
-* **The ledger** *audits* — it records every interaction immutably, and evaluators read from it. See xref:sdk:evaluators.adoc#_the_ledger_client[The ledger client].
+* xref:sdk:agents/guardrails.adoc[Guardrails] run at a call boundary and can stop an interaction.
+* xref:sdk:agents/classifiers.adoc[Classifiers] map text to a score or label, for a guardrail, an evaluator, or your own code to act on.
+* xref:sdk:evaluators.adoc[Evaluators] run after each interaction, out of band, to record a verdict.
+* The xref:sdk:evaluators.adoc#_the_ledger_client[ledger] records every interaction immutably, and evaluators read from it.
 
 == Compliance Certifications
 

--- a/docs/src/modules/concepts/pages/governance-and-the-runtime.adoc
+++ b/docs/src/modules/concepts/pages/governance-and-the-runtime.adoc
@@ -33,15 +33,15 @@ Akka's governance is not a separate product or integration. It is a property of 
 * **Runtime policy enforcement** — Guardrails, classifiers, evaluators, LLMs-as-a-judge, and sanitizers are fully embedded within the runtime. Bad requests get stopped before they consume tokens, not after.
 * **Self-explanation** — Every decision can be traced and explained, satisfying regulatory requirements for transparency.
 * **Self-containment** — Failures are contained at the point of origin. A misbehaving agent cannot cascade into other parts of your system.
-* **Interaction logging** — Every interaction is recorded immutably by the runtime that executed it, in the interaction ledger.
+* **Interaction logging** — Every interaction is recorded immutably by the runtime that executed it, in the ledger.
 * **Causal analysis** — Trace the chain of decisions that led to any outcome.
 
 These capabilities play distinct roles, and they compose:
 
 * **Guardrails** *enforce* — they run at a call boundary and can stop an interaction. See xref:sdk:agents/guardrails.adoc[].
-* **Classifiers** *score* — they map text to a score or label, and are consulted by guardrails, evaluators, or application code rather than dispatched by the runtime. See xref:sdk:agents/classifiers.adoc[].
+* **Classifiers** *score* — they map text to a score or label, consulted by guardrails, evaluators, or application code. See xref:sdk:agents/classifiers.adoc[].
 * **Evaluators** *assess* — the runtime triggers them per interaction to record a verdict, out of band. See xref:sdk:evaluators.adoc[].
-* **The interaction ledger** *audits* — it records every interaction immutably, and evaluators read from it. See xref:sdk:evaluators.adoc#_the_ledger_client[The ledger client].
+* **The ledger** *audits* — it records every interaction immutably, and evaluators read from it. See xref:sdk:evaluators.adoc#_the_ledger_client[The ledger client].
 
 == Compliance Certifications
 
@@ -56,7 +56,7 @@ Akka holds more than 19 compliance certifications including:
 
 * xref:sdk:agents/guardrails.adoc[Guardrails] — Configure runtime policy enforcement
 * xref:sdk:agents/classifiers.adoc[Classifiers] — Score or label text for guardrails, evaluators, and application code
-* xref:sdk:evaluators.adoc[Evaluators] — Assess agent interactions per interaction, and read the interaction ledger
+* xref:sdk:evaluators.adoc[Evaluators] — Assess agent interactions per interaction, and read the ledger
 * xref:sdk:sanitization.adoc[Data sanitization] — PII scrubbing implementation
 * xref:sdk:access-control.adoc[Access Control] — Service-level and component-level access control lists
 

--- a/docs/src/modules/reference/pages/glossary.adoc
+++ b/docs/src/modules/reference/pages/glossary.adoc
@@ -17,7 +17,7 @@ include::ROOT:partial$include.adoc[]
 
 [[CICD]]CI/CD:: You can deploy <<service>>s using a Continuous Integration/Continuous Delivery service. See xref:operations:integrating-cicd/index.adoc[] for instructions.
 
-[[classifier]]Classifier:: A named, config-bound unit that maps input text to a score and/or label, with optional confidence and attributes. Unlike a <<guardrails,guardrail>>, a classifier is never dispatched by the runtime; it is invoked inline by name through a `ClassifierClient` — from a guardrail, an <<evaluator>>, application code, or another classifier composing an ensemble. See xref:sdk:agents/classifiers.adoc[].
+[[classifier]]Classifier:: A named, config-bound unit that maps input text to a score and/or label, with optional confidence and attributes. It is invoked by name through a `ClassifierClient` — from a guardrail, an <<evaluator>>, or application code — and can compose other classifiers into an ensemble. See xref:sdk:agents/classifiers.adoc[].
 
 [[command]]Command:: A command comes from a _sender_, and a reply may be sent to the sender. A command expresses the intention to alter the state or retrieve information based on the state of an <<entity>> or <<workflow>>. A command is materialized by a message received by a component implementation. Commands are not persisted and might fail.
 
@@ -45,7 +45,7 @@ A _command handler_ is the code that handles a command. It may validate the comm
 
 [[eu_ai_act]]EU AI Act:: The European Union's regulation on artificial intelligence, requiring transparency, explainability, and human oversight for AI systems. Akka supports EU AI Act compliance through runtime-embedded governance, audit trails, and policy enforcement via <<guardrails>>.
 
-[[evaluator]]Evaluator:: A stateless <<component>> that assesses <<agent>> interactions. Bound to one or more agents in configuration, the runtime triggers it for each interaction of a bound agent, out of band, and records its verdict (pass/fail, with optional score, label, and attributes). An evaluator reads the interaction it assesses from the <<interaction_ledger>> and may delegate the verdict to an <<llm>>-as-judge agent. See xref:sdk:evaluators.adoc[].
+[[evaluator]]Evaluator:: A <<component>> that assesses <<agent>> interactions. Bound to one or more agents in configuration, the runtime triggers it for each interaction of a bound agent, out of band, and records its verdict (pass/fail, with optional score, label, and attributes). An evaluator reads the interaction it assesses from the <<ledger>> and may delegate the verdict to an <<llm>>-as-judge agent. See xref:sdk:evaluators.adoc[].
 
 [[event]]Event:: An _event_  indicates that a change has occurred to an entity and persists the current state. Events are stored in a _journal_, and are read and replayed each time the entity is reloaded by the Akka runtime state management system. An event emitted by one component or service might be interpreted as a command by another.
 
@@ -58,11 +58,11 @@ An _event handler_ is the only piece of code that is allowed to _update_ the sta
 
 [[id]]ID:: An id used to identify instances of a <<stateful_component>>s.
 
-[[interaction_ledger]]Interaction ledger:: The immutable log of recorded <<agent>> interactions — the model calls, tool calls, token usage, and outcomes of every interaction — kept by the runtime for console visibility, troubleshooting, and auditing. An <<evaluator>> reads from it through an injected `LedgerClient`. See xref:sdk:evaluators.adoc#_the_ledger_client[The ledger client].
-
 [[journal]]Journal:: Persistent storage for <<event>>s from <<event_sourced_entity>>s. Some documentation uses the terms _Event Log_ or _Event Store_ instead of journal. Akka handles event storage for you, relieving you of connecting to, configuring, or managing the journal.
 
 [[key_value_entity]]Key Value Entity:: A Key Value Entity stores state in an update-in-place model, similar to a Key-Value store that supports CRUD (Create, Read, Update, Delete) operations. In Domain Driven Design (DDD) terms, a Value Entity is an "Entity." In contrast with "Value Objects," you reference Entities by an identifier and the value associated with that identifier can change (be updated) over time. These are discussed in more detail in xref:concepts:state-model.adoc#_the_key_value_state_model[Key Value state model].
+
+[[ledger]]Ledger:: The immutable log of recorded <<agent>> interactions — the model calls, tool calls, token usage, and outcomes of every interaction — kept by the runtime for console visibility, troubleshooting, and auditing. An <<evaluator>> reads from it through an injected `LedgerClient`. See xref:sdk:evaluators.adoc#_the_ledger_client[The ledger client].
 
 [[llm]]LLM (Large Language Model):: AI models trained on large datasets that generate text, code, and structured output. Akka <<agent>>s use LLMs as their reasoning engine, with Akka providing the runtime infrastructure for durability, state management, and tool integration.
 

--- a/docs/src/modules/reference/pages/glossary.adoc
+++ b/docs/src/modules/reference/pages/glossary.adoc
@@ -17,7 +17,7 @@ include::ROOT:partial$include.adoc[]
 
 [[CICD]]CI/CD:: You can deploy <<service>>s using a Continuous Integration/Continuous Delivery service. See xref:operations:integrating-cicd/index.adoc[] for instructions.
 
-[[classifier]]Classifier:: A named, config-bound unit that maps input text to a score and/or label, with optional confidence and attributes. It is invoked by name through a `ClassifierClient` — from a guardrail, an <<evaluator>>, or application code — and can compose other classifiers into an ensemble. See xref:sdk:agents/classifiers.adoc[].
+[[classifier]]Classifier:: A named, config-bound unit that maps input text to a score or label, with optional confidence and attributes. It is invoked by name through a `ClassifierClient` — from a guardrail, an <<evaluator>>, or application code — and can compose other classifiers into an ensemble. See xref:sdk:agents/classifiers.adoc[].
 
 [[command]]Command:: A command comes from a _sender_, and a reply may be sent to the sender. A command expresses the intention to alter the state or retrieve information based on the state of an <<entity>> or <<workflow>>. A command is materialized by a message received by a component implementation. Commands are not persisted and might fail.
 

--- a/docs/src/modules/reference/pages/glossary.adoc
+++ b/docs/src/modules/reference/pages/glossary.adoc
@@ -17,6 +17,8 @@ include::ROOT:partial$include.adoc[]
 
 [[CICD]]CI/CD:: You can deploy <<service>>s using a Continuous Integration/Continuous Delivery service. See xref:operations:integrating-cicd/index.adoc[] for instructions.
 
+[[classifier]]Classifier:: A named, config-bound unit that maps input text to a score and/or label, with optional confidence and attributes. Unlike a <<guardrails,guardrail>>, a classifier is never dispatched by the runtime; it is invoked inline by name through a `ClassifierClient` — from a guardrail, an <<evaluator>>, application code, or another classifier composing an ensemble. See xref:sdk:agents/classifiers.adoc[].
+
 [[command]]Command:: A command comes from a _sender_, and a reply may be sent to the sender. A command expresses the intention to alter the state or retrieve information based on the state of an <<entity>> or <<workflow>>. A command is materialized by a message received by a component implementation. Commands are not persisted and might fail.
 
 [[command_handler]]Command handler::
@@ -43,6 +45,8 @@ A _command handler_ is the code that handles a command. It may validate the comm
 
 [[eu_ai_act]]EU AI Act:: The European Union's regulation on artificial intelligence, requiring transparency, explainability, and human oversight for AI systems. Akka supports EU AI Act compliance through runtime-embedded governance, audit trails, and policy enforcement via <<guardrails>>.
 
+[[evaluator]]Evaluator:: A stateless <<component>> that assesses <<agent>> interactions. Bound to one or more agents in configuration, the runtime triggers it for each interaction of a bound agent, out of band, and records its verdict (pass/fail, with optional score, label, and attributes). An evaluator reads the interaction it assesses from the <<interaction_ledger>> and may delegate the verdict to an <<llm>>-as-judge agent. See xref:sdk:evaluators.adoc[].
+
 [[event]]Event:: An _event_  indicates that a change has occurred to an entity and persists the current state. Events are stored in a _journal_, and are read and replayed each time the entity is reloaded by the Akka runtime state management system. An event emitted by one component or service might be interpreted as a command by another.
 
 [[event_handler]]Event handler::
@@ -53,6 +57,8 @@ An _event handler_ is the only piece of code that is allowed to _update_ the sta
 [[guardrails]]Guardrails:: Runtime policy enforcement mechanisms that validate, filter, or block Agent inputs and outputs. Guardrails ensure AI Agents operate within defined safety boundaries, supporting compliance with regulations such as the EU AI Act.
 
 [[id]]ID:: An id used to identify instances of a <<stateful_component>>s.
+
+[[interaction_ledger]]Interaction ledger:: The immutable log of recorded <<agent>> interactions — the model calls, tool calls, token usage, and outcomes of every interaction — kept by the runtime for console visibility, troubleshooting, and auditing. An <<evaluator>> reads from it through an injected `LedgerClient`. See xref:sdk:evaluators.adoc#_the_ledger_client[The ledger client].
 
 [[journal]]Journal:: Persistent storage for <<event>>s from <<event_sourced_entity>>s. Some documentation uses the terms _Event Log_ or _Event Store_ instead of journal. Akka handles event storage for you, relieving you of connecting to, configuring, or managing the journal.
 
@@ -81,6 +87,8 @@ An _event handler_ is the only piece of code that is allowed to _update_ the sta
 [[sdd]]SDD (Spec-Driven Development):: Akka's primary development approach where specifications are the source of truth and code is AI-generated. SDD uses a <<constitution>> for project-wide rules and individual specs for each component, enabling repeatable, high-quality development without requiring distributed systems expertise.
 
 [[service]]Service:: A service is implemented by the Akka SDK. At runtime, Akka enriches the incoming and outgoing messages with state management capabilities, such as the ability to receive and update state. You implement the  business logic for the service, which includes stateful entities. You deploy your services and Akka adds a <<runtime>> that handles incoming communication and persistence at runtime.
+
+[[spiffe]]SPIFFE identity:: A https://spiffe.io[SPIFFE] identity is the workload identity Akka assigns each component, encoding the calling <<service>>, component type, and component id (for example `spiffe://trust/svc/checkout/workflow/order`). It enables component-level access control finer than a whole service — matched in an `@Acl` or read programmatically — and is propagated across service boundaries. The service-level part is attested by the service mesh and cannot be spoofed. See xref:sdk:access-control.adoc[].
 
 [[snapshot]]Snapshot::
 A snapshot records current state of an <<event_sourced_entity>>. Akka persists snapshots periodically as an optimization. With snapshots, when the Entity is reloaded from the journal, the entire journal doesn't need to be replayed, just the changes since the last snapshot.

--- a/docs/src/modules/reference/pages/release-notes.adoc
+++ b/docs/src/modules/reference/pages/release-notes.adoc
@@ -10,22 +10,6 @@ Current versions
 * Akka CLI {akka-cli-version}
 * A glance of all Akka libraries and their current versions is presented at https://doc.akka.io/libraries/akka-dependencies/current[Akka library versions].
 
-== July 2026
-
-[sidebar]
-****
-
-**Governance suite**
-
-The governance capabilities have been extended beyond xref:sdk:agents/guardrails.adoc[guardrails] into a set of composable constructs:
-
-- **Enhanced guardrails** — guardrails now implement `ModelGuardrail` or `ToolGuardrail` and return an `Allow` / `Deny` / `Fail` xref:sdk:agents/guardrails.adoc#_kinds_of_guardrail[decision]. `ToolGuardrail` evaluates a function-tool call, with its name and arguments, before it is dispatched. The earlier `TextGuardrail` interface is deprecated.
-- **Classifiers** — the new xref:sdk:agents/classifiers.adoc[Classifier] maps text to a score and/or label. Unlike a guardrail it is never dispatched by the runtime; it is invoked inline by name through a `ClassifierClient`, and a guardrail can consult one to reach its decision.
-- **Evaluators** — the new xref:sdk:evaluators.adoc[Evaluator] component is triggered by the runtime for each interaction of a bound agent, records a verdict, and reads the interaction under evaluation from the interaction ledger via an injected `LedgerClient`.
-- **Component-level access control** — `@Acl` matchers can now match on the caller's xref:sdk:access-control.adoc#_component_level_access_with_spiffe[SPIFFE identity] for finer granularity than a whole service, and that identity is propagated across service boundaries and can be xref:sdk:access-control.adoc#_inspecting_the_callers_identity[read programmatically] in an endpoint.
-
-****
-
 == May 2026
 
 * Akka CLI 3.0.64

--- a/docs/src/modules/reference/pages/release-notes.adoc
+++ b/docs/src/modules/reference/pages/release-notes.adoc
@@ -10,6 +10,22 @@ Current versions
 * Akka CLI {akka-cli-version}
 * A glance of all Akka libraries and their current versions is presented at https://doc.akka.io/libraries/akka-dependencies/current[Akka library versions].
 
+== July 2026
+
+[sidebar]
+****
+
+**Governance suite**
+
+The governance capabilities have been extended beyond xref:sdk:agents/guardrails.adoc[guardrails] into a set of composable constructs:
+
+- **Enhanced guardrails** — guardrails now implement `ModelGuardrail` or `ToolGuardrail` and return an `Allow` / `Deny` / `Fail` xref:sdk:agents/guardrails.adoc#_kinds_of_guardrail[decision]. `ToolGuardrail` evaluates a function-tool call, with its name and arguments, before it is dispatched. The earlier `TextGuardrail` interface is deprecated.
+- **Classifiers** — the new xref:sdk:agents/classifiers.adoc[Classifier] maps text to a score and/or label. Unlike a guardrail it is never dispatched by the runtime; it is invoked inline by name through a `ClassifierClient`, and a guardrail can consult one to reach its decision.
+- **Evaluators** — the new xref:sdk:evaluators.adoc[Evaluator] component is triggered by the runtime for each interaction of a bound agent, records a verdict, and reads the interaction under evaluation from the interaction ledger via an injected `LedgerClient`.
+- **Component-level access control** — `@Acl` matchers can now match on the caller's xref:sdk:access-control.adoc#_component_level_access_with_spiffe[SPIFFE identity] for finer granularity than a whole service, and that identity is propagated across service boundaries and can be xref:sdk:access-control.adoc#_inspecting_the_callers_identity[read programmatically] in an endpoint.
+
+****
+
 == May 2026
 
 * Akka CLI 3.0.64

--- a/docs/src/modules/sdk/nav.adoc
+++ b/docs/src/modules/sdk/nav.adoc
@@ -11,6 +11,7 @@
 **** xref:sdk:agents/streaming.adoc[Streaming responses]
 **** xref:sdk:agents/orchestrating.adoc[Orchestrating multiple agents]
 **** xref:sdk:agents/guardrails.adoc[Guardrails]
+**** xref:sdk:agents/classifiers.adoc[Classifiers]
 **** xref:sdk:agents/llm_eval.adoc[LLM evaluation]
 **** xref:sdk:agents/testing.adoc[Testing]
 
@@ -32,6 +33,7 @@
 *** xref:sdk:workflows.adoc[Workflows]
 *** xref:sdk:timed-actions.adoc[Timers]
 *** xref:sdk:consuming-producing.adoc[Consumers]
+*** xref:sdk:evaluators.adoc[Evaluators]
 ** xref:sdk:use-cases/index.adoc[Use cases]
 *** xref:sdk:use-cases/conversational-ai.adoc[]
 *** xref:sdk:use-cases/autonomous-agents.adoc[]

--- a/docs/src/modules/sdk/pages/access-control.adoc
+++ b/docs/src/modules/sdk/pages/access-control.adoc
@@ -129,6 +129,29 @@ authenticated; matching a specific component additionally trusts the calling ser
 honestly.
 ====
 
+=== Inspecting the caller's identity
+
+Beyond matching in an `@Acl`, an HTTP, gRPC, or MCP endpoint can read the SPIFFE identity of its caller
+programmatically. The request context — `akka.javasdk.http.RequestContext`, `akka.javasdk.grpc.GrpcRequestContext`,
+or `akka.javasdk.mcp.McpRequestContext` — exposes `getSpiffeContext()`, which returns an
+`akka.javasdk.SpiffeContext` when SPIFFE is enabled:
+
+[source,java,indent=0]
+----
+requestContext.getSpiffeContext().ifPresent(spiffe -> {
+  String ownId = spiffe.getSpiffeId();                          // this endpoint's own SPIFFE id
+  spiffe.getCallerContext().ifPresent(caller -> {
+    String callerId = caller.getSpiffeId();                     // the calling component's SPIFFE id
+    // ... apply custom logic based on who is calling
+  });
+});
+----
+
+`getSpiffeContext()` is empty when SPIFFE is disabled. The caller context (`akka.javasdk.CallerSpiffeContext`) is
+present only when the request came from another Akka service in the same project — it is empty for external and
+internet callers. The service-level part of the caller's identity is attested by the service mesh; use this to make
+authorization or routing decisions that go beyond what a static `@Acl` matcher can express.
+
 == Default ACL
 
 If no ACLs are defined at all, Akka will deny requests from both other services and the internet to all components of

--- a/docs/src/modules/sdk/pages/agents.adoc
+++ b/docs/src/modules/sdk/pages/agents.adoc
@@ -5,7 +5,7 @@ include::ROOT:partial$include.adoc[]
 :page-component-type: agent
 :page-summary: Build AI agents that interact with large language models, maintain session memory, and invoke tools to perform tasks.
 :page-when-to-use: Use when you need LLM-backed autonomous or semi-autonomous behavior with tool calling, session context, and multi-agent collaboration.
-:page-related: xref:concepts:ai-agents.adoc[], xref:sdk:autonomous-agents.adoc[], xref:sdk:agents/guardrails.adoc[], xref:sdk:agents/memory.adoc[], xref:sdk:workflows.adoc[], xref:sdk:key-value-entities.adoc[]
+:page-related: xref:concepts:ai-agents.adoc[], xref:sdk:autonomous-agents.adoc[], xref:sdk:agents/guardrails.adoc[], xref:sdk:agents/classifiers.adoc[], xref:sdk:evaluators.adoc[], xref:sdk:agents/memory.adoc[], xref:sdk:workflows.adoc[], xref:sdk:key-value-entities.adoc[]
 :page-prerequisites: Familiarity with Akka components, a configured model provider (OpenAI, Anthropic, etc.)
 :page-persona: developer
 

--- a/docs/src/modules/sdk/pages/agents/classifiers.adoc
+++ b/docs/src/modules/sdk/pages/agents/classifiers.adoc
@@ -1,0 +1,123 @@
+= Classifiers
+:page-summary: Named, config-bound classifiers that map text to a score and/or label, invoked inline by a client rather than dispatched by the runtime.
+:page-when-to-use: When you need to score or categorize text — for toxicity, sentiment, topic, PII likelihood, or any custom signal — and consume that result from a guardrail, an evaluator, or application code.
+:page-related: xref:sdk:agents/guardrails.adoc[], xref:sdk:agents/llm_eval.adoc[], xref:concepts:governance-and-the-runtime.adoc[]
+:page-prerequisites: An Akka project with at least one agent defined.
+:page-persona: governance-compliance, governance-infosec, developer
+
+include::ROOT:partial$include.adoc[]
+
+== Overview
+
+A classifier maps an input string to a link:{attachmentsdir}/api/akka/javasdk/agent/Classification.html[`Classification`] — a numeric score and/or a categorical label, with optional confidence and attributes.
+How the mapping is computed is entirely up to the implementation: rules or a regex, embeddings, a traditional ML model, a small specialized model, a prompted or fine-tuned LLM, or an external classification API.
+
+Unlike a xref:sdk:agents/guardrails.adoc[guardrail], a classifier is **not bound to a call boundary and is never dispatched by the runtime**.
+It is enabled in configuration, given a name, and invoked inline — wherever a guardrail, an evaluator, or application code needs it — through an injected link:{attachmentsdir}/api/akka/javasdk/agent/ClassifierClient.html[`ClassifierClient`], by name.
+This separation is deliberate: a guardrail *decides* whether a call may proceed, while a classifier only *produces a signal*.
+The same classifier can inform a guardrail's decision on one path, feed an evaluator on another, and be called directly from a workflow on a third.
+
+== Implementing a classifier
+
+A classifier implements the link:{attachmentsdir}/api/akka/javasdk/agent/Classifier.html[`Classifier`] interface, whose single method returns a `CompletionStage<Classification>`:
+
+[source,java,indent=0]
+.{sample-base-url}/doc-snippets/src/main/java/com/example/classifier/ToxicityClassifier.java[ToxicityClassifier.java]
+----
+include::example$doc-snippets/src/main/java/com/example/classifier/ToxicityClassifier.java[tag=all]
+----
+<1> Implement the `Classifier` interface.
+<2> An optional link:{attachmentsdir}/api/akka/javasdk/agent/ClassifierContext.html[`ClassifierContext`] constructor parameter gives access to the classifier's configured name and its config section.
+<3> `classify` returns a `CompletionStage`, so the work can run off the calling thread.
+<4> A `Classification` carries a score and/or a label. Use the `score`, `label`, and `of` factory methods, or the full constructor to add confidence and attributes.
+
+The `Classification` record has four components — `score`, `label`, `confidence` (all `Optional`), and an `attributes` map — so a classifier can return only what it computes.
+A regex rule might return only a label; a scoring model might return only a score; an ensemble might return a score plus per-member detail in the attributes.
+
+== Configuring classifiers
+
+Classifiers are enabled under `akka.javasdk.agent.classifiers`.
+Each entry is a named section whose only required property is the implementation `class`; any further properties are read by the classifier from its `ClassifierContext`.
+
+[source,conf,indent=0]
+.src/main/resources/application.conf
+----
+akka.javasdk.agent.classifiers {
+  "toxicity" {                                          // <1>
+    class = "com.example.classifier.ToxicityClassifier" // <2>
+    threshold = 0.5                                     // <3>
+  }
+}
+----
+<1> The name the classifier is looked up by. This is the string passed to `ClassifierClient.classify`.
+<2> Implementation class. It must be public and have a public constructor.
+<3> An application-specific property, read by the classifier from `ClassifierContext.config()`.
+
+Unlike a guardrail, a classifier configuration has no `agents`, `agent-roles`, `use-for`, or `category` — a classifier is not scoped to a boundary or a set of agents.
+It exists as a named capability, and the caller decides where and when to use it.
+
+== Invoking a classifier
+
+A `ClassifierClient` can be injected into agents, guardrails, evaluators, and application code.
+It resolves a configured classifier by name and invokes it:
+
+[source,java,indent=0]
+----
+Classification result = classifierClient.classify("toxicity", text); // <1>
+result.label().ifPresent(label -> { /* ... */ });
+result.score().ifPresent(score -> { /* ... */ });
+----
+<1> `classify` blocks for the result and is safe to call on a Loom virtual thread. Use `classifyAsync` for the non-blocking variant. Both throw `IllegalArgumentException` if no classifier is configured with that name.
+
+For the guardrail case — where a guardrail consults a classifier to inform its decision — see xref:sdk:agents/guardrails.adoc#_classifier_backed_guardrails[Classifier-backed guardrails].
+
+== Composing classifiers
+
+Because a `ClassifierClient` can also be injected into a classifier's own constructor, one classifier can resolve and combine others by name — an ensemble built from configured members, without any of them knowing about the others:
+
+[source,java,indent=0]
+.{sample-base-url}/doc-snippets/src/main/java/com/example/classifier/EnsembleClassifier.java[EnsembleClassifier.java]
+----
+include::example$doc-snippets/src/main/java/com/example/classifier/EnsembleClassifier.java[tag=all]
+----
+<1> Inject a `ClassifierClient` to call other configured classifiers.
+<2> The `ClassifierContext` supplies the ensemble's own config; here the names of its members.
+<3> Resolve and invoke each member by name.
+<4> Combine the members' results into a single `Classification`.
+
+The corresponding configuration wires the members by name:
+
+[source,conf,indent=0]
+.src/main/resources/application.conf
+----
+akka.javasdk.agent.classifiers {
+  "toxicity" {
+    class = "com.example.classifier.ToxicityClassifier"
+    threshold = 0.5
+  }
+  "profanity" {
+    class = "com.example.classifier.ProfanityClassifier"
+  }
+  "safety-ensemble" {
+    class = "com.example.classifier.EnsembleClassifier"
+    members = ["toxicity", "profanity"] // <1>
+  }
+}
+----
+<1> The ensemble reads its member names from config, so the composition can be changed at deployment time without rebuilding.
+
+== Dependency injection
+
+Besides `ClassifierContext` and `ClassifierClient`, a classifier constructor can accept any type provided by a service's `DependencyProvider`, so a classifier can be given an HTTP client, a model client, or other collaborators it needs to compute a classification.
+See xref:sdk:setup-and-dependency-injection.adoc[].
+
+== Testing
+
+In a test, obtain a `ClassifierClient` from the testkit with `getClassifierClient()` and invoke your configured classifiers directly.
+See xref:sdk:agents/testing.adoc#_classifiers[Testing classifiers].
+
+== See also
+
+* xref:sdk:agents/guardrails.adoc[] — Runtime-dispatched checks that can consult a classifier to reach a decision.
+* xref:sdk:agents/llm_eval.adoc[] — Evaluators can call classifiers as part of assessing an interaction.
+* xref:concepts:governance-and-the-runtime.adoc[] — Where classifiers fit in Akka's governance model.

--- a/docs/src/modules/sdk/pages/agents/classifiers.adoc
+++ b/docs/src/modules/sdk/pages/agents/classifiers.adoc
@@ -26,7 +26,7 @@ include::example$doc-snippets/src/main/java/com/example/classifier/ToxicityClass
 ----
 <1> Implement the `Classifier` interface.
 <2> An optional link:{attachmentsdir}/api/akka/javasdk/agent/ClassifierContext.html[`ClassifierContext`] constructor parameter gives access to the classifier's configured name and its config section.
-<3> `classify` returns a `CompletionStage`, so the work can run off the calling thread.
+<3> `classify` returns a `CompletionStage`, so the work can run on a separate thread.
 <4> A `Classification` carries a score, a label, or both. Use the `score`, `label`, and `of` factory methods, or the full constructor to add confidence and attributes.
 
 The `Classification` record has four components — `score`, `label`, `confidence` (all `Optional`), and an `attributes` map — so a classifier can return only what it computes.
@@ -52,7 +52,7 @@ akka.javasdk.agent.classifiers {
 <3> An application-specific property, read by the classifier from `ClassifierContext.config()`.
 
 A classifier configuration has no `agents`, `agent-roles`, `use-for`, or `category`: a classifier is not scoped to a boundary or a set of agents.
-Callers just invoke it by name where they need it.
+Callers invoke it by name where they need it.
 
 == Invoking a classifier
 
@@ -83,7 +83,7 @@ include::example$doc-snippets/src/main/java/com/example/classifier/EnsembleClass
 <3> Resolve and invoke each member by name.
 <4> Combine the members' results into a single `Classification`.
 
-The corresponding configuration wires the members by name:
+The corresponding configuration lists the members by name:
 
 [source,conf,indent=0]
 .src/main/resources/application.conf

--- a/docs/src/modules/sdk/pages/agents/classifiers.adoc
+++ b/docs/src/modules/sdk/pages/agents/classifiers.adoc
@@ -17,7 +17,7 @@ Wherever a guardrail, an evaluator, or your own code needs to score or categoriz
 
 == Implementing a classifier
 
-A classifier implements the link:{attachmentsdir}/api/akka/javasdk/agent/Classifier.html[`Classifier`] interface, whose single method returns a `CompletionStage<Classification>`:
+A classifier implements the link:{attachmentsdir}/api/akka/javasdk/agent/Classifier.html[`Classifier`] interface: `classify` maps the input string to a `Classification`:
 
 [source,java,indent=0]
 .{sample-base-url}/doc-snippets/src/main/java/com/example/classifier/ToxicityClassifier.java[ToxicityClassifier.java]
@@ -26,7 +26,7 @@ include::example$doc-snippets/src/main/java/com/example/classifier/ToxicityClass
 ----
 <1> Implement the `Classifier` interface.
 <2> An optional link:{attachmentsdir}/api/akka/javasdk/agent/ClassifierContext.html[`ClassifierContext`] constructor parameter gives access to the classifier's configured name and its config section.
-<3> `classify` returns a `CompletionStage`, so the work can run on a separate thread.
+<3> `classify` may block, for example on a model or external API call: classifiers are always invoked on virtual threads. Implementations that prefer composing futures can override `classifyAsync` instead.
 <4> A `Classification` carries a score, a label, or both. Use the `score`, `label`, and `of` factory methods, or the full constructor to add confidence and attributes.
 
 The `Classification` record has four components — `score`, `label`, `confidence` (all `Optional`), and an `attributes` map — so a classifier can return only what it computes.

--- a/docs/src/modules/sdk/pages/agents/classifiers.adoc
+++ b/docs/src/modules/sdk/pages/agents/classifiers.adoc
@@ -60,10 +60,9 @@ A `ClassifierClient` can be injected into your components — such as a workflow
 It resolves a configured classifier by name and invokes it:
 
 [source,java,indent=0]
+.{sample-base-url}/doc-snippets/src/main/java/com/example/classifier/ClassifierUsage.java[ClassifierUsage.java]
 ----
-Classification result = classifierClient.classify("toxicity", text); // <1>
-result.label().ifPresent(label -> { /* ... */ });
-result.score().ifPresent(score -> { /* ... */ });
+include::example$doc-snippets/src/main/java/com/example/classifier/ClassifierUsage.java[tag=invoke]
 ----
 <1> `classify` blocks for the result and is safe to call on a Loom virtual thread. Use `classifyAsync` for the non-blocking variant. Both throw `IllegalArgumentException` if no classifier is configured with that name.
 

--- a/docs/src/modules/sdk/pages/agents/classifiers.adoc
+++ b/docs/src/modules/sdk/pages/agents/classifiers.adoc
@@ -1,5 +1,5 @@
 = Classifiers
-:page-summary: Named, config-bound classifiers that map text to a score and/or label, invoked inline by a client rather than dispatched by the runtime.
+:page-summary: Named, config-bound classifiers that map text to a score and/or label, for use by guardrails, evaluators, or application code.
 :page-when-to-use: When you need to score or categorize text — for toxicity, sentiment, topic, PII likelihood, or any custom signal — and consume that result from a guardrail, an evaluator, or application code.
 :page-related: xref:sdk:agents/guardrails.adoc[], xref:sdk:agents/llm_eval.adoc[], xref:concepts:governance-and-the-runtime.adoc[]
 :page-prerequisites: An Akka project with at least one agent defined.
@@ -12,10 +12,8 @@ include::ROOT:partial$include.adoc[]
 A classifier maps an input string to a link:{attachmentsdir}/api/akka/javasdk/agent/Classification.html[`Classification`] — a numeric score and/or a categorical label, with optional confidence and attributes.
 How the mapping is computed is entirely up to the implementation: rules or a regex, embeddings, a traditional ML model, a small specialized model, a prompted or fine-tuned LLM, or an external classification API.
 
-Unlike a xref:sdk:agents/guardrails.adoc[guardrail], a classifier is **not bound to a call boundary and is never dispatched by the runtime**.
-It is enabled in configuration, given a name, and invoked inline — wherever a guardrail, an evaluator, or application code needs it — through an injected link:{attachmentsdir}/api/akka/javasdk/agent/ClassifierClient.html[`ClassifierClient`], by name.
-This separation is deliberate: a guardrail *decides* whether a call may proceed, while a classifier only *produces a signal*.
-The same classifier can inform a guardrail's decision on one path, feed an evaluator on another, and be called directly from a workflow on a third.
+A classifier is enabled in configuration and given a name.
+It is invoked by name through a link:{attachmentsdir}/api/akka/javasdk/agent/ClassifierClient.html[`ClassifierClient`], wherever a guardrail, an evaluator, or application code needs to score or categorize some text.
 
 == Implementing a classifier
 
@@ -53,12 +51,12 @@ akka.javasdk.agent.classifiers {
 <2> Implementation class. It must be public and have a public constructor.
 <3> An application-specific property, read by the classifier from `ClassifierContext.config()`.
 
-Unlike a guardrail, a classifier configuration has no `agents`, `agent-roles`, `use-for`, or `category` — a classifier is not scoped to a boundary or a set of agents.
+A classifier configuration has no `agents`, `agent-roles`, `use-for`, or `category`: a classifier is not scoped to a boundary or a set of agents.
 It exists as a named capability, and the caller decides where and when to use it.
 
 == Invoking a classifier
 
-A `ClassifierClient` can be injected into agents, guardrails, evaluators, and application code.
+A `ClassifierClient` can be injected into your components — such as a workflow or an endpoint — and into guardrails and evaluators.
 It resolves a configured classifier by name and invokes it:
 
 [source,java,indent=0]
@@ -118,6 +116,6 @@ See xref:sdk:agents/testing.adoc#_classifiers[Testing classifiers].
 
 == See also
 
-* xref:sdk:agents/guardrails.adoc[] — Runtime-dispatched checks that can consult a classifier to reach a decision.
+* xref:sdk:agents/guardrails.adoc[] — Checks that can consult a classifier to reach a decision.
 * xref:sdk:agents/llm_eval.adoc[] — Evaluators can call classifiers as part of assessing an interaction.
 * xref:concepts:governance-and-the-runtime.adoc[] — Where classifiers fit in Akka's governance model.

--- a/docs/src/modules/sdk/pages/agents/classifiers.adoc
+++ b/docs/src/modules/sdk/pages/agents/classifiers.adoc
@@ -10,7 +10,7 @@ include::ROOT:partial$include.adoc[]
 == Overview
 
 A classifier maps an input string to a link:{attachmentsdir}/api/akka/javasdk/agent/Classification.html[`Classification`]: a numeric score, a categorical label, or both, with optional confidence and attributes.
-You decide how it gets there — a regex, an embedding model, or a call out to an external classifier are all fair game.
+You decide how it does that, for example with a regex, an embedding model, or a call to an external classification service.
 
 A classifier is enabled in configuration and given a name.
 Wherever a guardrail, an evaluator, or your own code needs to score or categorize some text, it calls the classifier by that name through a link:{attachmentsdir}/api/akka/javasdk/agent/ClassifierClient.html[`ClassifierClient`].

--- a/docs/src/modules/sdk/pages/agents/classifiers.adoc
+++ b/docs/src/modules/sdk/pages/agents/classifiers.adoc
@@ -1,5 +1,5 @@
 = Classifiers
-:page-summary: Named, config-bound classifiers that map text to a score and/or label, for use by guardrails, evaluators, or application code.
+:page-summary: Named, config-bound classifiers that map text to a score or label, for use by guardrails, evaluators, or application code.
 :page-when-to-use: When you need to score or categorize text — for toxicity, sentiment, topic, PII likelihood, or any custom signal — and consume that result from a guardrail, an evaluator, or application code.
 :page-related: xref:sdk:agents/guardrails.adoc[], xref:sdk:agents/llm_eval.adoc[], xref:concepts:governance-and-the-runtime.adoc[]
 :page-prerequisites: An Akka project with at least one agent defined.
@@ -9,11 +9,11 @@ include::ROOT:partial$include.adoc[]
 
 == Overview
 
-A classifier maps an input string to a link:{attachmentsdir}/api/akka/javasdk/agent/Classification.html[`Classification`] — a numeric score and/or a categorical label, with optional confidence and attributes.
-How the mapping is computed is entirely up to the implementation: rules or a regex, embeddings, a traditional ML model, a small specialized model, a prompted or fine-tuned LLM, or an external classification API.
+A classifier maps an input string to a link:{attachmentsdir}/api/akka/javasdk/agent/Classification.html[`Classification`]: a numeric score, a categorical label, or both, with optional confidence and attributes.
+You decide how it gets there — a regex, an embedding model, or a call out to an external classifier are all fair game.
 
 A classifier is enabled in configuration and given a name.
-It is invoked by name through a link:{attachmentsdir}/api/akka/javasdk/agent/ClassifierClient.html[`ClassifierClient`], wherever a guardrail, an evaluator, or application code needs to score or categorize some text.
+Wherever a guardrail, an evaluator, or your own code needs to score or categorize some text, it calls the classifier by that name through a link:{attachmentsdir}/api/akka/javasdk/agent/ClassifierClient.html[`ClassifierClient`].
 
 == Implementing a classifier
 
@@ -27,7 +27,7 @@ include::example$doc-snippets/src/main/java/com/example/classifier/ToxicityClass
 <1> Implement the `Classifier` interface.
 <2> An optional link:{attachmentsdir}/api/akka/javasdk/agent/ClassifierContext.html[`ClassifierContext`] constructor parameter gives access to the classifier's configured name and its config section.
 <3> `classify` returns a `CompletionStage`, so the work can run off the calling thread.
-<4> A `Classification` carries a score and/or a label. Use the `score`, `label`, and `of` factory methods, or the full constructor to add confidence and attributes.
+<4> A `Classification` carries a score, a label, or both. Use the `score`, `label`, and `of` factory methods, or the full constructor to add confidence and attributes.
 
 The `Classification` record has four components — `score`, `label`, `confidence` (all `Optional`), and an `attributes` map — so a classifier can return only what it computes.
 A regex rule might return only a label; a scoring model might return only a score; an ensemble might return a score plus per-member detail in the attributes.
@@ -52,7 +52,7 @@ akka.javasdk.agent.classifiers {
 <3> An application-specific property, read by the classifier from `ClassifierContext.config()`.
 
 A classifier configuration has no `agents`, `agent-roles`, `use-for`, or `category`: a classifier is not scoped to a boundary or a set of agents.
-It exists as a named capability, and the caller decides where and when to use it.
+Callers just invoke it by name where they need it.
 
 == Invoking a classifier
 

--- a/docs/src/modules/sdk/pages/agents/classifiers.adoc
+++ b/docs/src/modules/sdk/pages/agents/classifiers.adoc
@@ -105,7 +105,8 @@ akka.javasdk.agent.classifiers {
 
 == Dependency injection
 
-Besides `ClassifierContext` and `ClassifierClient`, a classifier constructor can accept any type provided by a service's `DependencyProvider`, so a classifier can be given an HTTP client, a model client, or other collaborators it needs to compute a classification.
+Besides `ClassifierContext` and `ClassifierClient`, a classifier constructor can accept the platform's managed dependencies — for example `ComponentClient` or `HttpClientProvider` — and any custom type provided by the service's `DependencyProvider`.
+That lets a classifier use whatever it needs to compute a classification, such as a model client or an external HTTP service.
 See xref:sdk:setup-and-dependency-injection.adoc[].
 
 == Testing

--- a/docs/src/modules/sdk/pages/agents/guardrails.adoc
+++ b/docs/src/modules/sdk/pages/agents/guardrails.adoc
@@ -27,14 +27,14 @@ NOTE: For protecting sensitive information like PII, see xref:sdk:sanitization.a
 
 A guardrail implements one of two interfaces, according to the boundary it protects:
 
-* link:{attachmentsdir}/api/akka/javasdk/agent/ModelGuardrail.html[`ModelGuardrail`] — evaluates model-side calls: the text of a model request or of a model response.
+* link:{attachmentsdir}/api/akka/javasdk/agent/ModelGuardrail.html[`ModelGuardrail`] — evaluates the agent's final reply, once per interaction (the before-agent-response boundary).
 * link:{attachmentsdir}/api/akka/javasdk/agent/ToolGuardrail.html[`ToolGuardrail`] — evaluates a function-tool call before it is dispatched (the before-tool-call boundary), with access to the tool name and its raw JSON arguments.
 
 Both return a link:{attachmentsdir}/api/akka/javasdk/agent/Decision.html[`Decision`]:
 
 * `Decision.Allow` — the guardrail saw nothing wrong; the call proceeds.
 * `Decision.Deny` — the call must not proceed. The `reason` is surfaced to the user as the failure message. Whether the interaction is aborted or merely recorded is governed by `report-only` (see <<_configuring_guardrails>>).
-* `Decision.Fail` — evaluation itself failed and reached no verdict. The `reason` and optional `cause` are propagated to the interaction's failure handling.
+* `Decision.Fail` — evaluation itself failed and reached no verdict. The `reason` and optional `cause` are propagated to the interaction's failure handling. Throwing from `decide` is equivalent to returning `Decision.Fail`.
 
 [NOTE]
 ====
@@ -45,7 +45,7 @@ New guardrails should implement `ModelGuardrail` or `ToolGuardrail`.
 
 == Implementing a model guardrail
 
-A `ModelGuardrail` receives a `CallContext` carrying the `text()` being evaluated — the user input when evaluating a model request, the model output when evaluating a model response — and returns a `Decision`:
+A `ModelGuardrail` receives a `CallContext` carrying the content being evaluated — the agent's final reply — along with the `agentId()`, `sessionId()`, and `modelName()` of the interaction, and returns a `Decision`:
 
 [source,java,indent=0]
 .{sample-base-url}/doc-snippets/src/main/java/com/example/guardrail/ProfanityModelGuard.java[ProfanityModelGuard.java]
@@ -58,7 +58,9 @@ include::example$doc-snippets/src/main/java/com/example/guardrail/ProfanityModel
 <4> Return `Decision.Deny` to reject the call, with a reason surfaced to the user.
 <5> Return `Decision.Allow` to let the call proceed.
 
-The same interface protects both the request and the response boundary; the `use-for` configuration decides which (see <<_configuring_guardrails>>).
+`decide` may block: guardrails are evaluated on virtual threads. Implementations that prefer composing futures can override `decideAsync` instead; the default `decideAsync` delegates to `decide`.
+
+When the content being checked is multimodal, `text()` is empty: check `textOnly()` and inspect the individual text, image, and PDF parts via `contents()`.
 
 == Implementing a tool guardrail
 
@@ -90,7 +92,7 @@ akka.javasdk.agent.guardrails {
     agents = ["planner-agent"]                           // <3>
     agent-roles = ["worker"]                             // <4>
     category = TOXIC                                     // <5>
-    use-for = ["model-response"]                         // <6>
+    use-for = ["before-agent-response"]                  // <6>
     report-only = false                                  // <7>
     search-for = "bad stuff"                             // <8>
   }
@@ -109,10 +111,12 @@ akka.javasdk.agent.guardrails {
 <3> Enable this guardrail for agents with these component ids.
 <4> Enable this guardrail for agents with these roles.
 <5> The type of validation, such as PII and TOXIC.
-<6> Where to use the guardrail, such as for the model request or model response.
+<6> The boundary the guardrail binds to; a `ModelGuardrail` binds to `before-agent-response`, the final agent reply.
 <7> If it didn't pass the evaluation criteria, the execution can either be aborted or continue anyway. In both cases, the result is tracked in logs, metrics and traces.
 <8> An application-specific property, read by the guardrail from its `GuardrailContext`.
 <9> A `ToolGuardrail` binds to the `before-tool-call` boundary.
+
+A before-tool-call guardrail can be restricted to specific tools with the optional `tools` property, for example `tools = ["transferFunds"]`. Without it, the guardrail sees every tool call on the selected agents.
 
 The implementation class of the guardrail is configured with the `class` property. The class must implement `ModelGuardrail` or `ToolGuardrail` (or the deprecated `TextGuardrail`), be public, and have a public constructor. The constructor may optionally take a link:{attachmentsdir}/api/akka/javasdk/agent/GuardrailContext.html[`GuardrailContext`] parameter, which includes the name and the config section for the specific guardrail. In the `ProfanityModelGuard` example above you can see how the configuration property `search-for` is read from the configuration of the `GuardrailContext` parameter.
 
@@ -131,15 +135,15 @@ This role is defined in the `@AgentRole` annotation.
 
 The name and the category are reported in logs, metrics, and traces. The `category` should classify the type of validation. It can be any value, but a few recommended categories are JAILBREAK, PROMPT_INJECTION, PII, TOXIC, HALLUCINATED, NSFW, FORMAT.
 
-The guardrail can be enabled for certain boundaries with the `use-for` property. The `use-for` property accepts the following values: `model-request`, `model-response`, `mcp-tool-request`, `mcp-tool-response`, `before-tool-call`, and `*`.
+The guardrail is bound to boundaries with the `use-for` property. Each value is tied to a guardrail interface: `before-agent-response` (fired once on the final agent reply) is for a `ModelGuardrail`, and `before-tool-call` (fired before a function-tool call) is for a `ToolGuardrail`. The values `model-request`, `model-response`, `mcp-tool-request`, and `mcp-tool-response` are deprecated and usable only by the deprecated `TextGuardrail`.
 
-NOTE: The `*` wildcard expands to the model and MCP-tool boundaries only. A `ToolGuardrail` bound to the `before-tool-call` boundary must list it explicitly; it is not included in `*`.
+NOTE: The `*` wildcard expands according to the guardrail's interface: `before-agent-response` for a `ModelGuardrail`, `before-tool-call` for a `ToolGuardrail`, and the deprecated model and MCP-tool boundaries for a `TextGuardrail`.
 
 == Classifier-backed guardrails
 
 A guardrail can delegate its decision to a xref:sdk:agents/classifiers.adoc[classifier], resolved by name through `GuardrailContext.classifierClient()`.
 The classifier does the scoring — how toxic the text is — and the guardrail turns that score into an allow or a deny.
-Because the classifier name comes from config, you can configure the guardrail to use a different classifier without rebuilding:
+Because the classifier name comes from config, you can configure the guardrail to use a different classifier without rebuilding. The blocking `classify` call is safe here, because guardrails are evaluated on virtual threads; to compose futures instead, use `classifyAsync` and override `decideAsync`:
 
 [source,java,indent=0]
 .{sample-base-url}/doc-snippets/src/main/java/com/example/guardrail/ClassifierBackedGuard.java[ClassifierBackedGuard.java]

--- a/docs/src/modules/sdk/pages/agents/guardrails.adoc
+++ b/docs/src/modules/sdk/pages/agents/guardrails.adoc
@@ -158,16 +158,9 @@ The classifier is configured separately under `akka.javasdk.agent.classifiers`; 
 When a `ModelGuardrail` returns `Decision.Deny` with `report-only = false`, the interaction is aborted and the reason is surfaced to the agent's failure handling as a `Guardrail.GuardrailException`, which you can map in `onFailure`:
 
 [source,java,indent=0]
+.{sample-base-url}/doc-snippets/src/main/java/com/example/guardrail/GuardedAgent.java[GuardedAgent.java]
 ----
-return effects()
-    .systemMessage("You are a helpful...")
-    .userMessage(question)
-    .map(SomeResponse::new)
-    .onFailure(cause -> switch (cause) {
-      case Guardrail.GuardrailException e -> new SomeResponse(e.getMessage());
-      default -> throw new RuntimeException(cause);
-    })
-    .thenReply();
+include::example$doc-snippets/src/main/java/com/example/guardrail/GuardedAgent.java[tag=on-failure]
 ----
 
 With `report-only = true`, a `Deny` is recorded in logs, metrics, and traces but the interaction continues.

--- a/docs/src/modules/sdk/pages/agents/guardrails.adoc
+++ b/docs/src/modules/sdk/pages/agents/guardrails.adoc
@@ -138,7 +138,8 @@ NOTE: The `*` wildcard expands to the model and MCP-tool boundaries only. A `Too
 == Classifier-backed guardrails
 
 A guardrail can delegate its decision to a xref:sdk:agents/classifiers.adoc[classifier], resolved by name through `GuardrailContext.classifierClient()`.
-This keeps the decision logic (deny when the classifier labels the text toxic) separate from the scoring logic (how toxicity is measured), and lets the guardrail-to-classifier binding be re-pointed at deployment time:
+The classifier does the scoring — how toxic the text is — and the guardrail turns that score into an allow or a deny.
+Because the classifier name comes from config, you can point the guardrail at a different classifier without rebuilding:
 
 [source,java,indent=0]
 .{sample-base-url}/doc-snippets/src/main/java/com/example/guardrail/ClassifierBackedGuard.java[ClassifierBackedGuard.java]
@@ -199,7 +200,7 @@ You can use this for other things than jailbreak attempt detection.
 
 == See also
 
-* xref:sdk:agents/classifiers.adoc[] — Named scoring/labeling components a guardrail can consult to reach a decision.
+* xref:sdk:agents/classifiers.adoc[] — Components that score or label text, which a guardrail can consult to reach a decision.
 * xref:concepts:governance-and-the-runtime.adoc[] — Why governance must live in the runtime, not in a sidecar.
 * xref:sdk:sanitization.adoc[] — Complementary PII protection through input and output sanitization.
 * {url-blog-trustworthy-ai}[Building Trustworthy AI^] — Background on the design principles behind Akka's risk controls.

--- a/docs/src/modules/sdk/pages/agents/guardrails.adoc
+++ b/docs/src/modules/sdk/pages/agents/guardrails.adoc
@@ -11,7 +11,7 @@ include::ROOT:partial$include.adoc[]
 
 Guardrails are runtime-enforced checks that validate what goes into and comes out of your agents.
 They protect against harmful inputs — such as jailbreak attempts and prompt injection — and damaging outputs — such as toxic language, hallucinated claims, or accidental disclosure of a competitor's product.
-A guardrail can also sit in front of a tool call and reject it before it runs.
+A guardrail can also intercept a tool call and reject it before it runs.
 
 Unlike external validation layers that sit outside your application, Akka guardrails are **part of the runtime itself**.
 You declare them in configuration, and the runtime enforces them on every interaction — whether the request targets a model, an MCP tool, or a function tool.
@@ -139,7 +139,7 @@ NOTE: The `*` wildcard expands to the model and MCP-tool boundaries only. A `Too
 
 A guardrail can delegate its decision to a xref:sdk:agents/classifiers.adoc[classifier], resolved by name through `GuardrailContext.classifierClient()`.
 The classifier does the scoring — how toxic the text is — and the guardrail turns that score into an allow or a deny.
-Because the classifier name comes from config, you can point the guardrail at a different classifier without rebuilding:
+Because the classifier name comes from config, you can configure the guardrail to use a different classifier without rebuilding:
 
 [source,java,indent=0]
 .{sample-base-url}/doc-snippets/src/main/java/com/example/guardrail/ClassifierBackedGuard.java[ClassifierBackedGuard.java]

--- a/docs/src/modules/sdk/pages/agents/guardrails.adoc
+++ b/docs/src/modules/sdk/pages/agents/guardrails.adoc
@@ -1,7 +1,7 @@
 = Guardrails
 :page-summary: Runtime-enforced guardrails that validate agent inputs and outputs, providing governance controls for toxicity, PII, jailbreak detection, and compliance without bolting on external tooling.
 :page-when-to-use: When you need to enforce content policies, prevent prompt injection, protect sensitive data, or satisfy regulatory requirements such as the EU AI Act across your agent fleet.
-:page-related: xref:concepts:governance-and-the-runtime.adoc[], xref:sdk:sanitization.adoc[], xref:sdk:agents/index.adoc[]
+:page-related: xref:concepts:governance-and-the-runtime.adoc[], xref:sdk:agents/classifiers.adoc[], xref:sdk:sanitization.adoc[], xref:sdk:agents/index.adoc[]
 :page-prerequisites: An Akka project with at least one agent defined.
 :page-persona: governance-compliance, governance-infosec, developer
 
@@ -11,9 +11,10 @@ include::ROOT:partial$include.adoc[]
 
 Guardrails are runtime-enforced checks that validate what goes into and comes out of your agents.
 They protect against harmful inputs — such as jailbreak attempts and prompt injection — and damaging outputs — such as toxic language, hallucinated claims, or accidental disclosure of a competitor's product.
+A guardrail can also sit in front of a tool call and reject it before it runs.
 
 Unlike external validation layers that sit outside your application, Akka guardrails are **part of the runtime itself**.
-You declare them in configuration, and the runtime enforces them on every interaction — whether the request targets a model, an MCP tool, or any other downstream resource.
+You declare them in configuration, and the runtime enforces them on every interaction — whether the request targets a model, an MCP tool, or a function tool.
 This distinction matters: bolt-on governance fails because it depends on developers remembering to call the right library at the right time.
 When governance lives in the runtime, it cannot be bypassed, forgotten, or misconfigured by individual teams.
 
@@ -22,20 +23,59 @@ Because every guardrail evaluation is recorded in logs, metrics, and traces, you
 
 NOTE: For protecting sensitive information like PII, see xref:sdk:sanitization.adoc[Sanitization].
 
-== Implementing a guardrail
+== Kinds of guardrail
 
-A guardrail implements the link:{attachmentsdir}/api/akka/javasdk/agent/TextGuardrail.html[`TextGuardrail` interface].
-It receives the input or output text as a parameter and returns a result indicating whether the text passed validation, including an explanation of why the decision was made.
-These results are included in metrics and traces.
-A guardrail can abort the interaction with the model, or only report the problem and continue anyway.
+A guardrail implements one of two interfaces, according to the boundary it protects:
 
-An example of a `Guardrail` implementation:
+* link:{attachmentsdir}/api/akka/javasdk/agent/ModelGuardrail.html[`ModelGuardrail`] — evaluates model-side calls: the text of a model request or of a model response.
+* link:{attachmentsdir}/api/akka/javasdk/agent/ToolGuardrail.html[`ToolGuardrail`] — evaluates a function-tool call before it is dispatched (the before-tool-call boundary), with access to the tool name and its raw JSON arguments.
+
+Both return a link:{attachmentsdir}/api/akka/javasdk/agent/Decision.html[`Decision`]:
+
+* `Decision.Allow` — the guardrail saw nothing wrong; the call proceeds.
+* `Decision.Deny` — the call must not proceed. The `reason` is surfaced to the user as the failure message. Whether the interaction is aborted or merely recorded is governed by `report-only` (see <<_configuring_guardrails>>).
+* `Decision.Fail` — evaluation itself failed and reached no verdict. The `reason` and optional `cause` are propagated to the interaction's failure handling.
+
+[NOTE]
+====
+The earlier link:{attachmentsdir}/api/akka/javasdk/agent/TextGuardrail.html[`TextGuardrail`] interface — which returns a `Guardrail.Result` (a boolean plus explanation) rather than a `Decision` — is deprecated for removal.
+Existing `TextGuardrail` implementations still run, and the built-in `SimilarityGuard` (see <<_guardrail_of_similar_text>>) is configured the same way.
+New guardrails should implement `ModelGuardrail` or `ToolGuardrail`.
+====
+
+== Implementing a model guardrail
+
+A `ModelGuardrail` receives a `CallContext` carrying the `text()` being evaluated — the user input when evaluating a model request, the model output when evaluating a model response — and returns a `Decision`:
 
 [source,java,indent=0]
-.{sample-base-url}/doc-snippets/src/main/java/com/example/guardrail/ToxicGuard.java[ToxicGuard.java]
+.{sample-base-url}/doc-snippets/src/main/java/com/example/guardrail/ProfanityModelGuard.java[ProfanityModelGuard.java]
 ----
-include::example$doc-snippets/src/main/java/com/example/guardrail/ToxicGuard.java[tag=all]
+include::example$doc-snippets/src/main/java/com/example/guardrail/ProfanityModelGuard.java[tag=all]
 ----
+<1> Implement `ModelGuardrail`.
+<2> An optional link:{attachmentsdir}/api/akka/javasdk/agent/GuardrailContext.html[`GuardrailContext`] constructor parameter gives access to the guardrail's configured name and its config section. Here the `search-for` property is read from configuration.
+<3> `decide` receives the per-call `CallContext`.
+<4> Return `Decision.Deny` to reject the call, with a reason surfaced to the user.
+<5> Return `Decision.Allow` to let the call proceed.
+
+The same interface protects both the request and the response boundary; the `use-for` configuration decides which (see <<_configuring_guardrails>>).
+
+== Implementing a tool guardrail
+
+A `ToolGuardrail` evaluates a function-tool call before it runs.
+Its `CallContext` exposes the calling `agentId()`, the `toolName()`, the `toolCallId()`, and the raw JSON `arguments()` the model produced:
+
+[source,java,indent=0]
+.{sample-base-url}/doc-snippets/src/main/java/com/example/guardrail/PaymentToolGuard.java[PaymentToolGuard.java]
+----
+include::example$doc-snippets/src/main/java/com/example/guardrail/PaymentToolGuard.java[tag=all]
+----
+<1> Implement `ToolGuardrail`.
+<2> `decide` inspects the tool call described by `CallContext`.
+<3> The arguments are delivered as the raw JSON string the model produced.
+<4> Return `Decision.Deny` to block the tool call before it is dispatched.
+
+A tool guardrail binds only to the before-tool-call boundary; see the note on `use-for` in <<_configuring_guardrails>>.
 
 == Configuring guardrails
 
@@ -45,22 +85,22 @@ Guardrails are enabled by configuration, so you can enforce at deployment time t
 .src/main/resources/application.conf
 ----
 akka.javasdk.agent.guardrails {
-  "pii guard" {                                     // <1>
-    class = "com.example.guardrail.PiiGuard"        // <2>
-    agents = ["planner-agent"]                      // <3>
-    agent-roles = ["worker"]                        // <4>
-    category = PII                                  // <5>
-    use-for = ["model-request", "mcp-tool-request"] // <6>
-    report-only = false                             // <7>
+  "profanity guard" {                                    // <1>
+    class = "com.example.guardrail.ProfanityModelGuard"  // <2>
+    agents = ["planner-agent"]                           // <3>
+    agent-roles = ["worker"]                             // <4>
+    category = TOXIC                                     // <5>
+    use-for = ["model-response"]                         // <6>
+    report-only = false                                  // <7>
+    search-for = "bad stuff"                             // <8>
   }
 
-  "toxic guard" {
-    class = "com.example.guardrail.ToxicGuard"
-    agent-roles = ["worker"]
-    category = TOXIC
-    use-for = ["model-response", "mcp-tool-response"]
+  "payment tool guard" {
+    class = "com.example.guardrail.PaymentToolGuard"
+    agents = ["*"]
+    category = POLICY
+    use-for = ["before-tool-call"]                       // <9>
     report-only = false
-    search-for = "bad stuff"
   }
 }
 ----
@@ -71,8 +111,10 @@ akka.javasdk.agent.guardrails {
 <5> The type of validation, such as PII and TOXIC.
 <6> Where to use the guardrail, such as for the model request or model response.
 <7> If it didn't pass the evaluation criteria, the execution can either be aborted or continue anyway. In both cases, the result is tracked in logs, metrics and traces.
+<8> An application-specific property, read by the guardrail from its `GuardrailContext`.
+<9> A `ToolGuardrail` binds to the `before-tool-call` boundary.
 
-The implementation class of the guardrail is configured with the `class` property. The class must implement the link:{attachmentsdir}/api/akka/javasdk/agent/TextGuardrail.html[`TextGuardrail` interface]. The class may optionally have a constructor with a link:{attachmentsdir}/api/akka/javasdk/agent/GuardrailContext.html[`GuardrailContext`] parameter, which includes the name and the config section for the specific guardrail. In above code example of the `ToxicGuard` you can see how the configuration property `search-for` is read from the configuration of the `GuardrailContext` parameter.
+The implementation class of the guardrail is configured with the `class` property. The class must implement `ModelGuardrail` or `ToolGuardrail` (or the deprecated `TextGuardrail`), be public, and have a public constructor. The constructor may optionally take a link:{attachmentsdir}/api/akka/javasdk/agent/GuardrailContext.html[`GuardrailContext`] parameter, which includes the name and the config section for the specific guardrail. In the `ProfanityModelGuard` example above you can see how the configuration property `search-for` is read from the configuration of the `GuardrailContext` parameter.
 
 === Agent selection
 
@@ -89,7 +131,46 @@ This role is defined in the `@AgentRole` annotation.
 
 The name and the category are reported in logs, metrics, and traces. The `category` should classify the type of validation. It can be any value, but a few recommended categories are JAILBREAK, PROMPT_INJECTION, PII, TOXIC, HALLUCINATED, NSFW, FORMAT.
 
-The guardrail can be enabled for certain inputs or outputs with the `use-for` property. The `use-for` property accepts the following values: `model-request`, `model-response`, `mcp-tool-request`, `mcp-tool-response`, and `*`.
+The guardrail can be enabled for certain boundaries with the `use-for` property. The `use-for` property accepts the following values: `model-request`, `model-response`, `mcp-tool-request`, `mcp-tool-response`, `before-tool-call`, and `*`.
+
+NOTE: The `*` wildcard expands to the model and MCP-tool boundaries only. A `ToolGuardrail` bound to the `before-tool-call` boundary must list it explicitly; it is not included in `*`.
+
+== Classifier-backed guardrails
+
+A guardrail can delegate its decision to a xref:sdk:agents/classifiers.adoc[classifier], resolved by name through `GuardrailContext.classifierClient()`.
+This keeps the decision logic (deny when the classifier labels the text toxic) separate from the scoring logic (how toxicity is measured), and lets the guardrail-to-classifier binding be re-pointed at deployment time:
+
+[source,java,indent=0]
+.{sample-base-url}/doc-snippets/src/main/java/com/example/guardrail/ClassifierBackedGuard.java[ClassifierBackedGuard.java]
+----
+include::example$doc-snippets/src/main/java/com/example/guardrail/ClassifierBackedGuard.java[tag=all]
+----
+<1> Obtain a `ClassifierClient` from the `GuardrailContext`.
+<2> Read the classifier name from the guardrail's own config, so it can be changed without rebuilding.
+<3> Invoke the classifier by name and turn its `Classification` into a `Decision`.
+<4> If the classifier invocation itself fails, return `Decision.Fail` rather than silently allowing the call.
+
+The classifier is configured separately under `akka.javasdk.agent.classifiers`; see xref:sdk:agents/classifiers.adoc[Classifiers].
+
+== Handling a denied interaction
+
+When a `ModelGuardrail` returns `Decision.Deny` with `report-only = false`, the interaction is aborted and the reason is surfaced to the agent's failure handling as a `Guardrail.GuardrailException`, which you can map in `onFailure`:
+
+[source,java,indent=0]
+----
+return effects()
+    .systemMessage("You are a helpful...")
+    .userMessage(question)
+    .map(SomeResponse::new)
+    .onFailure(cause -> switch (cause) {
+      case Guardrail.GuardrailException e -> new SomeResponse(e.getMessage());
+      default -> throw new RuntimeException(cause);
+    })
+    .thenReply();
+----
+
+With `report-only = true`, a `Deny` is recorded in logs, metrics, and traces but the interaction continues.
+A `Decision.Fail` is always propagated as a failure regardless of `report-only`, since the guardrail reached no verdict.
 
 == Guardrail of similar text
 
@@ -118,6 +199,7 @@ You can use this for other things than jailbreak attempt detection.
 
 == See also
 
+* xref:sdk:agents/classifiers.adoc[] — Named scoring/labeling components a guardrail can consult to reach a decision.
 * xref:concepts:governance-and-the-runtime.adoc[] — Why governance must live in the runtime, not in a sidecar.
 * xref:sdk:sanitization.adoc[] — Complementary PII protection through input and output sanitization.
 * {url-blog-trustworthy-ai}[Building Trustworthy AI^] — Background on the design principles behind Akka's risk controls.

--- a/docs/src/modules/sdk/pages/agents/llm_eval.adoc
+++ b/docs/src/modules/sdk/pages/agents/llm_eval.adoc
@@ -4,6 +4,12 @@ include::ROOT:partial$include.adoc[]
 
 Evaluating AI quality is critical when refining prompts and model parameters. Without evaluation with realistic scenarios and data, you won’t know whether a change improves performance, breaks a use case, or has no impact at all.
 
+[NOTE]
+====
+This page covers how to compute a verdict — implementing an LLM-as-judge as an agent, and the built-in evaluator agents.
+To have the runtime run an evaluation automatically for each interaction of an agent, bind an xref:sdk:evaluators.adoc[Evaluator component] to that agent; an Evaluator commonly delegates to one of the judge agents described here.
+====
+
 Testing with generative AI is difficult no matter what you're using to implement it. Interactions with an LLM are not _deterministic_. In other words, you shouldn't expect to get the same answer twice for the same prompt. Because interactions with an LLM are not deterministic, traditional assertions don't work.
 
 How can you write assertions for something like that? There are a ton of solutions, but most of them revolve around the idea that to verify an LLM's answer, you need another LLM. This pattern is often called "LLM-as-judge". You can get an answer from one agent, and then use another agent or model to review the session history and prompts to infer, with some level of confidence, if the agent behaved the way you want it to.

--- a/docs/src/modules/sdk/pages/agents/testing.adoc
+++ b/docs/src/modules/sdk/pages/agents/testing.adoc
@@ -71,6 +71,24 @@ akka.javasdk {
 
 Note that you should use `http`, and not `https`, the connection will be encrypted with TLS, but that is handled by the platform.
 
+[#_classifiers]
+== Classifiers
+
+To exercise your configured xref:sdk:agents/classifiers.adoc[classifiers] in a test, obtain a `ClassifierClient` from the testkit with `getClassifierClient()` and invoke them by name:
+
+[source,java,indent=0]
+----
+var classifierClient = testKit.getClassifierClient();
+var classification = classifierClient.classify("toxicity", "some input text");
+assertThat(classification.label()).contains("clean");
+----
+
+`TestKitSupport` exposes the same accessor, so a test extending `TestKitSupport` can call `getClassifierClient()` directly.
+
+== Evaluators
+
+To unit-test an xref:sdk:evaluators.adoc[Evaluator] in isolation — without binding it to an agent or running the full runtime — use `EvaluatorTestKit`; see xref:sdk:evaluators.adoc#_testing[Testing evaluators].
+
 == Log model request and response
 
 To see exactly what is sent to and received from the AI model, you can enable the following logger in `include-dev-loggers.xml`:

--- a/docs/src/modules/sdk/pages/agents/testing.adoc
+++ b/docs/src/modules/sdk/pages/agents/testing.adoc
@@ -77,13 +77,10 @@ Note that you should use `http`, and not `https`, the connection will be encrypt
 To exercise your configured xref:sdk:agents/classifiers.adoc[classifiers] in a test, obtain a `ClassifierClient` from the testkit with `getClassifierClient()` and invoke them by name:
 
 [source,java,indent=0]
+.{sample-base-url}/doc-snippets/src/test/java/com/example/classifier/ClassifierTestSample.java[ClassifierTestSample.java]
 ----
-var classifierClient = testKit.getClassifierClient();
-var classification = classifierClient.classify("toxicity", "some input text");
-assertThat(classification.label()).contains("clean");
+include::example$doc-snippets/src/test/java/com/example/classifier/ClassifierTestSample.java[tag=classify]
 ----
-
-`TestKitSupport` exposes the same accessor, so a test extending `TestKitSupport` can call `getClassifierClient()` directly.
 
 == Evaluators
 

--- a/docs/src/modules/sdk/pages/evaluators.adoc
+++ b/docs/src/modules/sdk/pages/evaluators.adoc
@@ -49,13 +49,10 @@ It is one of two kinds: an `AgentInteraction` produced directly by an agent, or 
 The link:{attachmentsdir}/api/akka/javasdk/evaluation/Evaluation.html[`Evaluation`] captures whether the interaction passed, an explanation, and optional quantitative (`score`) and categorical (`label`) results, plus arbitrary `attributes`.
 Build one with the fluent factories:
 
-// TODO: replace this inline example with a compiled snippet (e.g. from doc-snippets)
 [source,java,indent=0]
+.{sample-base-url}/doc-snippets/src/main/java/com/example/evaluator/EvaluationBuilding.java[EvaluationBuilding.java]
 ----
-Evaluation.passed("Response was accurate and helpful")
-    .withScore(0.92)
-    .withLabel("excellent")
-    .withAttribute("model", "gpt-4o");
+include::example$doc-snippets/src/main/java/com/example/evaluator/EvaluationBuilding.java[tag=build]
 ----
 
 The `Effect` returned by `evaluate` is one of:
@@ -101,17 +98,10 @@ Blocking calls made from `evaluate` run on virtual threads, so it is safe to use
 
 A common pattern is to have the evaluator delegate the verdict to an LLM-as-judge agent, run in its own evaluation-scoped session:
 
-// TODO: replace this inline example with a compiled snippet (e.g. from doc-snippets)
 [source,java,indent=0]
+.{sample-base-url}/doc-snippets/src/main/java/com/example/evaluator/JudgeDelegatingEvaluator.java[JudgeDelegatingEvaluator.java]
 ----
-QualityJudge.Verdict verdict = componentClient
-    .forAgent()
-    .inSession(context.evaluationId() + "-quality-judge") // isolated from the subject's session
-    .method(QualityJudge::evaluate)
-    .invoke(transcript);
-
-return effects().complete(
-    Evaluation.of(verdict.passed(), verdict.reason()).withScore(verdict.score()));
+include::example$doc-snippets/src/main/java/com/example/evaluator/JudgeDelegatingEvaluator.java[tag=delegate]
 ----
 
 For implementing the judge agent itself, see xref:sdk:agents/llm_eval.adoc[LLM evaluation].
@@ -120,18 +110,10 @@ For implementing the judge agent itself, see xref:sdk:agents/llm_eval.adoc[LLM e
 
 For an evaluation that involves several steps and must survive restarts, delegate to a xref:sdk:workflows.adoc[workflow] and suspend on its result with `asyncEffect`:
 
-// TODO: replace this inline example with a compiled snippet (e.g. from doc-snippets)
 [source,java,indent=0]
+.{sample-base-url}/doc-snippets/src/main/java/com/example/evaluator/DurableEvaluator.java[DurableEvaluator.java]
 ----
-CompletionStage<Effect> futureEffect = componentClient
-    .forWorkflow(context.evaluationId())
-    .method(EvaluationWorkflow::run)
-    .invokeAsync(transcript)
-    .thenCompose(started -> reportStage)     // await the workflow's completion report
-    .thenApply(report ->
-        effects().complete(Evaluation.passed(report.reason()).withScore(report.score())));
-
-return effects().asyncEffect(futureEffect);
+include::example$doc-snippets/src/main/java/com/example/evaluator/DurableEvaluator.java[tag=async]
 ----
 
 The workflow provides the durability; the evaluator suspends until it reports back.
@@ -142,11 +124,10 @@ The workflow provides the durability; the evaluator suspends until it reports ba
 The ledger is the log of recorded agent interactions. It is also used for console visibility and auditing.
 An link:{attachmentsdir}/api/akka/javasdk/ledger/LedgerClient.html[`LedgerClient`] fetches records from it. It can be injected into any component, but in practice it is mainly evaluators that use it.
 
-// TODO: replace this inline example with a compiled snippet (e.g. from doc-snippets)
 [source,java,indent=0]
+.{sample-base-url}/doc-snippets/src/main/java/com/example/evaluator/LedgerUsage.java[LedgerUsage.java]
 ----
-InteractionRecord record = ledger.getInteraction(interactionId);        // <1>
-CompletionStage<InteractionRecord> async = ledger.getInteractionAsync(interactionId); // <2>
+include::example$doc-snippets/src/main/java/com/example/evaluator/LedgerUsage.java[tag=fetch]
 ----
 <1> Fetch the full record for an interaction id. Blocks the calling thread — safe on a virtual thread — and throws `NoSuchElementException` if no interaction exists with that id.
 <2> The non-blocking variant.
@@ -184,17 +165,10 @@ Beyond these, the raw fields expose the full structure: `systemMessage`, `inputM
 
 Use link:{attachmentsdir}/testkit/akka/javasdk/testkit/EvaluatorTestKit.html[`EvaluatorTestKit`] to run an evaluator's `evaluate` handler over a chosen `Subject` and assert on the outcome, supplying whatever dependencies the evaluator needs (for example a stub `LedgerClient`) through the factory:
 
-// TODO: replace this inline example with a compiled snippet (e.g. from doc-snippets)
 [source,java,indent=0]
+.{sample-base-url}/doc-snippets/src/test/java/com/example/evaluator/EvaluatorTestKitSample.java[EvaluatorTestKitSample.java]
 ----
-var testKit = EvaluatorTestKit.of(() -> new InteractionQualityEvaluator(stubLedger));
-
-EvaluatorResult result = testKit.evaluate(
-    new Subject.AgentInteraction("support-agent", "interaction-1"));
-
-assertThat(result.isComplete()).isTrue();
-assertThat(result.getEvaluations()).hasSize(1);
-assertThat(result.getEvaluations().get(0).passed()).isTrue();
+include::example$doc-snippets/src/test/java/com/example/evaluator/EvaluatorTestKitSample.java[tag=test]
 ----
 
 An asynchronous effect is resolved before the `EvaluatorResult` is returned, so `isComplete()` and `isInconclusive()` reflect the terminal outcome; `isAsync()` additionally reports whether the effect was produced asynchronously.

--- a/docs/src/modules/sdk/pages/evaluators.adoc
+++ b/docs/src/modules/sdk/pages/evaluators.adoc
@@ -10,7 +10,7 @@ include::ROOT:partial$include.adoc[]
 
 == Overview
 
-An link:{attachmentsdir}/api/akka/javasdk/evaluation/Evaluator.html[`Evaluator`] is a stateless component that assesses agent interactions.
+An link:{attachmentsdir}/api/akka/javasdk/evaluation/Evaluator.html[`Evaluator`] is a component that assesses agent interactions.
 It is bound to one or more agents in configuration; the runtime then invokes the evaluator once for each interaction of a bound agent, passing the interaction to be evaluated.
 The evaluator returns a verdict — pass or fail, optionally with a score, a label, and attributes — which is recorded in metrics and traces.
 
@@ -49,6 +49,7 @@ It is one of two kinds: an `AgentInteraction` produced directly by an agent, or 
 The link:{attachmentsdir}/api/akka/javasdk/evaluation/Evaluation.html[`Evaluation`] captures whether the interaction passed, an explanation, and optional quantitative (`score`) and categorical (`label`) results, plus arbitrary `attributes`.
 Build one with the fluent factories:
 
+// TODO: replace this inline example with a compiled snippet (e.g. from doc-snippets)
 [source,java,indent=0]
 ----
 Evaluation.passed("Response was accurate and helpful")
@@ -100,6 +101,7 @@ Blocking calls made from `evaluate` run on virtual threads, so it is safe to use
 
 A common pattern is to have the evaluator delegate the verdict to an LLM-as-judge agent, run in its own evaluation-scoped session:
 
+// TODO: replace this inline example with a compiled snippet (e.g. from doc-snippets)
 [source,java,indent=0]
 ----
 QualityJudge.Verdict verdict = componentClient
@@ -118,6 +120,7 @@ For implementing the judge agent itself, see xref:sdk:agents/llm_eval.adoc[LLM e
 
 For an evaluation that involves several steps and must survive restarts, delegate to a xref:sdk:workflows.adoc[workflow] and suspend on its result with `asyncEffect`:
 
+// TODO: replace this inline example with a compiled snippet (e.g. from doc-snippets)
 [source,java,indent=0]
 ----
 CompletionStage<Effect> futureEffect = componentClient
@@ -136,9 +139,10 @@ The workflow provides the durability; the evaluator suspends until it reports ba
 [#_the_ledger_client]
 == The ledger client
 
-The ledger is the log of recorded agent interactions — the same interaction log used for console visibility, troubleshooting, and auditing.
+The ledger is the log of recorded agent interactions, used for console visibility, troubleshooting, and auditing.
 An link:{attachmentsdir}/api/akka/javasdk/ledger/LedgerClient.html[`LedgerClient`] fetches records from it and can be injected into any component; an evaluator is its primary consumer.
 
+// TODO: replace this inline example with a compiled snippet (e.g. from doc-snippets)
 [source,java,indent=0]
 ----
 InteractionRecord record = ledger.getInteraction(interactionId);        // <1>
@@ -180,6 +184,7 @@ Beyond these, the raw fields expose the full structure: `systemMessage`, `inputM
 
 Use link:{attachmentsdir}/testkit/akka/javasdk/testkit/EvaluatorTestKit.html[`EvaluatorTestKit`] to run an evaluator's `evaluate` handler over a chosen `Subject` and assert on the outcome, supplying whatever dependencies the evaluator needs (for example a stub `LedgerClient`) through the factory:
 
+// TODO: replace this inline example with a compiled snippet (e.g. from doc-snippets)
 [source,java,indent=0]
 ----
 var testKit = EvaluatorTestKit.of(() -> new InteractionQualityEvaluator(stubLedger));

--- a/docs/src/modules/sdk/pages/evaluators.adoc
+++ b/docs/src/modules/sdk/pages/evaluators.adoc
@@ -11,12 +11,12 @@ include::ROOT:partial$include.adoc[]
 == Overview
 
 An link:{attachmentsdir}/api/akka/javasdk/evaluation/Evaluator.html[`Evaluator`] is a component that assesses agent interactions.
-It is bound to one or more agents in configuration; the runtime then invokes the evaluator once for each interaction of a bound agent, passing the interaction to be evaluated.
+You bind it to one or more agents in configuration, and the runtime then invokes it once for each interaction of a bound agent, passing the interaction to evaluate.
 The evaluator returns a verdict — pass or fail, optionally with a score, a label, and attributes — which is recorded in metrics and traces.
 
-The key difference from calling an evaluator agent yourself (see xref:sdk:agents/llm_eval.adoc[LLM evaluation]) is *who triggers it and when*.
-An LLM-as-judge agent is a `how` — a way to compute a verdict. The Evaluator component is the `when/what`: the runtime drives it per interaction, so evaluation coverage is a property of the deployment rather than something each call site must remember to invoke.
-An Evaluator can, and often does, delegate the actual judging to a judge agent.
+You can already run an LLM-as-judge yourself by calling a judge agent (see xref:sdk:agents/llm_eval.adoc[LLM evaluation]).
+What an Evaluator adds is who starts it: the runtime runs it for every interaction of a bound agent, so the binding alone gives you evaluation coverage, with no call to add at each site.
+An Evaluator often hands the judging itself off to a judge agent.
 
 NOTE: Evaluators run out of band, after the interaction they assess has completed, so they do not add latency to the agent's response. To make an evaluation part of the agent's own flow — so its outcome can steer the next step — call the judge from the agent or workflow directly, as described in xref:sdk:agents/llm_eval.adoc[LLM evaluation].
 
@@ -139,8 +139,8 @@ The workflow provides the durability; the evaluator suspends until it reports ba
 [#_the_ledger_client]
 == The ledger client
 
-The ledger is the log of recorded agent interactions, used for console visibility, troubleshooting, and auditing.
-An link:{attachmentsdir}/api/akka/javasdk/ledger/LedgerClient.html[`LedgerClient`] fetches records from it and can be injected into any component; an evaluator is its primary consumer.
+The ledger is the log of recorded agent interactions that also drives console visibility and auditing.
+An link:{attachmentsdir}/api/akka/javasdk/ledger/LedgerClient.html[`LedgerClient`] fetches records from it. It can be injected into any component, but in practice it's the evaluators that reach for it.
 
 // TODO: replace this inline example with a compiled snippet (e.g. from doc-snippets)
 [source,java,indent=0]

--- a/docs/src/modules/sdk/pages/evaluators.adoc
+++ b/docs/src/modules/sdk/pages/evaluators.adoc
@@ -15,10 +15,10 @@ You bind it to one or more agents in configuration, and the runtime then invokes
 The evaluator returns a verdict — pass or fail, optionally with a score, a label, and attributes — which is recorded in metrics and traces.
 
 You can already run an LLM-as-judge yourself by calling a judge agent (see xref:sdk:agents/llm_eval.adoc[LLM evaluation]).
-What an Evaluator adds is who starts it: the runtime runs it for every interaction of a bound agent, so the binding alone gives you evaluation coverage, with no call to add at each site.
+What an Evaluator adds is who starts it: the runtime runs it for every interaction of a bound agent, so the binding alone gives you evaluation coverage, and you do not have to add an evaluation call yourself in each place.
 An Evaluator often delegates the judging itself to a judge agent.
 
-NOTE: Evaluators run out of band, after the interaction they assess has completed, so they do not add latency to the agent's response. To make an evaluation part of the agent's own flow — so its outcome can steer the next step — call the judge from the agent or workflow directly, as described in xref:sdk:agents/llm_eval.adoc[LLM evaluation].
+NOTE: Evaluators run out of band, after the interaction they assess has completed, so they do not add latency to the agent's response. To make an evaluation part of the agent's own flow — so its outcome can influence the next step — call the judge from the agent or workflow directly, as described in xref:sdk:agents/llm_eval.adoc[LLM evaluation].
 
 == Implementing an evaluator
 
@@ -86,7 +86,7 @@ akka.javasdk.evaluation.evaluators {
 <3> A binding can be disabled — for example in a deployment override — with `enabled = false`.
 
 Both an evaluator and an individual agent binding may set `enabled` (default `true`); set it to `false` to disable the whole evaluator or a single agent binding.
-Defaults applied to every evaluator and agent binding live under `akka.javasdk.evaluation.defaults`; change a default there to affect all bindings, or set the same key on an individual entry to override just that one.
+Defaults applied to every evaluator and agent binding live under `akka.javasdk.evaluation.defaults`; change a default there to affect all bindings, or set the same key on an individual entry to override only that one.
 
 NOTE: Evaluators typically use an LLM and therefore have a cost and overhead. You may want to enable them in test or staging environments and keep them disabled, or sampled, in high-volume production. Toggling a binding's `enabled` per deployment is the mechanism for that.
 
@@ -139,7 +139,7 @@ The workflow provides the durability; the evaluator suspends until it reports ba
 [#_the_ledger_client]
 == The ledger client
 
-The ledger is the log of recorded agent interactions that also drives console visibility and auditing.
+The ledger is the log of recorded agent interactions. It is also used for console visibility and auditing.
 An link:{attachmentsdir}/api/akka/javasdk/ledger/LedgerClient.html[`LedgerClient`] fetches records from it. It can be injected into any component, but in practice it is mainly evaluators that use it.
 
 // TODO: replace this inline example with a compiled snippet (e.g. from doc-snippets)

--- a/docs/src/modules/sdk/pages/evaluators.adoc
+++ b/docs/src/modules/sdk/pages/evaluators.adoc
@@ -16,7 +16,7 @@ The evaluator returns a verdict — pass or fail, optionally with a score, a lab
 
 You can already run an LLM-as-judge yourself by calling a judge agent (see xref:sdk:agents/llm_eval.adoc[LLM evaluation]).
 What an Evaluator adds is who starts it: the runtime runs it for every interaction of a bound agent, so the binding alone gives you evaluation coverage, with no call to add at each site.
-An Evaluator often hands the judging itself off to a judge agent.
+An Evaluator often delegates the judging itself to a judge agent.
 
 NOTE: Evaluators run out of band, after the interaction they assess has completed, so they do not add latency to the agent's response. To make an evaluation part of the agent's own flow — so its outcome can steer the next step — call the judge from the agent or workflow directly, as described in xref:sdk:agents/llm_eval.adoc[LLM evaluation].
 
@@ -140,7 +140,7 @@ The workflow provides the durability; the evaluator suspends until it reports ba
 == The ledger client
 
 The ledger is the log of recorded agent interactions that also drives console visibility and auditing.
-An link:{attachmentsdir}/api/akka/javasdk/ledger/LedgerClient.html[`LedgerClient`] fetches records from it. It can be injected into any component, but in practice it's the evaluators that reach for it.
+An link:{attachmentsdir}/api/akka/javasdk/ledger/LedgerClient.html[`LedgerClient`] fetches records from it. It can be injected into any component, but in practice it is mainly evaluators that use it.
 
 // TODO: replace this inline example with a compiled snippet (e.g. from doc-snippets)
 [source,java,indent=0]

--- a/docs/src/modules/sdk/pages/evaluators.adoc
+++ b/docs/src/modules/sdk/pages/evaluators.adoc
@@ -1,0 +1,201 @@
+= Evaluators
+:page-component-type: evaluator
+:page-summary: A component the runtime triggers for each interaction of a bound agent, to assess it and record a verdict.
+:page-when-to-use: When you want agent interactions assessed automatically as they happen — for quality tracking, regression detection, or compliance — without wiring evaluation calls into the agents themselves.
+:page-related: xref:sdk:agents/llm_eval.adoc[], xref:sdk:agents.adoc[], xref:concepts:governance-and-the-runtime.adoc[]
+:page-prerequisites: An Akka project with at least one agent defined.
+:page-persona: developer, governance-compliance
+
+include::ROOT:partial$include.adoc[]
+
+== Overview
+
+An link:{attachmentsdir}/api/akka/javasdk/evaluation/Evaluator.html[`Evaluator`] is a stateless component that assesses agent interactions.
+It is bound to one or more agents in configuration; the runtime then invokes the evaluator once for each interaction of a bound agent, passing the interaction to be evaluated.
+The evaluator returns a verdict — pass or fail, optionally with a score, a label, and attributes — which is recorded in metrics and traces.
+
+The key difference from calling an evaluator agent yourself (see xref:sdk:agents/llm_eval.adoc[LLM evaluation]) is *who triggers it and when*.
+An LLM-as-judge agent is a `how` — a way to compute a verdict. The Evaluator component is the `when/what`: the runtime drives it per interaction, so evaluation coverage is a property of the deployment rather than something each call site must remember to invoke.
+An Evaluator can, and often does, delegate the actual judging to a judge agent.
+
+NOTE: Evaluators run out of band, after the interaction they assess has completed, so they do not add latency to the agent's response. To make an evaluation part of the agent's own flow — so its outcome can steer the next step — call the judge from the agent or workflow directly, as described in xref:sdk:agents/llm_eval.adoc[LLM evaluation].
+
+== Implementing an evaluator
+
+An evaluator extends `Evaluator`, is annotated with `@Component`, and implements `evaluate(EvaluationContext)`.
+The context identifies the interaction to assess; the evaluator fetches that interaction from the xref:_the_ledger_client[ledger], reaches a verdict, and returns it through the `Effect` builder:
+
+[source,java,indent=0]
+.{sample-base-url}/doc-snippets/src/main/java/com/example/evaluator/InteractionQualityEvaluator.java[InteractionQualityEvaluator.java]
+----
+include::example$doc-snippets/src/main/java/com/example/evaluator/InteractionQualityEvaluator.java[tag=all]
+----
+<1> An evaluator is a component and needs a `@Component` id. The id is how the evaluator is referred to in configuration.
+<2> Extend `Evaluator`.
+<3> A `LedgerClient` is injected to fetch the interaction under evaluation.
+<4> `EvaluationContext.subject().interactionId()` identifies the interaction; fetch its record from the ledger.
+<5> `inconclusive` reports that the evaluator ran but reached no verdict — distinct from a failing verdict.
+<6> `complete` with an `Evaluation` records the verdict.
+<7> An `Evaluation` can carry a score, a label, and arbitrary attributes for downstream analysis.
+
+=== The evaluation subject
+
+link:{attachmentsdir}/api/akka/javasdk/evaluation/EvaluationContext.html[`EvaluationContext`] exposes the link:{attachmentsdir}/api/akka/javasdk/evaluation/Subject.html[`Subject`] being evaluated and the `evaluationId()` of this evaluation.
+A `Subject` identifies a single interaction by its stable `interactionId()`, together with the `agentComponentId()` that produced it.
+It is one of two kinds: an `AgentInteraction` produced directly by an agent, or a `FlowInteraction` produced by an agent running as part of an autonomous-agent flow (which additionally carries the `flowId`).
+
+=== Recording the verdict
+
+The link:{attachmentsdir}/api/akka/javasdk/evaluation/Evaluation.html[`Evaluation`] captures whether the interaction passed, an explanation, and optional quantitative (`score`) and categorical (`label`) results, plus arbitrary `attributes`.
+Build one with the fluent factories:
+
+[source,java,indent=0]
+----
+Evaluation.passed("Response was accurate and helpful")
+    .withScore(0.92)
+    .withLabel("excellent")
+    .withAttribute("model", "gpt-4o");
+----
+
+The `Effect` returned by `evaluate` is one of:
+
+* `effects().complete(evaluation, ...)` — the evaluation completed with one or more verdicts.
+* `effects().inconclusive(reason)` — the evaluator ran but reached no verdict, for example there was no transcript or the interaction was not applicable.
+* `effects().asyncEffect(futureEffect)` — continue asynchronously from a `CompletionStage` of another effect (see <<_durable_multi_step_evaluation>>).
+
+== Binding evaluators to agents
+
+Evaluators are bound to agents under `akka.javasdk.evaluation.evaluators`, keyed by the evaluator's `@Component` id.
+Each bound agent declares a `trigger` — currently only `interaction`, meaning the evaluator runs for each interaction of that agent:
+
+[source,conf,indent=0]
+.src/main/resources/application.conf
+----
+akka.javasdk.evaluation.evaluators {
+  interaction-quality-evaluator {                 // <1>
+    agents {
+      support-agent { trigger = interaction }     // <2>
+      billing-agent { trigger = interaction, enabled = false } // <3>
+    }
+  }
+}
+----
+<1> The evaluator's `@Component` id.
+<2> Bind the evaluator to `support-agent`; it runs for each of that agent's interactions.
+<3> A binding can be disabled — for example in a deployment override — with `enabled = false`.
+
+Both an evaluator and an individual agent binding may set `enabled` (default `true`); set it to `false` to disable the whole evaluator or a single agent binding.
+Defaults applied to every evaluator and agent binding live under `akka.javasdk.evaluation.defaults`; change a default there to affect all bindings, or set the same key on an individual entry to override just that one.
+
+NOTE: Evaluators typically use an LLM and therefore have a cost and overhead. You may want to enable them in test or staging environments and keep them disabled, or sampled, in high-volume production. Toggling a binding's `enabled` per deployment is the mechanism for that.
+
+== Dependency injection
+
+An evaluator constructor can accept the platform's managed dependencies — `akka.javasdk.client.ComponentClient`, `akka.javasdk.http.HttpClientProvider`, `akka.javasdk.timer.TimerScheduler`, `akka.stream.Materializer`, `com.typesafe.config.Config`, `akka.javasdk.agent.AgentRegistry`, and `akka.javasdk.ledger.LedgerClient` — as well as any custom type provided by the service's `DependencyProvider`.
+See xref:sdk:setup-and-dependency-injection.adoc[].
+
+Blocking calls made from `evaluate` run on virtual threads, so it is safe to use the blocking `LedgerClient.getInteraction` and `ComponentClient.invoke` methods directly.
+
+=== Delegating to a judge agent
+
+A common pattern is to have the evaluator delegate the verdict to an LLM-as-judge agent, run in its own evaluation-scoped session:
+
+[source,java,indent=0]
+----
+QualityJudge.Verdict verdict = componentClient
+    .forAgent()
+    .inSession(context.evaluationId() + "-quality-judge") // isolated from the subject's session
+    .method(QualityJudge::evaluate)
+    .invoke(transcript);
+
+return effects().complete(
+    Evaluation.of(verdict.passed(), verdict.reason()).withScore(verdict.score()));
+----
+
+For implementing the judge agent itself, see xref:sdk:agents/llm_eval.adoc[LLM evaluation].
+
+=== Durable multi-step evaluation
+
+For an evaluation that involves several steps and must survive restarts, delegate to a xref:sdk:workflows.adoc[workflow] and suspend on its result with `asyncEffect`:
+
+[source,java,indent=0]
+----
+CompletionStage<Effect> futureEffect = componentClient
+    .forWorkflow(context.evaluationId())
+    .method(EvaluationWorkflow::run)
+    .invokeAsync(transcript)
+    .thenCompose(started -> reportStage)     // await the workflow's completion report
+    .thenApply(report ->
+        effects().complete(Evaluation.passed(report.reason()).withScore(report.score())));
+
+return effects().asyncEffect(futureEffect);
+----
+
+The workflow provides the durability; the evaluator suspends until it reports back.
+
+[#_the_ledger_client]
+== The ledger client
+
+The ledger is the log of recorded agent interactions — the same interaction log used for console visibility, troubleshooting, and auditing.
+An link:{attachmentsdir}/api/akka/javasdk/ledger/LedgerClient.html[`LedgerClient`] fetches records from it and can be injected into any component; an evaluator is its primary consumer.
+
+[source,java,indent=0]
+----
+InteractionRecord record = ledger.getInteraction(interactionId);        // <1>
+CompletionStage<InteractionRecord> async = ledger.getInteractionAsync(interactionId); // <2>
+----
+<1> Fetch the full record for an interaction id. Blocks the calling thread — safe on a virtual thread — and throws `NoSuchElementException` if no interaction exists with that id.
+<2> The non-blocking variant.
+
+=== The interaction record
+
+link:{attachmentsdir}/api/akka/javasdk/ledger/InteractionRecord.html[`InteractionRecord`] holds the full record of a single interaction, plus convenience accessors for the common cases:
+
+[cols="1,3", options="header"]
+|===
+| Accessor | Description
+
+| `inputText()`, `finalResponseText()`
+| The user input, and the agent's final response text.
+
+| `toolCalls()`
+| The tool calls the model made during the interaction, as `ToolCall` records (id, name, JSON arguments, response).
+
+| `totalInputTokens()`, `totalOutputTokens()`
+| Token totals across the interaction's model calls.
+
+| `failed()`, `failureSummary()`
+| Whether the interaction terminated in a failure, and a summary of it.
+
+| `transcript()`
+| A flattened text rendering of the interaction, convenient for handing to a judge.
+
+| `isFlowInteraction()`
+| Whether the interaction was produced by an agent running as part of a flow.
+|===
+
+Beyond these, the raw fields expose the full structure: `systemMessage`, `inputMessage`, the ordered `modelResponses` (each a `ModelResponse` with content, thinking, token counts, and requested `toolCalls`), the `toolCallResponses` that arrived as model input, the model `metadata` (an `InteractionMetadata` wrapping the structured `ModelConfig` and the raw config map, call timings, and finish reason), an optional `TaskContext` for flow interactions, and an optional `Failure` when the interaction failed.
+
+== Testing
+
+Use link:{attachmentsdir}/testkit/akka/javasdk/testkit/EvaluatorTestKit.html[`EvaluatorTestKit`] to run an evaluator's `evaluate` handler over a chosen `Subject` and assert on the outcome, supplying whatever dependencies the evaluator needs (for example a stub `LedgerClient`) through the factory:
+
+[source,java,indent=0]
+----
+var testKit = EvaluatorTestKit.of(() -> new InteractionQualityEvaluator(stubLedger));
+
+EvaluatorResult result = testKit.evaluate(
+    new Subject.AgentInteraction("support-agent", "interaction-1"));
+
+assertThat(result.isComplete()).isTrue();
+assertThat(result.getEvaluations()).hasSize(1);
+assertThat(result.getEvaluations().get(0).passed()).isTrue();
+----
+
+An asynchronous effect is resolved before the `EvaluatorResult` is returned, so `isComplete()` and `isInconclusive()` reflect the terminal outcome; `isAsync()` additionally reports whether the effect was produced asynchronously.
+
+== See also
+
+* xref:sdk:agents/llm_eval.adoc[] — Implementing LLM-as-judge evaluator agents, including the built-in evaluators.
+* xref:sdk:agents/classifiers.adoc[] — Classifiers an evaluator can call to score an interaction.
+* xref:concepts:governance-and-the-runtime.adoc[] — Where evaluation fits in Akka's governance model.

--- a/docs/src/modules/sdk/pages/setup-and-dependency-injection.adoc
+++ b/docs/src/modules/sdk/pages/setup-and-dependency-injection.adoc
@@ -118,7 +118,9 @@ The following types can be injected in Service Setup, HTTP Endpoints, gRPC Endpo
 | `java.util.concurrent.Executor`
 | An executor which runs each task in a virtual thread, and is safe to use for blocking async work, for example with `CompletableFuture.supplyAsync(() -> blocking, executor)`
 | `akka.javasdk.ledger.LedgerClient`
-| For fetching recorded agent interactions from the ledger, primarily for evaluators.
+| For fetching recorded agent interactions from the ledger, primarily for evaluators, see xref:evaluators.adoc[]
+| `akka.javasdk.agent.ClassifierClient`
+| For invoking a configured classifier by name, see xref:agents/classifiers.adoc[]
 |===
 
 Furthermore, the following component specific types can also be injected:

--- a/docs/src/modules/sdk/pages/use-cases/governance-and-compliance.adoc
+++ b/docs/src/modules/sdk/pages/use-cases/governance-and-compliance.adoc
@@ -19,7 +19,9 @@ NOTE: *Status: Partial* -- This pattern guide describes the governance approach 
 
 === Akka Components Involved
 
-* *Guardrails* -- validate and filter agent inputs and outputs against defined policies
+* *Guardrails* -- validate and filter agent inputs, outputs, and tool calls against defined policies, and can stop an interaction at the boundary
+* *Classifiers* -- score or label text (toxicity, sentiment, PII likelihood, or any custom signal), consulted by guardrails, evaluators, or application code
+* *Evaluators* -- assess each interaction of a bound agent out of band, recording a verdict, and read the interaction ledger for the record to assess
 * *Sanitizers* -- detect and redact PII and sensitive data in agent interactions
 * *Agents* -- integrate governance checks into the agent processing pipeline
 
@@ -35,5 +37,7 @@ NOTE: A dedicated governance-focused sample may be needed for a full end-to-end 
 == See Also
 
 * xref:sdk:agents/guardrails.adoc[]
+* xref:sdk:agents/classifiers.adoc[]
+* xref:sdk:evaluators.adoc[]
 * xref:sdk:sanitization.adoc[]
 * xref:concepts:governance-and-the-runtime.adoc[]

--- a/docs/src/modules/sdk/pages/use-cases/governance-and-compliance.adoc
+++ b/docs/src/modules/sdk/pages/use-cases/governance-and-compliance.adoc
@@ -21,7 +21,7 @@ NOTE: *Status: Partial* -- This pattern guide describes the governance approach 
 
 * *Guardrails* -- validate and filter agent inputs, outputs, and tool calls against defined policies, and can stop an interaction at the boundary
 * *Classifiers* -- score or label text (toxicity, sentiment, PII likelihood, or any custom signal), consulted by guardrails, evaluators, or application code
-* *Evaluators* -- assess each interaction of a bound agent out of band, recording a verdict, and read the interaction ledger for the record to assess
+* *Evaluators* -- assess each interaction of a bound agent out of band, recording a verdict, and read the ledger for the record to assess
 * *Sanitizers* -- detect and redact PII and sensitive data in agent interactions
 * *Agents* -- integrate governance checks into the agent processing pipeline
 

--- a/docs/styles/config/vocabularies/Akka/accept.txt
+++ b/docs/styles/config/vocabularies/Akka/accept.txt
@@ -70,6 +70,7 @@ effectful
 enum
 env
 etcd
+evaluator's
 eventhubs
 exfiltration
 expirationSeconds

--- a/samples/doc-snippets/src/main/java/com/example/classifier/ClassifierUsage.java
+++ b/samples/doc-snippets/src/main/java/com/example/classifier/ClassifierUsage.java
@@ -14,8 +14,16 @@ public class ClassifierUsage {
   void inspect(String text) {
     // tag::invoke[]
     Classification result = classifierClient.classify("toxicity", text); // <1>
-    result.label().ifPresent(label -> { /* ... */ });
-    result.score().ifPresent(score -> { /* ... */ });
+    result
+      .label()
+      .ifPresent(label -> {
+        /* ... */
+      });
+    result
+      .score()
+      .ifPresent(score -> {
+        /* ... */
+      });
     // end::invoke[]
   }
 }

--- a/samples/doc-snippets/src/main/java/com/example/classifier/ClassifierUsage.java
+++ b/samples/doc-snippets/src/main/java/com/example/classifier/ClassifierUsage.java
@@ -1,0 +1,21 @@
+package com.example.classifier;
+
+import akka.javasdk.agent.Classification;
+import akka.javasdk.agent.ClassifierClient;
+
+public class ClassifierUsage {
+
+  private final ClassifierClient classifierClient;
+
+  public ClassifierUsage(ClassifierClient classifierClient) {
+    this.classifierClient = classifierClient;
+  }
+
+  void inspect(String text) {
+    // tag::invoke[]
+    Classification result = classifierClient.classify("toxicity", text); // <1>
+    result.label().ifPresent(label -> { /* ... */ });
+    result.score().ifPresent(score -> { /* ... */ });
+    // end::invoke[]
+  }
+}

--- a/samples/doc-snippets/src/main/java/com/example/classifier/EnsembleClassifier.java
+++ b/samples/doc-snippets/src/main/java/com/example/classifier/EnsembleClassifier.java
@@ -6,8 +6,6 @@ import akka.javasdk.agent.Classifier;
 import akka.javasdk.agent.ClassifierClient;
 import akka.javasdk.agent.ClassifierContext;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
 public class EnsembleClassifier implements Classifier {
 
@@ -20,15 +18,14 @@ public class EnsembleClassifier implements Classifier {
   }
 
   @Override
-  public CompletionStage<Classification> classify(String input) {
-    return CompletableFuture.supplyAsync(() -> {
-      double worst = members.stream()
-          .map(name -> classifierClient.classify(name, input)) // <3>
-          .flatMap(c -> c.score().stream())
-          .max(Double::compare)
-          .orElse(0.0);
-      return Classification.score(worst); // <4>
-    });
+  public Classification classify(String input) {
+    double worst = members
+      .stream()
+      .map(name -> classifierClient.classify(name, input)) // <3>
+      .flatMap(c -> c.score().stream())
+      .max(Double::compare)
+      .orElse(0.0);
+    return Classification.score(worst); // <4>
   }
 }
 // end::all[]

--- a/samples/doc-snippets/src/main/java/com/example/classifier/EnsembleClassifier.java
+++ b/samples/doc-snippets/src/main/java/com/example/classifier/EnsembleClassifier.java
@@ -1,0 +1,34 @@
+package com.example.classifier;
+
+// tag::all[]
+import akka.javasdk.agent.Classification;
+import akka.javasdk.agent.Classifier;
+import akka.javasdk.agent.ClassifierClient;
+import akka.javasdk.agent.ClassifierContext;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public class EnsembleClassifier implements Classifier {
+
+  private final ClassifierClient classifierClient; // <1>
+  private final List<String> members;
+
+  public EnsembleClassifier(ClassifierContext context, ClassifierClient classifierClient) { // <2>
+    this.classifierClient = classifierClient;
+    this.members = context.config().getStringList("members");
+  }
+
+  @Override
+  public CompletionStage<Classification> classify(String input) {
+    return CompletableFuture.supplyAsync(() -> {
+      double worst = members.stream()
+          .map(name -> classifierClient.classify(name, input)) // <3>
+          .flatMap(c -> c.score().stream())
+          .max(Double::compare)
+          .orElse(0.0);
+      return Classification.score(worst); // <4>
+    });
+  }
+}
+// end::all[]

--- a/samples/doc-snippets/src/main/java/com/example/classifier/ToxicityClassifier.java
+++ b/samples/doc-snippets/src/main/java/com/example/classifier/ToxicityClassifier.java
@@ -1,0 +1,31 @@
+package com.example.classifier;
+
+// tag::all[]
+import akka.javasdk.agent.Classification;
+import akka.javasdk.agent.Classifier;
+import akka.javasdk.agent.ClassifierContext;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public class ToxicityClassifier implements Classifier { // <1>
+
+  private final double threshold;
+
+  public ToxicityClassifier(ClassifierContext context) { // <2>
+    this.threshold = context.config().getDouble("threshold");
+  }
+
+  @Override
+  public CompletionStage<Classification> classify(String input) { // <3>
+    return CompletableFuture.supplyAsync(() -> {
+      double score = score(input); // a real implementation might call a model or an external API
+      String label = score >= threshold ? "toxic" : "clean";
+      return Classification.of(score, label); // <4>
+    });
+  }
+
+  private double score(String input) {
+    return input.toLowerCase().contains("toxic") ? 1.0 : 0.0;
+  }
+}
+// end::all[]

--- a/samples/doc-snippets/src/main/java/com/example/classifier/ToxicityClassifier.java
+++ b/samples/doc-snippets/src/main/java/com/example/classifier/ToxicityClassifier.java
@@ -4,8 +4,6 @@ package com.example.classifier;
 import akka.javasdk.agent.Classification;
 import akka.javasdk.agent.Classifier;
 import akka.javasdk.agent.ClassifierContext;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
 public class ToxicityClassifier implements Classifier { // <1>
 
@@ -16,12 +14,10 @@ public class ToxicityClassifier implements Classifier { // <1>
   }
 
   @Override
-  public CompletionStage<Classification> classify(String input) { // <3>
-    return CompletableFuture.supplyAsync(() -> {
-      double score = score(input); // a real implementation might call a model or an external API
-      String label = score >= threshold ? "toxic" : "clean";
-      return Classification.of(score, label); // <4>
-    });
+  public Classification classify(String input) { // <3>
+    double score = score(input); // a real implementation might call a model or an external API
+    String label = score >= threshold ? "toxic" : "clean";
+    return Classification.of(score, label); // <4>
   }
 
   private double score(String input) {

--- a/samples/doc-snippets/src/main/java/com/example/evaluator/DurableEvaluator.java
+++ b/samples/doc-snippets/src/main/java/com/example/evaluator/DurableEvaluator.java
@@ -1,0 +1,50 @@
+package com.example.evaluator;
+
+import akka.javasdk.annotations.Component;
+import akka.javasdk.client.ComponentClient;
+import akka.javasdk.evaluation.Evaluation;
+import akka.javasdk.evaluation.EvaluationContext;
+import akka.javasdk.evaluation.Evaluator;
+import akka.stream.Materializer;
+import akka.stream.javadsl.Sink;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * An evaluator that delegates a multi-step evaluation to a durable workflow and suspends via
+ * {@code asyncEffect} until the workflow publishes its completion report.
+ */
+@Component(id = "durable-evaluator")
+public class DurableEvaluator extends Evaluator {
+
+  private final ComponentClient componentClient;
+  private final Materializer materializer;
+
+  public DurableEvaluator(ComponentClient componentClient, Materializer materializer) {
+    this.componentClient = componentClient;
+    this.materializer = materializer;
+  }
+
+  @Override
+  public Effect evaluate(EvaluationContext context) {
+    String transcript = context.subject().interactionId();
+    String workflowId = context.evaluationId();
+    // tag::async[]
+    // Subscribe to the workflow's completion report before starting it, so it can't be missed.
+    CompletionStage<EvaluationWorkflow.Report> reportStage = componentClient
+        .forWorkflow(workflowId)
+        .notificationStream(EvaluationWorkflow::updates)
+        .source()
+        .runWith(Sink.head(), materializer);
+
+    CompletionStage<Effect> futureEffect = componentClient
+        .forWorkflow(workflowId)
+        .method(EvaluationWorkflow::run)
+        .invokeAsync(transcript)
+        .thenCompose(started -> reportStage)
+        .thenApply(report ->
+            effects().complete(Evaluation.passed(report.reason()).withScore(report.score())));
+
+    return effects().asyncEffect(futureEffect);
+    // end::async[]
+  }
+}

--- a/samples/doc-snippets/src/main/java/com/example/evaluator/DurableEvaluator.java
+++ b/samples/doc-snippets/src/main/java/com/example/evaluator/DurableEvaluator.java
@@ -31,18 +31,20 @@ public class DurableEvaluator extends Evaluator {
     // tag::async[]
     // Subscribe to the workflow's completion report before starting it, so it can't be missed.
     CompletionStage<EvaluationWorkflow.Report> reportStage = componentClient
-        .forWorkflow(workflowId)
-        .notificationStream(EvaluationWorkflow::updates)
-        .source()
-        .runWith(Sink.head(), materializer);
+      .forWorkflow(workflowId)
+      .notificationStream(EvaluationWorkflow::updates)
+      .source()
+      .runWith(Sink.head(), materializer);
 
     CompletionStage<Effect> futureEffect = componentClient
-        .forWorkflow(workflowId)
-        .method(EvaluationWorkflow::run)
-        .invokeAsync(transcript)
-        .thenCompose(started -> reportStage)
-        .thenApply(report ->
-            effects().complete(Evaluation.passed(report.reason()).withScore(report.score())));
+      .forWorkflow(workflowId)
+      .method(EvaluationWorkflow::run)
+      .invokeAsync(transcript)
+      .thenCompose(started -> reportStage)
+      .thenApply(
+        report ->
+          effects().complete(Evaluation.passed(report.reason()).withScore(report.score()))
+      );
 
     return effects().asyncEffect(futureEffect);
     // end::async[]

--- a/samples/doc-snippets/src/main/java/com/example/evaluator/EvaluationBuilding.java
+++ b/samples/doc-snippets/src/main/java/com/example/evaluator/EvaluationBuilding.java
@@ -1,0 +1,15 @@
+package com.example.evaluator;
+
+import akka.javasdk.evaluation.Evaluation;
+
+public class EvaluationBuilding {
+
+  Evaluation example() {
+    // tag::build[]
+    return Evaluation.passed("Response was accurate and helpful")
+        .withScore(0.92)
+        .withLabel("excellent")
+        .withAttribute("model", "gpt-4o");
+    // end::build[]
+  }
+}

--- a/samples/doc-snippets/src/main/java/com/example/evaluator/EvaluationBuilding.java
+++ b/samples/doc-snippets/src/main/java/com/example/evaluator/EvaluationBuilding.java
@@ -7,9 +7,9 @@ public class EvaluationBuilding {
   Evaluation example() {
     // tag::build[]
     return Evaluation.passed("Response was accurate and helpful")
-        .withScore(0.92)
-        .withLabel("excellent")
-        .withAttribute("model", "gpt-4o");
+      .withScore(0.92)
+      .withLabel("excellent")
+      .withAttribute("model", "gpt-4o");
     // end::build[]
   }
 }

--- a/samples/doc-snippets/src/main/java/com/example/evaluator/EvaluationWorkflow.java
+++ b/samples/doc-snippets/src/main/java/com/example/evaluator/EvaluationWorkflow.java
@@ -1,0 +1,52 @@
+package com.example.evaluator;
+
+import akka.javasdk.NotificationPublisher;
+import akka.javasdk.NotificationPublisher.NotificationStream;
+import akka.javasdk.annotations.Component;
+import akka.javasdk.workflow.Workflow;
+
+/**
+ * A multi-step evaluation workflow. It scores a transcript in one step, finalizes in another, and
+ * publishes the completed report as a notification the evaluator can await without polling.
+ */
+@Component(id = "evaluation-workflow")
+public class EvaluationWorkflow extends Workflow<EvaluationWorkflow.State> {
+
+  public record State(String transcript, int score) {
+    State scored(int newScore) {
+      return new State(transcript, newScore);
+    }
+  }
+
+  public record Report(int score, String reason) {}
+
+  private final NotificationPublisher<Report> notificationPublisher;
+
+  public EvaluationWorkflow(NotificationPublisher<Report> notificationPublisher) {
+    this.notificationPublisher = notificationPublisher;
+  }
+
+  public Effect<String> run(String transcript) {
+    return effects()
+        .updateState(new State(transcript, 0))
+        .transitionTo(EvaluationWorkflow::scoreStep)
+        .thenReply("started");
+  }
+
+  private StepEffect scoreStep() {
+    int score = currentState().transcript().length();
+    return stepEffects()
+        .updateState(currentState().scored(score))
+        .thenTransitionTo(EvaluationWorkflow::finishStep);
+  }
+
+  private StepEffect finishStep() {
+    var state = currentState();
+    notificationPublisher.publish(new Report(state.score(), "scored " + state.score()));
+    return stepEffects().thenEnd();
+  }
+
+  public NotificationStream<Report> updates() {
+    return notificationPublisher.stream();
+  }
+}

--- a/samples/doc-snippets/src/main/java/com/example/evaluator/EvaluationWorkflow.java
+++ b/samples/doc-snippets/src/main/java/com/example/evaluator/EvaluationWorkflow.java
@@ -28,16 +28,16 @@ public class EvaluationWorkflow extends Workflow<EvaluationWorkflow.State> {
 
   public Effect<String> run(String transcript) {
     return effects()
-        .updateState(new State(transcript, 0))
-        .transitionTo(EvaluationWorkflow::scoreStep)
-        .thenReply("started");
+      .updateState(new State(transcript, 0))
+      .transitionTo(EvaluationWorkflow::scoreStep)
+      .thenReply("started");
   }
 
   private StepEffect scoreStep() {
     int score = currentState().transcript().length();
     return stepEffects()
-        .updateState(currentState().scored(score))
-        .thenTransitionTo(EvaluationWorkflow::finishStep);
+      .updateState(currentState().scored(score))
+      .thenTransitionTo(EvaluationWorkflow::finishStep);
   }
 
   private StepEffect finishStep() {

--- a/samples/doc-snippets/src/main/java/com/example/evaluator/InteractionQualityEvaluator.java
+++ b/samples/doc-snippets/src/main/java/com/example/evaluator/InteractionQualityEvaluator.java
@@ -1,0 +1,39 @@
+package com.example.evaluator;
+
+// tag::all[]
+import akka.javasdk.annotations.Component;
+import akka.javasdk.evaluation.Evaluation;
+import akka.javasdk.evaluation.EvaluationContext;
+import akka.javasdk.evaluation.Evaluator;
+import akka.javasdk.ledger.InteractionRecord;
+import akka.javasdk.ledger.LedgerClient;
+
+@Component(id = "interaction-quality-evaluator") // <1>
+public class InteractionQualityEvaluator extends Evaluator { // <2>
+
+  private final LedgerClient ledger;
+
+  public InteractionQualityEvaluator(LedgerClient ledger) { // <3>
+    this.ledger = ledger;
+  }
+
+  @Override
+  public Effect evaluate(EvaluationContext context) {
+    InteractionRecord interaction =
+        ledger.getInteraction(context.subject().interactionId()); // <4>
+
+    if (interaction.failed()) {
+      return effects().inconclusive("interaction failed, nothing to evaluate"); // <5>
+    }
+
+    String finalText = interaction.finalResponseText();
+    if (finalText.isEmpty()) {
+      return effects().complete(Evaluation.failed("agent produced no final response")); // <6>
+    }
+    return effects().complete(
+        Evaluation.passed("agent responded")
+            .withScore(1.0)
+            .withAttribute("length", Integer.toString(finalText.length()))); // <7>
+  }
+}
+// end::all[]

--- a/samples/doc-snippets/src/main/java/com/example/evaluator/InteractionQualityEvaluator.java
+++ b/samples/doc-snippets/src/main/java/com/example/evaluator/InteractionQualityEvaluator.java
@@ -19,8 +19,7 @@ public class InteractionQualityEvaluator extends Evaluator { // <2>
 
   @Override
   public Effect evaluate(EvaluationContext context) {
-    InteractionRecord interaction =
-        ledger.getInteraction(context.subject().interactionId()); // <4>
+    InteractionRecord interaction = ledger.getInteraction(context.subject().interactionId()); // <4>
 
     if (interaction.failed()) {
       return effects().inconclusive("interaction failed, nothing to evaluate"); // <5>
@@ -30,10 +29,12 @@ public class InteractionQualityEvaluator extends Evaluator { // <2>
     if (finalText.isEmpty()) {
       return effects().complete(Evaluation.failed("agent produced no final response")); // <6>
     }
-    return effects().complete(
+    return effects()
+      .complete(
         Evaluation.passed("agent responded")
-            .withScore(1.0)
-            .withAttribute("length", Integer.toString(finalText.length()))); // <7>
+          .withScore(1.0)
+          .withAttribute("length", Integer.toString(finalText.length()))
+      ); // <7>
   }
 }
 // end::all[]

--- a/samples/doc-snippets/src/main/java/com/example/evaluator/JudgeDelegatingEvaluator.java
+++ b/samples/doc-snippets/src/main/java/com/example/evaluator/JudgeDelegatingEvaluator.java
@@ -20,13 +20,13 @@ public class JudgeDelegatingEvaluator extends Evaluator {
     String transcript = context.subject().interactionId();
     // tag::delegate[]
     QualityJudge.Verdict verdict = componentClient
-        .forAgent()
-        .inSession(context.evaluationId() + "-quality-judge") // isolated from the subject's session
-        .method(QualityJudge::evaluate)
-        .invoke(transcript);
+      .forAgent()
+      .inSession(context.evaluationId() + "-quality-judge") // isolated from the subject's session
+      .method(QualityJudge::evaluate)
+      .invoke(transcript);
 
-    return effects().complete(
-        Evaluation.of(verdict.passed(), verdict.reason()).withScore(verdict.score()));
+    return effects()
+      .complete(Evaluation.of(verdict.passed(), verdict.reason()).withScore(verdict.score()));
     // end::delegate[]
   }
 }

--- a/samples/doc-snippets/src/main/java/com/example/evaluator/JudgeDelegatingEvaluator.java
+++ b/samples/doc-snippets/src/main/java/com/example/evaluator/JudgeDelegatingEvaluator.java
@@ -1,0 +1,32 @@
+package com.example.evaluator;
+
+import akka.javasdk.annotations.Component;
+import akka.javasdk.client.ComponentClient;
+import akka.javasdk.evaluation.Evaluation;
+import akka.javasdk.evaluation.EvaluationContext;
+import akka.javasdk.evaluation.Evaluator;
+
+@Component(id = "judge-delegating-evaluator")
+public class JudgeDelegatingEvaluator extends Evaluator {
+
+  private final ComponentClient componentClient;
+
+  public JudgeDelegatingEvaluator(ComponentClient componentClient) {
+    this.componentClient = componentClient;
+  }
+
+  @Override
+  public Effect evaluate(EvaluationContext context) {
+    String transcript = context.subject().interactionId();
+    // tag::delegate[]
+    QualityJudge.Verdict verdict = componentClient
+        .forAgent()
+        .inSession(context.evaluationId() + "-quality-judge") // isolated from the subject's session
+        .method(QualityJudge::evaluate)
+        .invoke(transcript);
+
+    return effects().complete(
+        Evaluation.of(verdict.passed(), verdict.reason()).withScore(verdict.score()));
+    // end::delegate[]
+  }
+}

--- a/samples/doc-snippets/src/main/java/com/example/evaluator/LedgerUsage.java
+++ b/samples/doc-snippets/src/main/java/com/example/evaluator/LedgerUsage.java
@@ -1,0 +1,21 @@
+package com.example.evaluator;
+
+import akka.javasdk.ledger.InteractionRecord;
+import akka.javasdk.ledger.LedgerClient;
+import java.util.concurrent.CompletionStage;
+
+public class LedgerUsage {
+
+  private final LedgerClient ledger;
+
+  public LedgerUsage(LedgerClient ledger) {
+    this.ledger = ledger;
+  }
+
+  void fetch(String interactionId) {
+    // tag::fetch[]
+    InteractionRecord record = ledger.getInteraction(interactionId);                      // <1>
+    CompletionStage<InteractionRecord> async = ledger.getInteractionAsync(interactionId); // <2>
+    // end::fetch[]
+  }
+}

--- a/samples/doc-snippets/src/main/java/com/example/evaluator/LedgerUsage.java
+++ b/samples/doc-snippets/src/main/java/com/example/evaluator/LedgerUsage.java
@@ -14,7 +14,7 @@ public class LedgerUsage {
 
   void fetch(String interactionId) {
     // tag::fetch[]
-    InteractionRecord record = ledger.getInteraction(interactionId);                      // <1>
+    InteractionRecord record = ledger.getInteraction(interactionId); // <1>
     CompletionStage<InteractionRecord> async = ledger.getInteractionAsync(interactionId); // <2>
     // end::fetch[]
   }

--- a/samples/doc-snippets/src/main/java/com/example/evaluator/QualityJudge.java
+++ b/samples/doc-snippets/src/main/java/com/example/evaluator/QualityJudge.java
@@ -1,0 +1,18 @@
+package com.example.evaluator;
+
+import akka.javasdk.agent.Agent;
+import akka.javasdk.annotations.Component;
+
+@Component(id = "quality-judge")
+public class QualityJudge extends Agent {
+
+  public record Verdict(boolean passed, String reason, double score) {}
+
+  public Effect<Verdict> evaluate(String transcript) {
+    return effects()
+        .systemMessage("Judge the quality of the interaction. Reply with a passed flag, a reason, and a score.")
+        .userMessage(transcript)
+        .responseConformsTo(Verdict.class)
+        .thenReply();
+  }
+}

--- a/samples/doc-snippets/src/main/java/com/example/evaluator/QualityJudge.java
+++ b/samples/doc-snippets/src/main/java/com/example/evaluator/QualityJudge.java
@@ -10,9 +10,11 @@ public class QualityJudge extends Agent {
 
   public Effect<Verdict> evaluate(String transcript) {
     return effects()
-        .systemMessage("Judge the quality of the interaction. Reply with a passed flag, a reason, and a score.")
-        .userMessage(transcript)
-        .responseConformsTo(Verdict.class)
-        .thenReply();
+      .systemMessage(
+        "Judge the quality of the interaction. Reply with a passed flag, a reason, and a score."
+      )
+      .userMessage(transcript)
+      .responseConformsTo(Verdict.class)
+      .thenReply();
   }
 }

--- a/samples/doc-snippets/src/main/java/com/example/guardrail/ClassifierBackedGuard.java
+++ b/samples/doc-snippets/src/main/java/com/example/guardrail/ClassifierBackedGuard.java
@@ -1,0 +1,32 @@
+package com.example.guardrail;
+
+// tag::all[]
+import akka.javasdk.agent.ClassifierClient;
+import akka.javasdk.agent.Decision;
+import akka.javasdk.agent.GuardrailContext;
+import akka.javasdk.agent.ModelGuardrail;
+
+public class ClassifierBackedGuard implements ModelGuardrail {
+
+  private final ClassifierClient classifierClient;
+  private final String classifierName;
+
+  public ClassifierBackedGuard(GuardrailContext context) {
+    this.classifierClient = context.classifierClient(); // <1>
+    this.classifierName = context.config().getString("classifier"); // <2>
+  }
+
+  @Override
+  public Decision decide(CallContext ctx) {
+    try {
+      var classification = classifierClient.classify(classifierName, ctx.text()); // <3>
+      if (classification.label().map("toxic"::equals).orElse(false)) {
+        return new Decision.Deny("blocked by classifier " + classifierName);
+      }
+      return new Decision.Allow();
+    } catch (RuntimeException e) {
+      return new Decision.Fail("classifier invocation failed", e); // <4>
+    }
+  }
+}
+// end::all[]

--- a/samples/doc-snippets/src/main/java/com/example/guardrail/GuardedAgent.java
+++ b/samples/doc-snippets/src/main/java/com/example/guardrail/GuardedAgent.java
@@ -12,14 +12,15 @@ public class GuardedAgent extends Agent {
   public Effect<SomeResponse> ask(String question) {
     // tag::on-failure[]
     return effects()
-        .systemMessage("You are a helpful...")
-        .userMessage(question)
-        .map(SomeResponse::new)
-        .onFailure(cause -> switch (cause) {
+      .systemMessage("You are a helpful...")
+      .userMessage(question)
+      .map(SomeResponse::new)
+      .onFailure(cause ->
+        switch (cause) {
           case Guardrail.GuardrailException e -> new SomeResponse(e.getMessage());
           default -> throw new RuntimeException(cause);
         })
-        .thenReply();
+      .thenReply();
     // end::on-failure[]
   }
 }

--- a/samples/doc-snippets/src/main/java/com/example/guardrail/GuardedAgent.java
+++ b/samples/doc-snippets/src/main/java/com/example/guardrail/GuardedAgent.java
@@ -1,0 +1,25 @@
+package com.example.guardrail;
+
+import akka.javasdk.agent.Agent;
+import akka.javasdk.agent.Guardrail;
+import akka.javasdk.annotations.Component;
+
+@Component(id = "guarded-agent")
+public class GuardedAgent extends Agent {
+
+  public record SomeResponse(String response) {}
+
+  public Effect<SomeResponse> ask(String question) {
+    // tag::on-failure[]
+    return effects()
+        .systemMessage("You are a helpful...")
+        .userMessage(question)
+        .map(SomeResponse::new)
+        .onFailure(cause -> switch (cause) {
+          case Guardrail.GuardrailException e -> new SomeResponse(e.getMessage());
+          default -> throw new RuntimeException(cause);
+        })
+        .thenReply();
+    // end::on-failure[]
+  }
+}

--- a/samples/doc-snippets/src/main/java/com/example/guardrail/PaymentToolGuard.java
+++ b/samples/doc-snippets/src/main/java/com/example/guardrail/PaymentToolGuard.java
@@ -1,0 +1,21 @@
+package com.example.guardrail;
+
+// tag::all[]
+import akka.javasdk.agent.Decision;
+import akka.javasdk.agent.ToolGuardrail;
+
+public class PaymentToolGuard implements ToolGuardrail { // <1>
+
+  @Override
+  public Decision decide(CallContext ctx) { // <2>
+    if (!ctx.toolName().equals("transferFunds")) {
+      return new Decision.Allow();
+    }
+    // ctx exposes agentId(), toolName(), toolCallId(), and the raw JSON arguments()
+    if (ctx.arguments().contains("\"amount\":10000")) { // <3>
+      return new Decision.Deny("transfers of 10000 or more require human approval"); // <4>
+    }
+    return new Decision.Allow();
+  }
+}
+// end::all[]

--- a/samples/doc-snippets/src/main/java/com/example/guardrail/ProfanityModelGuard.java
+++ b/samples/doc-snippets/src/main/java/com/example/guardrail/ProfanityModelGuard.java
@@ -1,0 +1,24 @@
+package com.example.guardrail;
+
+// tag::all[]
+import akka.javasdk.agent.Decision;
+import akka.javasdk.agent.GuardrailContext;
+import akka.javasdk.agent.ModelGuardrail;
+
+public class ProfanityModelGuard implements ModelGuardrail { // <1>
+
+  private final String searchFor;
+
+  public ProfanityModelGuard(GuardrailContext context) { // <2>
+    this.searchFor = context.config().getString("search-for");
+  }
+
+  @Override
+  public Decision decide(CallContext ctx) { // <3>
+    if (ctx.text().contains(searchFor)) {
+      return new Decision.Deny("Response contained '%s'.".formatted(searchFor)); // <4>
+    }
+    return new Decision.Allow(); // <5>
+  }
+}
+// end::all[]

--- a/samples/doc-snippets/src/test/java/com/example/classifier/ClassifierTestSample.java
+++ b/samples/doc-snippets/src/test/java/com/example/classifier/ClassifierTestSample.java
@@ -1,0 +1,30 @@
+package com.example.classifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import akka.javasdk.testkit.TestKit;
+import akka.javasdk.testkit.TestKitSupport;
+import org.junit.jupiter.api.Test;
+
+public class ClassifierTestSample extends TestKitSupport {
+
+  @Override
+  protected TestKit.Settings testKitSettings() {
+    return TestKit.Settings.DEFAULT.withAdditionalConfig(
+        """
+        akka.javasdk.agent.classifiers.toxicity {
+          class = "com.example.classifier.ToxicityClassifier"
+          threshold = 0.5
+        }
+        """);
+  }
+
+  @Test
+  public void classifiesText() {
+    // tag::classify[]
+    var classifierClient = getClassifierClient();
+    var classification = classifierClient.classify("toxicity", "some input text");
+    assertThat(classification.label()).contains("clean");
+    // end::classify[]
+  }
+}

--- a/samples/doc-snippets/src/test/java/com/example/classifier/ClassifierTestSample.java
+++ b/samples/doc-snippets/src/test/java/com/example/classifier/ClassifierTestSample.java
@@ -11,12 +11,13 @@ public class ClassifierTestSample extends TestKitSupport {
   @Override
   protected TestKit.Settings testKitSettings() {
     return TestKit.Settings.DEFAULT.withAdditionalConfig(
-        """
-        akka.javasdk.agent.classifiers.toxicity {
-          class = "com.example.classifier.ToxicityClassifier"
-          threshold = 0.5
-        }
-        """);
+      """
+      akka.javasdk.agent.classifiers.toxicity {
+        class = "com.example.classifier.ToxicityClassifier"
+        threshold = 0.5
+      }
+      """
+    );
   }
 
   @Test

--- a/samples/doc-snippets/src/test/java/com/example/evaluator/EvaluatorTestKitSample.java
+++ b/samples/doc-snippets/src/test/java/com/example/evaluator/EvaluatorTestKitSample.java
@@ -1,0 +1,73 @@
+package com.example.evaluator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import akka.javasdk.ledger.InteractionMetadata;
+import akka.javasdk.ledger.InteractionRecord;
+import akka.javasdk.ledger.LedgerClient;
+import akka.javasdk.ledger.ModelConfig;
+import akka.javasdk.ledger.ModelResponse;
+import akka.javasdk.evaluation.Subject;
+import akka.javasdk.testkit.EvaluatorResult;
+import akka.javasdk.testkit.EvaluatorTestKit;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.junit.jupiter.api.Test;
+
+public class EvaluatorTestKitSample {
+
+  // A stub ledger that returns a canned interaction, so the evaluator can be run in isolation.
+  private final LedgerClient stubLedger =
+      new LedgerClient() {
+        @Override
+        public InteractionRecord getInteraction(String interactionId) {
+          return sampleRecord(interactionId);
+        }
+
+        @Override
+        public CompletionStage<InteractionRecord> getInteractionAsync(String interactionId) {
+          return CompletableFuture.completedFuture(sampleRecord(interactionId));
+        }
+      };
+
+  @Test
+  public void evaluatesAnInteraction() {
+    // tag::test[]
+    var testKit = EvaluatorTestKit.of(() -> new InteractionQualityEvaluator(stubLedger));
+
+    EvaluatorResult result =
+        testKit.evaluate(new Subject.AgentInteraction("support-agent", "interaction-1"));
+
+    assertThat(result.isComplete()).isTrue();
+    assertThat(result.getEvaluations()).hasSize(1);
+    assertThat(result.getEvaluations().get(0).passed()).isTrue();
+    // end::test[]
+  }
+
+  private static InteractionRecord sampleRecord(String interactionId) {
+    var metadata =
+        new InteractionMetadata(
+            new ModelConfig("openai", "gpt-4o", "", 0.0, 1.0, 0, 0),
+            Map.of(),
+            Instant.now(),
+            Instant.now(),
+            InteractionMetadata.FinishReason.STOP);
+    return new InteractionRecord(
+        interactionId,
+        "session-1",
+        "support-agent",
+        Optional.empty(),
+        metadata,
+        "system",
+        List.of(),
+        List.of(new ModelResponse("m1", "the agent's reply", 0, 0, "", List.of())),
+        List.of(),
+        Optional.empty(),
+        Optional.empty(),
+        Instant.now());
+  }
+}

--- a/samples/doc-snippets/src/test/java/com/example/evaluator/EvaluatorTestKitSample.java
+++ b/samples/doc-snippets/src/test/java/com/example/evaluator/EvaluatorTestKitSample.java
@@ -2,12 +2,12 @@ package com.example.evaluator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import akka.javasdk.evaluation.Subject;
 import akka.javasdk.ledger.InteractionMetadata;
 import akka.javasdk.ledger.InteractionRecord;
 import akka.javasdk.ledger.LedgerClient;
 import akka.javasdk.ledger.ModelConfig;
 import akka.javasdk.ledger.ModelResponse;
-import akka.javasdk.evaluation.Subject;
 import akka.javasdk.testkit.EvaluatorResult;
 import akka.javasdk.testkit.EvaluatorTestKit;
 import java.time.Instant;
@@ -21,26 +21,26 @@ import org.junit.jupiter.api.Test;
 public class EvaluatorTestKitSample {
 
   // A stub ledger that returns a canned interaction, so the evaluator can be run in isolation.
-  private final LedgerClient stubLedger =
-      new LedgerClient() {
-        @Override
-        public InteractionRecord getInteraction(String interactionId) {
-          return sampleRecord(interactionId);
-        }
+  private final LedgerClient stubLedger = new LedgerClient() {
+    @Override
+    public InteractionRecord getInteraction(String interactionId) {
+      return sampleRecord(interactionId);
+    }
 
-        @Override
-        public CompletionStage<InteractionRecord> getInteractionAsync(String interactionId) {
-          return CompletableFuture.completedFuture(sampleRecord(interactionId));
-        }
-      };
+    @Override
+    public CompletionStage<InteractionRecord> getInteractionAsync(String interactionId) {
+      return CompletableFuture.completedFuture(sampleRecord(interactionId));
+    }
+  };
 
   @Test
   public void evaluatesAnInteraction() {
     // tag::test[]
     var testKit = EvaluatorTestKit.of(() -> new InteractionQualityEvaluator(stubLedger));
 
-    EvaluatorResult result =
-        testKit.evaluate(new Subject.AgentInteraction("support-agent", "interaction-1"));
+    EvaluatorResult result = testKit.evaluate(
+      new Subject.AgentInteraction("support-agent", "interaction-1")
+    );
 
     assertThat(result.isComplete()).isTrue();
     assertThat(result.getEvaluations()).hasSize(1);
@@ -49,25 +49,26 @@ public class EvaluatorTestKitSample {
   }
 
   private static InteractionRecord sampleRecord(String interactionId) {
-    var metadata =
-        new InteractionMetadata(
-            new ModelConfig("openai", "gpt-4o", "", 0.0, 1.0, 0, 0),
-            Map.of(),
-            Instant.now(),
-            Instant.now(),
-            InteractionMetadata.FinishReason.STOP);
+    var metadata = new InteractionMetadata(
+      new ModelConfig("openai", "gpt-4o", "", 0.0, 1.0, 0, 0),
+      Map.of(),
+      Instant.now(),
+      Instant.now(),
+      InteractionMetadata.FinishReason.STOP
+    );
     return new InteractionRecord(
-        interactionId,
-        "session-1",
-        "support-agent",
-        Optional.empty(),
-        metadata,
-        "system",
-        List.of(),
-        List.of(new ModelResponse("m1", "the agent's reply", 0, 0, "", List.of())),
-        List.of(),
-        Optional.empty(),
-        Optional.empty(),
-        Instant.now());
+      interactionId,
+      "session-1",
+      "support-agent",
+      Optional.empty(),
+      metadata,
+      "system",
+      List.of(),
+      List.of(new ModelResponse("m1", "the agent's reply", 0, 0, "", List.of())),
+      List.of(),
+      Optional.empty(),
+      Optional.empty(),
+      Instant.now()
+    );
   }
 }


### PR DESCRIPTION
Documents the APIs introduced on `feature/governance`, which currently ship with no user-facing docs. Based on `feature/governance` (these APIs are not on `main` yet).

## Pages
- **Guardrails** (rework) — the page still described only `TextGuardrail` as "the Guardrail interface". Restructured around `ModelGuardrail` / `ToolGuardrail`, the `Allow`/`Deny`/`Fail` `Decision` model, the `before-tool-call` boundary, classifier-backed guardrails via `GuardrailContext.classifierClient()`, and `Deny`-vs-`Fail` handling. `TextGuardrail` marked deprecated.
- **Classifiers** (new) — `agents/classifiers.adoc`: config-bound classifiers invoked inline by name through `ClassifierClient` (never runtime-dispatched), `Classifier`/`Classification`, and ensemble composition via `ClassifierContext` + injected `ClassifierClient`.
- **Evaluators** (new) — top-level component page `evaluators.adoc`: `@Component`/`Evaluator`/`evaluate`, the `Effect` model (complete/inconclusive/asyncEffect), agent binding under `akka.javasdk.evaluation`, judge-agent and durable-workflow delegation, `EvaluatorTestKit`, and the **ledger** (`LedgerClient`, `InteractionRecord`).

## Cross-cutting
`llm_eval` positioning note, DI table (`ClassifierClient`), `testing.adoc`, `agents.adoc` related, access-control "Inspecting the caller's identity" (SPIFFE accessors), `acls.adoc` propagation note, both governance narrative pages, four glossary terms, a release-notes governance sidebar, nav entries, and the guardrails `reference.conf` comment (it renders into the config reference).

## Notes
- Doc-snippets compile against the built SDK; CI repoints the sample parent to the built snapshot before the `maven-samples` job.
- The release-notes entry is a version-agnostic sidebar — no tagged release carries these APIs yet; swap in the real version on release.