### PR TITLE
feat: expose the Bedrock rolling cache point

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/agent/ModelProvider.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/ModelProvider.java
@@ -2676,7 +2676,13 @@ public sealed interface ModelProvider {
   enum BedrockPromptCachePlacement {
     AFTER_SYSTEM,
     AFTER_USER_MESSAGE,
-    AFTER_TOOLS
+    AFTER_TOOLS,
+    /**
+     * Cache point after the most recent user message, so that it advances as the conversation
+     * grows. Requires a session history whose oldest messages are stable between turns, otherwise
+     * the cached prefix is invalidated before it can be read.
+     */
+    AFTER_LAST_USER_MESSAGE
   }
 
   record Bedrock(

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
@@ -329,6 +329,8 @@ private[impl] object AgentImpl {
               SpiAgent.ModelProvider.BedrockPromptCachePlacement.AfterUserMessage
             case ModelProvider.BedrockPromptCachePlacement.AFTER_TOOLS =>
               SpiAgent.ModelProvider.BedrockPromptCachePlacement.AfterTools
+            case ModelProvider.BedrockPromptCachePlacement.AFTER_LAST_USER_MESSAGE =>
+              SpiAgent.ModelProvider.BedrockPromptCachePlacement.AfterLastUserMessage
           })
       case p: ModelProvider.MistralAi =>
         new SpiAgent.ModelProvider.MistralAi(


### PR DESCRIPTION
SDK side of the runtime change. AFTER_LAST_USER_MESSAGE places the Bedrock cache point after the most recent user message, so it advances as the conversation grows, which is the placement that pays off in a tool-calling loop.

Requires an akka-runtime with the matching SPI.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/lightbend/akka-runtime/pull/5537
