### PR TITLE
docs(specify): correct the default conformance mode on the /akka:mode page

### DIFF
--- a/docs/src/modules/reference/pages/specify/mode.adoc
+++ b/docs/src/modules/reference/pages/specify/mode.adoc
@@ -16,8 +16,8 @@ Sets the project's conformance mode (recorded in `.akka/exit-conditions.yaml`) o
 
 The mode controls one thing: whether unmet exit conditions block shipping.
 
-* *Enforced* (the default) -- `ship` refuses to release the project until every applicable exit condition is `green` and not stale, or covered by an effective waiver. You use `signoff`, `strike` (to mark inapplicable), and `waive` to resolve each `open` or `red` condition before `ship` will proceed.
-* *À la carte* -- `ship` proceeds even when conditions are unmet, recording an explicit override. The conditions are still shown and evaluated; they simply do not block.
+* *À la carte* (the default) -- `ship` proceeds even when conditions are unmet, recording an explicit override. The conditions are still shown and evaluated; they simply do not block.
+* *Enforced* -- `ship` refuses to release the project until every applicable exit condition is `green` and not stale, or covered by an effective waiver. You use `signoff`, `strike` (to mark inapplicable), and `waive` to resolve each `open` or `red` condition before `ship` will proceed.
 
 Every Specify command is available in both modes -- the mode changes the ship gate, not the command set. The two locked process-integrity gates, `PROC-AUDITOR-COVERAGE` and `PROC-ADEQUACY-REVIEWED`, apply in both modes; the difference is only that enforced mode blocks ship while either is red, whereas à la carte computes them as advisory. A developer can switch only within the modes the organization allows; if the organization has locked the mode (see xref:reference:specify/policies.adoc[Policies]), the command refuses and says so.
 


### PR DESCRIPTION
## Problem

`reference/pages/specify/mode.adoc` marks **Enforced** as the default conformance mode. Since cli#160 (`feat(specify): default new projects to à-la-carte mode`, first tagged in `cli-3.0.70`) the default is **à la carte** — that is what `internal/exitconditions/manifest.go` resolves to with no org policy and no project override.

The page contradicted three others that already say à la carte:

- `sdk/pages/a-la-carte-mode.adoc:9`
- `sdk/pages/enforced-mode.adoc:9`
- `sdk/pages/spec-driven-development.adoc:27`

It is the page a reader lands on when they want to know which mode they are in, so it is the worst of the four to have wrong.

## Change

Move `(the default)` to the à-la-carte bullet and swap the two so the default leads. Wording is otherwise untouched, and the paragraph below already explains that an org policy may set a different default and lock it — so nothing was added.

## Scope

`policies.adoc:105` also shows `default: enforced`, but that is a `policy.yaml` example of an organization *overriding* the default. Correct as written, left alone.

The generated CLI reference page `cli/akka-cli/akka_specify_mode.adoc` already states the effective mode is `a-la-carte`, and `reference/nav.adoc` already lists `/akka:mode`, `/akka:status`, and `/akka:conform`. No other page needed a change.

## Companion PR

akka/ai-marketplace#25 adds the `/akka:mode`, `/akka:status`, and `/akka:conform` commands themselves. All three are documented here and listed in `reference/pages/specify/index.adoc`, but the marketplace only ever shipped 19 of the 22 — so invoking them did nothing. `/akka:mode` in particular is used in `getting-started/set-up-dev-env.adoc` and `spec-your-first-agent.adoc`, which is how this surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
