### PR TITLE
build: load the build from a git worktree

### DIFF
--- a/project/SdkVersion.scala
+++ b/project/SdkVersion.scala
@@ -1,3 +1,5 @@
+import com.github.sbt.git.GitPlugin
+import com.github.sbt.git.SbtGit.GitKeys.useConsoleForROGit
 import sbt.Keys._
 import sbt._
 import sbtdynver.DynVerPlugin
@@ -7,12 +9,14 @@ import sbtdynver.DynVerPlugin
  */
 object SdkVersion extends AutoPlugin {
 
-  override def requires = DynVerPlugin
+  override def requires = DynVerPlugin && GitPlugin
   override def trigger = allRequirements
 
   import DynVerPlugin.autoImport._
 
-  override def buildSettings = versionSettings
+  override def buildSettings = versionSettings ++ Seq(
+    // JGit cannot read the `.git` file that marks a git worktree, so shell out to git instead
+    useConsoleForROGit := (baseDirectory.value / ".git").isFile)
 
   // project settings, as versions can be different for different projects (sonatype snapshots)
   override def projectSettings = versionSettings


### PR DESCRIPTION
sbt-git reads the repository through JGit, which cannot handle the `.git` file that marks a git worktree. Loading the build from one fails:

    org.eclipse.jgit.errors.NoWorkTreeException: Bare Repository has
    neither a working tree, nor an index

sbt-git can shell out to the git CLI instead. Enable that only when `.git` is a file, so an ordinary clone keeps the JGit path, which is the plugin default.

sbt-git arrives transitively through sbt-ci-release. SdkVersion now declares GitPlugin alongside DynVerPlugin, which both makes that dependency explicit and orders these build settings after the ones they override.
