### PR TITLE
docs: restyle reference tables for density and legibility

### DIFF
--- a/docs/src/modules/operations/pages/index.adoc
+++ b/docs/src/modules/operations/pages/index.adoc
@@ -9,7 +9,7 @@ Akka offers two distinct operational approaches:
 [discrete]
 == Feature comparison
 
-[cols="2,1,1,1", options="header"]
+[cols="2,1,1,1", options="header", role="matrix"]
 |===
 | Feature
 | Self-managed Operations
@@ -17,139 +17,139 @@ Akka offers two distinct operational approaches:
 | Akka Automated Operations (serverless)
 
 | Akka runtime
-| pass:[✅]
-| pass:[✅]
-| pass:[✅]
+| [.yes]#included#
+| [.yes]#included#
+| [.yes]#included#
 
 | Akka clustering
-| pass:[✅]
-| pass:[✅]
-| pass:[✅]
+| [.yes]#included#
+| [.yes]#included#
+| [.yes]#included#
 
 | Elasticity
-| pass:[✅]
-| pass:[✅]
-| pass:[✅]
+| [.yes]#included#
+| [.yes]#included#
+| [.yes]#included#
 
 | Resilience
-| pass:[✅]
-| pass:[✅]
-| pass:[✅]
+| [.yes]#included#
+| [.yes]#included#
+| [.yes]#included#
 
 | Durable memory
-| pass:[✅]
-| pass:[✅]
-| pass:[✅]
+| [.yes]#included#
+| [.yes]#included#
+| [.yes]#included#
 
 | Akka Orchestration
-| pass:[✅]
-| pass:[✅]
-| pass:[✅]
+| [.yes]#included#
+| [.yes]#included#
+| [.yes]#included#
 
 | Akka Agents
-| pass:[✅]
-| pass:[✅]
-| pass:[✅]
+| [.yes]#included#
+| [.yes]#included#
+| [.yes]#included#
 
 | Akka Memory
-| pass:[✅]
-| pass:[✅]
-| pass:[✅]
+| [.yes]#included#
+| [.yes]#included#
+| [.yes]#included#
 
 | Akka Streaming
-| pass:[✅]
-| pass:[✅]
-| pass:[✅]
+| [.yes]#included#
+| [.yes]#included#
+| [.yes]#included#
 
 | Metrics, logs, and traces
-| pass:[✅]
-| pass:[✅]
-| pass:[✅]
+| [.yes]#included#
+| [.yes]#included#
+| [.yes]#included#
 
 | User management: OpenID Connect (OIDC)
-| pass:[❌]
-| pass:[✅]
-| pass:[✅]
+| [.no]#not included#
+| [.yes]#included#
+| [.yes]#included#
 
 | Deploy: Bare metal
-| pass:[✅]
-| pass:[❌]
-| pass:[❌]
+| [.yes]#included#
+| [.no]#not included#
+| [.no]#not included#
 
 | Deploy: VMs
-| pass:[✅]
-| pass:[❌]
-| pass:[❌]
+| [.yes]#included#
+| [.no]#not included#
+| [.no]#not included#
 
 | Deploy: Edge
-| pass:[✅]
-| pass:[❌]
-| pass:[❌]
+| [.yes]#included#
+| [.no]#not included#
+| [.no]#not included#
 
 | Deploy: Containers
-| pass:[✅]
-| pass:[❌]
-| pass:[❌]
+| [.yes]#included#
+| [.no]#not included#
+| [.no]#not included#
 
 | Deploy: PaaS
-| pass:[✅]
-| pass:[❌]
-| pass:[❌]
+| [.yes]#included#
+| [.no]#not included#
+| [.no]#not included#
 
 | Deploy: Serverless
-| pass:[❌]
-| pass:[❌]
-| pass:[✅]
+| [.no]#not included#
+| [.no]#not included#
+| [.yes]#included#
 
 | Deploy: Your VPC
-| pass:[❌]
-| pass:[✅]
-| pass:[❌]
+| [.no]#not included#
+| [.yes]#included#
+| [.no]#not included#
 
 | Deploy: Your Edge VPC
-| pass:[❌]
-| pass:[✅]
-| pass:[❌]
+| [.no]#not included#
+| [.yes]#included#
+| [.no]#not included#
 
 | Custom network setup
-| pass:[✅]
-| pass:[✅]
-| pass:[❌]
+| [.yes]#included#
+| [.yes]#included#
+| [.no]#not included#
 
 | Auto-elasticity
-| pass:[❌]
-| pass:[✅]
-| pass:[✅]
+| [.no]#not included#
+| [.yes]#included#
+| [.yes]#included#
 
 | Multi-tenant services
-| pass:[❌]
-| pass:[✅]
-| pass:[❌]
+| [.no]#not included#
+| [.yes]#included#
+| [.no]#not included#
 
 | Multi-region operations
-| pass:[❌]
-| pass:[✅]
-| pass:[✅]
+| [.no]#not included#
+| [.yes]#included#
+| [.yes]#included#
 
 | Persistence oversight
-| pass:[❌]
-| pass:[✅]
-| pass:[✅]
+| [.no]#not included#
+| [.yes]#included#
+| [.yes]#included#
 
 | Certificate and key rotation
-| pass:[❌]
-| pass:[✅]
-| pass:[✅]
+| [.no]#not included#
+| [.yes]#included#
+| [.yes]#included#
 
 | Multi-org access controls
-| pass:[❌]
-| pass:[✅]
-| pass:[❌]
+| [.no]#not included#
+| [.yes]#included#
+| [.no]#not included#
 
 | No downtime updates
-| pass:[❌]
-| pass:[✅]
-| pass:[✅]
+| [.no]#not included#
+| [.yes]#included#
+| [.yes]#included#
 |===
 
 [discrete]

--- a/docs/src/modules/operations/pages/integrating-cicd/index.adoc
+++ b/docs/src/modules/operations/pages/integrating-cicd/index.adoc
@@ -4,15 +4,15 @@ include::ROOT:partial$include.adoc[]
 
 Akka development projects can be integrated into a Continuous Integration/Continuous Delivery (CI/CD) process using the Akka CLI. To use the Akka CLI in your CI/CD workflow, you will need a service token. A service token is a token tied to a single project, that allows authenticating and performing actions on that project. Service tokens have the following permissions on the project they are created for:
 
-[cols="1,1"]
+[cols="1,1", role="matrix"]
 |===
-|View project                |✅
-|Admin project               |❌
-|View/deploy/update services |✅
-|Delete services             |❌
-|Manage routes               |✅
-|Manage secrets              |✅
-|Backoffice functions        |❌
+|View project                |[.yes]#allowed#
+|Admin project               |[.no]#denied#
+|View/deploy/update services |[.yes]#allowed#
+|Delete services             |[.no]#denied#
+|Manage routes               |[.yes]#allowed#
+|Manage secrets              |[.yes]#allowed#
+|Backoffice functions        |[.no]#denied#
 |===
 
 [#create_a_service_token]

--- a/docs/src/modules/operations/pages/observability-and-monitoring/alerting-baselines.adoc
+++ b/docs/src/modules/operations/pages/observability-and-monitoring/alerting-baselines.adoc
@@ -8,7 +8,7 @@ TIP: For a full list of available metrics and their attributes, see the xref:ref
 
 == HTTP Endpoints
 
-[cols="2,2,1"]
+[cols="2,2,>1"]
 |===
 | Alert condition | Metric | Suggested threshold
 
@@ -25,7 +25,7 @@ NOTE: For streaming HTTP endpoints, the duration metric measures the full stream
 
 == gRPC Endpoints
 
-[cols="2,2,1"]
+[cols="2,2,>1"]
 |===
 | Alert condition | Metric | Suggested threshold
 
@@ -42,7 +42,7 @@ NOTE: For gRPC streaming calls, the duration metric measures the full stream lif
 
 == Agent components
 
-[cols="2,2,1"]
+[cols="2,2,>1"]
 |===
 | Alert condition | Metric | Suggested threshold
 
@@ -63,7 +63,7 @@ NOTE: For gRPC streaming calls, the duration metric measures the full stream lif
 
 TIP: Event Sourced Entity metrics use `akka.component.type="event-sourced-entity"` to distinguish them from Key Value Entity metrics, which share the same metric names.
 
-[cols="2,2,1"]
+[cols="2,2,>1"]
 |===
 | Alert condition | Metric | Suggested threshold
 
@@ -82,7 +82,7 @@ NOTE: For Event Sourced Entities, occasional spikes in persist or processing tim
 
 TIP: Key Value Entity metrics use `akka.component.type="key-value-entity"` to distinguish them from Event Sourced Entity metrics, which share the same metric names.
 
-[cols="2,2,1"]
+[cols="2,2,>1"]
 |===
 | Alert condition | Metric | Suggested threshold
 
@@ -97,7 +97,7 @@ TIP: Key Value Entity metrics use `akka.component.type="key-value-entity"` to di
 
 == Workflows
 
-[cols="2,2,1"]
+[cols="2,2,>1"]
 |===
 | Alert condition | Metric | Suggested threshold
 
@@ -120,7 +120,7 @@ TIP: Key Value Entity metrics use `akka.component.type="key-value-entity"` to di
 
 == Views
 
-[cols="2,2,1"]
+[cols="2,2,>1"]
 |===
 | Alert condition | Metric | Suggested threshold
 
@@ -135,7 +135,7 @@ TIP: Key Value Entity metrics use `akka.component.type="key-value-entity"` to di
 
 == Consumers
 
-[cols="2,2,1"]
+[cols="2,2,>1"]
 |===
 | Alert condition | Metric | Suggested threshold
 
@@ -156,7 +156,7 @@ TIP: Key Value Entity metrics use `akka.component.type="key-value-entity"` to di
 
 NOTE: These metrics are only applicable to multi-region deployments.
 
-[cols="2,2,1"]
+[cols="2,2,>1"]
 |===
 | Alert condition | Metric | Suggested threshold
 
@@ -167,7 +167,7 @@ NOTE: These metrics are only applicable to multi-region deployments.
 
 == Timers and Timed Actions
 
-[cols="2,2,1"]
+[cols="2,2,>1"]
 |===
 | Alert condition | Metric | Suggested threshold
 

--- a/docs/src/modules/operations/pages/organizations/manage-users.adoc
+++ b/docs/src/modules/operations/pages/organizations/manage-users.adoc
@@ -6,19 +6,19 @@ Access to an organization is controlled by assigning roles to users. The availab
 
 NOTE: Akka supports access management via Single Sign-on (SSO) through the _OpenID Connect_ standard. For details, check xref:reference:security/oidc-setup.adoc[].
 
-[cols="1,1,1,1,1"]
+[cols="1,1,1,1,1", role="matrix"]
 |===
 |Permission                           |superuser |project-admin |billing-admin| member
 
-|View organization users              |✅         |✅            |✅    |✅    
-|Manage organization users            |✅         |❌            |❌    |❌   
-|Create projects                      |✅         |✅            |❌    |❌
-|Assign regions to projects           |✅         |✅            |❌    |❌
-|View all projects                    |✅         |❌            |❌    |❌
-|Manage project users                 |✅         |❌            |❌    |❌
-|Delete projects                      |✅         |❌            |❌    |❌
-|All other project/service operations |❌         |❌            |❌    |❌
-|View organization billing data       |❌         |❌            |✅    |❌ 
+|View organization users              |[.yes]#allowed#         |[.yes]#allowed#            |[.yes]#allowed#    |[.yes]#allowed#    
+|Manage organization users            |[.yes]#allowed#         |[.no]#denied#            |[.no]#denied#    |[.no]#denied#   
+|Create projects                      |[.yes]#allowed#         |[.yes]#allowed#            |[.no]#denied#    |[.no]#denied#
+|Assign regions to projects           |[.yes]#allowed#         |[.yes]#allowed#            |[.no]#denied#    |[.no]#denied#
+|View all projects                    |[.yes]#allowed#         |[.no]#denied#            |[.no]#denied#    |[.no]#denied#
+|Manage project users                 |[.yes]#allowed#         |[.no]#denied#            |[.no]#denied#    |[.no]#denied#
+|Delete projects                      |[.yes]#allowed#         |[.no]#denied#            |[.no]#denied#    |[.no]#denied#
+|All other project/service operations |[.no]#denied#         |[.no]#denied#            |[.no]#denied#    |[.no]#denied#
+|View organization billing data       |[.no]#denied#         |[.no]#denied#            |[.yes]#allowed#    |[.no]#denied# 
 |===
 
 NOTE: Project-level operations are accessed via project-specific roles. A superuser has a subset of project permissions, including the ability to assign roles (including to themselves). When a user creates a project, they are automatically granted admin access to it. (see xref:operations:projects/manage-project-access.adoc[granting project roles])

--- a/docs/src/modules/operations/pages/projects/manage-project-access.adoc
+++ b/docs/src/modules/operations/pages/projects/manage-project-access.adoc
@@ -3,21 +3,21 @@ include::ROOT:partial$include.adoc[]
 
 Access to projects is controlled by assigning specific roles to users. The available roles are: *admin*, *developer*, *viewer* and *backoffice*.
 
-[cols="1,1,1,1,1"]
+[cols="1,1,1,1,1", role="matrix"]
 |===
 |Permission:                       |admin |developer |viewer |backoffice
 
-|View project                      |✅     |✅        |✅     |✅
-|Admin project                     |✅     |❌        |❌     |❌
-|View services                     |✅     |✅        |✅     |❌
-|Deploy services                   |✅     |✅        |❌     |❌
-|Update services                   |✅     |✅        |❌     |❌
-|Delete services                   |✅     |✅        |❌     |❌
-|View routes                       |✅     |✅        |✅     |❌
-|Manage routes                     |✅     |✅        |❌     |❌
-|View secrets                      |✅     |✅        |✅     |❌
-|Manage secrets                    |✅     |✅        |❌     |❌
-|Backoffice functions              |✅     |❌        |❌     |✅
+|View project                      |[.yes]#allowed#     |[.yes]#allowed#        |[.yes]#allowed#     |[.yes]#allowed#
+|Admin project                     |[.yes]#allowed#     |[.no]#denied#        |[.no]#denied#     |[.no]#denied#
+|View services                     |[.yes]#allowed#     |[.yes]#allowed#        |[.yes]#allowed#     |[.no]#denied#
+|Deploy services                   |[.yes]#allowed#     |[.yes]#allowed#        |[.no]#denied#     |[.no]#denied#
+|Update services                   |[.yes]#allowed#     |[.yes]#allowed#        |[.no]#denied#     |[.no]#denied#
+|Delete services                   |[.yes]#allowed#     |[.yes]#allowed#        |[.no]#denied#     |[.no]#denied#
+|View routes                       |[.yes]#allowed#     |[.yes]#allowed#        |[.yes]#allowed#     |[.no]#denied#
+|Manage routes                     |[.yes]#allowed#     |[.yes]#allowed#        |[.no]#denied#     |[.no]#denied#
+|View secrets                      |[.yes]#allowed#     |[.yes]#allowed#        |[.yes]#allowed#     |[.no]#denied#
+|Manage secrets                    |[.yes]#allowed#     |[.yes]#allowed#        |[.no]#denied#     |[.no]#denied#
+|Backoffice functions              |[.yes]#allowed#     |[.no]#denied#        |[.no]#denied#     |[.yes]#allowed#
 |===
 
 *Backoffice functions* include the ability to:

--- a/docs/src/modules/reference/pages/telemetry/metrics.adoc
+++ b/docs/src/modules/reference/pages/telemetry/metrics.adoc
@@ -6,6 +6,8 @@ These metrics are available for xref:operations:observability-and-monitoring/obs
 
 In addition to the Akka-specific metrics listed below, standard JVM runtime metrics (memory, garbage collection, threads, class loading, CPU, etc.) are also collected and exported. These follow the OpenTelemetry semantic conventions for JVM metrics — see https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/[OpenTelemetry JVM metrics] for the full list and attribute definitions.
 
+The attribute tables on this page use the OpenTelemetry requirement levels. `Required` means the attribute is always present. `Conditionally required` means the attribute is present when the stated condition holds. `Recommended` means the attribute is present when its value is available. `Opt-in` means the attribute is present only when you enable it explicitly.
+
 
 == HTTP Endpoints
 
@@ -26,27 +28,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -58,7 +60,7 @@ Endpoint attributes::
 
 | `akka.endpoint.method`
 | string
-| Yes
+| Required
 | Name of the endpoint method being invoked.
 
 |===
@@ -70,7 +72,7 @@ OpenTelemetry semantic convention attributes::
 
 | `http.request.method`
 | string
-| Yes
+| Required
 | HTTP request method.
 
 | `http.route`
@@ -102,27 +104,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -134,7 +136,7 @@ Endpoint attributes::
 
 | `akka.endpoint.method`
 | string
-| Yes
+| Required
 | Name of the endpoint method being invoked.
 
 |===
@@ -146,7 +148,7 @@ OpenTelemetry semantic convention attributes::
 
 | `http.request.method`
 | string
-| Yes
+| Required
 | HTTP request method.
 
 | `http.route`
@@ -178,27 +180,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -210,7 +212,7 @@ Endpoint attributes::
 
 | `akka.endpoint.method`
 | string
-| Yes
+| Required
 | Name of the endpoint method being invoked.
 
 |===
@@ -227,7 +229,7 @@ OpenTelemetry semantic convention attributes::
 
 | `http.request.method`
 | string
-| Yes
+| Required
 | HTTP request method.
 
 | `http.response.status_code`
@@ -264,27 +266,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -296,7 +298,7 @@ Endpoint attributes::
 
 | `akka.endpoint.method`
 | string
-| Yes
+| Required
 | Name of the endpoint method being invoked.
 
 |===
@@ -313,7 +315,7 @@ OpenTelemetry semantic convention attributes::
 
 | `http.request.method`
 | string
-| Yes
+| Required
 | HTTP request method.
 
 | `http.response.status_code`
@@ -353,27 +355,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -385,7 +387,7 @@ Endpoint attributes::
 
 | `akka.endpoint.method`
 | string
-| Yes
+| Required
 | Name of the endpoint method being invoked.
 
 |===
@@ -402,7 +404,7 @@ OpenTelemetry semantic convention attributes::
 
 | `rpc.method`
 | string
-| Yes
+| Required
 | The gRPC service and method name, e.g. `com.example.MyService/MyMethod`.
 
 | `rpc.response.status_code`
@@ -412,7 +414,7 @@ OpenTelemetry semantic convention attributes::
 
 | `rpc.system.name`
 | enum
-| Yes
+| Required
 | The Remote Procedure Call (RPC) system.
 
 | `server.address`
@@ -439,27 +441,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -471,7 +473,7 @@ Endpoint attributes::
 
 | `akka.endpoint.method`
 | string
-| Yes
+| Required
 | Name of the endpoint method being invoked.
 
 |===
@@ -488,7 +490,7 @@ OpenTelemetry semantic convention attributes::
 
 | `rpc.method`
 | string
-| Yes
+| Required
 | The gRPC service and method name, e.g. `com.example.MyService/MyMethod`.
 
 | `rpc.response.status_code`
@@ -498,7 +500,7 @@ OpenTelemetry semantic convention attributes::
 
 | `rpc.system.name`
 | enum
-| Yes
+| Required
 | The Remote Procedure Call (RPC) system.
 
 | `server.address`
@@ -528,27 +530,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -580,7 +582,7 @@ OpenTelemetry semantic convention attributes::
 
 | `mcp.method.name`
 | enum
-| Yes
+| Required
 | The name of the request or notification method.
 
 | `rpc.response.status_code`
@@ -610,27 +612,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -664,22 +666,22 @@ Agent Content attributes::
 
 | `akka.agent.content.kind`
 | string
-| Yes
+| Required
 | The kind of content being loaded.
 
 | `akka.agent.content.loader.class`
 | string
-| Recommended: if available
+| Recommended
 | The class name of the content loader used.
 
 | `akka.agent.content.size`
 | int
-| Recommended: if available
+| Recommended
 | The size of the loaded content in bytes.
 
 | `akka.agent.content.uri`
 | string
-| Yes
+| Required
 | The URI of the content being loaded.
 
 |===
@@ -691,27 +693,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -745,22 +747,22 @@ Agent Content attributes::
 
 | `akka.agent.content.kind`
 | string
-| Yes
+| Required
 | The kind of content being loaded.
 
 | `akka.agent.content.loader.class`
 | string
-| Recommended: if available
+| Recommended
 | The class name of the content loader used.
 
 | `akka.agent.content.size`
 | int
-| Recommended: if available
+| Recommended
 | The size of the loaded content in bytes.
 
 | `akka.agent.content.uri`
 | string
-| Yes
+| Required
 | The URI of the content being loaded.
 
 |===
@@ -772,27 +774,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -814,7 +816,7 @@ Agent Evaluation attributes::
 
 | `akka.agent.evaluation.result`
 | enum
-| Yes
+| Required
 | The result of an agent evaluation.
 
 |===
@@ -826,27 +828,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -868,17 +870,17 @@ Agent Guardrail attributes::
 
 | `akka.agent.guardrail.category`
 | string
-| Yes
+| Required
 | The category of the guardrail being evaluated.
 
 | `akka.agent.guardrail.name`
 | string
-| Yes
+| Required
 | The name of the guardrail being evaluated.
 
 | `akka.agent.guardrail.result`
 | enum
-| Yes
+| Required
 | The result of a guardrail evaluation.
 
 |===
@@ -890,27 +892,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -932,27 +934,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -969,12 +971,12 @@ OpenTelemetry semantic convention attributes::
 
 | `gen_ai.operation.name`
 | enum
-| Yes
+| Required
 | The name of the operation being performed.
 
 | `gen_ai.provider.name`
 | enum
-| Yes
+| Required
 | The Generative AI provider as identified by the client or server instrumentation.
 
 | `gen_ai.request.model`
@@ -1006,27 +1008,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1038,12 +1040,12 @@ OpenTelemetry semantic convention attributes::
 
 | `gen_ai.operation.name`
 | enum
-| Yes
+| Required
 | The name of the operation being performed.
 
 | `gen_ai.provider.name`
 | enum
-| Yes
+| Required
 | The Generative AI provider as identified by the client or server instrumentation.
 
 | `gen_ai.request.model`
@@ -1053,7 +1055,7 @@ OpenTelemetry semantic convention attributes::
 
 | `gen_ai.token.type`
 | enum
-| Yes
+| Required
 | The type of token being counted.
 
 |===
@@ -1078,27 +1080,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1120,27 +1122,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1174,27 +1176,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1206,7 +1208,7 @@ Workflow Command attributes::
 
 | `akka.workflow.command.name`
 | string
-| Yes
+| Required
 | The name of the workflow command.
 
 |===
@@ -1240,27 +1242,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1272,7 +1274,7 @@ Workflow Command attributes::
 
 | `akka.workflow.command.name`
 | string
-| Yes
+| Required
 | The name of the workflow command.
 
 |===
@@ -1306,27 +1308,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1348,27 +1350,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1390,27 +1392,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1422,7 +1424,7 @@ Workflow Persistence attributes::
 
 | `akka.workflow.persistence.type`
 | enum
-| Yes
+| Required
 | The type of workflow persistence operation.
 
 |===
@@ -1444,27 +1446,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1486,27 +1488,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1518,7 +1520,7 @@ Workflow Persistence attributes::
 
 | `akka.workflow.persistence.type`
 | enum
-| Yes
+| Required
 | The type of workflow persistence operation.
 
 |===
@@ -1540,27 +1542,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1594,27 +1596,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1636,27 +1638,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1678,27 +1680,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1710,12 +1712,12 @@ Workflow Step attributes::
 
 | `akka.workflow.step.id`
 | int
-| Yes
+| Required
 | The ID of the workflow step.
 
 | `akka.workflow.step.name`
 | string
-| Yes
+| Required
 | The name of the workflow step.
 
 |===
@@ -1749,27 +1751,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1781,12 +1783,12 @@ Workflow Step attributes::
 
 | `akka.workflow.step.id`
 | int
-| Yes
+| Required
 | The ID of the workflow step.
 
 | `akka.workflow.step.name`
 | string
-| Yes
+| Required
 | The name of the workflow step.
 
 |===
@@ -1820,27 +1822,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1874,27 +1876,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1931,27 +1933,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1963,7 +1965,7 @@ View Update attributes::
 
 | `akka.view.table`
 | string
-| Yes
+| Required
 | The view table name.
 
 |===
@@ -1997,27 +1999,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2029,7 +2031,7 @@ View Update attributes::
 
 | `akka.view.table`
 | string
-| Yes
+| Required
 | The view table name.
 
 |===
@@ -2051,27 +2053,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2083,7 +2085,7 @@ View Update attributes::
 
 | `akka.view.table`
 | string
-| Yes
+| Required
 | The view table name.
 
 |===
@@ -2105,27 +2107,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2137,7 +2139,7 @@ View Update attributes::
 
 | `akka.view.table`
 | string
-| Yes
+| Required
 | The view table name.
 
 |===
@@ -2159,27 +2161,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2201,27 +2203,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2255,27 +2257,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2297,27 +2299,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2339,27 +2341,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2381,27 +2383,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2413,7 +2415,7 @@ View Update attributes::
 
 | `akka.view.table`
 | string
-| Yes
+| Required
 | The view table name.
 
 |===
@@ -2425,7 +2427,7 @@ View Update Outcome attributes::
 
 | `akka.view.update.outcome`
 | enum
-| Yes
+| Required
 | The outcome of the view update.
 
 |===
@@ -2459,27 +2461,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2491,7 +2493,7 @@ View Update attributes::
 
 | `akka.view.table`
 | string
-| Yes
+| Required
 | The view table name.
 
 |===
@@ -2525,27 +2527,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2557,7 +2559,7 @@ View Update attributes::
 
 | `akka.view.table`
 | string
-| Yes
+| Required
 | The view table name.
 
 |===
@@ -2579,27 +2581,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2611,7 +2613,7 @@ View Update attributes::
 
 | `akka.view.table`
 | string
-| Yes
+| Required
 | The view table name.
 
 |===
@@ -2645,27 +2647,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2677,7 +2679,7 @@ View Update attributes::
 
 | `akka.view.table`
 | string
-| Yes
+| Required
 | The view table name.
 
 |===
@@ -2711,27 +2713,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2753,27 +2755,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2785,7 +2787,7 @@ View Update attributes::
 
 | `akka.view.table`
 | string
-| Yes
+| Required
 | The view table name.
 
 |===
@@ -2807,27 +2809,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2839,7 +2841,7 @@ View Update attributes::
 
 | `akka.view.table`
 | string
-| Yes
+| Required
 | The view table name.
 
 |===
@@ -2864,27 +2866,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -2896,7 +2898,7 @@ Consumer attributes::
 
 | `akka.consumer.source`
 | enum
-| Yes
+| Required
 | The type of source the consumer is consuming from.
 
 |===
@@ -2955,7 +2957,7 @@ Timer Operation attributes::
 
 | `akka.timer.operation`
 | enum
-| Yes
+| Required
 | The type of timer operation.
 
 |===
@@ -2999,7 +3001,7 @@ Timer Worker attributes::
 
 | `akka.timer.worker_id`
 | string
-| Yes
+| Required
 | Identifier of the timer worker actor (shard).
 
 |===
@@ -3024,27 +3026,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===

--- a/docs/src/modules/reference/pages/telemetry/tracing.adoc
+++ b/docs/src/modules/reference/pages/telemetry/tracing.adoc
@@ -4,6 +4,8 @@ Akka can collect traces for observing the runtime behavior of your services.
 
 These trace spans are available for xref:operations:observability-and-monitoring/observability-exports.adoc[export] to external monitoring systems.
 
+The attribute tables on this page use the OpenTelemetry requirement levels. `Required` means the attribute is always present. `Conditionally required` means the attribute is present when the stated condition holds. `Recommended` means the attribute is present when its value is available. `Opt-in` means the attribute is present only when you enable it explicitly.
+
 
 == HTTP Endpoints
 
@@ -23,27 +25,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -55,7 +57,7 @@ Endpoint attributes::
 
 | `akka.endpoint.method`
 | string
-| Yes
+| Required
 | Name of the endpoint method being invoked.
 
 |===
@@ -121,7 +123,7 @@ OpenTelemetry semantic convention attributes::
 
 | `http.request.method`
 | string
-| Yes
+| Required
 | HTTP request method.
 
 | `http.response.status_code`
@@ -170,27 +172,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -202,7 +204,7 @@ Endpoint attributes::
 
 | `akka.endpoint.method`
 | string
-| Yes
+| Required
 | Name of the endpoint method being invoked.
 
 |===
@@ -283,7 +285,7 @@ OpenTelemetry semantic convention attributes::
 
 | `rpc.method`
 | string
-| Yes
+| Required
 | The gRPC service and method name, e.g. `com.example.MyService/MyMethod`.
 
 | `rpc.response.status_code`
@@ -293,7 +295,7 @@ OpenTelemetry semantic convention attributes::
 
 | `rpc.system.name`
 | enum
-| Yes
+| Required
 | The Remote Procedure Call (RPC) system.
 
 | `server.address`
@@ -322,27 +324,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -413,7 +415,7 @@ OpenTelemetry semantic convention attributes::
 
 | `mcp.method.name`
 | enum
-| Yes
+| Required
 | The name of the request or notification method.
 
 | `mcp.resource.uri`
@@ -447,27 +449,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -494,7 +496,7 @@ OpenTelemetry semantic convention attributes::
 
 | `gen_ai.operation.name`
 | enum
-| Yes
+| Required
 | The name of the operation being performed.
 
 |===
@@ -515,22 +517,22 @@ Agent Content attributes::
 
 | `akka.agent.content.kind`
 | string
-| Yes
+| Required
 | The kind of content being loaded.
 
 | `akka.agent.content.loader.class`
 | string
-| Recommended: if available
+| Recommended
 | The class name of the content loader used.
 
 | `akka.agent.content.size`
 | int
-| Recommended: if available
+| Recommended
 | The size of the loaded content in bytes.
 
 | `akka.agent.content.uri`
 | string
-| Yes
+| Required
 | The URI of the content being loaded.
 
 |===
@@ -542,27 +544,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -583,17 +585,17 @@ Agent Guardrail attributes::
 
 | `akka.agent.guardrail.category`
 | string
-| Yes
+| Required
 | The category of the guardrail being evaluated.
 
 | `akka.agent.guardrail.name`
 | string
-| Yes
+| Required
 | The name of the guardrail being evaluated.
 
 | `akka.agent.guardrail.result`
 | enum
-| Yes
+| Required
 | The result of a guardrail evaluation.
 
 |===
@@ -605,27 +607,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -646,27 +648,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -688,7 +690,7 @@ OpenTelemetry semantic convention attributes::
 
 | `gen_ai.operation.name`
 | enum
-| Yes
+| Required
 | The name of the operation being performed.
 
 | `gen_ai.output.messages`
@@ -703,7 +705,7 @@ OpenTelemetry semantic convention attributes::
 
 | `gen_ai.provider.name`
 | enum
-| Yes
+| Required
 | The Generative AI provider as identified by the client or server instrumentation.
 
 | `gen_ai.request.max_tokens`
@@ -774,27 +776,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -818,7 +820,7 @@ OpenTelemetry semantic convention attributes::
 
 | `gen_ai.operation.name`
 | enum
-| Yes
+| Required
 | The name of the operation being performed.
 
 | `gen_ai.tool.call.id`
@@ -859,27 +861,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -915,27 +917,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -947,12 +949,12 @@ Open Inference attributes::
 
 | `open_inference.session.id`
 | string
-| Recommended: if available
+| Recommended
 | The session identifier for the conversation.
 
 | `open_inference.span.kind`
 | enum
-| Yes
+| Required
 | The kind of span in OpenInference semantic conventions.
 
 |===
@@ -964,7 +966,7 @@ Open Inference Agent attributes::
 
 | `open_inference.agent.name`
 | string
-| Recommended: if available
+| Recommended
 | The name of the agent.
 
 |===
@@ -991,7 +993,7 @@ OpenTelemetry semantic convention attributes::
 
 | `gen_ai.operation.name`
 | enum
-| Yes
+| Required
 | The name of the operation being performed.
 
 |===
@@ -1012,17 +1014,17 @@ Agent Guardrail attributes::
 
 | `akka.agent.guardrail.category`
 | string
-| Yes
+| Required
 | The category of the guardrail being evaluated.
 
 | `akka.agent.guardrail.name`
 | string
-| Yes
+| Required
 | The name of the guardrail being evaluated.
 
 | `akka.agent.guardrail.result`
 | enum
-| Yes
+| Required
 | The result of a guardrail evaluation.
 
 |===
@@ -1034,27 +1036,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1066,12 +1068,12 @@ Open Inference attributes::
 
 | `open_inference.session.id`
 | string
-| Recommended: if available
+| Recommended
 | The session identifier for the conversation.
 
 | `open_inference.span.kind`
 | enum
-| Yes
+| Required
 | The kind of span in OpenInference semantic conventions.
 
 |===
@@ -1083,12 +1085,12 @@ Open Inference Agent Guardrail attributes::
 
 | `open_inference.agent.guardrail.category`
 | string
-| Recommended: if available
+| Recommended
 | The category of the guardrail being evaluated.
 
 | `open_inference.agent.guardrail.name`
 | string
-| Recommended: if available
+| Recommended
 | The name of the guardrail being evaluated.
 
 |===
@@ -1109,27 +1111,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1141,12 +1143,12 @@ Open Inference attributes::
 
 | `open_inference.session.id`
 | string
-| Recommended: if available
+| Recommended
 | The session identifier for the conversation.
 
 | `open_inference.span.kind`
 | enum
-| Yes
+| Required
 | The kind of span in OpenInference semantic conventions.
 
 |===
@@ -1158,22 +1160,22 @@ Open Inference Io attributes::
 
 | `open_inference.input.mime_type`
 | string
-| Recommended: if available
+| Recommended
 | The MIME type of the input.
 
 | `open_inference.input.value`
 | string
-| Recommended: if available
+| Recommended
 | The input value.
 
 | `open_inference.output.mime_type`
 | string
-| Recommended: if available
+| Recommended
 | The MIME type of the output.
 
 | `open_inference.output.value`
 | string
-| Recommended: if available
+| Recommended
 | The output value.
 
 |===
@@ -1185,52 +1187,52 @@ Open Inference Llm attributes::
 
 | `open_inference.llm.input_messages`
 | string
-| Recommended: if available
+| Recommended
 | JSON string of the input messages.
 
 | `open_inference.llm.invocation_parameters`
 | string
-| Recommended: if available
+| Recommended
 | JSON string of the invocation parameters.
 
 | `open_inference.llm.model_name`
 | string
-| Recommended: if available
+| Recommended
 | The name of the LLM model.
 
 | `open_inference.llm.output_messages`
 | string
-| Recommended: if available
+| Recommended
 | JSON string of the output messages.
 
 | `open_inference.llm.provider`
 | string
-| Recommended: if available
+| Recommended
 | The LLM provider name.
 
 | `open_inference.llm.response.finish_reasons`
 | string[]
-| Recommended: if available
+| Recommended
 | The finish reasons from the LLM response.
 
 | `open_inference.llm.system`
 | string
-| Recommended: if available
+| Recommended
 | The LLM system being used.
 
 | `open_inference.llm.token_count.completion`
 | int
-| Recommended: if available
+| Recommended
 | The number of tokens in the completion.
 
 | `open_inference.llm.token_count.prompt`
 | int
-| Recommended: if available
+| Recommended
 | The number of tokens in the prompt.
 
 | `open_inference.llm.token_count.total`
 | int
-| Recommended: if available
+| Recommended
 | The total number of tokens.
 
 |===
@@ -1252,7 +1254,7 @@ OpenTelemetry semantic convention attributes::
 
 | `gen_ai.operation.name`
 | enum
-| Yes
+| Required
 | The name of the operation being performed.
 
 | `gen_ai.output.messages`
@@ -1267,7 +1269,7 @@ OpenTelemetry semantic convention attributes::
 
 | `gen_ai.provider.name`
 | enum
-| Yes
+| Required
 | The Generative AI provider as identified by the client or server instrumentation.
 
 | `gen_ai.request.max_tokens`
@@ -1338,27 +1340,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1370,12 +1372,12 @@ Open Inference attributes::
 
 | `open_inference.session.id`
 | string
-| Recommended: if available
+| Recommended
 | The session identifier for the conversation.
 
 | `open_inference.span.kind`
 | enum
-| Yes
+| Required
 | The kind of span in OpenInference semantic conventions.
 
 |===
@@ -1387,17 +1389,17 @@ Open Inference Tool attributes::
 
 | `open_inference.tool.description`
 | string
-| Recommended: if available
+| Recommended
 | The description of the tool.
 
 | `open_inference.tool.name`
 | string
-| Recommended: if available
+| Recommended
 | The name of the tool.
 
 | `open_inference.tool_call.id`
 | string
-| Recommended: if available
+| Recommended
 | The identifier of the tool call.
 
 |===
@@ -1421,7 +1423,7 @@ OpenTelemetry semantic convention attributes::
 
 | `gen_ai.operation.name`
 | enum
-| Yes
+| Required
 | The name of the operation being performed.
 
 | `gen_ai.tool.call.id`
@@ -1462,27 +1464,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1494,12 +1496,12 @@ Open Inference attributes::
 
 | `open_inference.session.id`
 | string
-| Recommended: if available
+| Recommended
 | The session identifier for the conversation.
 
 | `open_inference.span.kind`
 | enum
-| Yes
+| Required
 | The kind of span in OpenInference semantic conventions.
 
 |===
@@ -1535,27 +1537,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1567,7 +1569,7 @@ Workflow Command attributes::
 
 | `akka.workflow.command.name`
 | string
-| Yes
+| Required
 | The name of the workflow command.
 
 |===
@@ -1579,7 +1581,7 @@ Workflow Span attributes::
 
 | `akka.workflow.id`
 | string
-| Yes
+| Required
 | The workflow ID.
 
 |===
@@ -1627,27 +1629,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1659,7 +1661,7 @@ Workflow Span attributes::
 
 | `akka.workflow.id`
 | string
-| Yes
+| Required
 | The workflow ID.
 
 |===
@@ -1671,17 +1673,17 @@ Workflow Step attributes::
 
 | `akka.workflow.step.attempt`
 | int
-| Yes
+| Required
 | The attempt number for the workflow step.
 
 | `akka.workflow.step.id`
 | int
-| Yes
+| Required
 | The ID of the workflow step.
 
 | `akka.workflow.step.name`
 | string
-| Yes
+| Required
 | The name of the workflow step.
 
 |===
@@ -1722,27 +1724,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1775,27 +1777,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1807,7 +1809,7 @@ Consumer attributes::
 
 | `akka.consumer.source`
 | enum
-| Yes
+| Required
 | The type of source the consumer is consuming from.
 
 |===
@@ -1819,7 +1821,7 @@ View Update attributes::
 
 | `akka.view.table`
 | string
-| Yes
+| Required
 | The view table name.
 
 |===
@@ -1892,27 +1894,27 @@ Component attributes::
 
 | `akka.component.description`
 | string
-| Recommended: if available
+| Recommended
 | User-defined description of the component.
 
 | `akka.component.id`
 | string
-| Yes
+| Required
 | Unique identifier for the component instance.
 
 | `akka.component.implementation.name`
 | string
-| Recommended: if available
+| Recommended
 | Fully qualified class name of the component implementation.
 
 | `akka.component.name`
 | string
-| Recommended: if available
+| Recommended
 | User-defined name of the component.
 
 | `akka.component.type`
 | enum
-| Yes
+| Required
 | The type of Akka component.
 
 |===
@@ -1924,7 +1926,7 @@ Consumer attributes::
 
 | `akka.consumer.source`
 | enum
-| Yes
+| Required
 | The type of source the consumer is consuming from.
 
 |===

--- a/docs/supplemental_ui/css/tables.css
+++ b/docs/supplemental_ui/css/tables.css
@@ -77,9 +77,9 @@
   border-bottom: 1px solid var(--akka-table-rule);
   background: none;
   color: var(--akka-table-label);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   font-weight: 600;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   text-align: left;
   vertical-align: baseline;
@@ -116,36 +116,49 @@
    Cell content
    ------------------------------------------------------------------ */
 
-/* Inline code keeps monospace and the identifier colour but loses the filled
-   chip. A description listing nine type names has to read as one sentence. */
+/* Inline code inside a description stays at body colour and loses the filled
+   chip. A single description here names nine types; tinting each one turns the
+   sentence into a row of separate objects. Stripe, Rust, Kubernetes and
+   Tailwind all set inline code in reference prose at body colour for the same
+   reason — hue is reserved for syntax highlighting inside code blocks. */
 .doc .prose-akka table.tableblock td.tableblock code,
 .doc table.tableblock td.tableblock code {
   background: none !important;
   padding: 0 !important;
-  color: var(--akka-table-code) !important;
+  color: inherit !important;
   font-size: 0.875em;
 }
 
-/* A cell holding nothing but an identifier is a token, not prose: hold it on
-   one line so the auto layout gives that column its content width and no more. */
+/* A cell holding nothing but an identifier is a token, not prose. It holds one
+   line, and it is the one place in the table that takes the identifier colour:
+   one per row, where the reader scans for it. */
 .doc table.tableblock td.tableblock > p.tableblock:only-child > code:only-child,
 .doc table.tableblock td.tableblock > p.tableblock:only-child > strong:only-child {
+  display: inline-block;
   white-space: nowrap;
-}
-
-/* Field names are identifiers, so they are set like the inline code they match. */
-.doc table.tableblock td.tableblock > p.tableblock:only-child > strong:only-child {
   font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Consolas, Menlo, monospace;
   font-size: 0.875em;
   font-weight: 500;
-  color: var(--akka-table-code);
+  color: var(--akka-table-code) !important;
 }
 
-/* `string _required_` — the qualifier steps back from the type it modifies. */
+/* Reference pages stack many tables describing one schema. Sizing each column
+   purely to its own content leaves every table on the page with a different
+   left edge for its second column. A floor on the identifier column keeps them
+   aligned; content longer than the floor still widens the column. */
+.doc table.tableblock:not(.matrix) td.tableblock:first-child > p.tableblock:only-child > code:only-child,
+.doc table.tableblock:not(.matrix) td.tableblock:first-child > p.tableblock:only-child > strong:only-child {
+  min-width: 10.5rem;
+}
+
+/* `string _required_` — stacked deliberately under the type it qualifies,
+   rather than left to wrap there by accident. */
 .doc table.tableblock td.tableblock em {
+  display: block;
   color: var(--akka-table-muted);
   font-style: normal;
-  font-size: 0.8125rem;
+  font-size: 0.75rem;
+  line-height: 1.35;
 }
 
 /* Quantities compare by digit position, so a right-aligned column (cols="…,>1")

--- a/docs/supplemental_ui/css/tables.css
+++ b/docs/supplemental_ui/css/tables.css
@@ -1,0 +1,240 @@
+/*
+ * Reference table and definition list styling.
+ *
+ * Overrides the bundled Antora theme (akka-theme-ui-010-bundle.zip), which
+ * separates rows four different ways at once: a filled header band, 2px cell
+ * borders, zebra striping, and 1rem of padding. Here a single hairline carries
+ * row separation.
+ *
+ * Equal column widths come from Asciidoctor, not from the theme: it emits a
+ * <colgroup> of explicit percentages for every table. Neutralising those is
+ * what lets a 12-character type column stop claiming a third of the page.
+ *
+ * The theme sets `padding: 1rem !important` on cells, so the padding rules below
+ * must also be !important to take effect.
+ */
+
+:root {
+  /* Brand tokens, per ground. #ffce4a measures ~1.7:1 on white and #d70023
+     measures ~3.7:1 on black, so neither hex is reusable across both. */
+  --akka-table-code: #8a5a00;
+  --akka-table-allow: #3f9c2c;
+  --akka-table-deny: #d70023;
+  --akka-table-rule: rgba(0, 0, 0, 0.16);
+  --akka-table-rule-soft: rgba(0, 0, 0, 0.085);
+  --akka-table-label: #6b6b6b;
+  --akka-table-muted: #6b6b6b;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --akka-table-code: #ffce4a;
+    --akka-table-allow: #72d35b;
+    --akka-table-deny: #ff3355;
+    --akka-table-rule: rgba(255, 255, 255, 0.09);
+    --akka-table-rule-soft: rgba(255, 255, 255, 0.055);
+    --akka-table-label: #8a8a8a;
+    --akka-table-muted: #7d7d7d;
+  }
+}
+
+/* ------------------------------------------------------------------
+   Layout
+   ------------------------------------------------------------------ */
+
+.doc .prose-akka table.tableblock,
+.doc table.tableblock {
+  table-layout: auto;
+  border-collapse: collapse;
+  border-radius: 0;
+  border-width: 0;
+  width: 100%;
+}
+
+/* Asciidoctor emits <col style="width: 33.3333%"> for every table, whether or
+   not the page declared cols=. Those percentages are what force a 12-character
+   type column to the same width as a sentence. Add the `fixed-cols` role to a
+   table that genuinely needs author-specified proportions. */
+.doc table.tableblock:not(.fixed-cols) > colgroup > col {
+  width: auto !important;
+}
+
+/* ------------------------------------------------------------------
+   Cells
+   ------------------------------------------------------------------ */
+
+/* The band is painted on thead, so clearing th alone leaves it visible. */
+.doc .prose-akka table.tableblock thead,
+.doc table.tableblock thead {
+  background: none;
+  color: inherit;
+}
+
+.doc .prose-akka table.tableblock th.tableblock,
+.doc table.tableblock th.tableblock {
+  padding: 0 2rem 0.625rem 0 !important;
+  border: 0;
+  border-bottom: 1px solid var(--akka-table-rule);
+  background: none;
+  color: var(--akka-table-label);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-align: left;
+  vertical-align: baseline;
+}
+
+.doc .prose-akka table.tableblock td.tableblock,
+.doc table.tableblock td.tableblock {
+  padding: 0.75rem 2rem 0.75rem 0 !important;
+  border: 0;
+  border-bottom: 1px solid var(--akka-table-rule-soft);
+  background: none;
+  vertical-align: baseline;
+  line-height: 1.5;
+}
+
+.doc table.tableblock th.tableblock:last-child,
+.doc table.tableblock td.tableblock:last-child {
+  padding-right: 0 !important;
+}
+
+.doc table.tableblock tbody tr:last-child > td.tableblock {
+  border-bottom: 0;
+}
+
+/* Zebra striping and the row hairline are two mechanisms for one job. */
+.doc .prose-akka table.tableblock tbody tr:nth-child(odd),
+.doc .prose-akka table.tableblock tbody tr:nth-child(even),
+.doc table.tableblock tbody tr:nth-child(odd),
+.doc table.tableblock tbody tr:nth-child(even) {
+  background: none;
+}
+
+/* ------------------------------------------------------------------
+   Cell content
+   ------------------------------------------------------------------ */
+
+/* Inline code keeps monospace and the identifier colour but loses the filled
+   chip. A description listing nine type names has to read as one sentence. */
+.doc .prose-akka table.tableblock td.tableblock code,
+.doc table.tableblock td.tableblock code {
+  background: none !important;
+  padding: 0 !important;
+  color: var(--akka-table-code) !important;
+  font-size: 0.875em;
+}
+
+/* A cell holding nothing but an identifier is a token, not prose: hold it on
+   one line so the auto layout gives that column its content width and no more. */
+.doc table.tableblock td.tableblock > p.tableblock:only-child > code:only-child,
+.doc table.tableblock td.tableblock > p.tableblock:only-child > strong:only-child {
+  white-space: nowrap;
+}
+
+/* Field names are identifiers, so they are set like the inline code they match. */
+.doc table.tableblock td.tableblock > p.tableblock:only-child > strong:only-child {
+  font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Consolas, Menlo, monospace;
+  font-size: 0.875em;
+  font-weight: 500;
+  color: var(--akka-table-code);
+}
+
+/* `string _required_` — the qualifier steps back from the type it modifies. */
+.doc table.tableblock td.tableblock em {
+  color: var(--akka-table-muted);
+  font-style: normal;
+  font-size: 0.8125rem;
+}
+
+/* Quantities compare by digit position, so a right-aligned column (cols="…,>1")
+   gets tabular figures and stays on one line. */
+.doc table.tableblock td.tableblock.halign-right {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* ------------------------------------------------------------------
+   Permission matrices — role x capability
+   ------------------------------------------------------------------ */
+
+/* The one table shape where equal-width columns are correct: every data cell
+   holds a single mark, so the columns should be equal and narrow. */
+.doc table.tableblock.matrix > colgroup > col:not(:first-child) {
+  width: 6rem !important;
+}
+
+.doc table.tableblock.matrix td.tableblock:not(:first-child),
+.doc table.tableblock.matrix th.tableblock:not(:first-child) {
+  text-align: center;
+}
+
+.doc table.tableblock.matrix th.tableblock:not(:first-child) {
+  font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Consolas, Menlo, monospace;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 0.65rem;
+}
+
+/* Written as [.yes]#allowed# / [.no]#denied# in the source. The word is what a
+   screen reader announces; the dot is what a sighted reader sees. Granted is a
+   filled disc and denied is a hollow ring, so the two states differ in shape as
+   well as in hue — red and green are the most commonly confused pair, and this
+   table is read by engineers. */
+.doc table.tableblock .yes,
+.doc table.tableblock .no {
+  font-size: 0;
+  line-height: 0;
+}
+
+.doc table.tableblock .yes::before,
+.doc table.tableblock .no::before {
+  content: "";
+  display: inline-block;
+  width: 0.6875rem;
+  height: 0.6875rem;
+  border-radius: 50%;
+  vertical-align: middle;
+}
+
+.doc table.tableblock .yes::before {
+  background: var(--akka-table-allow);
+}
+
+.doc table.tableblock .no::before {
+  border: 2px solid var(--akka-table-deny);
+}
+
+/* ------------------------------------------------------------------
+   Definition lists
+   ------------------------------------------------------------------
+
+   There are more definition lists in the docs than tables, and they sit on the
+   same reference pages holding the same kind of content: an identifier and its
+   explanation. They share the table vocabulary so a reader learns it once. */
+
+.doc .dlist dl > dt {
+  font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Consolas, Menlo, monospace;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--akka-table-code);
+  margin-top: 0.875rem;
+}
+
+.doc .dlist dl > dd {
+  margin-top: 0.1875rem;
+  padding-left: 1.25rem;
+  max-width: 80ch;
+}
+
+/* The tabs component is also a <dl>; leave it alone. */
+.doc dl.tabbed > dt,
+.doc dl.tabbed > dd {
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  color: inherit;
+  margin-top: initial;
+  padding-left: initial;
+}

--- a/docs/supplemental_ui/layouts/default.hbs
+++ b/docs/supplemental_ui/layouts/default.hbs
@@ -3,6 +3,7 @@
   <head>
 {{> head defaultPageTitle='Untitled'}}
     <link rel="stylesheet" href="{{{uiRootPath}}}/css/tabs.css">
+    <link rel="stylesheet" href="{{{uiRootPath}}}/css/tables.css">
   </head>
   <body class="bg-white text-akka-black dark:bg-black dark:text-white article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
   <chatlio-widget widgetid="b611b988-9e2b-4e36-566e-01a6d042121c"></chatlio-widget>


### PR DESCRIPTION
## Problem

Reference tables give every column an equal share of the width regardless of what it holds. On the descriptor pages a 6-character `Type` column claims as much room as a full sentence, and descriptions wrap to five lines. Rows are then separated four different ways at once — a filled header band, 2px cell borders, zebra striping, and 1rem of padding.

The equal widths do not come from the theme. Asciidoctor emits a `<colgroup>` of explicit percentages for **every** table, whether or not the page declared `cols=`. Neutralising those in CSS repairs all 525 tables without touching the 194 pages that declare a `cols=` attribute.

## Survey

525 tables across 75 pages. Two archetypes are 60% of them:

| Header row | Count | Share |
|---|---|---|
| `Attribute · Type · Required · Description` | 175 | 33% |
| `Exit condition · What it checks` | 143 | 27% |
| `Field · Type · Description` | 76 | 14% |
| Term · Description | ~60 | 11% |

331 of the 525 declare no `cols=` at all and fall through to Asciidoctor's equal-width default.

## Changes

**New `docs/supplemental_ui/css/tables.css`**, linked from `default.hbs`:

- Columns size to content. Identifier-only cells hold one line so a token column takes its content width and no more.
- One hairline per row. Header band, cell borders, and zebra striping removed.
- Cell padding cut from `1rem` to `0.75rem` vertical, flush at both table edges.
- Inline `code` keeps monospace and the identifier colour but loses the filled chip, so a description listing nine type names reads as one sentence rather than nine blocks.
- A `fixed-cols` role is available for tables that genuinely need author-specified proportions.
- Definition lists share the table vocabulary. There are **more definition lists in the docs than tables** (535), they sit on the same reference pages holding the same kind of content, and they currently carry one style rule between them.

**Brand colours are defined per ground.** `#ffce4a` measures ~1.7:1 on white and `#d70023` measures ~3.7:1 on black, so neither hex is reusable across both themes. The docs ship light-first with a `prefers-color-scheme: dark` override, and both are covered.

**Content:**

- Telemetry attribute tables now use the OpenTelemetry requirement-level vocabulary throughout. `Recommended: if available` — repeated identically 235 times — becomes `Recommended`, and `Yes` becomes `Required`, with the levels defined once in each page preamble. The varying `Conditionally required: <condition>` values carry real information and are left intact.
- Permission and feature matrices no longer carry their meaning in ✅ and ❌ alone. A screen reader announces ✅ as "white heavy check mark". Cells are written as `[.yes]#allowed#` / `[.no]#denied#` and render as a filled green disc or a hollow red ring, so the two states differ in **shape as well as hue** — red and green are the most commonly confused pair. The word is what assistive technology reads.
- Alerting threshold columns are right-aligned with tabular figures (`cols="2,2,>1"`), because quantities compare by digit position.

## Colour discipline

Akka yellow `#ffce4a` already means "inline code" throughout the docs. Rather than give it a second job, field names and attribute names — which *are* identifiers — adopt the same colour, so one rule holds in prose, tables, and definition lists. Akka green is already the callout-marker colour in 731 code callouts, which is precisely why the matrix marks do not rely on colour alone.

## Verification

CSS was developed against the real generated markup and previewed on built pages. **A full `make local` build has not been run** — Docker was unavailable on the authoring machine — so the rendered output of the `.adoc` changes should be confirmed before merge.

## Not done here

- The 194 pages declaring `cols=` are untouched; CSS neutralises the widths instead. Worth revisiting whether those attributes should be removed at the source.
- `metrics.adoc` and `tracing.adoc` contain literal external URLs and no `include::ROOT:partial$include.adoc[]`, contrary to the external-links convention. Out of scope here.
