### PR TITLE
docs(operations): add dependency vulnerability scanning guidance

### DIFF
--- a/docs/src/modules/operations/nav.adoc
+++ b/docs/src/modules/operations/nav.adoc
@@ -47,6 +47,7 @@
 
 **** xref:operations:integrating-cicd/index.adoc[]
 ***** xref:operations:integrating-cicd/github-actions.adoc[]
+***** xref:operations:integrating-cicd/scanning-dependencies.adoc[]
 
 **** xref:operations:cli/index.adoc[]
 ***** xref:operations:cli/installation.adoc[]

--- a/docs/src/modules/operations/pages/integrating-cicd/scanning-dependencies.adoc
+++ b/docs/src/modules/operations/pages/integrating-cicd/scanning-dependencies.adoc
@@ -18,7 +18,7 @@ Akka patches the JVM, the container base image, the operating system, and the Ak
 
 A deployed Akka service combines two sources:
 
-. *Your service image* — A small image that holds your application JAR and its direct SDK dependencies. The `mvn install` command builds this image. It copies these libraries to `/opt/local-lib/` in the running container.
+. *Your service image* — A small image that holds your application JAR and its direct SDK dependencies. The `mvn install` command builds this image. It includes these libraries in `/opt/local-lib/` in the built image.
 . *The Akka runtime base image* — The image that actually runs. It provides the JVM, the Akka runtime, and all platform dependencies (for example gRPC, Netty, Jackson, and Logback). Akka builds, scans, and patches this image.
 
 Scan the libraries that you add in step 1. These are the dependencies that you control. If a scan finds a vulnerability, you fix it by updating your `pom.xml`.

--- a/docs/src/modules/operations/pages/integrating-cicd/scanning-dependencies.adoc
+++ b/docs/src/modules/operations/pages/integrating-cicd/scanning-dependencies.adoc
@@ -1,0 +1,79 @@
+= Scanning vulnerabilities
+include::ROOT:partial$include.adoc[]
+:page-summary: Scan the libraries you add to an Akka service for known vulnerabilities. Akka scans and patches the runtime; you scan the dependencies you introduce.
+:page-when-to-use: Setting up dependency vulnerability scanning in CI for a service you build with the Akka SDK.
+:page-related: operations:integrating-cicd/github-actions.adoc, operations:production-readiness/index.adoc, operations:services/deploy-service.adoc
+:page-persona: operator-platform, builder-developer
+
+Your Akka service ships with the libraries that you add to it. You must scan these libraries for known vulnerabilities. This page shows the recommended way to do it.
+
+Akka scans and patches the runtime part of your service. You scan the dependencies that you introduce. This split follows the xref:operations:production-readiness/index.adoc[shared responsibility model].
+
+[NOTE]
+====
+Akka patches the JVM, the container base image, the operating system, and the Akka runtime that ship inside your deployed service. Akka runs continuous scanning on these parts. Akka addresses critical and high severity findings as soon as possible. You do not need to scan the runtime. See the xref:operations:production-readiness/index.adoc[shared responsibility model] for the full split.
+====
+
+== What ships in your service
+
+A deployed Akka service combines two sources:
+
+. *Your service image* — A small image that holds your application JAR and its direct SDK dependencies. The `mvn install` command builds this image. It copies these libraries to `/opt/local-lib/` in the running container.
+. *The Akka runtime base image* — The image that actually runs. It provides the JVM, the Akka runtime, and all platform dependencies (for example gRPC, Netty, Jackson, and Logback). Akka builds, scans, and patches this image.
+
+Scan the libraries that you add in step 1. These are the dependencies that you control. If a scan finds a vulnerability, you fix it by updating your `pom.xml`.
+
+[TIP]
+====
+Do not scan the whole Maven project directly. The project dependency tree includes `akka-runtime-dev`, the local development runtime. This runtime does not ship in your service image. A scan of the whole tree reports findings for libraries that Akka provides and patches. These findings are noise for you.
+====
+
+== Scan the shipped libraries
+
+Build your service image first. The build writes the shipped libraries to a known folder under `target/`. Then point your scanner at that folder.
+
+The folder path follows this pattern:
+
+[source]
+----
+target/docker/<service-name>/<tag>/build/maven/
+----
+
+The following example uses https://snyk.io[Snyk, window="new"]. Replace `<service-name>` and `<tag>` with your values.
+
+[source, command line]
+----
+mvn clean install -DskipTests
+snyk test --scan-all-unmanaged -- --target-dir=target/docker/my-service/latest/build/maven/
+----
+
+The `--scan-all-unmanaged` flag scans each JAR file in the folder. Snyk matches each JAR against its vulnerability database.
+
+[NOTE]
+====
+A scanner that matches JAR files identifies them by fingerprint. It skips a JAR that it does not recognize, for example a shaded or internally built artifact. It also reports no dependency paths, but only the vulnerable JAR.
+====
+
+
+== Scan the container image
+
+You can scan the built container image instead. Point the scanner at `/opt/local-lib/`. This folder holds the libraries that you introduce.
+
+Use this method when your process scans images rather than folders. It reports the same libraries as the folder scan.
+
+== Run the scan in CI
+
+Run the scan in your CI pipeline after the build step. This checks every change before you deploy it. See xref:operations:integrating-cicd/github-actions.adoc[] for how to set up a workflow.
+
+A typical job does the following:
+
+. Build the service image with `mvn clean install -DskipTests`.
+. Install the scanner.
+. Scan `target/docker/<service-name>/<tag>/build/maven/`.
+. Fail the job when the scanner finds a vulnerability at or above your threshold.
+
+== See also
+
+* xref:operations:integrating-cicd/github-actions.adoc[]
+* xref:operations:production-readiness/index.adoc[]
+* xref:operations:services/deploy-service.adoc[]

--- a/docs/src/modules/operations/pages/production-readiness/byoc/checklist.adoc
+++ b/docs/src/modules/operations/pages/production-readiness/byoc/checklist.adoc
@@ -208,7 +208,7 @@ Akka instruments the platform with its own observability stack and runs baseline
 
 [NOTE]
 ====
-*Scope scans to what you control.* Scan your application code and the dependencies you introduce. The container base image, JVM, OS, and the Akka runtime (including the dependencies it provides at runtime) are patched by Akka (see the xref:operations:production-readiness/byoc/shared-responsibility.adoc[Shared Responsibility Model]), so findings against those are Akka's to remediate; scope or triage them out so the report reflects what you own.
+*Scope scans to what you control.* Scan your application code and the dependencies you introduce. The container base image, JVM, OS, and the Akka runtime (including the dependencies it provides at runtime) are patched by Akka (see the xref:operations:production-readiness/byoc/shared-responsibility.adoc[Shared Responsibility Model]), so findings against those are Akka's to remediate; scope or triage them out so the report reflects what you own. For how to scope a scan to the dependencies you introduce on an Akka service, see xref:operations:integrating-cicd/scanning-dependencies.adoc[].
 ====
 
 [discrete]

--- a/docs/src/modules/operations/pages/production-readiness/byok8s/checklist.adoc
+++ b/docs/src/modules/operations/pages/production-readiness/byok8s/checklist.adoc
@@ -209,7 +209,7 @@ Akka instruments the platform with its own observability stack and runs baseline
 
 [NOTE]
 ====
-*Scope scans to what you control.* Scan your application code and the dependencies you introduce. The container base image, JVM, OS, and the Akka runtime (including the dependencies it provides at runtime) are patched by Akka (see the xref:operations:production-readiness/byok8s/shared-responsibility.adoc[Shared Responsibility Model]), so findings against those are Akka's to remediate; scope or triage them out so the report reflects what you own.
+*Scope scans to what you control.* Scan your application code and the dependencies you introduce. The container base image, JVM, OS, and the Akka runtime (including the dependencies it provides at runtime) are patched by Akka (see the xref:operations:production-readiness/byok8s/shared-responsibility.adoc[Shared Responsibility Model]), so findings against those are Akka's to remediate; scope or triage them out so the report reflects what you own. For how to scope a scan to the dependencies you introduce on an Akka service, see xref:operations:integrating-cicd/scanning-dependencies.adoc[].
 ====
 
 [discrete]

--- a/docs/src/modules/operations/pages/production-readiness/dedicated/checklist.adoc
+++ b/docs/src/modules/operations/pages/production-readiness/dedicated/checklist.adoc
@@ -206,7 +206,7 @@ Akka instruments the platform with its own observability stack and runs baseline
 
 [NOTE]
 ====
-*Scope scans to what you control.* Scan your application code and the dependencies you introduce. The container base image, JVM, OS, and the Akka runtime (including the dependencies it provides at runtime) are patched by Akka (see the xref:operations:production-readiness/dedicated/shared-responsibility.adoc[Shared Responsibility Model]), so findings against those are Akka's to remediate; scope or triage them out so the report reflects what you own.
+*Scope scans to what you control.* Scan your application code and the dependencies you introduce. The container base image, JVM, OS, and the Akka runtime (including the dependencies it provides at runtime) are patched by Akka (see the xref:operations:production-readiness/dedicated/shared-responsibility.adoc[Shared Responsibility Model]), so findings against those are Akka's to remediate; scope or triage them out so the report reflects what you own. For how to scope a scan to the dependencies you introduce on an Akka service, see xref:operations:integrating-cicd/scanning-dependencies.adoc[].
 ====
 
 [discrete]


### PR DESCRIPTION
Add a new Operations > Integrating with CI/CD page that documents the recommended way to scan the dependencies a user introduces into an Akka service.

Cross-link the page from the Dedicated, BYOC, and BYOK8s production readiness checklists.

Refs https://github.com/lightbend/akka-runtime/issues/5487
