### PR TITLE
chore: align jackson-databind and logback versions with runtime

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,11 +24,11 @@ object Dependencies {
 
   val ScalaTestVersion = "3.2.14"
   // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L31
-  val JacksonVersion = "2.21.2"
+  val JacksonVersion = "2.21.5"
   val JacksonDatabindVersion = JacksonVersion
   val JacksonAnnotationsVersion = "2.21"
   val Langchain4jVersion = "1.15.0"
-  val LogbackVersion = "1.5.23"
+  val LogbackVersion = "1.5.38"
   val LogbackContribVersion = "0.1.5"
   val JUnitVersion = "4.13.2"
   val JUnitInterfaceVersion = "0.11"


### PR DESCRIPTION
Bumps direct dependency versions declared in the akka-javasdk POM to align with the runtime:

- jackson-databind (and other Jackson 2.21 modules): 2.21.2 -> 2.21.5
- logback-classic: 1.5.23 -> 1.5.38

These dependencies are not used when running in production (the runtime provides its own), but the old versions declared in the POM are flagged by dependency scanners on the consumer side (reported by a customer against 3.6.1).