### PR TITLE
docs(specify): document dormant exit conditions in à la carte mode

### DIFF
--- a/docs/src/modules/reference/pages/specify/docs.adoc
+++ b/docs/src/modules/reference/pages/specify/docs.adoc
@@ -13,7 +13,7 @@ Generate rendered documentation for the current Akka project and verify it again
 
 `/akka:docs` is primarily an xref:sdk:a-la-carte-mode.adoc[À la carte mode] command. A developer runs it directly when they want to (re)generate the project's rendered documentation and see how the content-governance exit conditions decided.
 
-The same activity also runs in xref:sdk:enforced-mode.adoc[Enforced mode] as part of the engine's autonomous build loop, whenever a content-governance exit condition is `open` and the assistant can act on it. In both modes the command's behavior is identical; only ship-gating differs.
+The same activity also runs in xref:sdk:enforced-mode.adoc[Enforced mode] as part of the engine's autonomous build loop, whenever a content-governance exit condition is `open` and the assistant can act on it. The command's behavior is identical wherever the exit-condition set is active, and only ship-gating differs. While the set is dormant the command still generates the pages, and records no conditions.
 
 == What it produces
 

--- a/docs/src/modules/reference/pages/specify/mode.adoc
+++ b/docs/src/modules/reference/pages/specify/mode.adoc
@@ -22,7 +22,7 @@ The mode controls two things: whether Akka Specify creates exit conditions on it
 * *À la carte* (the default) -- the exit-condition set is dormant until you ask for it. Only the Akka-intrinsic baseline resolves. No auditors are created and `/akka:specify` captures nothing. Once you ask for conditions, they are evaluated and shown, but `ship` still proceeds when they are unmet, recording an explicit override.
 * *Enforced* -- the full set applies from the start. `ship` refuses to release the project until every applicable exit condition is `green` and not stale, or covered by an effective waiver. You use `signoff`, `strike` (to mark inapplicable), and `waive` to resolve each `open` or `red` condition before `ship` will proceed.
 
-Use `--ecs=honor` to start using conditions in à la carte mode, or `--ecs=ignore` to set them aside. Setting them aside does not delete anything. The captured conditions stay in `.akka/exit-conditions.yaml` and `--ecs=honor` brings them back.
+Use `--exit-conditions=honor` to start using conditions in à la carte mode, or `--exit-conditions=ignore` to set them aside. Setting them aside does not delete anything. The captured conditions stay in `.akka/exit-conditions.yaml` and `--exit-conditions=honor` brings them back.
 
 Every Specify command is available in both modes. The mode changes what the engine does on its own, not the command set. The two locked process-integrity gates, `PROC-AUDITOR-COVERAGE` and `PROC-ADEQUACY-REVIEWED`, apply whenever the exit-condition set is active. Enforced mode blocks ship while either is red, and à la carte computes them as advisory. While the set is dormant they do not resolve at all, because there is nothing yet to have covered or reviewed.
 
@@ -34,8 +34,8 @@ Switching to à la carte is not a silent change when the project already carries
 
 [source]
 ----
-/akka:mode a-la-carte --ecs=honor
-/akka:mode a-la-carte --ecs=ignore
+/akka:mode a-la-carte --exit-conditions=honor
+/akka:mode a-la-carte --exit-conditions=ignore
 ----
 
 A project with no conditions yet switches without any question.

--- a/docs/src/modules/reference/pages/specify/mode.adoc
+++ b/docs/src/modules/reference/pages/specify/mode.adoc
@@ -17,12 +17,28 @@ you have to xref:getting-started:set-up-dev-env.adoc#_update_the_plugin[update t
 
 Sets the project's conformance mode (recorded in `.akka/exit-conditions.yaml`) or, with no argument, prints the current mode.
 
-The mode controls one thing: whether unmet exit conditions block shipping.
+The mode controls two things: whether Akka Specify creates exit conditions on its own, and whether unmet conditions block shipping.
 
-* *À la carte* (the default) -- `ship` proceeds even when conditions are unmet, recording an explicit override. The conditions are still shown and evaluated; they simply do not block.
-* *Enforced* -- `ship` refuses to release the project until every applicable exit condition is `green` and not stale, or covered by an effective waiver. You use `signoff`, `strike` (to mark inapplicable), and `waive` to resolve each `open` or `red` condition before `ship` will proceed.
+* *À la carte* (the default) -- the exit-condition set is dormant until you ask for it. Only the Akka-intrinsic baseline resolves. No auditors are created and `/akka:specify` captures nothing. Once you ask for conditions, they are evaluated and shown, but `ship` still proceeds when they are unmet, recording an explicit override.
+* *Enforced* -- the full set applies from the start. `ship` refuses to release the project until every applicable exit condition is `green` and not stale, or covered by an effective waiver. You use `signoff`, `strike` (to mark inapplicable), and `waive` to resolve each `open` or `red` condition before `ship` will proceed.
 
-Every Specify command is available in both modes -- the mode changes the ship gate, not the command set. The two locked process-integrity gates, `PROC-AUDITOR-COVERAGE` and `PROC-ADEQUACY-REVIEWED`, apply in both modes; the difference is only that enforced mode blocks ship while either is red, whereas à la carte computes them as advisory. A developer can switch only within the modes the organization allows; if the organization has locked the mode (see xref:reference:specify/policies.adoc[Policies]), the command refuses and says so.
+Use `--ecs=honor` to start using conditions in à la carte mode, or `--ecs=ignore` to set them aside. Setting them aside does not delete anything. The captured conditions stay in `.akka/exit-conditions.yaml` and `--ecs=honor` brings them back.
+
+Every Specify command is available in both modes. The mode changes what the engine does on its own, not the command set. The two locked process-integrity gates, `PROC-AUDITOR-COVERAGE` and `PROC-ADEQUACY-REVIEWED`, apply whenever the exit-condition set is active. Enforced mode blocks ship while either is red, and à la carte computes them as advisory. While the set is dormant they do not resolve at all, because there is nothing yet to have covered or reviewed.
+
+A developer can switch only within the modes the organization allows. If the organization has locked the mode (see xref:reference:specify/policies.adoc[Policies]), the command refuses and says so.
+
+== Switching a project that already has conditions
+
+Switching to à la carte is not a silent change when the project already carries exit conditions and auditors. The command refuses and names the two options, so the choice stays with you:
+
+[source]
+----
+/akka:mode a-la-carte --ecs=honor
+/akka:mode a-la-carte --ecs=ignore
+----
+
+A project with no conditions yet switches without any question.
 
 See xref:sdk:spec-driven-development.adoc#choosing-your-mode[Conformance modes] for more on choosing a mode.
 

--- a/docs/src/modules/sdk/pages/a-la-carte-mode.adoc
+++ b/docs/src/modules/sdk/pages/a-la-carte-mode.adoc
@@ -6,7 +6,11 @@
 
 include::ROOT:partial$include.adoc[]
 
-À la carte is the default mode. You drive the spec-driven workflow one command at a time. Nothing blocks you, and `/akka:ship` proceeds whether or not a definition of done is met -- you own the rigor. It is faster and lighter than xref:sdk:enforced-mode.adoc[Enforced mode], which gates each phase on machine-checkable exit conditions. Switch to Enforced with `/akka:mode enforced` when you want that rigor, and back with `/akka:mode a-la-carte`.
+À la carte is the default mode. You drive the spec-driven workflow one command at a time. Nothing blocks you, and `/akka:ship` proceeds whether or not a definition of done is met. You own the rigor.
+
+The exit-condition machinery stays out of your way until you ask for it. A new project starts with the set dormant: no conditions are captured, no auditors are created, and you are not asked to approve anything. Run `/akka:mode a-la-carte --ecs=honor` when you want the checks, and they run as an advisory checklist rather than a gate.
+
+À la carte is faster and lighter than xref:sdk:enforced-mode.adoc[Enforced mode], which gates each phase on machine-checkable exit conditions. Switch to Enforced with `/akka:mode enforced` when you want that rigor, and back with `/akka:mode a-la-carte`.
 
 This page walks the commands in the order you would normally run them. Every command is also documented in the xref:reference:specify/index.adoc[Specify commands reference].
 
@@ -29,7 +33,7 @@ The short description becomes a branch name like `00#-feature-short-description`
 
 This creates a specification in `specs/001-core-users` on the `001-core-users` branch. Resist manually editing the spec -- clarification is the next step. Keep features scoped small enough that you have a clear idea of the acceptance criteria and the generated code is easy to review.
 
-NOTE: Even in À la carte mode, `/akka:specify` captures your definition of done as exit conditions and runs the adversarial adequacy review, exactly as it does in Enforced mode. The difference is only at ship time: the `PROC-AUDITOR-COVERAGE` and `PROC-ADEQUACY-REVIEWED` gates are advisory here. They are computed and reported, but you drive the phases and `/akka:ship` is not blocked when they are red.
+NOTE: In À la carte mode, `/akka:specify` does not create exit conditions or auditors on its own. The exit-condition set is dormant until you ask for it, so the command produces a specification and nothing else. To start capturing your definition of done as exit conditions and running the adversarial adequacy review, run `/akka:mode a-la-carte --ecs=honor`. The checks are advisory even then: the `PROC-AUDITOR-COVERAGE` and `PROC-ADEQUACY-REVIEWED` gates are computed and reported, but you drive the phases and `/akka:ship` is not blocked when they are red.
 
 == Clarify the specification
 

--- a/docs/src/modules/sdk/pages/a-la-carte-mode.adoc
+++ b/docs/src/modules/sdk/pages/a-la-carte-mode.adoc
@@ -8,7 +8,7 @@ include::ROOT:partial$include.adoc[]
 
 À la carte is the default mode. You drive the spec-driven workflow one command at a time. Nothing blocks you, and `/akka:ship` proceeds whether or not a definition of done is met. You own the rigor.
 
-The exit-condition machinery stays out of your way until you ask for it. A new project starts with the set dormant: no conditions are captured, no auditors are created, and you are not asked to approve anything. Run `/akka:mode a-la-carte --ecs=honor` when you want the checks, and they run as an advisory checklist rather than a gate.
+The exit-condition machinery stays out of your way until you ask for it. A new project starts with the set dormant: no conditions are captured, no auditors are created, and you are not asked to approve anything. Run `/akka:mode a-la-carte --exit-conditions=honor` when you want the checks, and they run as an advisory checklist rather than a gate.
 
 À la carte is faster and lighter than xref:sdk:enforced-mode.adoc[Enforced mode], which gates each phase on machine-checkable exit conditions. Switch to Enforced with `/akka:mode enforced` when you want that rigor, and back with `/akka:mode a-la-carte`.
 
@@ -33,7 +33,7 @@ The short description becomes a branch name like `00#-feature-short-description`
 
 This creates a specification in `specs/001-core-users` on the `001-core-users` branch. Resist manually editing the spec -- clarification is the next step. Keep features scoped small enough that you have a clear idea of the acceptance criteria and the generated code is easy to review.
 
-NOTE: In À la carte mode, `/akka:specify` does not create exit conditions or auditors on its own. The exit-condition set is dormant until you ask for it, so the command produces a specification and nothing else. To start capturing your definition of done as exit conditions and running the adversarial adequacy review, run `/akka:mode a-la-carte --ecs=honor`. The checks are advisory even then: the `PROC-AUDITOR-COVERAGE` and `PROC-ADEQUACY-REVIEWED` gates are computed and reported, but you drive the phases and `/akka:ship` is not blocked when they are red.
+NOTE: In À la carte mode, `/akka:specify` does not create exit conditions or auditors on its own. The exit-condition set is dormant until you ask for it, so the command produces a specification and nothing else. To start capturing your definition of done as exit conditions and running the adversarial adequacy review, run `/akka:mode a-la-carte --exit-conditions=honor`. The checks are advisory even then: the `PROC-AUDITOR-COVERAGE` and `PROC-ADEQUACY-REVIEWED` gates are computed and reported, but you drive the phases and `/akka:ship` is not blocked when they are red.
 
 == Clarify the specification
 

--- a/docs/src/modules/sdk/pages/spec-driven-development.adoc
+++ b/docs/src/modules/sdk/pages/spec-driven-development.adoc
@@ -17,16 +17,16 @@ image::sdd-workflow.png[Spec-driven development workflow: specify, clarify, plan
 [#choosing-your-mode]
 == Choosing your mode
 
-Akka Specify runs in one of two modes. The mode decides whether your definition of done is a hard gate or an advisory checklist.
+Akka Specify runs in one of two modes. The mode decides whether you get a definition of done at all, and whether it is a hard gate or an advisory checklist.
 
-* *xref:sdk:a-la-carte-mode.adoc[À la carte mode]* (the default) lets you run the specification commands individually -- specify, clarify, plan, tasks, implement, build, and the rest -- with nothing blocking you. It is faster and lighter; you own the rigor.
+* *xref:sdk:a-la-carte-mode.adoc[À la carte mode]* (the default) lets you run the specification commands individually -- specify, clarify, plan, tasks, implement, build, and the rest -- with nothing blocking you. Exit conditions stay dormant until you ask for them, so a new project acquires no conditions and no auditors on its own. It is faster and lighter; you own the rigor.
 * *xref:sdk:enforced-mode.adoc[Enforced mode]* makes you define "done" -- as machine-checkable exit conditions -- before any code is written, and will not let a feature ship until those conditions are met. You get a cleaner, auditable, repeatable result. In Enforced mode an *enterprise can define exit conditions and definitions of done that Akka enforces* across every project. The cost is more up-front definition and a longer, more thorough build. Opt in with `/akka:mode enforced`.
 
 [cols="1,2,2",options="header"]
 |===
 | | À la carte (default) | Enforced
 
-| Definition of done | Optional, advisory | Required, gated
+| Definition of done | Off until you ask for it, then advisory | Required, gated
 | Result | Flexible, developer-driven | Cleaner, auditable, repeatable
 | Cost & time | Lower -- run only what you need | Higher -- more up front, more thorough
 | Enterprise governance | Not enforced | Org-defined conditions enforced by Akka


### PR DESCRIPTION
## Problem

The docs stated that à la carte resolves the same conditions as enforced and differs only at ship time. The à la carte page said it outright:

> Even in À la carte mode, `/akka:specify` captures your definition of done as exit conditions and runs the adversarial adequacy review, exactly as it does in Enforced mode.

That is no longer how the mode behaves.

## Change

Documents the mode as governing **two** things — whether Akka Specify creates exit conditions on its own, and whether unmet conditions block shipping — rather than only the second.

- `reference/specify/mode.adoc` — rewrites the mode contract, records `--ecs=honor` / `--ecs=ignore`, and adds a section on switching a project that already has conditions.
- `sdk/a-la-carte-mode.adoc` — replaces the NOTE quoted above; states that a new project starts dormant and is asked nothing.
- `sdk/spec-driven-development.adoc` — the comparison table row now reads "Off until you ask for it, then advisory".
- `reference/specify/docs.adoc` — qualifies its "in both modes" claim.

`sdk/enforced-mode.adoc` needed no change: it already describes enforced as opt-in with new installs starting in à la carte.

Written to the standards in `docs/CLAUDE.md` (second person, no contractions, short sentences). Not yet previewed with `make local` — worth a rendered check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Part of a three-repo change

Mode-gating the exit-condition set touches the engine, the assistant prompts, and the docs. All three are needed for the behavior to be coherent; any one alone leaves a contradiction.

| | PR | What it does |
|---|---|---|
| Engine | akka/cli#166 | Dormant resolution, the `ECs` opt-in state, and the `--ecs` switch |
| Prompts | akka/ai-marketplace#26 | Skips capture while dormant; asks honor-vs-ignore on the switch |
| Docs | akka/akka-sdk#1789 | Documents the mode as governing creation, not only gating |

**Suggested merge order:** engine, then prompts, then docs. The prompts call `akka specify mode --ecs=…`, which does not exist until akka/cli#166 ships, so merging prompts first would leave the skills invoking an unknown flag.
