### PR TITLE
fix: SessionMemoryEntity.State tokenUsage deserialization should use TokenUsage.EMPTY instead of null

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SessionMemoryEntityTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SessionMemoryEntityTest.java
@@ -95,6 +95,37 @@ public class SessionMemoryEntityTest {
   }
 
   @Test
+  public void shouldDeserializeWithNullTokenUsage() {
+    // given
+    var testKit =
+        EventSourcedTestKit.ofEntityWithState(
+            (context) -> new SessionMemoryEntity(config, context, agentRegistryEmpty),
+            new SessionMemoryEntity.State("sId", 10000, 100, null, null, false, 0));
+    var timestamp = Instant.now();
+    String userMsg = "Hello, how are you?";
+    String aiMsg = "I'm fine, thanks for asking!";
+    UserMessage userMessage = new UserMessage(timestamp, userMsg, COMPONENT_ID);
+    var aiMessage = new AiMessage(timestamp, aiMsg, COMPONENT_ID, Collections.emptyList());
+
+    // when
+    EventSourcedResult<Done> result =
+        testKit
+            .method(SessionMemoryEntity::addInteraction)
+            .invoke(new AddInteractionCmd(userMessage, aiMessage));
+
+    // then
+    assertThat(result.getReply()).isEqualTo(done());
+
+    // Check events - ignoring timestamp comparison
+    var events = result.getAllEvents();
+    assertThat(events).hasSize(2);
+
+    var state = (SessionMemoryEntity.State) result.getUpdatedState();
+    assertThat(state.messages()).isNotNull();
+    assertThat(state.tokenUsage()).isNotNull();
+  }
+
+  @Test
   public void shouldAddMessageWithAttributesToHistory() {
     // given
     var testKit =

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMemoryEntity.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMemoryEntity.java
@@ -111,6 +111,7 @@ public final class SessionMemoryEntity extends EventSourcedEntity<State, Event> 
       if (maxSizeInBytes <= 0)
         throw new IllegalArgumentException("Maximum size must be greater than 0");
       messages = messages != null ? messages : new LinkedList<>();
+      tokenUsage = tokenUsage != null ? tokenUsage : TokenUsage.EMPTY;
       int sizeBefore = messages.size();
       currentSizeInBytes =
           enforceMaxCapacity(sessionId, messages, currentSizeInBytes, maxSizeInBytes);


### PR DESCRIPTION
ref: https://github.com/lightbend/akka-runtime/issues/5518
