### PR TITLE
build: upgrade langchain4j to 1.18.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,10 @@ Global / initialize := {
     throw new MessageOnlyException(s"JDK 21 or higher is required, found: $specificationVersion")
 }
 
+// hold Jackson at the version akka resolves, against the newer one langchain4j asks for,
+// see Dependencies.jacksonModules
+ThisBuild / dependencyOverrides ++= Dependencies.jacksonModules
+
 lazy val `akka-javasdk-root` = project
   .in(file("."))
   .aggregate(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
   val JacksonVersion = "2.21.5"
   val JacksonDatabindVersion = JacksonVersion
   val JacksonAnnotationsVersion = "2.21"
-  val Langchain4jVersion = "1.15.0"
+  val Langchain4jVersion = "1.18.1"
   val LogbackVersion = "1.5.38"
   val LogbackContribVersion = "0.1.5"
   val JUnitVersion = "4.13.2"
@@ -59,6 +59,20 @@ object Dependencies {
   val jacksonJsr310 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % JacksonVersion
   val jacksonParameterNames = "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % JacksonVersion
   val jacksonScala = "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonVersion
+
+  // TODO advance Jackson to 2.22.x. langchain4j 1.18.x depends on 2.22.1, and coursier resolves the
+  // higher version unless every module is held down together: jackson-module-scala refuses to load
+  // against a databind from a different minor. Held at the version akka resolves until the whole
+  // build, and the runtime, can move.
+  val jacksonModules: Seq[ModuleID] =
+    Seq(
+      jacksonAnnotations,
+      jacksonCore,
+      jacksonDatabind,
+      jacksonJdk8,
+      jacksonJsr310,
+      jacksonParameterNames,
+      jacksonScala)
 
   val langchain4j = "dev.langchain4j" % "langchain4j" % Langchain4jVersion
 

--- a/samples/ask-akka-agent/pom.xml
+++ b/samples/ask-akka-agent/pom.xml
@@ -18,7 +18,7 @@
 
     <name>ask-akka</name>
     <properties>
-        <langchain4j.version>1.15.0</langchain4j.version>
+        <langchain4j.version>1.18.1</langchain4j.version>
     </properties>
     <dependencies>
         <dependency>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-mongodb-atlas</artifactId>
-            <version>1.15.0-beta25</version>
+            <version>1.18.1-beta28</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Was 1.15.0. langchain4j is excluded from the user assembly and supplied by the runtime classpath, so this has to move with the runtime side of the same upgrade.

Jackson is held where it is. langchain4j-core 1.18.1 depends on Jackson 2.22.1, which coursier resolves over our 2.21.5, and jackson-module-scala then refuses to load against a databind from a different minor. Dependencies.jacksonModules holds the whole module family at the version akka resolves, and carries a TODO to advance it on its own.

The ask-akka-agent sample carries its own langchain4j pin, which Common.performAdditionalValidation checks against this one, so it moves too, along with the langchain4j-mongodb-atlas beta suffix (-beta25 to -beta28).

What the upgrade brings, on the SDK-visible surface: Anthropic honours cache_control on AiMessage and ToolExecutionResultMessage (1.18.0, PR 5729), AnthropicChatRequestParameters for per-call overrides (1.17.0, PR 5390), Anthropic cache diagnostics (1.18.0, PR 5659), Bedrock enableAdaptiveReasoning (1.17.0, PR 5358), unmapped raw streaming events (1.17.0, PR 5589), MistralAiBatchChatModel with a unified batch response model (1.18.0, PR 5750), and an EmbeddingModel request/response API with per-call parameters (1.18.0, PR 5735).


References https://github.com/lightbend/akka-runtime/pull/5540
