### PR TITLE
feat: report prompt cache token counts

### DIFF
--- a/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SessionMemoryEntityTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/components/agent/SessionMemoryEntityTest.java
@@ -5,9 +5,11 @@
 package akkajavasdk.components.agent;
 
 import static akka.Done.done;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import akka.Done;
+import akka.javasdk.JsonSupport;
 import akka.javasdk.agent.AgentRegistry;
 import akka.javasdk.agent.MemoryFilter;
 import akka.javasdk.agent.MessageContent;
@@ -92,6 +94,24 @@ public class SessionMemoryEntityTest {
     var resultAiMessage = ((AiMessage) historyResult.getReply().messages().getLast());
     assertThat(resultAiMessage.attributes().isEmpty()).isTrue();
     assertThat(resultAiMessage.thinking().isEmpty()).isTrue();
+  }
+
+  @Test
+  public void shouldReadTokenUsageWrittenBeforeTheEffectiveInputCountExisted() {
+    var legacy =
+        JsonSupport.decodeJson(
+            TokenUsage.class, "{\"inputTokens\":100,\"outputTokens\":20}".getBytes(UTF_8));
+
+    assertThat(legacy.effectiveInputTokens()).isEqualTo(100);
+    assertThat(legacy.cacheReadInputTokens()).isZero();
+  }
+
+  @Test
+  public void shouldSumTheEffectiveInputCount() {
+    var first = new TokenUsage(100, 20, 11, 22, 133);
+    var second = new TokenUsage(200, 30, 5, 0, 205);
+
+    assertThat(first.add(second)).isEqualTo(new TokenUsage(300, 50, 16, 22, 338));
   }
 
   @Test

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/Agent.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/Agent.java
@@ -66,9 +66,10 @@ public abstract class Agent implements AgentDelegationWorker {
   /**
    * The number of tokens consumed by a model interaction.
    *
-   * <p>Raw provider counts. Anthropic and Bedrock report the cache counts outside {@code
-   * inputTokens}, OpenAI and Gemini report cache reads within it, so summing them requires knowing
-   * the provider.
+   * <p>{@code inputTokens} and the two cache counts are raw provider numbers, and providers
+   * disagree on how they compose: Anthropic and Bedrock report the cache counts outside {@code
+   * inputTokens}, OpenAI and Gemini report cache reads within it. Use {@code effectiveInputTokens}
+   * rather than adding them up yourself, which only works if you know which provider produced them.
    *
    * @param inputTokens tokens in the request sent to the model
    * @param outputTokens tokens in the response returned by the model
@@ -76,13 +77,19 @@ public abstract class Agent implements AgentDelegationWorker {
    *     the provider reports nothing
    * @param cacheWriteInputTokens prompt tokens written to the provider's prompt cache, or 0 when
    *     the provider reports nothing
+   * @param effectiveInputTokens every prompt token the interaction consumed, counted once, whatever
+   *     the provider
    */
   public record TokenUsage(
-      int inputTokens, int outputTokens, int cacheReadInputTokens, int cacheWriteInputTokens) {
+      int inputTokens,
+      int outputTokens,
+      int cacheReadInputTokens,
+      int cacheWriteInputTokens,
+      int effectiveInputTokens) {
 
     /** A usage with no prompt cache activity. */
     public TokenUsage(int inputTokens, int outputTokens) {
-      this(inputTokens, outputTokens, 0, 0);
+      this(inputTokens, outputTokens, 0, 0, inputTokens);
     }
   }
 

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/Agent.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/Agent.java
@@ -66,10 +66,25 @@ public abstract class Agent implements AgentDelegationWorker {
   /**
    * The number of tokens consumed by a model interaction.
    *
+   * <p>Raw provider counts. Anthropic and Bedrock report the cache counts outside {@code
+   * inputTokens}, OpenAI and Gemini report cache reads within it, so summing them requires knowing
+   * the provider.
+   *
    * @param inputTokens tokens in the request sent to the model
    * @param outputTokens tokens in the response returned by the model
+   * @param cacheReadInputTokens prompt tokens served from the provider's prompt cache, or 0 when
+   *     the provider reports nothing
+   * @param cacheWriteInputTokens prompt tokens written to the provider's prompt cache, or 0 when
+   *     the provider reports nothing
    */
-  public record TokenUsage(int inputTokens, int outputTokens) {}
+  public record TokenUsage(
+      int inputTokens, int outputTokens, int cacheReadInputTokens, int cacheWriteInputTokens) {
+
+    /** A usage with no prompt cache activity. */
+    public TokenUsage(int inputTokens, int outputTokens) {
+      this(inputTokens, outputTokens, 0, 0);
+    }
+  }
 
   /**
    * A detailed reply from an agent component call, containing both the result and additional

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMessage.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMessage.java
@@ -124,15 +124,29 @@ public sealed interface SessionMessage {
   /** A tool call requested by the model as part of an {@link AiMessage}. */
   record ToolCallRequest(String id, String name, String arguments) {}
 
-  /** Token usage for a single {@link AiMessage}. */
-  record TokenUsage(int inputTokens, int outputTokens) {
+  /**
+   * Token usage for a single {@link AiMessage}.
+   *
+   * <p>See {@link Agent.TokenUsage} for how the prompt cache counts relate to {@code inputTokens}.
+   */
+  record TokenUsage(
+      int inputTokens, int outputTokens, int cacheReadInputTokens, int cacheWriteInputTokens) {
+
     /** No tokens consumed. */
-    public static final TokenUsage EMPTY = new TokenUsage(0, 0);
+    public static final TokenUsage EMPTY = new TokenUsage(0, 0, 0, 0);
+
+    /** A usage with no prompt cache activity. */
+    public TokenUsage(int inputTokens, int outputTokens) {
+      this(inputTokens, outputTokens, 0, 0);
+    }
 
     /** The sum of this and another usage. */
     public TokenUsage add(TokenUsage tokenUsage) {
       return new TokenUsage(
-          inputTokens + tokenUsage.inputTokens, outputTokens + tokenUsage.outputTokens);
+          inputTokens + tokenUsage.inputTokens,
+          outputTokens + tokenUsage.outputTokens,
+          cacheReadInputTokens + tokenUsage.cacheReadInputTokens,
+          cacheWriteInputTokens + tokenUsage.cacheWriteInputTokens);
     }
   }
 

--- a/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMessage.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/agent/SessionMessage.java
@@ -130,14 +130,27 @@ public sealed interface SessionMessage {
    * <p>See {@link Agent.TokenUsage} for how the prompt cache counts relate to {@code inputTokens}.
    */
   record TokenUsage(
-      int inputTokens, int outputTokens, int cacheReadInputTokens, int cacheWriteInputTokens) {
+      int inputTokens,
+      int outputTokens,
+      int cacheReadInputTokens,
+      int cacheWriteInputTokens,
+      int effectiveInputTokens) {
 
     /** No tokens consumed. */
-    public static final TokenUsage EMPTY = new TokenUsage(0, 0, 0, 0);
+    public static final TokenUsage EMPTY = new TokenUsage(0, 0, 0, 0, 0);
+
+    public TokenUsage {
+      // Session memory written before effectiveInputTokens existed deserializes it as 0, which is
+      // never valid for a call that consumed input: the effective count is at least inputTokens.
+      // Those messages predate the cache counts too, so inputTokens is the effective count.
+      if (effectiveInputTokens == 0) {
+        effectiveInputTokens = inputTokens;
+      }
+    }
 
     /** A usage with no prompt cache activity. */
     public TokenUsage(int inputTokens, int outputTokens) {
-      this(inputTokens, outputTokens, 0, 0);
+      this(inputTokens, outputTokens, 0, 0, inputTokens);
     }
 
     /** The sum of this and another usage. */
@@ -146,7 +159,8 @@ public sealed interface SessionMessage {
           inputTokens + tokenUsage.inputTokens,
           outputTokens + tokenUsage.outputTokens,
           cacheReadInputTokens + tokenUsage.cacheReadInputTokens,
-          cacheWriteInputTokens + tokenUsage.cacheWriteInputTokens);
+          cacheWriteInputTokens + tokenUsage.cacheWriteInputTokens,
+          effectiveInputTokens + tokenUsage.effectiveInputTokens);
     }
   }
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
@@ -856,7 +856,11 @@ private[impl] final class AgentImpl(
             componentId,
             requests,
             res.thinking.toJava,
-            new TokenUsage(res.inputTokenCount, res.outputTokenCount),
+            new TokenUsage(
+              res.inputTokenCount,
+              res.outputTokenCount,
+              res.cacheReadInputTokens,
+              res.cacheWriteInputTokens),
             res.attributes.asJava)
 
         case res: SpiAgent.ToolCallResponse =>

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/agent/AgentImpl.scala
@@ -857,10 +857,11 @@ private[impl] final class AgentImpl(
             requests,
             res.thinking.toJava,
             new TokenUsage(
-              res.inputTokenCount,
-              res.outputTokenCount,
-              res.cacheReadInputTokens,
-              res.cacheWriteInputTokens),
+              res.tokenUsage.inputTokenCount,
+              res.tokenUsage.outputTokenCount,
+              res.tokenUsage.cacheReadInputTokens,
+              res.tokenUsage.cacheWriteInputTokens,
+              res.tokenUsage.effectiveInputTokenCount),
             res.attributes.asJava)
 
         case res: SpiAgent.ToolCallResponse =>

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AgentInvokeReplyOnlyMethodRefImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AgentInvokeReplyOnlyMethodRefImpl.scala
@@ -49,6 +49,9 @@ private[impl] case class AgentInvokeReplyOnlyMethodRefImpl[A1, R](componentMetho
   private def toTokenUsage(metadata: Metadata): Agent.TokenUsage = {
     val input = metadata.get(SpiAgent.AgentInputTokensKey).map[Integer](_.toInt).orElse(0)
     val output = metadata.get(SpiAgent.AgentOutputTokensKey).map[Integer](_.toInt).orElse(0)
-    new Agent.TokenUsage(input, output)
+    // Absent when running against a runtime older than the one that added these keys.
+    val cacheRead = metadata.get(SpiAgent.AgentCacheReadTokensKey).map[Integer](_.toInt).orElse(0)
+    val cacheWrite = metadata.get(SpiAgent.AgentCacheWriteTokensKey).map[Integer](_.toInt).orElse(0)
+    new Agent.TokenUsage(input, output, cacheRead, cacheWrite)
   }
 }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AgentInvokeReplyOnlyMethodRefImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/client/AgentInvokeReplyOnlyMethodRefImpl.scala
@@ -49,9 +49,12 @@ private[impl] case class AgentInvokeReplyOnlyMethodRefImpl[A1, R](componentMetho
   private def toTokenUsage(metadata: Metadata): Agent.TokenUsage = {
     val input = metadata.get(SpiAgent.AgentInputTokensKey).map[Integer](_.toInt).orElse(0)
     val output = metadata.get(SpiAgent.AgentOutputTokensKey).map[Integer](_.toInt).orElse(0)
-    // Absent when running against a runtime older than the one that added these keys.
+    // Absent when running against a runtime older than the one that added these keys. An older
+    // runtime reports no cache activity, so the input count is the effective count.
     val cacheRead = metadata.get(SpiAgent.AgentCacheReadTokensKey).map[Integer](_.toInt).orElse(0)
     val cacheWrite = metadata.get(SpiAgent.AgentCacheWriteTokensKey).map[Integer](_.toInt).orElse(0)
-    new Agent.TokenUsage(input, output, cacheRead, cacheWrite)
+    val effectiveInput =
+      metadata.get(SpiAgent.AgentEffectiveInputTokensKey).map[Integer](_.toInt).orElse(input)
+    new Agent.TokenUsage(input, output, cacheRead, cacheWrite, effectiveInput)
   }
 }


### PR DESCRIPTION
SDK side of the runtime change. Agent.TokenUsage and SessionMessage.TokenUsage gain cacheReadInputTokens, cacheWriteInputTokens and effectiveInputTokens, populated from SpiAgent.ModelResponse for session history and from the reply metadata for AgentReply.

The two cache counts are raw provider numbers and providers disagree on how they compose: Anthropic and Bedrock report them outside inputTokens, OpenAI and Gemini report cache reads within it. The runtime resolves that and reports effectiveInputTokens, every prompt token the call consumed counted once, so a caller no longer has to know which provider produced the numbers to add them up.

Both records keep a two argument constructor, so existing calls compile and link unchanged. The metadata keys are absent when running against an older runtime: the cache counts then read as zero and effectiveInputTokens falls back to inputTokens.

SessionMessage.TokenUsage is persisted in session memory, and rows written before effectiveInputTokens existed deserialize it as 0, which is never valid for a call that consumed input. The canonical constructor reads that as "no cache activity" and falls back to inputTokens.

Requires an akka-runtime with the matching SPI.

References https://github.com/lightbend/akka-runtime/pull/5538
