### PR TITLE
docs: refresh AGENTS.md for SDK 3.5.19 through 3.6.1

### DIFF
--- a/docs/src/modules/ROOT/attachments/AGENTS.md
+++ b/docs/src/modules/ROOT/attachments/AGENTS.md
@@ -569,13 +569,24 @@ When an HTTP method returns an `akka.http.javadsl.model.HttpResponse` instead of
 A service can serve its own browser UI. Put the files in `src/main/resources/static-resources`
 and return them from an endpoint method with `HttpResponses.staticResource`.
 
-For a single-page application, map one method to a `**` subtree and pass the prefix to strip to
-`HttpResponses.staticResource(request, "/pages/")`. Do not write one `@Get` per file. See the
-compiled example at `samples/doc-snippets/src/main/java/com/example/api/StaticResourcesEndpoint.java`
-(the `static-resource-tree-from-classpath` tag).
+For a single-page application, map one method to a `**` subtree and strip the prefix. Do not
+write one `@Get` per file:
 
-`GET /pages/app.css` serves `static-resources/app.css`. When the remaining path is empty or ends
-with `/`, `index.html` from that directory is served, so `GET /pages/` returns the application shell.
+```java
+@HttpEndpoint
+@Acl(allow = @Acl.Matcher(principal = Acl.Principal.ALL)) // required for browser access
+public class UiEndpoint {
+
+  @Get("/ui/**")
+  public HttpResponse assets(HttpRequest request) {
+    return HttpResponses.staticResource(request, "/ui/");
+  }
+}
+```
+
+`GET /ui/app.css` serves `static-resources/app.css`. When the remaining path is empty or ends
+with `/`, `index.html` from that directory is served, so `GET /ui/` returns the application shell.
+
 Content types are set from the file extension.
 
 Use `HttpResponses.of(StatusCodes.OK, ContentTypes.TEXT_HTML_UTF8, bytes)` when the page is

--- a/docs/src/modules/ROOT/attachments/AGENTS.md
+++ b/docs/src/modules/ROOT/attachments/AGENTS.md
@@ -49,8 +49,21 @@ Access these documentation files for detailed patterns:
 - `akka-context/sdk/http-endpoints.html.md` - RESTful APIs, server-sent events, WebSockets, serving web application files
 - `akka-context/sdk/web-applications.html.md` - Serving a browser UI from the service: single-page application files, generated HTML, custom domains
 - `akka-context/sdk/grpc-endpoints.html.md` - Protocol buffer APIs
+- `akka-context/sdk/mcp-endpoints.html.md` - Exposing tools, resources, and prompts to MCP clients
 - `akka-context/sdk/timed-actions.html.md` - Scheduling and timers
 - `akka-context/sdk/setup-and-dependency-injection.html.md` - Service bootstrap and dependency injection
+
+**Cross-cutting concerns:**
+- `akka-context/sdk/access-control.html.md` - ACLs on components and endpoints
+- `akka-context/sdk/auth-with-jwts.html.md` - JWT authentication
+- `akka-context/sdk/component-and-service-calls.html.md` - Calling other components and services
+- `akka-context/sdk/errors-and-failures.html.md` - Error handling and failure semantics
+- `akka-context/sdk/serialization.html.md` - `@TypeName`, JSON serialization, schema evolution
+- `akka-context/sdk/integrations/object-storage.html.md` - Binary objects in buckets, `object://` URIs for multimodal agents
+- `akka-context/sdk/sanitization.html.md` - Masking PII in agent interactions
+- `akka-context/sdk/metric.html.md` - Custom OpenTelemetry metrics
+- `akka-context/sdk/model-provider-details.html.md` - Model provider configuration and API keys
+- `akka-context/sdk/streaming.html.md` - Stream processing and Akka Streams
 
 **Guides and reference:**
 - `akka-context/getting-started/planner-agent/dynamic-team.html.md` - Dynamic agent planning and orchestration
@@ -83,10 +96,15 @@ Access these documentation files for detailed patterns:
 - Returns `Effect<T>` or `StreamEffect` (for streaming responses)
 - Use `effects().systemMessage().userMessage().thenReply()`
 - Three types of tools: `@FunctionTool` (agent methods), external tools via `.tools()`, MCP tools via `.mcpTools()`
+- A tool returning a plain type produces a JSON tool response. To return media to the model, declare the return type as `MessageContent` and return `ImageMessageContent.fromBytes(...)`, `PdfMessageContent.fromBytes(...)`, or `TextMessageContent` (SDK 3.6.1+)
+- To return several pieces of content in one tool result, declare `List<MessageContent>`; elements are delivered in list order. `List<? extends MessageContent>` and subtype lists work; any other element type falls back to a plain JSON response
+- A `MessageContent` tool must return a non-null value, and a list form must contain at least one non-null element — otherwise `IllegalArgumentException`
+- Inline bytes are not kept in session memory; they become an `[image]`/`[pdf]` placeholder. To keep media across turns, store it with `ObjectStorage` and return `ImageUrlMessageContent.create(bucket, key)` — the `object://` reference is persisted and resolved on each request
 - Stateless design (no mutable state in agent class)
 - Session memory automatic via session ID (shared across agents with same session ID)
 - Session ID typically UUID for new interactions, or workflow ID for orchestration
 - Control memory with `MemoryProvider.none()`, `.limitedWindow()`, or `.limitedWindow().readLast(N)`
+- In multi-agent sessions, restrict what an agent sees with `MemoryFilter.includeFromAgentId(...)`, `.excludeFromAgentId(...)`, or `.includeFromAgentRole(...)`; the factories return a supplier that chains fluently
 - Structured responses: use `responseConformsTo(Class)` (preferred) or `responseAs(Class)` with manual JSON instructions
 - Model config: prefer default in config, override with `.model(ModelProvider.openAi()...)` if needed
 - Error handling with `.onFailure(throwable -> fallbackValue)`
@@ -142,6 +160,7 @@ Access these documentation files for detailed patterns:
 - Step methods accept 0 or 1 parameter and return `StepEffect`
 - Steps use `@StepName`, `stepEffects()` in steps, `effects()` in commands
 - Compensation via `thenTransitionTo(compensationStep)` on failure
+- A running workflow can be stopped from outside with `componentClient.forWorkflow(id).terminate(MyWorkflow.class)`, or the overload taking a `reason`. It cannot be resumed afterwards, and calling `terminate` again is a safe no-op. The workflow passivates and stops consuming runtime resources
 
 **Consumer**
 - Extends `Consumer`, has `@Component(id = "...")`
@@ -564,6 +583,54 @@ Favor endpoint APIs that follow REST principles.
 
 When an HTTP method returns an `akka.http.javadsl.model.HttpResponse` instead of a custom type and it can return errors, avoid throwing exceptions. Instead, use HTTP error response methods such as `akka.javasdk.http.HttpResponses.badRequest` or `akka.javasdk.http.HttpResponses.notFound`.
 
+### MCP Endpoints
+
+Use an MCP endpoint to expose capabilities to MCP clients. This is the reverse direction from
+`.mcpTools()` on an agent, which *consumes* a remote MCP server.
+
+```java
+@Acl(allow = @Acl.Matcher(principal = Acl.Principal.ALL))
+@McpEndpoint(serverName = "my-service-mcp", serverVersion = "0.0.1")
+public class MyMcpEndpoint {
+
+  @McpTool(name = "add", description = "Add two numbers")
+  public String add(@Description("The first number") int n1, @Description("The second number") int n2) {
+    return String.valueOf(n1 + n2);
+  }
+}
+```
+
+- Served at `/mcp` by default.
+- Three member kinds: `@McpTool` (callable), `@McpResource` (fetchable content), `@McpPrompt`.
+- Descriptions matter — the calling LLM relies on them. Use `@Description` on every parameter.
+- Tool input classes must use primitives, boxed primitives, or `String`. All fields are required
+  by default; make a parameter optional by typing it `Optional<T>`.
+- See `akka-context/sdk/mcp-endpoints.html.md`.
+
+### Object storage
+
+For binary data (images, PDFs, documents), inject `ObjectStorageProvider` and call `forBucket`.
+Do not put large binaries in entity state.
+
+```java
+public class ImageEndpoint {
+  private final ObjectStorage bucket;
+
+  public ImageEndpoint(ObjectStorageProvider provider) {
+    this.bucket = provider.forBucket("images");
+  }
+}
+```
+
+- `put`, `get`, `getMetadata`, `delete`, `list` for small to medium payloads.
+- `putStreamAsync`, `getStreamAsync`, `streamList` for large objects — prefer these over `list()`
+  on large buckets.
+- Objects are reachable by agents as multimodal content via `ImageUrlMessageContent.create(bucket, key)`
+  and `PdfUrlMessageContent.create(bucket, key)`, which produce `object://` URIs the SDK resolves.
+- Dev mode uses a local filesystem backend with no configuration; any bucket name is accepted.
+- `TestKitSupport` provides an in-memory backend, isolated per test class.
+- See `akka-context/sdk/integrations/object-storage.html.md`.
+
 ### Endpoint with web UI
 
 A service can serve its own browser UI. Put the files in `src/main/resources/static-resources`
@@ -731,6 +798,10 @@ public class MyEndpointIntegrationTest extends TestKitSupport {
 - Static import `maxRetries` -> use `RecoverStrategy.maxRetries()` (import `Workflow.RecoverStrategy`)
 - Write one `@Get` per file when serving a web UI → map a `**` subtree and strip the prefix with `HttpResponses.staticResource(request, prefix)`
 - Put web UI files directly in `src/main/resources` → they must be in `src/main/resources/static-resources`
+- Store large binaries in entity state → put them in a bucket via `ObjectStorageProvider`
+- Return raw bytes from a `@FunctionTool` expecting the model to see an image → declare the return type as `MessageContent` and use `ImageMessageContent.fromBytes(...)`
+- Expect inline tool image/PDF bytes to persist in session memory → they become an `[image]`/`[pdf]` placeholder; store in a bucket and return `ImageUrlMessageContent.create(bucket, key)` to keep them
+- Use `@McpTool` parameter types other than primitives, boxed primitives, or `String` → unsupported; mark optional parameters `Optional<T>`
 
 ✅ **DO:**
 - Use Java records for immutable data

--- a/samples/doc-snippets/src/main/java/com/example/api/StaticResourcesEndpoint.java
+++ b/samples/doc-snippets/src/main/java/com/example/api/StaticResourcesEndpoint.java
@@ -44,7 +44,10 @@ public class StaticResourcesEndpoint {
   public HttpResponse status() {
     var html = "<html><body><h1>Service is running</h1></body></html>"; // <1>
     return HttpResponses.of(
-        StatusCodes.OK, ContentTypes.TEXT_HTML_UTF8, html.getBytes(StandardCharsets.UTF_8)); // <2>
+      StatusCodes.OK,
+      ContentTypes.TEXT_HTML_UTF8,
+      html.getBytes(StandardCharsets.UTF_8)
+    ); // <2>
   }
   // end::generated-html[]
 }

--- a/samples/doc-snippets/src/main/java/com/example/api/StaticResourcesEndpoint.java
+++ b/samples/doc-snippets/src/main/java/com/example/api/StaticResourcesEndpoint.java
@@ -44,10 +44,7 @@ public class StaticResourcesEndpoint {
   public HttpResponse status() {
     var html = "<html><body><h1>Service is running</h1></body></html>"; // <1>
     return HttpResponses.of(
-      StatusCodes.OK,
-      ContentTypes.TEXT_HTML_UTF8,
-      html.getBytes(StandardCharsets.UTF_8)
-    ); // <2>
+        StatusCodes.OK, ContentTypes.TEXT_HTML_UTF8, html.getBytes(StandardCharsets.UTF_8)); // <2>
   }
   // end::generated-html[]
 }


### PR DESCRIPTION
Brings `AGENTS.md` up to date with the SDK. It was last updated on 2026-05-21; releases 3.5.19, 3.6.0, and 3.6.1 have shipped since and the file mentioned none of their additions.

This matters more than an ordinary doc gap: the Akka CLI fetches `AGENTS.md` from `https://doc.akka.io/_attachments/AGENTS.md` at `akka specify init`, so anything missing here is missing from every new project's AI coding context.

> **Depends on #1749** and should merge after it. Both touch `AGENTS.md`, so this branch is built on top of that one — the commit list here includes #1749's commit. Review only the second commit, `docs: refresh AGENTS.md for SDK 3.5.19 through 3.6.1`; once #1749 merges, this diff reduces to that commit alone.

## Changes

**Capabilities that were absent entirely**

- **Function tools returning media** (3.6.1) — a tool can declare `MessageContent` or `List<MessageContent>` and return `ImageMessageContent.fromBytes(...)`, `PdfMessageContent.fromBytes(...)`, or `TextMessageContent`. Includes the non-null requirement, the accepted list forms, and the fact that inline bytes become an `[image]`/`[pdf]` placeholder rather than persisting in session memory.
- **MCP Endpoints** — a component with its own nav entry that `AGENTS.md` never mentioned. Its only two MCP references were about *consuming* remote MCP tools from an agent, not exposing one. Adds `@McpEndpoint`, `@McpTool`, `@McpResource`, `@McpPrompt`, the parameter type restrictions, and the `Optional<T>` rule for optional parameters.
- **Object storage** — `ObjectStorageProvider`, `forBucket`, the regular and streaming operations, and how a stored object reaches an agent as multimodal content through `object://` URIs.
- **Workflow termination** — `componentClient.forWorkflow(id).terminate(MyWorkflow.class)`, its idempotency, and passivation behaviour.
- **`MemoryFilter`** — restricting which session history an agent sees in multi-agent sessions.

**Documentation index**

Added the cross-cutting pages that were never listed: access control, JWTs, component and service calls, errors and failures, serialization, object storage, sanitization, metrics, model provider details, and streaming. Worth noting that the file already instructed assistants to use `@Acl` and `@TypeName` without pointing at the pages that explain either.

**Common Mistakes to Avoid**

Five new entries covering binaries in entity state, raw bytes from a tool where media was intended, expecting inline tool media to persist, and unsupported `@McpTool` parameter types.

## Verification

Every API name, factory method, and signature was checked against the SDK source rather than taken from docs prose — including `MemoryFilter`'s eight factory methods, `ObjectStorageProvider#forBucket`, and `WorkflowClient#terminate`. One draft line was corrected in the process: `terminate` exists on both `AutonomousAgentClient` and `WorkflowClient` with different signatures.

All 32 pre-existing `akka-context/*.html.md` references were validated as resolving to real pages; the June–July restructure did not break any of them.

## Note for @ennru — this needs a CI trigger

`AGENTS.md` is hand-maintained markdown with no drift protection, and it drifted for ten weeks across two SDK releases. The `.adoc` pages do not have this problem because their code comes from tagged includes in `samples/`, so an API change breaks the build. `AGENTS.md` has ~15 embedded Java blocks that nothing compiles and no check that ties them to a release.

Could we add a CI trigger that flags `AGENTS.md` for review whenever an SDK release ships — ideally on the release PR, so the two land together? Even a reminder that fails the release checklist until someone confirms "no AGENTS.md change needed" would prevent this recurring. A stronger version would extract the embedded Java into a compiled sample the way the `.adoc` pages do, but that is a larger change and the reminder alone would have caught everything in this PR.

Given the CLI fetches this file live, drift here propagates to every new project immediately, which argues for treating it closer to shipped code than to documentation.
