### PR TITLE
chore: bump GH Ruby action (for Node 24)

### DIFF
--- a/.github/workflows/docs-cli-updates.yml
+++ b/.github/workflows/docs-cli-updates.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Set up Ruby
       # https://github.com/ruby/setup-ruby/releases
-      uses: ruby/setup-ruby@v1.289.0
+      uses: ruby/setup-ruby@v1.321.0
       with:
         ruby-version: '3.1'
 


### PR DESCRIPTION
Bumping the action version should allow it to run on Node 24 (as Node 20 is discontinued.)