### PR TITLE
docs(specify): position /akka:docs as an à-la-carte-first capability

### DIFF
--- a/docs/src/modules/getting-started/pages/set-up-dev-env.adoc
+++ b/docs/src/modules/getting-started/pages/set-up-dev-env.adoc
@@ -39,15 +39,15 @@ This ensures the Akka CLI is installed, Java and Maven are available, and your A
 
 The Akka Specify plugin runs in one of two modes:
 
-* *Enforced* (the default) makes you define "done" as machine-checkable exit conditions before code is written, and gates shipping until they are met -- a cleaner, auditable result.
-* *À la carte* lets you run the specification commands individually, with nothing blocking you -- faster and lighter.
+* *À la carte* (the default) lets you run the specification commands individually, with nothing blocking you -- faster and lighter.
+* *Enforced* makes you define "done" as machine-checkable exit conditions before code is written, and gates shipping until they are met -- a cleaner, auditable result. Opt in when you want that rigor.
 
-New installs start in *Enforced* mode. Switch at any time:
+New installs start in *À la carte* mode. Switch at any time:
 
 [source]
 ----
-/akka:mode enforced
 /akka:mode a-la-carte
+/akka:mode enforced
 ----
 
 See xref:sdk:spec-driven-development.adoc#choosing-your-mode[Choosing your mode] for the trade-offs. Then build your first agent with the xref:getting-started:spec-your-first-agent.adoc[Spec-first hello agent] tutorial, which walks the same build in either mode.

--- a/docs/src/modules/getting-started/pages/spec-your-first-agent.adoc
+++ b/docs/src/modules/getting-started/pages/spec-your-first-agent.adoc
@@ -8,14 +8,14 @@ Spec-driven development runs in two modes, and you can build this agent either w
 
 == Choose your style
 
-* *xref:sdk:enforced-mode.adoc[Enforced mode]* (the default) -- you define "done" as machine-checkable exit conditions and the assistant drives the build until they are met. A cleaner, auditable result. Follow <<enforced,Build in Enforced mode>>.
-* *xref:sdk:a-la-carte-mode.adoc[À la carte mode]* -- you run each specification command yourself, one at a time. Faster and lighter; you own the rigor. Follow <<a-la-carte,Build À la carte>>.
+* *xref:sdk:a-la-carte-mode.adoc[À la carte mode]* (the default) -- you run each specification command yourself, one at a time. Faster and lighter; you own the rigor. Follow <<a-la-carte,Build À la carte>>.
+* *xref:sdk:enforced-mode.adoc[Enforced mode]* -- you define "done" as machine-checkable exit conditions and the assistant drives the build until they are met. A cleaner, auditable result. Follow <<enforced,Build in Enforced mode>>.
 
-New installs start in *Enforced* mode. To use À la carte, switch first:
+New installs start in *À la carte* mode. To use Enforced, switch first:
 
 [source]
 ----
-/akka:mode a-la-carte
+/akka:mode enforced
 ----
 
 == Prerequisites
@@ -25,6 +25,13 @@ New installs start in *Enforced* mode. To use À la carte, switch first:
 
 [#enforced]
 == Build in Enforced mode
+
+Enforced mode is opt-in; switch to it first (new installs default to À la carte):
+
+[source]
+----
+/akka:mode enforced
+----
 
 In Enforced mode you drive the whole build through one re-entrant command, `/akka:specify`, instead of running `clarify`, `plan`, `tasks`, and `implement` individually -- `/akka:specify` sequences those phases for you.
 
@@ -156,12 +163,7 @@ Run `/akka:ship release`. It runs the auditors for every applicable exit conditi
 [#a-la-carte]
 == Build À la carte
 
-In À la carte mode you run each command yourself. Switch to it first (new installs default to Enforced):
-
-[source]
-----
-/akka:mode a-la-carte
-----
+In À la carte mode you run each command yourself. It is the default, so no switch is needed unless you previously moved to Enforced.
 
 === Specify the feature
 

--- a/docs/src/modules/reference/pages/specify/docs.adoc
+++ b/docs/src/modules/reference/pages/specify/docs.adoc
@@ -1,6 +1,6 @@
 = /akka:docs
 
-Generate rendered documentation for the current Akka project.
+Generate rendered documentation for the current Akka project and verify it against the content-governance exit conditions.
 
 == Usage
 
@@ -9,21 +9,76 @@ Generate rendered documentation for the current Akka project.
 /akka:docs
 ----
 
-== Description
+== When to use it
 
-Introspects the project's components, design artifacts, and source, then generates a self-contained documentation site into the project's `docs/` folder:
+`/akka:docs` is primarily an xref:sdk:a-la-carte-mode.adoc[À la carte mode] command. A developer runs it directly when they want to (re)generate the project's rendered documentation and see how the content-governance exit conditions decided.
 
-* an *entity diagram* -- each entity's state fields, its events, and the domain objects it references;
-* an *interaction diagram* -- a sequence view of how a request flows through endpoints, entities, views, and workflows;
-* a *component graph* -- the components grouped by layer (edge, domain, read model);
-* a *component reference* -- every component explained, with a syntax-highlighted code excerpt.
+The same activity also runs in xref:sdk:enforced-mode.adoc[Enforced mode] as part of the engine's autonomous build loop, whenever a content-governance exit condition is `open` and the assistant can act on it. In both modes the command's behavior is identical; only ship-gating differs.
 
-Everything is assembled into `docs/index.html`, styled to match Akka, with each section collapsible so you can open just what you need. When generation finishes, the command prints the path to the rendered documentation -- open `docs/index.html` in a browser to read it.
+== What it produces
+
+Introspects the project's components, design artifacts, and source, then generates a self-contained documentation site into the project's `docs/` folder. The site is a single `docs/index.html` file — no external JavaScript, no external CSS, no build step needed to view it. Every diagram is rendered inline as SVG so the file can be opened directly in a browser or served from any static host.
+
+The site is styled to match Akka's design language, and every section is collapsible so a reader can open just the parts they need. Four diagrams and one reference view are produced:
+
+*Entity diagram.* For every entity in the project — event-sourced entities and key-value entities — the diagram shows:
+
+* the entity's state fields, with their Java types;
+* the events the entity emits (for event-sourced entities), each labeled with the state transition it produces;
+* the domain objects the state and events reference, drawn as attached blocks with their own fields.
+
+Each entity is rendered as its own inline SVG. Entities are color-coded by kind (event-sourced entities in one accent color, key-value entities in another) so the reader can see the shape of the domain at a glance.
+
+*Interaction diagram.* A sequence view of how a request flows through the system — from an HTTP endpoint through the component client into an entity, on to a view or workflow, and back. Each lane on the diagram is a component; the arrows are method invocations labeled with the invoked method name and payload shape. The diagram is drawn inline as SVG with activation bars on each participant, so the reader can trace the request-response path visually without a diagramming tool.
+
+*Component graph.* The project's components grouped into three layers, arranged top-to-bottom:
+
+* *Edge* — endpoints and any external-facing components;
+* *Domain* — entities and workflows;
+* *Read model* — views and their consumers.
+
+Each component is drawn as a node color-coded by its Akka type (event-sourced entity, key-value entity, workflow, view, agent, endpoint). A legend maps the color to the type name. The layered arrangement makes it visible which read models draw from which entities, and which endpoints reach which domain components.
+
+*Component reference.* For every component in the project, one collapsible section that combines:
+
+* the component's kind and its `@ComponentId`;
+* a plain-language description of what it does and where it fits;
+* a syntax-highlighted excerpt of its Java source (Java keywords, types, annotations, and strings each in their own color);
+* the invocations it makes into other components, phrased in prose.
+
+When generation finishes, the command prints the path to the rendered documentation -- open `docs/index.html` in a browser to read it.
 
 .Rendered `docs/index.html` for a sample shopping-cart service
 image::akka-docs-output.png[Rendered Akka project documentation showing the entity diagram, interaction diagram, component graph, and component reference,width=100%]
 
+== Content-governance exit conditions
+
+`/akka:docs` is paired with three exit conditions that verify the generated documentation. See xref:reference:specify/exit-condition-states.adoc[Exit condition states] for the state model and xref:reference:specify/exit-condition-states.adoc#ship-tiers[Ship tiers] for the tier defaults noted below.
+
+[cols="1,2,1,3",options="header"]
+|===
+| Condition | What it checks | Default tier | How it resolves
+
+| `CONTENT-LANGUAGE`
+| A Vale prose linter over `docs/`, using the project's `.vale.ini`. Catches banned phrasings, mandated substitutions, terminology, and structural conventions.
+| `author`
+| `green` when Vale finds no violations, `red` when it does, or `open` with reason `blocked-outside-project` when Vale is not installed on this machine.
+
+| Completeness
+| Every documentable thing (active exit condition, à-la-carte command, detected public endpoint) has a page under `docs/`. This is the documentation surface class of the coverage gate.
+| `author`
+| `green` when every documentable thing has a page; `red` when a documentable thing has no page and no waiver.
+
+| `CONTENT-TONE`
+| A decomposed adversarial rubric the assistant applies to the generated prose. The rubric asks whether the prose is declarative, whether it states facts rather than flourishes, whether it reads as machine-written.
+| `review`
+| `open` with reason `needs-user-action` until the assistant records an attestation via `akka_harness_attest`, then `green`. The attestation is keyed to a content-plus-rubric signature — an edit to the prose or a change to the rubric invalidates it and returns the condition to `open`.
+|===
+
 == See also
 
 * xref:sdk:a-la-carte-mode.adoc[]
+* xref:sdk:enforced-mode.adoc[]
+* xref:reference:specify/exit-condition-states.adoc[Exit condition states]
+* xref:reference:specify/attestations.adoc[Attestations]
 * xref:reference:specify/index.adoc[]

--- a/docs/src/modules/reference/pages/specify/exit-condition-states.adoc
+++ b/docs/src/modules/reference/pages/specify/exit-condition-states.adoc
@@ -244,7 +244,6 @@ The condition stays visible on the manifest so a reviewer can see what was exclu
 
 `/akka:ship` releases only when the verdict is `READY_TO_SHIP` in enforced mode. In à la carte mode the ship proceeds anyway, with the verdict recorded as an override on the conformance receipt.
 
-
 == Ship tiers
 
 Every condition is declared at one of three ship tiers. The tier names *when* the condition must be green, orthogonal to its state (open/green/red), its kind (introspective/provisioned/delegated), and its properties (provenance/applicable/waiver).

--- a/docs/src/modules/reference/pages/specify/exit-condition-states.adoc
+++ b/docs/src/modules/reference/pages/specify/exit-condition-states.adoc
@@ -244,6 +244,7 @@ The condition stays visible on the manifest so a reviewer can see what was exclu
 
 `/akka:ship` releases only when the verdict is `READY_TO_SHIP` in enforced mode. In à la carte mode the ship proceeds anyway, with the verdict recorded as an override on the conformance receipt.
 
+
 == Ship tiers
 
 Every condition is declared at one of three ship tiers. The tier names *when* the condition must be green, orthogonal to its state (open/green/red), its kind (introspective/provisioned/delegated), and its properties (provenance/applicable/waiver).

--- a/docs/src/modules/sdk/pages/a-la-carte-mode.adoc
+++ b/docs/src/modules/sdk/pages/a-la-carte-mode.adoc
@@ -1,12 +1,12 @@
 = À la carte mode
-:page-summary: Run the Akka Specify commands individually — the flexible, command-by-command spec-driven workflow.
+:page-summary: The default Akka Specify mode — run the commands individually, one at a time, with nothing blocking you.
 :page-when-to-use: Use À la carte mode when you want to drive each phase yourself, without the hard gates of Enforced mode.
 :page-related: xref:sdk:enforced-mode.adoc[], xref:reference:specify/index.adoc[]
 :page-persona: Developer, Tech Lead, Architect
 
 include::ROOT:partial$include.adoc[]
 
-In À la carte mode you drive the spec-driven workflow one command at a time. Nothing blocks you, and `/akka:ship` proceeds whether or not a definition of done is met -- you own the rigor. It is faster and lighter than xref:sdk:enforced-mode.adoc[Enforced mode], which gates each phase on machine-checkable exit conditions. Switch between the two with `/akka:mode`.
+À la carte is the default mode. You drive the spec-driven workflow one command at a time. Nothing blocks you, and `/akka:ship` proceeds whether or not a definition of done is met -- you own the rigor. It is faster and lighter than xref:sdk:enforced-mode.adoc[Enforced mode], which gates each phase on machine-checkable exit conditions. Switch to Enforced with `/akka:mode enforced` when you want that rigor, and back with `/akka:mode a-la-carte`.
 
 This page walks the commands in the order you would normally run them. Every command is also documented in the xref:reference:specify/index.adoc[Specify commands reference].
 

--- a/docs/src/modules/sdk/pages/enforced-mode.adoc
+++ b/docs/src/modules/sdk/pages/enforced-mode.adoc
@@ -1,12 +1,12 @@
 = Enforced mode
-:page-summary: The default Akka Specify mode — define done as machine-checkable exit conditions up front, and ship only when they are met.
+:page-summary: The opt-in Akka Specify mode — define done as machine-checkable exit conditions up front, and ship only when they are met.
 :page-when-to-use: Use Enforced mode when you want a repeatable, auditable result and are willing to define "done" before code is written.
 :page-related: xref:sdk:a-la-carte-mode.adoc[], xref:reference:specify/policies.adoc[], xref:reference:specify/default-library.adoc[]
 :page-persona: Developer, Tech Lead, Architect
 
 include::ROOT:partial$include.adoc[]
 
-Enforced mode is the default. It guides you to define "done" up front as machine-checkable conditions, then will not let a feature ship until those conditions are met. You get a cleaner, auditable result -- at the cost of more up-front definition and a longer, more thorough build. For the lighter, run-the-commands-yourself flow, see xref:sdk:a-la-carte-mode.adoc[À la carte mode]; switch between the two with `/akka:mode`.
+Enforced mode is opt-in. It guides you to define "done" up front as machine-checkable conditions, then will not let a feature ship until those conditions are met. You get a cleaner, auditable result -- at the cost of more up-front definition and a longer, more thorough build. New installs start in xref:sdk:a-la-carte-mode.adoc[À la carte mode], the lighter, run-the-commands-yourself flow; switch to Enforced with `/akka:mode enforced` (and back with `/akka:mode a-la-carte`).
 
 [#exit-conditions]
 == Exit conditions and Definition of Done

--- a/docs/src/modules/sdk/pages/spec-driven-development.adoc
+++ b/docs/src/modules/sdk/pages/spec-driven-development.adoc
@@ -19,18 +19,18 @@ image::sdd-workflow.png[Spec-driven development workflow: specify, clarify, plan
 
 Akka Specify runs in one of two modes. The mode decides whether your definition of done is a hard gate or an advisory checklist.
 
-* *xref:sdk:enforced-mode.adoc[Enforced mode]* (the default) makes you define "done" -- as machine-checkable exit conditions -- before any code is written, and will not let a feature ship until those conditions are met. You get a cleaner, auditable, repeatable result. In Enforced mode an *enterprise can define exit conditions and definitions of done that Akka enforces* across every project. The cost is more up-front definition and a longer, more thorough build.
-* *xref:sdk:a-la-carte-mode.adoc[À la carte mode]* lets you run the specification commands individually -- specify, clarify, plan, tasks, implement, build, and the rest -- with nothing blocking you. It is faster and lighter; you own the rigor.
+* *xref:sdk:a-la-carte-mode.adoc[À la carte mode]* (the default) lets you run the specification commands individually -- specify, clarify, plan, tasks, implement, build, and the rest -- with nothing blocking you. It is faster and lighter; you own the rigor.
+* *xref:sdk:enforced-mode.adoc[Enforced mode]* makes you define "done" -- as machine-checkable exit conditions -- before any code is written, and will not let a feature ship until those conditions are met. You get a cleaner, auditable, repeatable result. In Enforced mode an *enterprise can define exit conditions and definitions of done that Akka enforces* across every project. The cost is more up-front definition and a longer, more thorough build. Opt in with `/akka:mode enforced`.
 
 [cols="1,2,2",options="header"]
 |===
-| | Enforced (default) | À la carte
+| | À la carte (default) | Enforced
 
-| Definition of done | Required, gated | Optional, advisory
-| Result | Cleaner, auditable, repeatable | Flexible, developer-driven
-| Cost & time | Higher -- more up front, more thorough | Lower -- run only what you need
-| Enterprise governance | Org-defined conditions enforced by Akka | Not enforced
-| Best for | Production systems, teams, regulated work | Prototypes, exploration, experienced solo developers
+| Definition of done | Optional, advisory | Required, gated
+| Result | Flexible, developer-driven | Cleaner, auditable, repeatable
+| Cost & time | Lower -- run only what you need | Higher -- more up front, more thorough
+| Enterprise governance | Not enforced | Org-defined conditions enforced by Akka
+| Best for | Prototypes, exploration, experienced solo developers | Production systems, teams, regulated work
 |===
 
 == Getting started with SDD


### PR DESCRIPTION
**Stacked on:** https://github.com/akka/akka-sdk/pull/1753 (state model). Base branch is \`main\`, so this PR's diff includes the state-model changes; to see only the /akka:docs delta, diff \`spec/akka-docs-alignment\` against \`spec/ec-state-model\`. Do not merge before #1753 lands; rebase to main once it does.

**Also depends on:** the ai-marketplace PR for /akka:docs prose (https://github.com/akka/ai-marketplace/pull/22).

## Summary

Repositions \`/akka:docs\` in the reference documentation. À la carte mode is the primary caller — a developer types \`/akka:docs\` when they want to (re)generate the project's rendered documentation. Enforced mode is the secondary caller: the engine runs the same activity autonomously during its build loop whenever a content-governance exit condition is \`open\` and the assistant can act on it. The behavior is identical in both modes; only ship-gating differs.

## What changed

Adds a "When to use it" section that names the two callers. Adds a "Content-governance exit conditions" section that documents the three conditions the command feeds — CONTENT-LANGUAGE, Completeness, CONTENT-TONE — with their default ship tiers and how each resolves under the new state model. Cross-references the exit-condition-states page and the attestations page.

## Ship-tier defaults for the three conditions

- CONTENT-LANGUAGE → \`author\` (Vale is fast; runs on every commit)
- Completeness → \`author\` (page-exists; runs on every commit)
- CONTENT-TONE → \`review\` (attestation runs before team review, not per commit — re-attesting on every source-file change would be excessive)

## Reviewer note

The docs vocabulary (\`open\` with reason \`blocked-outside-project\` for missing Vale, \`needs-user-action\` for missing tone attestation) matches the state model in akka/cli#158. This PR only touches \`docs/src/modules/reference/pages/specify/docs.adoc\`.