### PR TITLE
docs: apply the writing guide to the governance pages

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/evaluation/package-info.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/evaluation/package-info.java
@@ -1,0 +1,2 @@
+/** {@link akka.javasdk.evaluation.Evaluator} component for assessing agent interactions. */
+package akka.javasdk.evaluation;

--- a/akka-javasdk/src/main/java/akka/javasdk/ledger/package-info.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/ledger/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * {@link akka.javasdk.ledger.LedgerClient} for reading recorded agent interactions from the ledger.
+ */
+package akka.javasdk.ledger;

--- a/docs/src/modules/concepts/pages/governance-and-the-runtime.adoc
+++ b/docs/src/modules/concepts/pages/governance-and-the-runtime.adoc
@@ -60,7 +60,7 @@ Akka holds more than 19 compliance certifications including:
 * xref:sdk:sanitization.adoc[Data sanitization] — PII scrubbing implementation
 * xref:sdk:access-control.adoc[Access Control] — Service-level and component-level access control lists
 
-== See Also
+== See also
 
 * link:{url-blog-trustworthy-ai}[Trustworthy AI with Akka, window="new"]
 * link:{url-blog-webinar-certainty}[Webinar: Creating Certainty in the Age of Agentic AI, window="new"]

--- a/docs/src/modules/getting-started/pages/spec-your-first-agent.adoc
+++ b/docs/src/modules/getting-started/pages/spec-your-first-agent.adoc
@@ -17,31 +17,31 @@ In this guide, you will:
 * Complete xref:getting-started:set-up-dev-env.adoc#_set_up_your_ai_harness[Set up your AI harness] — install the Akka Specify Plugin and run `/akka:setup`.
 * An https://platform.openai.com/api-keys[OpenAI API key, window="new"]. This sample's application code uses OpenAI (not necessarily your AI coding assistant). Set `OPENAI_API_KEY` in your environment — on Mac/Linux use `export` so child processes inherit it — before starting your coding assistant.
 
-Now you're ready to initialize a specification.
+Now you are ready to initialize a specification.
 
 == Initialize a new spec-driven project
-If you're using the Claude Code Akka marketplace plugin, you can skip this step and go directly to specifying the main feature.
+If you are using the Claude Code Akka marketplace plugin, you can skip this step and go directly to specifying the main feature.
 
-If you're using the CLI to start a new project using Spec-Driven Development, we use the `akka specify init` command. You have a few options here:
+If you are using the CLI to start a new project using Spec-Driven Development, we use the `akka specify init` command. You have a few options here:
 
 * Type `akka specify init helloworld-agent` to create a new directory called `helloworld-agent`
 * Manually create your own directory, `cd` into that directory, and run `akka specify init .`
 
 This will copy the default Akka template files, give you a chance to add your own additional constitution (which you can skip for this exercise), and set up an empty Akka service project with a Maven `pom.xml` file. It will also set the directory up as a git repository.
 
-Once you've successfully initialized the project, you can start Claude Code in your terminal. This guide doesn't cover using the web app.
+Once you have successfully initialized the project, you can start Claude Code in your terminal. This guide does not cover using the web app.
 
 == Specify the main feature
-To specify the main feature of the application, we use `/akka.specify` (`/akka:specify` in the Claude Code plugin). The following prompt shows this in action. If you're feeling adventurous, you can experiment with changing the prompt to see how it affects the final results. Copy and paste this `/akka.specify` (or `/akka:specify`) command into your agent session:
+To specify the main feature of the application, we use `/akka.specify` (`/akka:specify` in the Claude Code plugin). The following prompt shows this in action. If you are feeling adventurous, you can experiment with changing the prompt to see how it affects the final results. Copy and paste this `/akka.specify` (or `/akka:specify`) command into your agent session:
 
 .Hello agent single feature
 [cols="1"]
 :table-caption: Prompt
 |===
-|**/akka.specify** main feature - _The greeter agent generates greetings in different languages using an LLM. The consumer of the agent supplies a name and some greeting text in their native language. The agent will then respond with a friendly greeting in English. Each subsequent message sent by a given user will result in a greeting in a randomly chosen language that hasn't yet been used in that agent session._
+|**/akka.specify** main feature - _The greeter agent generates greetings in different languages using an LLM. The consumer of the agent supplies a name and some greeting text in their native language. The agent will then respond with a friendly greeting in English. Each subsequent message sent by a given user will result in a greeting in a randomly chosen language that has not yet been used in that agent session._
 |===
 
-After submitting that prompt, you will be asked for permission to run a number of MCP tools. These relate to setting up a new git branch and creating the first specification file (you're likely to be asked for permission to overwrite the spec file). If you typed the prompt exactly as above, then you will have a new branch called `001-main-feature`.
+After submitting that prompt, you will be asked for permission to run a number of MCP tools. These relate to setting up a new git branch and creating the first specification file (you are likely to be asked for permission to overwrite the spec file). If you typed the prompt exactly as above, then you will have a new branch called `001-main-feature`.
 
 When using Claude, you will get a summary of the specification as the assistant understands it. It might look like the following:
 
@@ -67,9 +67,9 @@ If this summary is different than what you expected or intended, then you should
 Under normal circumstances you would use `/akka.clarify` to fill in potential gaps in the specification. For a very simple 1-feature application like this, we can skip that step.
 
 == Create a plan
-Once we've got a specification we're pleased with, we need to create an implementation plan. This plan tells the coding assistant _how_ to implement the specification. Here is where we dictate the technical architecture and requirements.
+Once we have got a specification we are pleased with, we need to create an implementation plan. This plan tells the coding assistant _how_ to implement the specification. Here is where we dictate the technical architecture and requirements.
 
-Copy and paste this slash command into your Claude session (use `/akka:plan` if you're using the marketplace plugin):
+Copy and paste this slash command into your Claude session (use `/akka:plan` if you are using the marketplace plugin):
 
 .Technical implementation plan
 [cols="1"]
@@ -81,7 +81,7 @@ Copy and paste this slash command into your Claude session (use `/akka:plan` if 
 
 * Start the response with a greeting in a specific language
 
-* Always append the language you're using in parenthesis in English. E.g. "Hola (Spanish)"
+* Always append the language you are using in parenthesis in English. E.g. "Hola (Spanish)"
 
 * The first greeting should be in English
 
@@ -100,7 +100,7 @@ Copy and paste this slash command into your Claude session (use `/akka:plan` if 
 This implementation should result in a single agent, the `HelloWorldAgent`, and a single endpoint, the `HelloWorldEndpoint`. There are no domain objects nor are there any entity components. The application should obtain its model target configuration from the standard Akka SDK model provider configuration. If insufficient configuration is provided, then the endpoint request should fail with a 500 error code.
 |===
 
-As usual with AI, the results will vary. Here's an example of a summary of the plan that we might get with Claude Code:
+As usual with AI, the results will vary. Here is an example of a summary of the plan that we might get with Claude Code:
 
 ```
   Branch: 001-greeter-agent
@@ -149,7 +149,7 @@ This plan looks good and the architecture is exactly what we wanted, so now we c
 
 To generate the tasks from this plan, run `/akka.tasks` (or `/akka:tasks` when using the plugin)
 
-Here's a sample summary output from generating tasks. Note that it has analyzed which tasks can be done in parallel.
+Here is a sample summary output from generating tasks. Note that it has analyzed which tasks can be done in parallel.
 
 ```
   Summary
@@ -181,16 +181,16 @@ Here's a sample summary output from generating tasks. Note that it has analyzed 
   functional with a tested greeting flow.
 ```
 
-With the plan and tasks ready to go, we can move on to implementation. It's worth noting that the actual writing of the code is one of the smaller parts of the process, and is done at the end of the feature definition, not the beginning.
+With the plan and tasks ready to go, we can move on to implementation. It is worth noting that the actual writing of the code is one of the smaller parts of the process, and is done at the end of the feature definition, not the beginning.
 
 == Implement the agent
-Now it's time to generate some code. Run the `/akka.implement` (or `/akka:implement` with the plugin) command and allow it to proceed with any operations for which it requests permission.
+Now it is time to generate some code. Run the `/akka.implement` (or `/akka:implement` with the plugin) command and allow it to proceed with any operations for which it requests permission.
 
 During implementation it is not unusual to see your AI assistant get a number of things wrong. Code may fail to compile and tests might not pass. We should try and leave the agent alone and let it try and fix the problems on its own before we intervene. Only if it looks like the agent is stuck (>5 attempts to fix the same thing) should we step in and provide instructions to solve the problem. This implementation is simple enough that errors and failure loops are unlikely.
 
-If you're not happy with the generated results, consider re-running the implement phase with a different model and/or effort level.
+If you are not happy with the generated results, consider re-running the implement phase with a different model and/or effort level.
 
-Here's an example summary of an implementation phase:
+Here is an example summary of an implementation phase:
 
 ```
   Summary
@@ -217,11 +217,11 @@ Here's an example summary of an implementation phase:
 
   All 4 tests pass (1 agent unit + 3 endpoint integration). mvn verify succeeds.
 ```
-If you can, resist the temptation to go look at the code right now. Exercise the application and make sure it does what you want before looking at the code. If the app fails to meet core requirements, then the code is all going to be thrown away anyway as you'll re-do the `plan` or `specify` phases.
+If you can, resist the temptation to go look at the code right now. Exercise the application and make sure it does what you want before looking at the code. If the app fails to meet core requirements, then the code is all going to be thrown away anyway as you will re-do the `plan` or `specify` phases.
 
-It's also a recommended practice to not commit this feature branch back to `main` until you've exercised the final result.
+It is also a recommended practice to not commit this feature branch back to `main` until you have exercised the final result.
 
-If we're satisfied with these results, we can move on to the next step.
+If we are satisfied with these results, we can move on to the next step.
 
 == Exercise the agent API
 Exercising the agent API is easy. At this point, run `/akka.build` (or `/akka:build`). This will recompile your project, run tests, and issue a sample command to the RESTful API endpoint.
@@ -255,11 +255,11 @@ If you can verify that no previous instances of your service are running and tha
   Next steps: Iterate with /akka.implement or ship with /akka.deploy.
 ```
 
-We shouldn't have to leave the Claude session for any reason.
+We should not have to leave the Claude session for any reason.
 
 == Next steps
 Next we move on to a more involved tutorial that uses multiple components to create a multi-agent trip planning system. We also encourage you to take a look at the various samples and tutorials and see if you can work backwards from the implementation to come up with the specification and then go through a spec-driven flow.
 
-The more you go through the spec-driven process, the better and more precise you'll find your specs.
+The more you go through the spec-driven process, the better and more precise you will find your specs.
 
 If you want to see how the code-first version of this tutorial unfolds, see xref:getting-started:author-your-first-service.adoc[].

--- a/docs/src/modules/sdk/pages/agents/classifiers.adoc
+++ b/docs/src/modules/sdk/pages/agents/classifiers.adoc
@@ -112,7 +112,7 @@ See xref:sdk:setup-and-dependency-injection.adoc[].
 == Testing
 
 In a test, obtain a `ClassifierClient` from the testkit with `getClassifierClient()` and invoke your configured classifiers directly.
-See xref:sdk:agents/testing.adoc#_classifiers[Testing classifiers].
+See xref:sdk:agents/testing.adoc#_testing_classifiers[Testing classifiers].
 
 == See also
 

--- a/docs/src/modules/sdk/pages/agents/guardrails.adoc
+++ b/docs/src/modules/sdk/pages/agents/guardrails.adoc
@@ -170,7 +170,7 @@ include::example$doc-snippets/src/main/java/com/example/guardrail/GuardedAgent.j
 With `report-only = true`, a `Deny` is recorded in logs, metrics, and traces but the interaction continues.
 A `Decision.Fail` is always propagated as a failure regardless of `report-only`, since the guardrail reached no verdict.
 
-== Guardrail of similar text
+== Similarity guardrail
 
 The built-in link:{attachmentsdir}/api/akka/javasdk/agent/SimilarityGuard.html[`SimilarityGuard`] evaluates the text by making a similarity search in a dataset of "bad examples". If the similarity exceeds a threshold, the result is flagged as blocked.
 
@@ -194,6 +194,10 @@ akka.javasdk.agent.guardrails {
 Here, it is using predefined examples of jailbreak prompts in `guardrail/jailbreak`. Those have been incorporated from https://github.com/verazuo/jailbreak_llms/[https://github.com/verazuo/jailbreak_llms, window="new"], but you can define your own examples and place in a subdirectory of  `src/main/resources/`. All text files in the configured `bad-examples-resource-dir` are included in the similarity search.
 
 You can use this for other things than jailbreak attempt detection.
+
+== Testing
+
+Guardrails run in integration tests the same way they run in production. Configure the guardrail in `src/test/resources/application.conf`, run the agent with `TestKitSupport`, and use a `TestModelProvider` to produce text that triggers or passes the guardrail. A denied interaction surfaces as a `GuardrailException`, which the agent handles as shown in <<Handling a denied interaction>>.
 
 == See also
 

--- a/docs/src/modules/sdk/pages/agents/guardrails.adoc
+++ b/docs/src/modules/sdk/pages/agents/guardrails.adoc
@@ -112,7 +112,7 @@ akka.javasdk.agent.guardrails {
 <4> Enable this guardrail for agents with these roles.
 <5> The type of validation, such as PII and TOXIC.
 <6> The boundary the guardrail binds to; a `ModelGuardrail` binds to `before-agent-response`, the final agent reply.
-<7> If it didn't pass the evaluation criteria, the execution can either be aborted or continue anyway. In both cases, the result is tracked in logs, metrics and traces.
+<7> If it did not pass the evaluation criteria, the execution can either be aborted or continue anyway. In both cases, the result is tracked in logs, metrics and traces.
 <8> An application-specific property, read by the guardrail from its `GuardrailContext`.
 <9> A `ToolGuardrail` binds to the `before-tool-call` boundary.
 
@@ -191,7 +191,7 @@ akka.javasdk.agent.guardrails {
 }
 ----
 
-Here, it's using predefined examples of jailbreak prompts in `guardrail/jailbreak`. Those have been incorporated from https://github.com/verazuo/jailbreak_llms/[https://github.com/verazuo/jailbreak_llms, window="new"], but you can define your own examples and place in a subdirectory of  `src/main/resources/`. All text files in the configured `bad-examples-resource-dir` are included in the similarity search.
+Here, it is using predefined examples of jailbreak prompts in `guardrail/jailbreak`. Those have been incorporated from https://github.com/verazuo/jailbreak_llms/[https://github.com/verazuo/jailbreak_llms, window="new"], but you can define your own examples and place in a subdirectory of  `src/main/resources/`. All text files in the configured `bad-examples-resource-dir` are included in the similarity search.
 
 You can use this for other things than jailbreak attempt detection.
 

--- a/docs/src/modules/sdk/pages/agents/guardrails.adoc
+++ b/docs/src/modules/sdk/pages/agents/guardrails.adoc
@@ -39,7 +39,7 @@ Both return a link:{attachmentsdir}/api/akka/javasdk/agent/Decision.html[`Decisi
 [NOTE]
 ====
 The earlier link:{attachmentsdir}/api/akka/javasdk/agent/TextGuardrail.html[`TextGuardrail`] interface — which returns a `Guardrail.Result` (a boolean plus explanation) rather than a `Decision` — is deprecated for removal.
-Existing `TextGuardrail` implementations still run, and the built-in `SimilarityGuard` (see <<_guardrail_of_similar_text>>) is configured the same way.
+Existing `TextGuardrail` implementations still run, and the built-in `SimilarityGuard` (see <<_similarity_guardrail>>) is configured the same way.
 New guardrails should implement `ModelGuardrail` or `ToolGuardrail`.
 ====
 

--- a/docs/src/modules/sdk/pages/agents/llm_eval.adoc
+++ b/docs/src/modules/sdk/pages/agents/llm_eval.adoc
@@ -109,3 +109,7 @@ Default system message:
 include::example$akka-javasdk/src/main/java/akka/javasdk/agent/evaluator/HallucinationEvaluator.java[tag=prompt]
 ----
 
+== See also
+
+* xref:sdk:evaluators.adoc[Evaluators]
+* xref:sdk:agents/testing.adoc[Testing the agent]

--- a/docs/src/modules/sdk/pages/agents/llm_eval.adoc
+++ b/docs/src/modules/sdk/pages/agents/llm_eval.adoc
@@ -2,7 +2,7 @@
 
 include::ROOT:partial$include.adoc[]
 
-Evaluating AI quality is critical when refining prompts and model parameters. Without evaluation with realistic scenarios and data, you won’t know whether a change improves performance, breaks a use case, or has no impact at all.
+Evaluating AI quality is critical when refining prompts and model parameters. Without evaluation with realistic scenarios and data, you will not know whether a change improves performance, breaks a use case, or has no impact at all.
 
 [NOTE]
 ====
@@ -10,7 +10,7 @@ This page covers how to compute a verdict — implementing an LLM-as-judge as an
 To have the runtime run an evaluation automatically for each interaction of an agent, bind an xref:sdk:evaluators.adoc[Evaluator component] to that agent; an Evaluator commonly delegates to one of the judge agents described here.
 ====
 
-Testing with generative AI is difficult no matter what you're using to implement it. Interactions with an LLM are not _deterministic_. In other words, you shouldn't expect to get the same answer twice for the same prompt. Because interactions with an LLM are not deterministic, traditional assertions don't work.
+Testing with generative AI is difficult no matter what you are using to implement it. Interactions with an LLM are not _deterministic_. In other words, you should not expect to get the same answer twice for the same prompt. Because interactions with an LLM are not deterministic, traditional assertions do not work.
 
 How can you write assertions for something like that? There are a ton of solutions, but most of them revolve around the idea that to verify an LLM's answer, you need another LLM. This pattern is often called "LLM-as-judge". You can get an answer from one agent, and then use another agent or model to review the session history and prompts to infer, with some level of confidence, if the agent behaved the way you want it to.
 
@@ -25,7 +25,7 @@ You can implement an LLM-as-judge evaluator as an Akka `Agent`. The result of th
 ----
 include::example$doc-snippets/src/main/java/com/example/evaluator/HumanVsAiEvaluator.java[tag=all]
 ----
-<1> It's an ordinary `Agent`
+<1> It is an ordinary `Agent`
 <2> It can have any type of request parameter
 <3> The result from the model
 <4> The return type must implement `EvaluationResult`, but may also include more information
@@ -33,7 +33,7 @@ include::example$doc-snippets/src/main/java/com/example/evaluator/HumanVsAiEvalu
 <6> The method with return type implementing `EvaluationResult`
 <7> Transform the model result
 
-In this example, we use one result representation from the model, and a slightly different as the response type. These could be the same, but the model might be more accurate when using text labels instead of boolean values. It's also good to include validation in that transformation.
+In this example, we use one result representation from the model, and a slightly different as the response type. These could be the same, but the model might be more accurate when using text labels instead of boolean values. It is also good to include validation in that transformation.
 
 Since the evaluator is an ordinary `Agent` you can call it with the component client in the same way as any other agent. For example, from a Consumer that listens for task completions from an xref:sdk:autonomous-agents.adoc[Autonomous Agent]:
 
@@ -48,7 +48,7 @@ include::example$multi-agent/src/main/java/demo/multiagent/application/Evaluatio
 <4> Call the custom evaluator agent. Additional logging is included here, but metrics and traces are updated automatically from the evaluation result.
 <5> Call the built-in `ToxicityEvaluator` on the final answer.
 
-This illustrates that evaluation happens asynchronously, in the background, to capture the results for analytics and later development improvements of prompts. However, the evaluators can also be part of the core agent workflow and thereby have a more immediate impact on the workflow. For example, if the outcome of some step in the workflow doesn't pass the evaluation it can refine the plan and iterate. In this case it's still good to capture the results in metrics and traces by using the `EvaluationResult`. The concrete, application specific, result may include more things than `EvaluationResult`, which can be used for adjusting the execution plan in the workflow.
+This illustrates that evaluation happens asynchronously, in the background, to capture the results for analytics and later development improvements of prompts. However, the evaluators can also be part of the core agent workflow and thereby have a more immediate impact on the workflow. For example, if the outcome of some step in the workflow does not pass the evaluation it can refine the plan and iterate. In this case it is still good to capture the results in metrics and traces by using the `EvaluationResult`. The concrete, application specific, result may include more things than `EvaluationResult`, which can be used for adjusting the execution plan in the workflow.
 
 NOTE: Evaluator agents have an associated cost and overhead since they typically use an LLM. You might want to enable them only in test environments and not for large scale production environments. You can xref:setup-and-dependency-injection.adoc#_disabling_components[disable consumers] that are calling evaluator agents.
 
@@ -58,7 +58,7 @@ External evaluation products can be integrated with Akka by operating on the tra
 
 == Built-in evaluators
 
-As shown above, it's easy to implement your own evaluator agents, but for convenience Akka provides a few built-in evaluators that you can use by calling them with the `ComponentClient`. The `EvaluationConsumer` example above also shows how to call the built-in `ToxicityEvaluator`.
+As shown above, it is easy to implement your own evaluator agents, but for convenience Akka provides a few built-in evaluators that you can use by calling them with the `ComponentClient`. The `EvaluationConsumer` example above also shows how to call the built-in `ToxicityEvaluator`.
 
 The model provider for these agents can be defined in a specific configuration for each agent, which by default is the same as the default model provider.
 

--- a/docs/src/modules/sdk/pages/agents/llm_eval.adoc
+++ b/docs/src/modules/sdk/pages/agents/llm_eval.adoc
@@ -2,7 +2,7 @@
 
 include::ROOT:partial$include.adoc[]
 
-Evaluating AI quality is critical when refining prompts and model parameters. Without evaluation with realistic scenarios and data, you will not know whether a change improves performance, breaks a use case, or has no impact at all.
+LLM evaluation verifies an agent's model interactions by judging their quality, typically with another model. Use it when refining prompts and model parameters: without evaluation against realistic scenarios and data, you will not know whether a change improves performance, breaks a use case, or has no impact at all.
 
 [NOTE]
 ====
@@ -12,7 +12,7 @@ To have the runtime run an evaluation automatically for each interaction of an a
 
 Testing with generative AI is difficult no matter what you are using to implement it. Interactions with an LLM are not _deterministic_. In other words, you should not expect to get the same answer twice for the same prompt. Because interactions with an LLM are not deterministic, traditional assertions do not work.
 
-How can you write assertions for something like that? There are a ton of solutions, but most of them revolve around the idea that to verify an LLM's answer, you need another LLM. This pattern is often called "LLM-as-judge". You can get an answer from one agent, and then use another agent or model to review the session history and prompts to infer, with some level of confidence, if the agent behaved the way you want it to.
+How can you write assertions for something like that? Most solutions revolve around the idea that to verify an LLM's answer, you need another LLM. This pattern is often called "LLM-as-judge". You can get an answer from one agent, and then use another agent or model to review the session history and prompts to infer, with some level of confidence, if the agent behaved the way you want it to.
 
 For instance, after a test run, you could send the session history to a powerful model like GPT-4 with a prompt like: "Based on the user's question about activities, did the agent correctly use the provided `getWeather` tool? Respond with only YES or NO."
 

--- a/docs/src/modules/sdk/pages/agents/testing.adoc
+++ b/docs/src/modules/sdk/pages/agents/testing.adoc
@@ -72,7 +72,7 @@ akka.javasdk {
 Note that you should use `http`, and not `https`, the connection will be encrypted with TLS, but that is handled by the platform.
 
 [#_classifiers]
-== Classifiers
+== Testing classifiers
 
 To exercise your configured xref:sdk:agents/classifiers.adoc[classifiers] in a test, obtain a `ClassifierClient` from the testkit with `getClassifierClient()` and invoke them by name:
 
@@ -82,7 +82,7 @@ To exercise your configured xref:sdk:agents/classifiers.adoc[classifiers] in a t
 include::example$doc-snippets/src/test/java/com/example/classifier/ClassifierTestSample.java[tag=classify]
 ----
 
-== Evaluators
+== Testing evaluators
 
 To unit-test an xref:sdk:evaluators.adoc[Evaluator] in isolation — without binding it to an agent or running the full runtime — use `EvaluatorTestKit`; see xref:sdk:evaluators.adoc#_testing[Testing evaluators].
 
@@ -95,3 +95,8 @@ To see exactly what is sent to and received from the AI model, you can enable th
   <logger name="kalix.runtime.agent.AkkaLangChain4jHttpClient" level="TRACE"/>
 ----
 
+== See also
+
+* xref:sdk:agents.adoc[Agents]
+* xref:sdk:evaluators.adoc[Evaluators]
+* xref:sdk:autonomous-agents/testing.adoc[Testing autonomous agents]

--- a/docs/src/modules/sdk/pages/agents/testing.adoc
+++ b/docs/src/modules/sdk/pages/agents/testing.adoc
@@ -6,7 +6,7 @@ Testing agents built with Generative AI involves two complementary approaches: e
 
 == Mocking responses from the model
 
-For predictable and repeatable tests of your agent's business logic and component integrations, it's essential to use deterministic responses. This allows you to verify that your agent behaves correctly when it receives a known model output.
+For predictable and repeatable tests of your agent's business logic and component integrations, it is essential to use deterministic responses. This allows you to verify that your agent behaves correctly when it receives a known model output.
 
 Use the `TestKitSupport` and the `ComponentClient` to call the components from the test. The `ModelProvider` of the agents can be replaced with link:{attachmentsdir}/testkit/akka/javasdk/testkit/TestModelProvider.html[TestModelProvider], which provides ways to mock the responses without using the real AI model.
 

--- a/docs/src/modules/sdk/pages/agents/testing.adoc
+++ b/docs/src/modules/sdk/pages/agents/testing.adoc
@@ -1,4 +1,4 @@
-= Testing the agent
+= Testing
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/sdk/pages/autonomous-agents/client.adoc
+++ b/docs/src/modules/sdk/pages/autonomous-agents/client.adoc
@@ -174,7 +174,7 @@ include::example$autonomous-agent-playground/src/test/java/demo/docs/ClientApiSa
 
 The same shape applies to `suspendAsync()`, `resumeAsync()`, `terminateAsync()`, `assignTasksAsync(...)`, `runSingleTaskAsync(...)`, and the `forTask` operations. Each returns a `CompletionStage` that completes once the runtime acknowledges the operation. Mixing styles is fine: use synchronous calls where they read more clearly, async ones where the call needs to compose with other futures.
 
-== See Also
+== See also
 
 * xref:sdk:autonomous-agents/notifications.adoc[Notifications] for the full notification reference
 * xref:sdk:autonomous-agents/tasks.adoc[Tasks]

--- a/docs/src/modules/sdk/pages/autonomous-agents/client.adoc
+++ b/docs/src/modules/sdk/pages/autonomous-agents/client.adoc
@@ -14,7 +14,7 @@ The simplest pattern: create a task, start an agent, and automatically stop the 
 include::example$autonomous-agent-playground/src/main/java/demo/helloworld/api/QuestionEndpoint.java[tag=run-single-task]
 ----
 
-This returns the task id for later status checks. Each call spins up an independent agent instance.
+This returns the task id for later status checks. Each call starts an independent agent instance.
 
 `runSingleTask` only constrains how the work starts. It provides exactly one task to the agent. Once the agent is running, its capabilities can still create more tasks during the loop. A coordinator with a `Delegation` capability creates subtasks for its workers, and a team lead with `TeamLeadership` creates tasks in the team's shared list. The agent stops automatically once its task queue is fully drained, including the original task and anything spawned along the way.
 
@@ -25,11 +25,9 @@ For more control over multiple tasks, pipelines, or long-lived agents, create ta
 *Create tasks:*
 
 [source,java,indent=0]
+.{sample-base-url}/autonomous-agent-playground/src/main/java/demo/pipeline/api/PipelineEndpoint.java[PipelineEndpoint.java]
 ----
-var taskId = UUID.randomUUID().toString();
-componentClient
-  .forTask(taskId)
-  .create(PipelineTasks.COLLECT.instructions("Collect data on: " + topic));
+include::example$autonomous-agent-playground/src/main/java/demo/pipeline/api/PipelineEndpoint.java[tag=create-task]
 ----
 
 *Assign tasks to an agent:*
@@ -49,10 +47,9 @@ If the agent uses xref:sdk:autonomous-agents/defining.adoc#dynamic-configuration
 *Terminate an agent:*
 
 [source,java,indent=0]
+.{sample-base-url}/autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[ClientApiSample.java]
 ----
-componentClient
-  .forAutonomousAgent(ReportAgent.class, agentInstanceId)
-  .terminate();
+include::example$autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[tag=terminate]
 ----
 
 IMPORTANT: When you manage tasks and agents separately, you are responsible for the agent's lifecycle. Call `terminate()` when an agent is permanently done. The `runSingleTask` shortcut handles this automatically. The explicit `assignTasks` flow does not. Idle agents are passivated automatically to release memory, and reactivates transparently on the next command (e.g. `assignTask`). An agent that holds access to a shared backlog stays resident rather than passivating, so it does not miss new claimable tasks pushed to it.
@@ -64,8 +61,9 @@ Beyond `create` and `get`, the `forTask(...)` client exposes the operations that
 *Assign a task to an owner:*
 
 [source,java,indent=0]
+.{sample-base-url}/autonomous-agent-playground/src/main/java/demo/publishing/api/PublishingEndpoint.java[PublishingEndpoint.java]
 ----
-componentClient.forTask(taskId).assign("alice@example.com");
+include::example$autonomous-agent-playground/src/main/java/demo/publishing/api/PublishingEndpoint.java[tag=assign]
 ----
 
 A task must be assigned before it can be completed or failed. The assignee is a free-form identifier (a user id, team name, or process identifier) that records who took ownership.
@@ -73,10 +71,9 @@ A task must be assigned before it can be completed or failed. The assignee is a 
 *Complete a task with a typed result:*
 
 [source,java,indent=0]
+.{sample-base-url}/autonomous-agent-playground/src/main/java/demo/publishing/api/PublishingEndpoint.java[PublishingEndpoint.java]
 ----
-componentClient
-  .forTask(taskId)
-  .complete(PublishingTasks.APPROVAL, new ApprovalDecision("alice", "Looks good"));
+include::example$autonomous-agent-playground/src/main/java/demo/publishing/api/PublishingEndpoint.java[tag=complete]
 ----
 
 The result is validated against the task definition's result type. The task transitions to `COMPLETED` and any dependents become eligible to start.
@@ -84,8 +81,9 @@ The result is validated against the task definition's result type. The task tran
 *Fail a task with a reason:*
 
 [source,java,indent=0]
+.{sample-base-url}/autonomous-agent-playground/src/main/java/demo/publishing/api/PublishingEndpoint.java[PublishingEndpoint.java]
 ----
-componentClient.forTask(taskId).fail("Approval rejected: tone is too informal");
+include::example$autonomous-agent-playground/src/main/java/demo/publishing/api/PublishingEndpoint.java[tag=fail]
 ----
 
 The task transitions to `FAILED`. Any dependents are cancelled automatically.
@@ -95,34 +93,21 @@ The task transitions to `FAILED`. Any dependents are cancelled automatically.
 A running agent can be suspended and later resumed. While suspended, the agent stops iterating: it will not start new model calls or process queued tasks. Tasks already assigned remain in the queue and are processed when the agent resumes.
 
 [source,java,indent=0]
+.{sample-base-url}/autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[ClientApiSample.java]
 ----
-// Suspend the agent
-componentClient
-  .forAutonomousAgent(ReportAgent.class, agentInstanceId)
-  .suspend();
+include::example$autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[tag=suspend-resume]
+----
 
-// Resume the agent
-componentClient
-  .forAutonomousAgent(ReportAgent.class, agentInstanceId)
-  .resume();
-----
+Both `suspend(...)` and `terminate(...)` accept an optional reason string, recorded on the corresponding `Suspended` and `Stopped` notifications.
 
 == Agent state
 
 Query the current state of an agent instance with `getState()`. The returned `AgentState` provides a snapshot of the agent's execution status.
 
 [source,java,indent=0]
+.{sample-base-url}/autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[ClientApiSample.java]
 ----
-var state = componentClient
-  .forAutonomousAgent(ReportAgent.class, agentInstanceId)
-  .getState();
-
-state.phase();           // execution phase, e.g. "model", "tools", "stopped"
-state.suspended();       // whether the agent is suspended
-state.instructions();    // the agent's current instructions
-state.totalTokenUsage(); // cumulative token usage (inputTokens, outputTokens)
-state.currentTask();     // Optional<TaskKey> with the task currently being worked on
-state.pendingTaskIds();  // List<String> with ids of tasks queued but not yet started
+include::example$autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[tag=get-state]
 ----
 
 The `currentTask()` returns an `Optional<TaskKey>` containing the `id` and `name` of the task the agent is actively processing. When the agent is idle or between tasks, it is empty.
@@ -134,20 +119,17 @@ Task results are typed based on the task definition's `resultConformsTo` type. T
 *Read a snapshot:*
 
 [source,java,indent=0]
+.{sample-base-url}/autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[ClientApiSample.java]
 ----
-var snapshot = componentClient.forTask(taskId).get(ResearchTasks.BRIEF);
-if (snapshot.status() == TaskStatus.COMPLETED) {
-  ResearchBrief brief = snapshot.result().orElseThrow();
-  var title = brief.title();
-  var findings = brief.keyFindings();
-}
+include::example$autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[tag=get-snapshot]
 ----
 
 *Wait for the terminal result:*
 
 [source,java,indent=0]
+.{sample-base-url}/autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[ClientApiSample.java]
 ----
-ResearchBrief brief = componentClient.forTask(taskId).result(ResearchTasks.BRIEF);
+include::example$autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[tag=result]
 ----
 
 `result(...)` blocks the calling thread until the task is `COMPLETED`, `FAILED`, or `CANCELLED`. It returns the typed result on success, or throws `TaskException.Failed` / `TaskException.Cancelled` on failure or cancellation. Use it when the caller wants to wait for the outcome rather than poll. In non-blocking code paths, prefer the async variant covered in <<asynchronous-execution>>.
@@ -158,11 +140,9 @@ ResearchBrief brief = componentClient.forTask(taskId).result(ResearchTasks.BRIEF
 Subscribe to notifications for an agent instance to observe its execution progress in real time. Notifications are published by the runtime, not by user code, as the agent moves through its execution loop and participates in coordination patterns.
 
 [source,java,indent=0]
+.{sample-base-url}/autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[ClientApiSample.java]
 ----
-componentClient
-  .forAutonomousAgent(QuestionAnswerer.class, agentInstanceId)
-  .notificationStream()
-  .runForeach(System.out::println, materializer);
+include::example$autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[tag=notification-stream]
 ----
 
 Subscribe before triggering the agent to avoid missing early events. The stream stays open as long as the agent instance exists. Use it for dashboards, logging, cost tracking, or coordinating external processes with agent progress.
@@ -170,15 +150,9 @@ Subscribe before triggering the agent to avoid missing early events. The stream 
 Every notification implements the `Notification` sealed interface and exactly one capability-grouped marker sub-interface. Pattern-match on a marker to handle a whole family generically:
 
 [source,java,indent=0]
+.{sample-base-url}/autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[ClientApiSample.java]
 ----
-agentClient.notificationStream().runForeach(n -> {
-  switch (n) {
-    case Notification.LifecycleNotification lifecycle -> renderLifecycle(lifecycle);
-    case Notification.TaskNotification task -> renderTask(task);
-    case Notification.TeamNotification team -> renderTeam(team);
-    default -> { /* ignore */ }
-  }
-}, materializer);
+include::example$autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[tag=notification-families]
 ----
 
 For the full set of notification types and their fields, see xref:sdk:autonomous-agents/notifications.adoc[].
@@ -193,12 +167,9 @@ WARNING: Notifications should not be used to drive business logic. Akka does not
 The `ComponentClient` calls in this page use the synchronous form, which is the right default for most code. Each call has an `*Async` variant that returns a `CompletionStage<T>` instead. Use the async form when you want to start work and continue without blocking, fan out several calls in parallel, or compose with other asynchronous code:
 
 [source,java,indent=0]
+.{sample-base-url}/autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[ClientApiSample.java]
 ----
-var stateF = componentClient
-  .forAutonomousAgent(ReportAgent.class, agentInstanceId)
-  .getStateAsync();
-
-stateF.thenAccept(state -> log.info("Phase: {}", state.phase()));
+include::example$autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[tag=async]
 ----
 
 The same shape applies to `suspendAsync()`, `resumeAsync()`, `terminateAsync()`, `assignTasksAsync(...)`, `runSingleTaskAsync(...)`, and the `forTask` operations. Each returns a `CompletionStage` that completes once the runtime acknowledges the operation. Mixing styles is fine: use synchronous calls where they read more clearly, async ones where the call needs to compose with other futures.

--- a/docs/src/modules/sdk/pages/autonomous-agents/client.adoc
+++ b/docs/src/modules/sdk/pages/autonomous-agents/client.adoc
@@ -25,9 +25,9 @@ For more control over multiple tasks, pipelines, or long-lived agents, create ta
 *Create tasks:*
 
 [source,java,indent=0]
-.{sample-base-url}/autonomous-agent-playground/src/main/java/demo/pipeline/api/PipelineEndpoint.java[PipelineEndpoint.java]
+.{sample-base-url}/autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[ClientApiSample.java]
 ----
-include::example$autonomous-agent-playground/src/main/java/demo/pipeline/api/PipelineEndpoint.java[tag=create-task]
+include::example$autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[tag=create-task]
 ----
 
 *Assign tasks to an agent:*
@@ -61,9 +61,9 @@ Beyond `create` and `get`, the `forTask(...)` client exposes the operations that
 *Assign a task to an owner:*
 
 [source,java,indent=0]
-.{sample-base-url}/autonomous-agent-playground/src/main/java/demo/publishing/api/PublishingEndpoint.java[PublishingEndpoint.java]
+.{sample-base-url}/autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[ClientApiSample.java]
 ----
-include::example$autonomous-agent-playground/src/main/java/demo/publishing/api/PublishingEndpoint.java[tag=assign]
+include::example$autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[tag=assign]
 ----
 
 A task must be assigned before it can be completed or failed. The assignee is a free-form identifier (a user id, team name, or process identifier) that records who took ownership.
@@ -71,9 +71,9 @@ A task must be assigned before it can be completed or failed. The assignee is a 
 *Complete a task with a typed result:*
 
 [source,java,indent=0]
-.{sample-base-url}/autonomous-agent-playground/src/main/java/demo/publishing/api/PublishingEndpoint.java[PublishingEndpoint.java]
+.{sample-base-url}/autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[ClientApiSample.java]
 ----
-include::example$autonomous-agent-playground/src/main/java/demo/publishing/api/PublishingEndpoint.java[tag=complete]
+include::example$autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[tag=complete]
 ----
 
 The result is validated against the task definition's result type. The task transitions to `COMPLETED` and any dependents become eligible to start.
@@ -81,9 +81,9 @@ The result is validated against the task definition's result type. The task tran
 *Fail a task with a reason:*
 
 [source,java,indent=0]
-.{sample-base-url}/autonomous-agent-playground/src/main/java/demo/publishing/api/PublishingEndpoint.java[PublishingEndpoint.java]
+.{sample-base-url}/autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[ClientApiSample.java]
 ----
-include::example$autonomous-agent-playground/src/main/java/demo/publishing/api/PublishingEndpoint.java[tag=fail]
+include::example$autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java[tag=fail]
 ----
 
 The task transitions to `FAILED`. Any dependents are cancelled automatically.

--- a/docs/src/modules/sdk/pages/evaluators.adoc
+++ b/docs/src/modules/sdk/pages/evaluators.adoc
@@ -163,13 +163,14 @@ Beyond these, the raw fields expose the full structure: `systemMessage`, `inputM
 
 == Testing
 
-Use link:{attachmentsdir}/testkit/akka/javasdk/testkit/EvaluatorTestKit.html[`EvaluatorTestKit`] to run an evaluator's `evaluate` handler over a chosen `Subject` and assert on the outcome, supplying whatever dependencies the evaluator needs (for example a stub `LedgerClient`) through the factory:
+Use link:{attachmentsdir}/testkit/akka/javasdk/testkit/EvaluatorTestKit.html[`EvaluatorTestKit`] to run an evaluator's `evaluate` handler over a chosen `Subject` and assert on the outcome, supplying whatever dependencies the evaluator needs through the factory. For an evaluator that reads from the ledger, seed a link:{attachmentsdir}/testkit/akka/javasdk/testkit/TestLedgerClient.html[`TestLedgerClient`] with the interaction records it should fetch, instead of running a real ledger:
 
 [source,java,indent=0]
 .{sample-base-url}/doc-snippets/src/test/java/com/example/evaluator/EvaluatorTestKitSample.java[EvaluatorTestKitSample.java]
 ----
 include::example$doc-snippets/src/test/java/com/example/evaluator/EvaluatorTestKitSample.java[tag=test]
 ----
+<1> `TestLedgerClient.create().seed(...)` builds an in-memory `LedgerClient` holding the given records, keyed by interaction id.
 
 An asynchronous effect is resolved before the `EvaluatorResult` is returned, so `isComplete()` and `isInconclusive()` reflect the terminal outcome; `isAsync()` additionally reports whether the effect was produced asynchronously.
 

--- a/samples/autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java
+++ b/samples/autonomous-agent-playground/src/test/java/demo/docs/ClientApiSample.java
@@ -12,11 +12,15 @@ import demo.devteam.application.DeveloperTasks;
 import demo.docreview.application.ReviewResult;
 import demo.docreview.application.ReviewTasks;
 import demo.helloworld.application.QuestionAnswerer;
+import demo.pipeline.application.PipelineTasks;
 import demo.pipeline.application.ReportAgent;
+import demo.publishing.application.ApprovalDecision;
+import demo.publishing.application.PublishingTasks;
 import demo.research.application.ResearchBrief;
 import demo.research.application.ResearchTasks;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +39,35 @@ class ClientApiSample {
   ClientApiSample(ComponentClient componentClient, Materializer materializer) {
     this.componentClient = componentClient;
     this.materializer = materializer;
+  }
+
+  void createTask(String topic) {
+    // tag::create-task[]
+    var taskId = UUID.randomUUID().toString();
+    componentClient
+      .forTask(taskId)
+      .create(PipelineTasks.COLLECT.instructions("Collect data on: " + topic));
+    // end::create-task[]
+  }
+
+  void assignTask(String taskId) {
+    // tag::assign[]
+    componentClient.forTask(taskId).assign("alice@example.com");
+    // end::assign[]
+  }
+
+  void completeTask(String taskId) {
+    // tag::complete[]
+    componentClient
+      .forTask(taskId)
+      .complete(PublishingTasks.APPROVAL, new ApprovalDecision("alice", "Looks good"));
+    // end::complete[]
+  }
+
+  void failTask(String taskId) {
+    // tag::fail[]
+    componentClient.forTask(taskId).fail("Approval rejected: tone is too informal");
+    // end::fail[]
   }
 
   void terminate(String agentInstanceId) {
@@ -73,7 +106,8 @@ class ClientApiSample {
     var snapshot = componentClient.forTask(taskId).get(ResearchTasks.BRIEF);
     if (snapshot.status() == TaskStatus.COMPLETED) {
       ResearchBrief brief = snapshot.result().orElseThrow();
-      log.info("{}: {}", brief.title(), brief.keyFindings());
+      var title = brief.title();
+      var findings = brief.keyFindings();
     }
     // end::get-snapshot[]
   }

--- a/samples/doc-snippets/src/test/java/com/example/evaluator/EvaluatorTestKitSample.java
+++ b/samples/doc-snippets/src/test/java/com/example/evaluator/EvaluatorTestKitSample.java
@@ -2,45 +2,31 @@ package com.example.evaluator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import akka.javasdk.evaluation.Subject;
 import akka.javasdk.ledger.InteractionMetadata;
 import akka.javasdk.ledger.InteractionRecord;
-import akka.javasdk.ledger.LedgerClient;
 import akka.javasdk.ledger.ModelConfig;
 import akka.javasdk.ledger.ModelResponse;
+import akka.javasdk.evaluation.Subject;
 import akka.javasdk.testkit.EvaluatorResult;
 import akka.javasdk.testkit.EvaluatorTestKit;
+import akka.javasdk.testkit.TestLedgerClient;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import org.junit.jupiter.api.Test;
 
 public class EvaluatorTestKitSample {
 
-  // A stub ledger that returns a canned interaction, so the evaluator can be run in isolation.
-  private final LedgerClient stubLedger = new LedgerClient() {
-    @Override
-    public InteractionRecord getInteraction(String interactionId) {
-      return sampleRecord(interactionId);
-    }
-
-    @Override
-    public CompletionStage<InteractionRecord> getInteractionAsync(String interactionId) {
-      return CompletableFuture.completedFuture(sampleRecord(interactionId));
-    }
-  };
-
   @Test
   public void evaluatesAnInteraction() {
     // tag::test[]
+    var stubLedger = TestLedgerClient.create().seed(sampleRecord("interaction-1")); // <1>
+
     var testKit = EvaluatorTestKit.of(() -> new InteractionQualityEvaluator(stubLedger));
 
-    EvaluatorResult result = testKit.evaluate(
-      new Subject.AgentInteraction("support-agent", "interaction-1")
-    );
+    EvaluatorResult result =
+        testKit.evaluate(new Subject.AgentInteraction("support-agent", "interaction-1"));
 
     assertThat(result.isComplete()).isTrue();
     assertThat(result.getEvaluations()).hasSize(1);
@@ -49,26 +35,25 @@ public class EvaluatorTestKitSample {
   }
 
   private static InteractionRecord sampleRecord(String interactionId) {
-    var metadata = new InteractionMetadata(
-      new ModelConfig("openai", "gpt-4o", "", 0.0, 1.0, 0, 0),
-      Map.of(),
-      Instant.now(),
-      Instant.now(),
-      InteractionMetadata.FinishReason.STOP
-    );
+    var metadata =
+        new InteractionMetadata(
+            new ModelConfig("openai", "gpt-4o", "", 0.0, 1.0, 0, 0),
+            Map.of(),
+            Instant.now(),
+            Instant.now(),
+            InteractionMetadata.FinishReason.STOP);
     return new InteractionRecord(
-      interactionId,
-      "session-1",
-      "support-agent",
-      Optional.empty(),
-      metadata,
-      "system",
-      List.of(),
-      List.of(new ModelResponse("m1", "the agent's reply", 0, 0, "", List.of())),
-      List.of(),
-      Optional.empty(),
-      Optional.empty(),
-      Instant.now()
-    );
+        interactionId,
+        "session-1",
+        "support-agent",
+        Optional.empty(),
+        metadata,
+        "system",
+        List.of(),
+        List.of(new ModelResponse("m1", "the agent's reply", 0, 0, "", List.of())),
+        List.of(),
+        Optional.empty(),
+        Optional.empty(),
+        Instant.now());
   }
 }

--- a/samples/doc-snippets/src/test/java/com/example/evaluator/EvaluatorTestKitSample.java
+++ b/samples/doc-snippets/src/test/java/com/example/evaluator/EvaluatorTestKitSample.java
@@ -2,11 +2,11 @@ package com.example.evaluator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import akka.javasdk.evaluation.Subject;
 import akka.javasdk.ledger.InteractionMetadata;
 import akka.javasdk.ledger.InteractionRecord;
 import akka.javasdk.ledger.ModelConfig;
 import akka.javasdk.ledger.ModelResponse;
-import akka.javasdk.evaluation.Subject;
 import akka.javasdk.testkit.EvaluatorResult;
 import akka.javasdk.testkit.EvaluatorTestKit;
 import akka.javasdk.testkit.TestLedgerClient;
@@ -25,8 +25,9 @@ public class EvaluatorTestKitSample {
 
     var testKit = EvaluatorTestKit.of(() -> new InteractionQualityEvaluator(stubLedger));
 
-    EvaluatorResult result =
-        testKit.evaluate(new Subject.AgentInteraction("support-agent", "interaction-1"));
+    EvaluatorResult result = testKit.evaluate(
+      new Subject.AgentInteraction("support-agent", "interaction-1")
+    );
 
     assertThat(result.isComplete()).isTrue();
     assertThat(result.getEvaluations()).hasSize(1);
@@ -35,25 +36,26 @@ public class EvaluatorTestKitSample {
   }
 
   private static InteractionRecord sampleRecord(String interactionId) {
-    var metadata =
-        new InteractionMetadata(
-            new ModelConfig("openai", "gpt-4o", "", 0.0, 1.0, 0, 0),
-            Map.of(),
-            Instant.now(),
-            Instant.now(),
-            InteractionMetadata.FinishReason.STOP);
+    var metadata = new InteractionMetadata(
+      new ModelConfig("openai", "gpt-4o", "", 0.0, 1.0, 0, 0),
+      Map.of(),
+      Instant.now(),
+      Instant.now(),
+      InteractionMetadata.FinishReason.STOP
+    );
     return new InteractionRecord(
-        interactionId,
-        "session-1",
-        "support-agent",
-        Optional.empty(),
-        metadata,
-        "system",
-        List.of(),
-        List.of(new ModelResponse("m1", "the agent's reply", 0, 0, "", List.of())),
-        List.of(),
-        Optional.empty(),
-        Optional.empty(),
-        Instant.now());
+      interactionId,
+      "session-1",
+      "support-agent",
+      Optional.empty(),
+      metadata,
+      "system",
+      List.of(),
+      List.of(new ModelResponse("m1", "the agent's reply", 0, 0, "", List.of())),
+      List.of(),
+      Optional.empty(),
+      Optional.empty(),
+      Instant.now()
+    );
   }
 }


### PR DESCRIPTION
Applies the docs writing guide to the governance pages, and fills the API-doc gaps for the packages those pages describe.

- **API docs** — package-info for the `evaluation` and `ledger` packages ([`3ecfa93e1`](https://github.com/akka/akka-sdk/pull/1723/commits/3ecfa93e1)).
- **Evaluators** — `TestLedgerClient` is documented for evaluator unit tests, backed by a compiled `EvaluatorTestKitSample` ([`5818d8a8a`](https://github.com/akka/akka-sdk/pull/1723/commits/5818d8a8a), [`0645f55c2`](https://github.com/akka/akka-sdk/pull/1723/commits/0645f55c2)).
- **Autonomous agents client** — inline code blocks become tagged includes from the playground sample, so the examples compile ([`423bfd51b`](https://github.com/akka/akka-sdk/pull/1723/commits/423bfd51b)).
- **Guardrails** — the xref anchor follows the *Similarity guardrail* heading ([`c6de9c6d8`](https://github.com/akka/akka-sdk/pull/1723/commits/c6de9c6d8)).
- **Across the governance pages** — contractions expanded in body text ([`733778aae`](https://github.com/akka/akka-sdk/pull/1723/commits/733778aae)); the page-structure template applied, adding Testing and See also sections and self-descriptive headings ([`8c1424e3f`](https://github.com/akka/akka-sdk/pull/1723/commits/8c1424e3f)); noun-form titles with an extractable first-sentence definition ([`ccf77b8e6`](https://github.com/akka/akka-sdk/pull/1723/commits/ccf77b8e6)).

The guide itself, the internal-reference check, and the agent, task, and autonomous API docs are already on this branch's base.
