### PR TITLE
chore: update alpine base image version to 3.24.1

### DIFF
--- a/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-parent/pom.xml
@@ -676,8 +676,6 @@
                                         <build>
                                             <!-- Base Docker image which contains jre-->
                                             <from>${docker.base.image}</from>
-                                            <!-- Run as the Alpine built-in non-root "nobody" user (uid/gid 65534) -->
-                                            <user>65534</user>
                                             <buildOptions>
                                                 <platform>${docker.platform}</platform>
                                             </buildOptions>

--- a/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-parent/pom.xml
@@ -137,6 +137,8 @@
                                 <build>
                                     <!-- Base Docker image which contains jre-->
                                     <from>${docker.base.image}</from>
+                                    <!-- Run as the Alpine built-in non-root "nobody" user (uid/gid 65534) -->
+                                    <user>65534</user>
                                     <buildOptions>
                                         <platform>${docker.platform}</platform>
                                     </buildOptions>
@@ -674,6 +676,8 @@
                                         <build>
                                             <!-- Base Docker image which contains jre-->
                                             <from>${docker.base.image}</from>
+                                            <!-- Run as the Alpine built-in non-root "nobody" user (uid/gid 65534) -->
+                                            <user>65534</user>
                                             <buildOptions>
                                                 <platform>${docker.platform}</platform>
                                             </buildOptions>

--- a/akka-javasdk-parent/pom.xml
+++ b/akka-javasdk-parent/pom.xml
@@ -57,7 +57,7 @@
         <docker.tag>${project.version}-${build.timestamp}</docker.tag>
 
         <!-- note that this image does never actually run the service in a JVM, it's just a means for distribution -->
-        <docker.base.image>us-docker.pkg.dev/kalix-images/infrastructure/alpine:3.23.3</docker.base.image>
+        <docker.base.image>us-docker.pkg.dev/kalix-images/infrastructure/alpine:3.24.1</docker.base.image>
         <docker.platform>linux/amd64</docker.platform>
 
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>


### PR DESCRIPTION
Fix some vulns reports, although this image is only run as an init container. Also, sets user to non-root.

Refs:
- https://github.com/lightbend/akka-runtime/issues/5577