### PR TITLE
chore: Report Consumer and Timed action exceptions to the unhandled ex reporter

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -679,6 +679,11 @@ private final class Sdk(
   // guardrail name => component ids
   private var guardrailEnabledForComponent = Map.empty[String, Set[String]]
 
+  // Set once `spiComponents` below is computed (after this scanning loop). Consumers and timed
+  // actions are constructed during the loop but only read this lazily, when handling a message,
+  // by which point the whole SdkRunner constructor - and thus this assignment - has completed.
+  private var unhandledExceptionReporterFn: Option[UnhandledExceptionReporting.Reporter] = None
+
   // Lazy: snapshots the var registries above. Must not be forced before scanning
   // completes; see scanTimeAutonomousAgentInjects for the only scan-time path.
   private lazy val agentCapabilityConverter: CapabilityConverter = {
@@ -886,7 +891,8 @@ private final class Sdk(
             sdkTracerFactory,
             serializer,
             regionInfo,
-            ComponentDescriptor.descriptorFor(timedActionClass, serializer))
+            ComponentDescriptor.descriptorFor(timedActionClass, serializer),
+            () => unhandledExceptionReporterFn)
         timedActionDescriptors :+=
           new TimedActionDescriptor(
             componentId,
@@ -919,7 +925,8 @@ private final class Sdk(
             serializer,
             ComponentDescriptorFactory.findIgnore(consumerClass),
             componentDescriptor,
-            regionInfo)
+            regionInfo,
+            () => unhandledExceptionReporterFn)
         consumerDescriptors :+=
           new ConsumerDescriptor(
             componentId,
@@ -1268,6 +1275,7 @@ private final class Sdk(
             Done
           }(sdkExecutionContext)
       }
+    unhandledExceptionReporterFn = onUnhandledException
 
     val guardrailSetup = new SpiGuardrailSetup(guardrailProvider.configuredGuardrails.map { g =>
       new SpiConfiguredGuardrail(

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/UnhandledExceptionReporting.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/UnhandledExceptionReporting.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import akka.Done
+import akka.annotation.InternalApi
+import akka.runtime.sdk.spi.SpiUnhandledException
+import org.slf4j.Logger
+
+/**
+ * INTERNAL API
+ *
+ * Stateless components (consumers, timed actions) catch exceptions thrown by user code and turn them into a successful
+ * effect, so that failure is reported through the component's own error/retry protocol rather than failing the runtime
+ * call. That means the exception never reaches the runtime as a failed `Future`, so the runtime's own
+ * unhandled-exception reporting (triggered from failed Futures) never fires for it. These components must report
+ * directly instead, using the same `onUnhandledException` callback the runtime would otherwise invoke.
+ */
+@InternalApi
+private[impl] object UnhandledExceptionReporting {
+
+  type Reporter = SpiUnhandledException => Future[Done]
+
+  def report(
+      reporter: () => Option[Reporter],
+      throwable: Throwable,
+      correlationId: String,
+      componentId: String,
+      componentClassName: String,
+      log: Logger)(implicit ec: ExecutionContext): Unit =
+    reporter().foreach { doReport =>
+      doReport(new SpiUnhandledException(throwable, correlationId, None, componentId, componentClassName)).failed
+        .foreach(ex => log.warn("Unhandled exception reporter failed", ex))
+    }
+
+}

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/consumer/ConsumerImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/consumer/ConsumerImpl.scala
@@ -24,6 +24,7 @@ import akka.javasdk.impl.AnySupport
 import akka.javasdk.impl.ComponentDescriptor
 import akka.javasdk.impl.ErrorHandling
 import akka.javasdk.impl.MetadataImpl
+import akka.javasdk.impl.UnhandledExceptionReporting
 import akka.javasdk.impl.consumer.ConsumerEffectImpl.AsyncEffect
 import akka.javasdk.impl.consumer.ConsumerEffectImpl.ConsumedEffect
 import akka.javasdk.impl.consumer.ConsumerEffectImpl.ProduceEffect
@@ -63,7 +64,8 @@ private[impl] final class ConsumerImpl[C <: Consumer](
     internalSerializer: Serializer,
     ignoreUnknown: Boolean,
     componentDescriptor: ComponentDescriptor,
-    regionInfo: RegionInfo)
+    regionInfo: RegionInfo,
+    unhandledExceptionReporter: () => Option[UnhandledExceptionReporting.Reporter] = () => None)
     extends SpiConsumer {
 
   private val log: Logger = LoggerFactory.getLogger(consumerClass)
@@ -158,6 +160,13 @@ private[impl] final class ConsumerImpl[C <: Consumer](
         s"Failure during handling message of type [${message.payload.fold("none")(
           _.contentType)}] from Consumer component [${consumerClass.getSimpleName}].",
         ex)
+      UnhandledExceptionReporting.report(
+        unhandledExceptionReporter,
+        ex,
+        correlationId,
+        componentId,
+        consumerClass.getName,
+        log)
       protocolFailure(correlationId)
     }
   }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/timedaction/TimedActionImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/timedaction/TimedActionImpl.scala
@@ -16,6 +16,7 @@ import akka.javasdk.impl.AbstractContext
 import akka.javasdk.impl.ComponentDescriptor
 import akka.javasdk.impl.ErrorHandling
 import akka.javasdk.impl.MetadataImpl
+import akka.javasdk.impl.UnhandledExceptionReporting
 import akka.javasdk.impl.serialization.Serializer
 import akka.javasdk.impl.telemetry.SpanTracingImpl
 import akka.javasdk.impl.telemetry.Telemetry
@@ -78,7 +79,8 @@ private[impl] final class TimedActionImpl[TA <: TimedAction](
     tracerFactory: () => Tracer,
     jsonSerializer: Serializer,
     regionInfo: RegionInfo,
-    componentDescriptor: ComponentDescriptor)
+    componentDescriptor: ComponentDescriptor,
+    unhandledExceptionReporter: () => Option[UnhandledExceptionReporting.Reporter] = () => None)
     extends SpiTimedAction {
   import TimedActionImpl.CommandContextImpl
 
@@ -139,6 +141,13 @@ private[impl] final class TimedActionImpl[TA <: TimedAction](
       log.error(
         s"Failure during handling command [${command.name}] from TimedAction component [${timedActionClass.getSimpleName}].",
         ex)
+      UnhandledExceptionReporting.report(
+        unhandledExceptionReporter,
+        ex,
+        correlationId,
+        componentId,
+        timedActionClass.getName,
+        log)
       protocolFailure(correlationId)
     }
   }

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/consumer/ConsumerImplSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/consumer/ConsumerImplSpec.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.javasdk.impl.consumer
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import akka.Done
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.LoggingTestKit
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.scaladsl.adapter._
+import akka.javasdk.consumer.Consumer
+import akka.javasdk.impl.AnySupport.BytesPrimitive
+import akka.javasdk.impl.ComponentDescriptor
+import akka.javasdk.impl.MethodInvoker
+import akka.javasdk.impl.UnhandledExceptionReporting
+import akka.javasdk.impl.serialization.Serializer
+import akka.runtime.sdk.spi.BytesPayload
+import akka.runtime.sdk.spi.ConsumerSource
+import akka.runtime.sdk.spi.RegionInfo
+import akka.runtime.sdk.spi.SpiConsumer
+import akka.runtime.sdk.spi.SpiUnhandledException
+import akka.runtime.sdk.spi.TimerClient
+import akka.util.ByteString
+import io.opentelemetry.api.OpenTelemetry
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class ConsumerImplSpec
+    extends ScalaTestWithActorTestKit
+    with LogCapturing
+    with AnyWordSpecLike
+    with Matchers
+    with BeforeAndAfterAll {
+
+  private val classicSystem = system.toClassic
+
+  private val serializer = new Serializer
+  private val timerClient = new TimerClient {
+    override def startSingleTimer(
+        name: String,
+        delay: FiniteDuration,
+        maxRetries: Int,
+        deferredRequest: akka.runtime.sdk.spi.DeferredRequest): Future[Done] = ???
+    override def removeTimer(name: String): Future[Done] = ???
+    override def isTimerActive(name: String): Future[Boolean] = ???
+  }
+
+  final class ThrowingConsumer extends Consumer {
+    def onBytes(bytes: Array[Byte]): Consumer.Effect =
+      throw new IllegalStateException("spike-16304: deliberate exception from consumer onEvent")
+  }
+
+  private val componentDescriptor = ComponentDescriptor(
+    Map(
+      BytesPrimitive.fullName -> MethodInvoker(classOf[ThrowingConsumer].getMethods.find(_.getName == "onBytes").get)))
+
+  def create(unhandledExceptionReporter: () => Option[UnhandledExceptionReporting.Reporter] = () => None)
+      : ConsumerImpl[ThrowingConsumer] =
+    new ConsumerImpl(
+      "throwing-consumer",
+      _ => new ThrowingConsumer,
+      classOf[ThrowingConsumer],
+      new ConsumerSource.EventSourcedEntitySource("dummy-source", startFromSnapshots = false),
+      None,
+      classicSystem,
+      timerClient,
+      classicSystem.dispatcher,
+      () => OpenTelemetry.noop().getTracer("test"),
+      serializer,
+      ignoreUnknown = false,
+      componentDescriptor,
+      new RegionInfo(""),
+      unhandledExceptionReporter)
+
+  private def throwingMessage = new SpiConsumer.Message(
+    Some(new BytesPayload(ByteString("some bytes"), BytesPrimitive.fullName)),
+    None,
+    akka.runtime.sdk.spi.SpiMetadata.empty,
+    io.opentelemetry.context.Context.root())
+
+  "The consumer service" should {
+
+    "turn thrown command handler exceptions into failure responses" in {
+      val service = create()
+
+      val reply =
+        LoggingTestKit
+          .error("Failure during handling message")
+          .expect {
+            service.handleMessage(throwingMessage).futureValue.asInstanceOf[SpiConsumer.ErrorEffect]
+          }
+
+      reply.error.description should startWith("Unexpected error")
+    }
+
+    "report an unhandled exception thrown by the user's onEvent method to the unhandled exception reporter" in {
+      val reported = new java.util.concurrent.CompletableFuture[SpiUnhandledException]()
+      val reporter: UnhandledExceptionReporting.Reporter = { spiEx =>
+        reported.complete(spiEx)
+        Future.successful(Done)
+      }
+      val service = create(() => Some(reporter))
+
+      LoggingTestKit.error("Failure during handling message").expect {
+        service.handleMessage(throwingMessage).futureValue
+      }
+
+      val spiException = reported.get(5, java.util.concurrent.TimeUnit.SECONDS)
+      spiException.throwable.getMessage should include("spike-16304")
+      spiException.componentId shouldBe "throwing-consumer"
+      spiException.componentClassName shouldBe classOf[ThrowingConsumer].getName
+    }
+  }
+}

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/timedaction/TimedActionImplSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/timedaction/TimedActionImplSpec.scala
@@ -15,6 +15,7 @@ import akka.actor.typed.scaladsl.adapter._
 import akka.javasdk.annotations.Component
 import akka.javasdk.impl.ComponentDescriptor
 import akka.javasdk.impl.TimedActionDescriptorFactory
+import akka.javasdk.impl.UnhandledExceptionReporting
 import akka.javasdk.impl.serialization.Serializer
 import akka.javasdk.timedaction.TimedAction
 import akka.runtime.sdk.spi.BytesPayload
@@ -22,6 +23,7 @@ import akka.runtime.sdk.spi.DeferredRequest
 import akka.runtime.sdk.spi.RegionInfo
 import akka.runtime.sdk.spi.SpiMetadata
 import akka.runtime.sdk.spi.SpiTimedAction
+import akka.runtime.sdk.spi.SpiUnhandledException
 import akka.runtime.sdk.spi.TimerClient
 import akka.util.ByteString
 import io.opentelemetry.api.OpenTelemetry
@@ -55,7 +57,10 @@ class TimedActionImplSpec
     override def isTimerActive(name: String): Future[Boolean] = ???
   }
 
-  def create(componentDescriptor: ComponentDescriptor): TimedActionImpl[TestTimedAction] = {
+  def create(
+      componentDescriptor: ComponentDescriptor,
+      unhandledExceptionReporter: () => Option[UnhandledExceptionReporting.Reporter] = () => None)
+      : TimedActionImpl[TestTimedAction] = {
     new TimedActionImpl(
       "dummy-id",
       _ => new TestTimedAction,
@@ -66,7 +71,8 @@ class TimedActionImplSpec
       () => OpenTelemetry.noop().getTracer("test"),
       serializer,
       new RegionInfo(""),
-      componentDescriptor)
+      componentDescriptor,
+      unhandledExceptionReporter)
   }
 
   @Component(id = "dummy-id")
@@ -112,6 +118,35 @@ class TimedActionImplSpec
           }
 
       reply.error.description should startWith("Unexpected error")
+    }
+
+    "report an unhandled exception thrown by the command handler to the unhandled exception reporter" in {
+      val reported = new java.util.concurrent.CompletableFuture[SpiUnhandledException]()
+      val reporter: UnhandledExceptionReporting.Reporter = { spiEx =>
+        reported.complete(spiEx)
+        Future.successful(Done)
+      }
+      val service =
+        create(
+          TimedActionDescriptorFactory.buildDescriptorFor(classOf[TestTimedAction], serializer),
+          () => Some(reporter))
+
+      LoggingTestKit
+        .error("Failure during handling command [MyMethodWithException] from TimedAction component [TestTimedAction]")
+        .expect {
+          service
+            .handleCommand(
+              new SpiTimedAction.Command(
+                "MyMethodWithException",
+                Some(new BytesPayload(ByteString.empty, "")),
+                SpiMetadata.empty))
+            .futureValue
+        }
+
+      val spiException = reported.get(5, java.util.concurrent.TimeUnit.SECONDS)
+      spiException.throwable.getMessage should include("MyMethodWithException")
+      spiException.componentId shouldBe "dummy-id"
+      spiException.componentClassName shouldBe classOf[TestTimedAction].getName
     }
 
   }


### PR DESCRIPTION
References
 - https://github.com/lightbend/akka-runtime/issues/5553

Was missing because runtime expected to see those exceptions but SDK catches and turns into an effect. Therefore we need to handle on SDK side.