### PR TITLE
docs: drop a stray fragment from the concepts nav

### DIFF
--- a/docs/src/modules/concepts/nav.adoc
+++ b/docs/src/modules/concepts/nav.adoc
@@ -12,5 +12,4 @@
 *** Agentic concepts
 **** xref:concepts:ai-agents.adoc[]
 **** xref:concepts:ai-orchestration-patterns.adoc[]
- section
 *** xref:ROOT:resources.adoc[Resources]


### PR DESCRIPTION
`docs/src/modules/concepts/nav.adoc` carries a stray ` section` line between the *Agentic concepts* group and *Resources*. It is not valid navigation content and carries no meaning.

Antora discards the line, so this is a source-level tidy-up: the rendered navigation is byte-for-byte the same before and after.

```
 *** Agentic concepts
 **** xref:concepts:ai-agents.adoc[]
 **** xref:concepts:ai-orchestration-patterns.adoc[]
- section
 *** xref:ROOT:resources.adoc[Resources]
```
