### PR TITLE
docs: add Akka Automated Operations technical overview page

### DIFF
--- a/.github/workflows/docs-prod.yml
+++ b/.github/workflows/docs-prod.yml
@@ -49,6 +49,16 @@ jobs:
         run: |
           make managed prod
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Render white paper PDFs
+        run: |
+          (cd docs/bin/whitepaper && npm install && npx playwright install --with-deps chromium)
+          node docs/bin/whitepaper/render-pdf.mjs
+
       - name: LLM friendly markdown
         run: |
           sudo ./docs/bin/docs2markdown.sh

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ prod: docker-image managed antora-prod done
 
 antora-local:
 	docker run \
+		--user "$$(id -u):$$(id -g)" \
 		-v ${ROOT_DIR}:/antora \
 		--rm \
 		-t ${antora_docker_image}:${antora_docker_image_tag} \
@@ -111,6 +112,7 @@ antora-local:
 
 antora-prod:
 	docker run \
+		--user "$$(id -u):$$(id -g)" \
 		-v ${ROOT_DIR}:/antora \
 		--rm \
 		-t ${antora_docker_image}:${antora_docker_image_tag} \

--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,15 @@ bundles:
 	./docs/bin/bundle.sh --zip "${java_managed_attachments}/workflow-quickstart.zip" samples/transfer-workflow-compensation
 
 whitepapers:
-	cd docs/bin/whitepaper && npm install && npx playwright install chromium
-	node docs/bin/whitepaper/render-pdf.mjs "${TARGET_DIR}" operations/technical-overview.html "${TARGET_DIR}/operations/_attachments/whitepapers/aao-technical-overview.pdf"
+	if ! command -v node >/dev/null 2>&1; then \
+	  echo ">> Skipping white paper PDF: Node.js not found (install Node to render it locally)."; \
+	else \
+	  if [ ! -d docs/bin/whitepaper/node_modules ]; then \
+	    echo ">> Installing white paper render tooling (Playwright + Chromium), first run only..."; \
+	    (cd docs/bin/whitepaper && npm install && npx playwright install chromium); \
+	  fi; \
+	  node docs/bin/whitepaper/render-pdf.mjs "${TARGET_DIR}" operations/technical-overview.html "${TARGET_DIR}/operations/_attachments/whitepapers/aao-technical-overview.pdf"; \
+	fi
 
 done:
 	@echo "Generated docs at ${TARGET_DIR}/index.html"
@@ -90,7 +97,7 @@ done:
 open:
 	open "${TARGET_DIR}/index.html"
 
-local: docker-image examples antora-local done
+local: docker-image examples antora-local whitepapers done
 
 prod: docker-image managed antora-prod done
 

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,10 @@ bundles:
 	./docs/bin/bundle.sh --zip "${java_managed_attachments}/choreography-saga-quickstart.zip" samples/choreography-saga-quickstart
 	./docs/bin/bundle.sh --zip "${java_managed_attachments}/workflow-quickstart.zip" samples/transfer-workflow-compensation
 
+whitepapers:
+	cd docs/bin/whitepaper && npm install && npx playwright install chromium
+	node docs/bin/whitepaper/render-pdf.mjs "${TARGET_DIR}" operations/technical-overview.html "${TARGET_DIR}/operations/_attachments/whitepapers/aao-technical-overview.pdf"
+
 done:
 	@echo "Generated docs at ${TARGET_DIR}/index.html"
 

--- a/docs/bin/whitepaper/.gitignore
+++ b/docs/bin/whitepaper/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/docs/bin/whitepaper/package.json
+++ b/docs/bin/whitepaper/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "akka-whitepaper-pdf",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Renders built Antora pages into branded white paper PDFs for doc.akka.io.",
+  "dependencies": {
+    "playwright": "^1.48.0"
+  }
+}

--- a/docs/bin/whitepaper/print.css
+++ b/docs/bin/whitepaper/print.css
@@ -1,0 +1,112 @@
+/* Whitepaper print skin — recreates the AAO "white paper" look over the rendered
+   Antora docs page, applied only when generating the downloadable PDF.
+   Palette/fonts mirror the original Drive whitepaper. */
+:root{
+  --wp-accent:#02a4a7; --wp-accent-bright:#28d7e5;
+  --wp-gold:#f5b60b; --wp-gold-dk:#c99a10; --wp-orange:#ff5400; --wp-red:#d70023;
+  --wp-ink:#1a1a1a; --wp-soft:#2b2b2b; --wp-muted:#5f6b73;
+  --wp-border:#e1e1e1; --wp-border-strong:#c9c9c9; --wp-rule:#adadad;
+  --wp-code-bg:#1a1a1a; --wp-inline-bg:#e5e5e5; --wp-card-bg:#f6f6f6;
+  --wp-sans:'Instrument Sans',-apple-system,BlinkMacSystemFont,sans-serif;
+  --wp-mono:'Roboto Mono','SF Mono',Menlo,Consolas,monospace;
+  --wp-grad:linear-gradient(90deg,#ffce4a,#04c4c5 50%,#d70023);
+}
+
+/* ---- strip everything but the article ---- */
+header, .navbar, #topbar-nav, [id*="topbar"], .topbar-nav,
+.nav-container, #navPanel, nav.pagination, aside, .toolbar,
+.toc-menu, .breadcrumbs, .edit-this-page, footer, .feedback,
+.hide-for-print, .doc > .header-title, button, .nav-panel-explore,
+.nav-panel-menu, .page-versions, .banner, .survey{
+  display:none !important;
+}
+
+/* ---- page canvas ---- */
+html,body{background:#fff !important;}
+body{ font-family:var(--wp-sans) !important; color:var(--wp-ink) !important;
+  -webkit-print-color-adjust:exact; print-color-adjust:exact; }
+.content, .content > *, main.article, main{ display:block !important; }
+article.doc, .doc{
+  color:var(--wp-ink) !important;
+  max-width:none !important; width:100% !important;
+  margin:0 !important; padding:0 !important; min-height:0 !important;
+  grid-column:auto !important; font-size:10.6pt !important; line-height:1.55 !important;
+}
+.doc p{ color:var(--wp-ink) !important; margin:0 0 .7em !important; }
+.doc strong{ color:var(--wp-ink) !important; font-weight:600 !important; }
+.doc a{ color:var(--wp-accent) !important; text-decoration:none !important; }
+
+/* hide the in-article H1 (the cover carries the title instead) + any download button */
+.doc > h1.page, .doc h1.page, .wp-hide{ display:none !important; }
+
+/* ---- cover ---- */
+.wp-cover{ display:block !important; page-break-after:always; padding-top:24pt; }
+.wp-cover .wp-brandbar{ height:5px; background:var(--wp-grad); border-radius:3px; margin-bottom:52pt; }
+.wp-cover .wp-eyebrow{ font-family:var(--wp-mono); font-size:11pt; letter-spacing:3px;
+  text-transform:uppercase; color:var(--wp-accent); margin-bottom:16pt; }
+.wp-cover .wp-title{ font-family:var(--wp-sans); font-weight:500; color:var(--wp-gold);
+  font-size:42pt; line-height:1.05; letter-spacing:-.5px; margin:0 0 18pt; }
+.wp-cover .wp-sub{ font-size:13pt; color:var(--wp-muted); line-height:1.6; max-width:34em; }
+.wp-cover .wp-meta{ margin-top:44pt; font-family:var(--wp-mono); font-size:9.5pt;
+  letter-spacing:1px; color:var(--wp-muted); text-transform:uppercase; }
+
+/* ---- headings ---- */
+.doc h2{ font-family:var(--wp-sans) !important; font-weight:500 !important;
+  font-size:19pt !important; color:var(--wp-ink) !important; letter-spacing:-.2px;
+  margin:26pt 0 12pt !important; padding-bottom:7pt !important;
+  border-bottom:1px solid var(--wp-rule) !important; page-break-after:avoid; }
+.doc h3{ font-family:var(--wp-sans) !important; font-weight:700 !important;
+  font-size:13.5pt !important; color:var(--wp-ink) !important; margin:18pt 0 8pt !important;
+  page-break-after:avoid; }
+.doc h4{ font-family:var(--wp-sans) !important; font-weight:700 !important;
+  font-size:11pt !important; color:var(--wp-ink) !important; margin:13pt 0 6pt !important;
+  page-break-after:avoid; }
+
+/* ---- lists / description lists ---- */
+.doc ul, .doc ol{ margin:0 0 .8em 1.1em !important; }
+.doc li{ margin-bottom:.35em !important; color:var(--wp-ink) !important; }
+.doc .dlist dt{ font-weight:700 !important; color:var(--wp-ink) !important; margin-top:.5em; }
+
+/* ---- inline + block code ---- */
+.doc code, .doc .literal{ font-family:var(--wp-mono) !important; font-size:.86em !important;
+  background:var(--wp-inline-bg) !important; color:var(--wp-ink) !important;
+  padding:1.5px 5px !important; border-radius:4px !important; }
+.doc .listingblock pre, .doc pre{ background:var(--wp-code-bg) !important; color:#f1f1f1 !important;
+  border:none !important; border-radius:6px !important; padding:14pt !important;
+  font-family:var(--wp-mono) !important; font-size:8.9pt !important; line-height:1.6 !important;
+  white-space:pre-wrap !important; page-break-inside:avoid; }
+.doc .listingblock pre code, .doc pre code{ background:none !important; color:#f1f1f1 !important; padding:0 !important; }
+
+/* ---- tables ---- */
+.doc table.tableblock{ width:100% !important; border-collapse:collapse !important;
+  margin:14pt 0 !important; font-size:9.6pt !important; page-break-inside:auto; }
+.doc table.tableblock th{ text-align:left !important; color:var(--wp-ink) !important;
+  font-weight:700 !important; background:var(--wp-card-bg) !important;
+  border-bottom:2px solid var(--wp-gold-dk) !important; padding:8pt 10pt !important; }
+.doc table.tableblock td{ border-bottom:1px solid var(--wp-border-strong) !important;
+  padding:8pt 10pt !important; vertical-align:top !important; color:var(--wp-ink) !important; }
+.doc table.tableblock tr{ page-break-inside:avoid; }
+
+/* ---- admonitions → whitepaper "callout" ---- */
+.doc .admonitionblock{ margin:14pt 0 !important; page-break-inside:avoid; }
+.doc .admonitionblock > table, .doc .admonitionblock td.content{
+  border:none !important; background:var(--wp-inline-bg) !important; }
+.doc .admonitionblock td.content{ border-left:3px solid var(--wp-accent) !important;
+  padding:11pt 14pt !important; border-radius:0 6px 6px 0 !important; }
+.doc .admonitionblock.warning td.content{ border-left-color:var(--wp-gold-dk) !important; }
+.doc .admonitionblock td.icon{ display:none !important; }
+
+/* ---- tabs flattened (script reveals panels + injects labels) ---- */
+.doc .tablist{ display:none !important; }
+.doc .tabpanel{ display:block !important; margin:0 0 6pt !important; }
+.doc .tabpanel[hidden]{ display:block !important; }
+.doc .wp-tab-label{ font-family:var(--wp-mono) !important; font-size:9.5pt !important;
+  letter-spacing:1px; text-transform:uppercase; color:var(--wp-accent) !important;
+  font-weight:700 !important; margin:14pt 0 6pt !important; padding-left:10pt;
+  border-left:3px solid var(--wp-accent) !important; page-break-after:avoid; }
+
+/* hide cookie-consent / overlays that the docs site injects */
+[class*="cookie" i],[id*="cookie" i],[class*="consent" i],[id*="consent" i],
+[class*="osano" i],[id*="osano" i],.cc-window,.cookie-banner,.banner,[role="dialog"]{ display:none !important; }
+
+img,svg,tr{ page-break-inside:avoid; }

--- a/docs/bin/whitepaper/render-pdf.mjs
+++ b/docs/bin/whitepaper/render-pdf.mjs
@@ -25,6 +25,10 @@ await page.goto(pageUrl, { waitUntil: 'networkidle', timeout: 60000 });
 
 // Flatten tabs: reveal every panel and label it with its tab name; build a cover.
 await page.evaluate(({ eyebrow, title, subtitle }) => {
+  // Drop the self-referential "download as PDF" note — pointless inside the PDF itself.
+  document.querySelectorAll('a[href*="aao-technical-overview.pdf"]').forEach(a => {
+    (a.closest('.admonitionblock') || a.closest('.paragraph') || a).remove();
+  });
   document.querySelectorAll('.tabpanel').forEach(panel => {
     panel.removeAttribute('hidden');
     const labId = panel.getAttribute('aria-labelledby');

--- a/docs/bin/whitepaper/render-pdf.mjs
+++ b/docs/bin/whitepaper/render-pdf.mjs
@@ -1,0 +1,75 @@
+// Render a built Antora page into a branded "white paper" PDF.
+// Usage: node render-pdf.mjs <site-dir> <page-rel-path> <out-pdf> [--png]
+// Defaults target the AAO technical overview.
+import { chromium } from 'playwright';
+import { readFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const siteDir  = resolve(process.argv[2] || 'target/site');
+const pageRel  = process.argv[3] || 'operations/technical-overview.html';
+const outPdf   = resolve(process.argv[4] || 'target/site/operations/_attachments/whitepapers/aao-technical-overview.pdf');
+const wantPng  = process.argv.includes('--png');
+const cssPath  = resolve(dirname(new URL(import.meta.url).pathname), 'print.css');
+
+const EYEBROW  = process.env.WP_EYEBROW  || 'Akka Automated Operations';
+const TITLE    = process.env.WP_TITLE    || 'Technical Overview';
+const SUBTITLE = process.env.WP_SUBTITLE || 'Architecture, installation, and operations across Kubernetes on AWS, Azure, and GCP.';
+
+const pageUrl = pathToFileURL(resolve(siteDir, pageRel)).href;
+const printCss = readFileSync(cssPath, 'utf8');
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+await page.goto(pageUrl, { waitUntil: 'networkidle', timeout: 60000 });
+
+// Flatten tabs: reveal every panel and label it with its tab name; build a cover.
+await page.evaluate(({ eyebrow, title, subtitle }) => {
+  document.querySelectorAll('.tabpanel').forEach(panel => {
+    panel.removeAttribute('hidden');
+    const labId = panel.getAttribute('aria-labelledby');
+    const tab = labId && document.getElementById(labId);
+    const name = tab ? tab.textContent.trim() : null;
+    if (name) {
+      const h = document.createElement('div');
+      h.className = 'wp-tab-label';
+      h.textContent = name;
+      panel.insertBefore(h, panel.firstChild);
+    }
+  });
+  const doc = document.querySelector('article.doc') || document.querySelector('.doc');
+  if (doc) {
+    const cover = document.createElement('div');
+    cover.className = 'wp-cover';
+    cover.innerHTML =
+      '<div class="wp-brandbar"></div>' +
+      '<div class="wp-eyebrow">' + eyebrow + '</div>' +
+      '<div class="wp-title">' + title + '</div>' +
+      '<div class="wp-sub">' + subtitle + '</div>' +
+      '<div class="wp-meta">doc.akka.io &middot; Akka</div>';
+    doc.insertBefore(cover, doc.firstChild);
+  }
+}, { eyebrow: EYEBROW, title: TITLE, subtitle: SUBTITLE });
+
+await page.addStyleTag({ content: printCss });
+await page.emulateMedia({ media: 'print' });
+await page.evaluate(() => document.fonts.ready);
+
+mkdirSync(dirname(outPdf), { recursive: true });
+if (wantPng) {
+  await page.screenshot({ path: outPdf.replace(/\.pdf$/, '.png'), fullPage: true });
+}
+await page.pdf({
+  path: outPdf,
+  format: 'A4',
+  printBackground: true,
+  margin: { top: '16mm', bottom: '18mm', left: '16mm', right: '16mm' },
+  displayHeaderFooter: true,
+  headerTemplate: '<span></span>',
+  footerTemplate:
+    '<div style="width:100%;font-family:\'Roboto Mono\',monospace;font-size:7pt;color:#8a8a8a;padding:0 16mm;display:flex;justify-content:space-between;">' +
+    '<span>Akka Automated Operations &mdash; Technical Overview</span>' +
+    '<span class="pageNumber"></span>/<span class="totalPages"></span></div>',
+});
+await browser.close();
+console.log('wrote', outPdf);

--- a/docs/bin/whitepaper/render-pdf.mjs
+++ b/docs/bin/whitepaper/render-pdf.mjs
@@ -41,12 +41,21 @@ await page.evaluate(({ eyebrow, title, subtitle }) => {
   if (doc) {
     const cover = document.createElement('div');
     cover.className = 'wp-cover';
-    cover.innerHTML =
-      '<div class="wp-brandbar"></div>' +
-      '<div class="wp-eyebrow">' + eyebrow + '</div>' +
-      '<div class="wp-title">' + title + '</div>' +
-      '<div class="wp-sub">' + subtitle + '</div>' +
-      '<div class="wp-meta">doc.akka.io &middot; Akka</div>';
+    // Build with textContent (never innerHTML) so cover text is treated as
+    // data, not markup — no injection sink even for build-supplied values.
+    const el = (cls, text) => {
+      const d = document.createElement('div');
+      d.className = cls;
+      if (text != null) d.textContent = text;
+      return d;
+    };
+    cover.append(
+      el('wp-brandbar'),
+      el('wp-eyebrow', eyebrow),
+      el('wp-title', title),
+      el('wp-sub', subtitle),
+      el('wp-meta', 'doc.akka.io · Akka'),
+    );
     doc.insertBefore(cover, doc.firstChild);
   }
 }, { eyebrow: EYEBROW, title: TITLE, subtitle: SUBTITLE });

--- a/docs/src/modules/operations/nav.adoc
+++ b/docs/src/modules/operations/nav.adoc
@@ -56,6 +56,7 @@
 ***** xref:operations:cli/system-config.adoc[]
 
 *** xref:operations:operator-best-practices.adoc[]
+*** xref:operations:technical-overview.adoc[Technical Overview]
 *** xref:operations:production-readiness/index.adoc[]
 **** Dedicated
 ***** xref:operations:production-readiness/dedicated/shared-responsibility.adoc[]

--- a/docs/src/modules/operations/nav.adoc
+++ b/docs/src/modules/operations/nav.adoc
@@ -4,6 +4,8 @@
 *** xref:operations:configuring.adoc[Self-managed operations]
 *** xref:operations:akka-platform.adoc[Akka Automated Operations]
 
+**** xref:operations:technical-overview.adoc[Technical Overview]
+
 **** xref:operations:organizations/index.adoc[]
 ***** xref:operations:organizations/manage-users.adoc[Manage users]
 ***** xref:operations:organizations/regions.adoc[]
@@ -56,7 +58,6 @@
 ***** xref:operations:cli/system-config.adoc[]
 
 *** xref:operations:operator-best-practices.adoc[]
-*** xref:operations:technical-overview.adoc[Technical Overview]
 *** xref:operations:production-readiness/index.adoc[]
 **** Dedicated
 ***** xref:operations:production-readiness/dedicated/shared-responsibility.adoc[]

--- a/docs/src/modules/operations/pages/akka-platform.adoc
+++ b/docs/src/modules/operations/pages/akka-platform.adoc
@@ -9,7 +9,7 @@ include::ROOT:partial$include.adoc[]
 
 == Overview
 
-Akka Automated Operations (AAO) is the operational backbone of the Akka platform. It manages, monitors, and gathers insights from your deployed Akka services so you can focus on building rather than babysitting infrastructure. For the full architecture and installation reference, see the xref:operations:technical-overview.adoc[AAO Technical Overview], also available as a downloadable PDF.
+Akka Automated Operations (AAO) is the operational backbone of the Akka platform. It manages, monitors, and gathers insights from your deployed Akka services so you can focus on building rather than babysitting infrastructure. For the full architecture and installation reference, see the xref:operations:technical-overview.adoc[AAO Technical Overview].
 
 AAO is built on a Kubernetes-based control plane and application plane purpose-designed for executing Akka services with fully automated operations. It handles elasticity, agility, and resilience out of the box — you deploy your service and AAO takes care of the rest.
 

--- a/docs/src/modules/operations/pages/akka-platform.adoc
+++ b/docs/src/modules/operations/pages/akka-platform.adoc
@@ -20,6 +20,12 @@ AAO is built on a Kubernetes-based control plane and application plane purpose-d
 * You need deep observability — logs, metrics, and traces — integrated from day one.
 * You operate under regulatory or data-sovereignty constraints that demand dedicated infrastructure.
 
+== White papers
+
+Akka Automated Operations is documented in downloadable white papers.
+
+* xref:operations:technical-overview.adoc[AAO Technical Overview] — the two-plane architecture, installation, and operations across AWS, Azure, and GCP. Read it online or download it as a PDF.
+
 == Reliability
 
 Reliability is a first-class dimension across every AAO tier. The platform is designed around the principle that failures are inevitable and recovery must be automatic:

--- a/docs/src/modules/operations/pages/akka-platform.adoc
+++ b/docs/src/modules/operations/pages/akka-platform.adoc
@@ -9,7 +9,7 @@ include::ROOT:partial$include.adoc[]
 
 == Overview
 
-Akka Automated Operations (AAO) is the operational backbone of the Akka platform. It manages, monitors, and gathers insights from your deployed Akka services so you can focus on building rather than babysitting infrastructure.
+Akka Automated Operations (AAO) is the operational backbone of the Akka platform. It manages, monitors, and gathers insights from your deployed Akka services so you can focus on building rather than babysitting infrastructure. For the full architecture and installation reference, see the xref:operations:technical-overview.adoc[AAO Technical Overview], also available as a downloadable PDF.
 
 AAO is built on a Kubernetes-based control plane and application plane purpose-designed for executing Akka services with fully automated operations. It handles elasticity, agility, and resilience out of the box — you deploy your service and AAO takes care of the rest.
 
@@ -19,12 +19,6 @@ AAO is built on a Kubernetes-based control plane and application plane purpose-d
 * You require multi-region replication with automatic failover for business-critical workloads.
 * You need deep observability — logs, metrics, and traces — integrated from day one.
 * You operate under regulatory or data-sovereignty constraints that demand dedicated infrastructure.
-
-== White papers
-
-Akka Automated Operations is documented in downloadable white papers.
-
-* xref:operations:technical-overview.adoc[AAO Technical Overview] — the two-plane architecture, installation, and operations across AWS, Azure, and GCP. Read it online or download it as a PDF.
 
 == Reliability
 

--- a/docs/src/modules/operations/pages/technical-overview.adoc
+++ b/docs/src/modules/operations/pages/technical-overview.adoc
@@ -1,0 +1,526 @@
+= Akka Automated Operations technical overview
+:page-summary: A technical overview of Akka Automated Operations (AAO): the two-plane architecture, what Akka automates and provisions, and how a region is installed and operated across Kubernetes on AWS, Azure, and GCP — including the BYOC and BYOK8s models.
+:page-when-to-use: Use this to understand how AAO works end to end and to plan an installation, whether Akka provisions a region in your cloud (BYOC) or you bring your own Kubernetes cluster (BYOK8s).
+:page-related: xref:concepts:deployment-model.adoc[], xref:operations:akka-platform.adoc[], xref:operations:regions/index.adoc[], xref:operations:production-readiness/index.adoc[]
+:page-persona: operator-platform, operator-sre
+
+include::ROOT:partial$include.adoc[]
+
+Akka Automated Operations (AAO) is a remotely installed, actively maintained Akka region that runs inside your own cloud account, on Kubernetes across AWS, Azure, or GCP. You keep custodial ownership of the infrastructure; Akka installs, monitors, patches, and scales it, targeting up to six-nines (99.9999%) availability with low latency.
+
+image::concepts:akka-automated-operations.png[Akka Automated Operations]
+
+== Overview
+
+When you build with the Akka SDK your services are already production-grade, self-clustering, and elastic, but you own the operations. AAO is a managed platform, controlled within your own environment, that automates the Day-2 concerns of deploying and running those services.
+
+AAO offers three deployment options:
+
+* Akka's serverless environment hosted at akka.io.
+* *Bring Your Own Cloud (BYOC)* — Akka-provisioned regions in your own VPC on AWS, GCP, or Azure.
+* *Bring Your Own Kubernetes (BYOK8s)* — installation on Kubernetes clusters you provide, including your own data centers.
+
+With both self-managed models, regions operate entirely within your own environment: application data never leaves it or interacts with the Akka Federation Plane. Akka installs, monitors, and updates these regions, so your teams get Akka's operational expertise while retaining complete control of the environment.
+
+Your cloud, any provider:: AWS, Azure, and GCP; services can even be deployed across multiple providers simultaneously.
+Data stays put:: Data remains in your chosen environment, aiding GDPR / HIPAA and regional regulatory alignment.
+Your contracts:: Use existing cloud pricing and reduce cross-cloud egress and transfer fees.
+
+== Federation Plane and Application Plane
+
+AAO splits into two planes: a global coordination layer run by Akka, and one or more runtime regions that live inside your accounts.
+
+=== Federation Plane
+
+The central coordination point for organizations, accounts, billing, user access, key rotation, token issuance, and app deployment across regions, which runs at akka.io. It is distributed and highly resilient, but in the extreme exception that it does become unavailable, running applications continue without interruption.
+
+=== Application Plane
+
+The runtime that hosts your workloads, where each federated region independently pulls and deploys application images, scales instances, and connects to peer regions. Application data stays isolated within your own environment and never reaches the Federation Plane.
+
+=== What an Application Plane region embeds
+
+* A managed *Kubernetes cluster* for orchestrating Akka instances as OCI containers.
+* An *encrypted application data store* (append-only, event-sourced, non-queryable journal).
+* A set of *Akka operators* for elasticity, observability, routing, and service management.
+* *Proxies* for traffic steering between regions.
+* Physical *compute and storage* for application execution.
+* An *image repository* caching packed applications available in that region.
+
+=== Key terminology
+
+[cols="1,3", options="header"]
+|===
+| Term | Description
+
+| Akka Application
+| An app built with the Akka SDK: APIs, workflows, streaming consumers, timers, and views. Packed into OCI images and deployed as self-clustering service instances that act as their own in-memory, durable database.
+
+| Application Plane
+| Runtime environment hosting Akka apps within one or more regions; provides compute, storage, I/O, autoscaling, observability, and infrastructure management to meet SLAs.
+
+| Federation Plane
+| Global coordination point federating multiple regions into a single deployment substrate. Runs and is managed at akka.io.
+
+| Akka CLI
+| Interface for developers, operators, and InfoSec teams: build, test, pack, deploy, observe, and manage secrets and accounts.
+
+| Data Persistence
+| Durable, encrypted-at-rest event store using event sourcing; optimized for Akka's internal processing and not directly queryable.
+
+| VPC
+| A private, isolated network environment in a major cloud provider (general term, not exclusively AWS's implementation).
+
+| Cloud Account
+| The billing and administrative entity: a _subscription_ (Azure), an _account_ (AWS), or a _project_ (GCP).
+|===
+
+== What AAO automates
+
+Beyond operations, AAO provides behavioral extensions that would otherwise require custom application code and libraries.
+
+[cols="1,3", options="header"]
+|===
+| Capability | Description
+
+| Runtime Patching
+| Live-updates JVM and infrastructure runtimes without triggering app versioning or a customer redeployment; no repackaging required.
+
+| Rolling Updates
+| Zero-disruption rolling deployment, even across data-model changes; old and new versions run side by side during the transition.
+
+| Elastic
+| Cold starts and automatic instance adjustment to traffic; persistence expands and can shard to >1M writes/sec at <20ms write latency.
+
+| HA / DR
+| Cross-region zero-trust with rotating mTLS, multi-AZ database and Kubernetes clustering, continuous point-in-time backups, full region recovery, and CLI-based failover/failback.
+
+| App Data Replication
+| Replicate app data across regions (pinned single-region, write-local, or active-active) with developer-defined replication filters.
+
+| Multi-Region Deploy
+| Deploy a service once across one or more regions, with optional global routes for cross-region traffic.
+
+| Multi-Tenancy
+| Multiple projects and teams share compute and data infrastructure for substantial cost savings. Dedicated single-tenant regions are available for isolation requirements.
+
+| Observability
+| A Control Tower aggregates traces, spans, metrics, logs, and agentic evaluations across regions (agentic evaluations for testing use only).
+|===
+
+== What Akka provisions in a region
+
+Networking:: Set up using best practices for the specific cloud provider: VPC, subnets, load balancers, NAT.
+DNS Zones:: Automatically provisioned in your cloud account to resolve names for services deployed in the region.
+Persistence:: Encrypted-at-rest data store for app data, Akka events, and read-only views. Append-only, lock-free, and sharded; benchmarked past 1M TPS.
+Kubernetes:: A managed cluster from your cloud provider orchestrates Akka instances deployed as OCI containers.
+Registry:: An OCI registry hosting immutable, signed, versioned service assets. You may optionally use your own registry.
+Akka Operators:: Route management, elasticity automation, metadata sync, rolling deploys, certificate management, key rotation, and multi-region failover/recovery.
+
+[NOTE]
+====
+*Observability split.* Akka runs a _platform observability_ stack for internal backend monitoring. Separately, _your_ application logs, metrics, traces, and evaluations are forwarded to your observability vendor; some also go to the Federation Plane for consolidated cross-region reporting. See xref:operations:observability-and-monitoring/index.adoc[].
+====
+
+== Shared responsibility
+
+System management is shared between you and Akka across provisioning and ongoing operations. The table below is a summary; for the authoritative, row-by-row breakdown with the full Responsible / Accountable / Consulted / Informed split, see the xref:operations:production-readiness/index.adoc[production readiness] section and its xref:operations:production-readiness/byoc/raci.adoc[BYOC RACI].
+
+[cols="1,2,2", options="header"]
+|===
+| Area | Customer | Akka
+
+| Account
+| Set up a dedicated cloud account with non-human privileged roles (deploy), read-only ops (monitoring), and ops (infra). Define human user roles per your policy.
+| Akka remote access verification.
+
+| Bootstrapping
+| Review default networking/compute/persistence config; recommend changes; integrate cloud security services for audit logging.
+| Infrastructure provisioning, configuration, and validation.
+
+| Maintenance
+| Provide a recurring maintenance window (typically 1–4 hrs/week). In practice most updates are non-events.
+| Security patches and upgrades to the Federation and Application planes.
+
+| Encryption
+| Provide secrets via a Key Management Store (KMS); create region-group root and per-region intermediate certificates.
+| Rotate secrets and keys across the Federation and Application planes.
+
+| IAM
+| Provide enterprise identity, authN/authZ systems, and policies.
+| Integrate with known IAM systems; ACL- and token-based enterprise IAM in your services.
+
+| DNS
+| Configure DNS record sets so the region is reachable by hostname.
+| Region-specific routes, service names, certificates, and optional global routes.
+
+| Connectivity
+| Review required ingress/egress ports and optional private connectivity patterns.
+| Documentation and implementation details for per-cloud private connectivity.
+
+| Monitoring
+| Export app metrics, logs, and traces to your observability tools.
+| Monitoring and availability of the Federation Plane.
+
+| Backup / DR
+| Own the app-side DR runbook; schedule exports outside the prod region; join the periodic joint DR exercise.
+| Regular infrastructure and persistence-store backups.
+
+| Cost Controls
+| Review subscription charges (compute, egress, data); tune instance sizing and ahead-of-use allocation.
+| Auto-provision/de-provision compute; autoscale persistence to demand.
+
+| SDLC Tooling
+| Provide IDE, source repo, CI/CD, and (optionally) your own deployment registry.
+| IDE AI assistants, local dev, test services, deployment tooling, optional image registry.
+|===
+
+[#byoc-installation]
+== Installation (BYOC)
+
+Eight steps take you from first contact to a region ready for deployments. This is the *BYOC* path, where Akka provisions and operates a region inside your own cloud account. Bringing your own cluster instead? See <<byok8s,Bring Your Own Kubernetes (BYOK8s)>>.
+
+. *Understand.* This overview is your introduction to AAO. Next, receive and review the `akka-bootstrap` utility from your Akka Success Team. Reviewing it lets you inspect exactly which permissions Akka's deployment identity will require in your account.
+. *Request a region.* Submit a region request through the form in the Akka customer portal. It captures all the details Akka needs to provision the environment.
+. *Cloud account.* Create a new cloud account for Akka. Not strictly required, but a dedicated account simplifies cost management.
+. *Apply permissions.* Run the `akka-bootstrap` utility to configure your account, then attach the generated deployment-identity details to the region request case you opened.
+. *Provision.* Akka remotely provisions the region and attaches it to a platform organization created for you.
+. *DNS.* Create record sets in your DNS zone mapping to the region's load-balancer IP so users and the Federation Plane can reach it.
+. *Smoke tests.* Akka attaches the region to the Federation Plane and runs smoke tests, so the region can then accept deployments.
+. *Region handover.* Register a user at akka.io with a corporate email; Akka makes them your organization's primary owner, so your team can begin using the region through the console and CLI. A production-labeled region isn't fully handed over until you complete the xref:operations:production-readiness/byoc/checklist.adoc[region-readiness steps] with your Akka Success Team.
+
+== The akka-bootstrap utility
+
+A utility that prepares your cloud account for AAO by creating the *Deployment Identity* role the Federation Plane uses to create and manage infrastructure.
+
+It creates and manages the Deployment Identity operations role only; the Editor, Viewer, and SRE identities must be created by you. Its outputs are consumed by the Federation Plane's provisioning module to enable automated resource management.
+
+=== Directory structure
+
+[source]
+----
+.
+├── main.tftpl        # template → generates provider config + module calls
+├── modules
+│   ├── aws/          # IAM roles, trust policies
+│   ├── azure/        # App registration, service principal, roles
+│   └── google/       # Service account, IAM bindings
+├── README.md
+└── terragrunt.hcl    # orchestration: reads values.hcl
+----
+
+Each module ships the standard Terraform files (`main.tf`, `variables.tf`, `outputs.tf`, `versions.tf`) plus provider-specific IAM/permission definitions.
+
+=== Usage
+
+Create a `values.hcl` in the root with your backend and region details:
+
+[source,hcl]
+----
+inputs = {
+  backend = {
+    type = "gcs"                          # or "s3", "azurerm", etc.
+    config = {
+      bucket = "your-terraform-state-bucket"
+      prefix = "akka-bootstrap"
+    }
+  }
+  akka_regions = {
+    azure = [
+      {
+        environment       = "prod"        # dev | stage | prod
+        akka_region_name  = "az-<tenant>-<region>"
+        tenant_id         = "azure-tenant-id"
+        subscription_id   = "azure-subscription-id"
+      }
+    ]
+    gcp = []
+    aws = []
+  }
+}
+----
+
+Then run the standard Terragrunt lifecycle:
+
+[source,command line]
+----
+terragrunt init     # initialize + validate generated main.tf
+terragrunt plan     # review planned changes
+terragrunt apply    # provision identity, roles, and credentials
+----
+
+[NOTE]
+====
+*Share identity details securely.* After a successful apply, attach the generated deployment-identity details to your region request case so the Federation Plane can manage resources in your account: the role ARN to assume on AWS, the service-principal credentials on Azure, or the service-account identity to impersonate on GCP.
+====
+
+[#platform-setup]
+== Setup by platform
+
+The Application Plane always runs on Kubernetes. Below are the shared Kubernetes model, followed by the identity and resource specifics for each cloud provider. These specifics cover the *BYOC* path, where Akka provisions into your cloud. If you're bringing your own Kubernetes cluster, see <<byok8s,Bring Your Own Kubernetes (BYOK8s)>>.
+
+[tabs]
+====
+Kubernetes::
++
+--
+Each region embeds a *managed Kubernetes cluster* from the cloud provider (AKS / GKE / EKS) that physically orchestrates Akka instances as OCI containers. On top of it, Akka deploys operators for route management, elasticity, metadata sync, rolling deployment, certificate management, key rotation, and multi-region failover.
+
+*Kubernetes access.* The `akka-bootstrap` utility creates least-permission roles for the cloud provider. Within Kubernetes, Akka actively ensures least privilege is used, for both impersonation and actual usage. Akka takes no access to customer-owned Kubernetes resources.
+
+Key Encryption Keys (KEKs) are stored separately as Kubernetes secrets and rotated periodically; rotating a KEK re-encrypts associated Data Encryption Keys (DEKs) without re-encrypting the underlying data.
+--
+
+AWS::
++
+--
+The cloud account to be used is an *AWS account*. To begin, create a *non-human privileged IAM role* with the minimum permissions to set up and manage the Akka environment, plus a *trust policy* that lets the Federation Plane's identity assume it, enabling it to securely bootstrap and manage the environment.
+
+This privileged role handles initial infrastructure bootstrapping, release deployments, and ongoing maintenance. Roles for human users (Editor, Viewer, SRE) can be created by you, configured with limited, time-based access tailored to your security and compliance requirements.
+
+Amazon EKS::: Managed Kubernetes hosts the Application Plane; workloads spread across availability zones.
+Transit Gateway::: Optional AWS Transit Gateway keeps region-to-internal traffic off the public internet.
+
+Bootstrap is driven by the `modules/aws` Terraform module in the `akka-bootstrap` utility.
+--
+
+Azure::
++
+--
+The cloud account to be used is an *Azure subscription*. An enterprise application is registered in *Microsoft Entra ID* (Azure AD) to create its identity, and a *service principal* is created for it. A non-human privileged role with minimum permissions is configured and injected into the Federation Plane to securely bootstrap and manage the environment.
+
+*Resource providers to register.* These register automatically through `akka-bootstrap`'s usage; verify they are enabled on the subscription:
+
+* `Microsoft.Authorization`
+* `Microsoft.ContainerService`
+* `Microsoft.DBforPostgreSQL`
+* `Microsoft.ManagedIdentity`
+* `Microsoft.Resources`
+* `Microsoft.Network`
+* `Microsoft.Storage`
+
+The subscription must also have `EncryptionAtHost` enabled:
+
+[source,command line]
+----
+az feature register --name EncryptionAtHost --namespace Microsoft.Compute
+az provider register -n Microsoft.Compute
+----
+
+*Azure resources used:*
+
+* *Entra ID:* applications, app registrations, service principals.
+* *Resource Manager:* subscription, resource group, roles & role assignments.
+* *Networking:* virtual network, subnet, public IP, NAT gateway, load balancer; private & public DNS zones.
+* *Compute:* AKS cluster, node pools (VM scale sets), network security groups.
+* *Data:* Azure Database for PostgreSQL flexible server.
+* *Storage:* storage accounts and blob containers.
+* *Identity:* managed identities and federated credentials.
+
+VNet Peering + Azure Firewall::: Virtual Network Peering with user-defined NAT gateways keeps region-to-internal traffic private.
+--
+
+GCP::
++
+--
+The cloud account to be used is a *GCP project*. A dedicated *Google service account* is created for the region and assigned a non-human privileged role with the minimum permissions to set up and manage it. The service account is then configured so the Federation Plane's identity can impersonate it to bootstrap and manage the region.
+
+Google GKE::: Managed Kubernetes hosts the Application Plane; instances spread topologically across zones.
+VPC Peering::: Optional VPC Peering limits internet exposure for region-to-internal communication.
+
+*Impersonation model.* Rather than long-lived exported keys, the Federation Plane's identity _impersonates_ the dedicated service account, keeping bootstrap and management credential-free on the customer side.
+
+Bootstrap is driven by the `modules/google` Terraform module in the `akka-bootstrap` utility.
+--
+====
+
+[#byok8s]
+== Bring Your Own Kubernetes (BYOK8s)
+
+AAO can also be installed on a Kubernetes cluster _you provision_, in your cloud or your own data center. You build the infrastructure to Akka's specification and install Teleport to grant access; Akka then configures the cluster as an application-plane region, runs smoke tests, and hands the region over. Want Akka to provision against your existing cloud infrastructure instead? See <<byoc-installation,Installation (BYOC)>>.
+
+[WARNING]
+====
+*Coordinate changes.* Once the region is running, do not change any provisioned infrastructure without first informing Akka; it could break the Akka region.
+====
+
+=== Installation flow
+
+. *Understand.* This overview is your introduction to AAO. Contact your Akka Success Team for a package specific to a bring-your-own-Kubernetes (BYOK8s) deployment.
+. *Capacity planning.* Work with your Akka Success Team to size the environment for your requirements.
+. *Infrastructure requirements.* Work with your Akka Success Team to agree on infrastructure requirements, such as DNS subdomain zones, certificate provider, and related decisions.
+. *Infrastructure provisioning.* Provision the network, cluster, and database; set up the domain allowlist for egress traffic.
+. *Customer smoke tests.* Run the smoke-testing checklist below before handing the cluster to Akka.
+. *Teleport.* Install the Akka-provided Teleport Helm chart to grant Akka its access. Deploy it promptly, as the join token Akka gives you has a 3-hour TTL.
+. *Installation.* Akka configures the cluster as an application-plane region and sets up internal platform observability. You seed database credentials into the namespaces provided by Akka.
+. *Akka smoke tests.* Akka attaches the region to the Federation Plane and runs smoke tests, so the region can then accept deployments.
+. *Region handover.* Akka concludes smoke tests and assigns the region to your Akka organization on the console. A production-labeled region isn't fully handed over until you complete the xref:operations:production-readiness/byok8s/checklist.adoc[region-readiness steps] with your Akka Success Team.
+
+=== Infrastructure requirements
+
+[cols="1,3", options="header"]
+|===
+| Requirement | Specification
+
+| Kubernetes
+| Version `1.34` at minimum. Cilium or Calico is mandatory for network-policy enforcement; configure it as an overlay network only when the cloud-native CNI is unfeasible due to IPAM constraints.
+
+| Cluster CIDRs
+| `/17` for the pod network and `/17` for the service network.
+
+| Network
+| Minimum `/21` CIDR block from your IPAM allocation, subdivided into three database subnets (`/27` each) and three private subnets (`/24` each).
+
+| Nodes
+| 16 vCPU / 64 GB RAM instances (e.g. AWS `m5.4xlarge` family, GCP `n2d-standard-16`, Azure `Standard_D16s_v6`). Minimum one node; Kubernetes autoscales node count with demand.
+
+| Service Mesh
+| Akka deploys *Linkerd*, currently the only supported service mesh.
+
+| Load Balancer
+| Public Layer 4 by default; an internal load balancer is supported, and a subnet or IP can be specified on supported clouds.
+
+| DNS & Certificates
+| Two subdomain DNS zones, one for platform APIs and one for deployed services (e.g. `akka.acme.com`, `apps.akka.acme.com`), plus cert-manager `ClusterIssuer` objects for automatic certificate generation on both.
+
+| PostgreSQL
+| Version `17+`, provisioned and configured by you, highly available across zones (RDS on AWS, CloudSQL on GCP, Azure Database for PostgreSQL Flexible Server).
+
+| CSI Driver
+| The cloud-specific secrets-store CSI (Container Storage Interface) driver provider (AWS / GCP / Azure).
+
+| Registry
+| Platform images can be pulled through your Artifactory, using Akka's container registry as a mirror.
+|===
+
+==== Database credentials
+
+You seed connection credentials (username, password, host, database name) as Kubernetes Secrets into both the `kalix-system` and `kalix-management-system` namespaces. You create these namespaces if needed, but must not manage them: AAO imports them into its management scope and actively reconciles them. Akka recommends the external-secrets operator to mirror credentials from your cloud secret store.
+
+==== Access
+
+Akka's access to a customer-provisioned cluster is restricted to least-privilege permissions, scoped to the Akka-managed namespaces.
+
+=== Capacity planning
+
+Database size is driven by total application data operations per second at peak load. Work with your Akka Success Team to determine sizing. Multiple databases can also be set up if you have stricter data-segregation needs.
+
+[cols="1,1,1,1,1,1", options="header"]
+|===
+| DB Size | Data ops/sec | CPU | Memory (GB) | Storage (GB) | Max Connections
+
+| XSmall | 1,000  | 1  | 4   | 100   | 200
+| Small  | 3,000  | 2  | 16  | 200   | 500
+| Medium | 6,000  | 4  | 32  | 400   | 1,000
+| Large  | 12,000 | 8  | 64  | 800   | 1,500
+| XLarge | 24,000 | 16 | 128 | 1,600 | 2,000
+|===
+
+=== Customer smoke-testing checklist
+
+* Check connectivity between the database instance and the Kubernetes cluster.
+* Ensure the `ClusterIssuer` is ready and in a good state; verify all tokens it uses.
+* In multi-region configurations, ensure traffic flows in both directions between regions.
+
+== Networking and ports
+
+The default network configuration includes a VPC with three subnets per region plus load balancers. By default, connectivity between the region and your environment traverses the internet; private connectivity options are available per cloud.
+
+=== Region port usage
+
+Each flow below is inbound (ingress) or outbound (egress) relative to the region. All use TLS on port 443, except the infrastructure identity platform, which also uses ports 3023, 3024, and 3026.
+
+[cols="2,1,1", options="header"]
+|===
+| Flow | Type | Port(s)
+
+| Akka Applications → Akka Control Tower | Egress | 443
+| Akka Federation Plane → Akka Region API | Ingress | 443
+| Data Import / Export | Ingress | 443
+| Container Registry | Ingress | 443
+| Backoffice Functions | Ingress | 443
+| Kubernetes Cluster → Akka Platform Container Registry (platform image pulls) | Egress | 443
+| Akka Region → Akka Federation Plane & Console | Egress | 443
+| Platform Observability Agent → Akka | Egress | 443
+| Infrastructure Identity Platform | Egress | 443, 3023, 3024, 3026
+|===
+
+The full hostname and IP allowlist for egress traffic (Teleport, console, Federation Plane, Control Tower, observability, and container registry endpoints) is provided in the cloud-specific specification document.
+
+=== Private connectivity by cloud
+
+By default, traffic between the region and your internal networks traverses the internet. Each cloud offers a private-connectivity option to keep it off the public internet:
+
+[tabs]
+====
+AWS::
++
+--
+*Transit Gateway* — route region-to-internal traffic privately across accounts and VPCs.
+--
+
+GCP::
++
+--
+*VPC Peering* — peer the region VPC with internal networks to avoid public exposure.
+--
+
+Azure::
++
+--
+*VNet Peering + Firewall* — VNet Peering with Azure Firewall and user-defined NAT gateways.
+--
+====
+
+=== Command and control
+
+The Federation Plane and Application Plane expose the *Management API* and *Execution API* respectively, secured with TLS and bearer tokens in the HTTP Authorization header. By default these APIs are internet-facing with certificates from a globally trusted CA; private connectivity options keep endpoints off the public internet entirely. Inter-region traffic uses *mutual TLS* with per-client/per-service certificates, coordinated by a multi-region ingress service embedded in each region. See xref:operations:regions/infrastructure.adoc[] for the multi-region certificate and ingress details.
+
+== Security and encryption
+
+Application-plane data is completely isolated from the Federation Plane and stays within your own environment. It is stored in an encrypted, durable event store that cannot be externally queried.
+
+=== Encryption layers
+
+Data at rest uses the store's default encryption; keys can be provided by Akka or your KMS. Akka adds a further encryption layer for:
+
+* Secrets synced to regional execution clusters from the Federation Plane via the management API.
+* Authentication secrets such as TOTP secrets and OpenID refresh tokens.
+* Secrets you provide through environment variables or your KMS.
+
+==== DEK / KEK rotation
+
+Data Encryption Keys encrypt data and are stored alongside it, themselves encrypted by a Key Encryption Key. KEKs live separately as Kubernetes secrets and rotate periodically; rotating a KEK re-encrypts DEKs without re-encrypting the underlying data.
+
+==== Inter-region mTLS
+
+Each client and service gets unique certificates (issued by Akka's or your KMS). Communication is established only if both sides mutually authenticate; otherwise it is blocked.
+
+[NOTE]
+====
+Akka adheres to a range of compliance standards. Full certification detail lives in the https://trust.akka.io[Akka Trust Center, window="new"]. Infrastructure change control uses a declarative model with drift detection, self-healing, RBAC, and audit logging.
+====
+
+== Default sizing and scaling
+
+A new region and its services start with these defaults; each scales automatically with demand and can be tuned with your Akka Success Team.
+
+Persistence — 1M+ TPS ceiling:: Default is a small store: thousands of TPS, lowest initial cost. Scales and shards to well past 1M writes/sec at <20ms latency.
+Compute — Multi-AZ:: Always-available instance pools spread topologically across zones. Default mixes on-demand and spot instances to balance cost and performance.
+Service instance — 3× instances:: Each deployed service defaults to 3 instances across AZs with 2,560 MB RAM each. Autoscales on CPU usage; sizing tunable with your Akka Success Team.
+
+== Backups and disaster recovery
+
+Single-region Kubernetes resources and databases are backed up and recoverable. Infrastructure and configuration upgrades can improve these commitments.
+
+Persistence RPO — 5 min:: Maximum data-loss window for the persistence store.
+Persistence RTO — 24 hr:: Target recovery time for the persistence store.
+Kubernetes RTO / RPO — 1 hr:: Recovery targets for Kubernetes cluster state and configuration.
+
+Higher availability and resiliency are available through multi-region support, which replicates your application across regions for low-latency failover. See xref:operations:regions/index.adoc[]. Akka also provides data-export capabilities to move customer data to external storage for additional processing or long-term retention.
+
+== Support and maintenance
+
+Akka continuously applies security patches and software upgrades to the underlying platform, including infrastructure upgrades needed to keep it secure and performant. Compute nodes are elastic and expand/contract with deployed services; database storage autoscales, while additional database CPU/memory is applied by the Akka team when workloads exceed utilization thresholds. On request, Akka can pre-warm environments ahead of anticipated spikes.
+
+If issues arise, Akka provides a customer support portal where cases can be created per the Customer Support Policy and addressed based on severity and impact.

--- a/docs/src/modules/operations/pages/technical-overview.adoc
+++ b/docs/src/modules/operations/pages/technical-overview.adoc
@@ -1,7 +1,7 @@
 = Akka Automated Operations technical overview
 :page-summary: A technical overview of Akka Automated Operations (AAO): the two-plane architecture, what Akka automates and provisions, and how a region is installed and operated across Kubernetes on AWS, Azure, and GCP — including the BYOC and BYOK8s models.
 :page-when-to-use: Use this to understand how AAO works end to end and to plan an installation, whether Akka provisions a region in your cloud (BYOC) or you bring your own Kubernetes cluster (BYOK8s).
-:page-related: xref:concepts:deployment-model.adoc[], xref:operations:akka-platform.adoc[], xref:operations:regions/index.adoc[], xref:operations:production-readiness/index.adoc[]
+:page-related: xref:concepts:deployment-model.adoc[], xref:operations:akka-platform.adoc[], xref:operations:regions/index.adoc[]
 :page-persona: operator-platform, operator-sre
 
 include::ROOT:partial$include.adoc[]
@@ -124,7 +124,8 @@ Akka Operators:: Route management, elasticity automation, metadata sync, rolling
 
 == Shared responsibility
 
-System management is shared between you and Akka across provisioning and ongoing operations. The table below is a summary; for the authoritative, row-by-row breakdown with the full Responsible / Accountable / Consulted / Informed split, see the xref:operations:production-readiness/index.adoc[production readiness] section and its xref:operations:production-readiness/byoc/raci.adoc[BYOC RACI].
+System management is shared between you and Akka across provisioning and ongoing operations. The table below summarizes who owns what across the lifecycle.
+// TODO: cross-link to the production-readiness RACI once we're ready to couple these documents.
 
 [cols="1,2,2", options="header"]
 |===
@@ -187,7 +188,7 @@ Eight steps take you from first contact to a region ready for deployments. This 
 . *Provision.* Akka remotely provisions the region and attaches it to a platform organization created for you.
 . *DNS.* Create record sets in your DNS zone mapping to the region's load-balancer IP so users and the Federation Plane can reach it.
 . *Smoke tests.* Akka attaches the region to the Federation Plane and runs smoke tests, so the region can then accept deployments.
-. *Region handover.* Register a user at akka.io with a corporate email; Akka makes them your organization's primary owner, so your team can begin using the region through the console and CLI. A production-labeled region isn't fully handed over until you complete the xref:operations:production-readiness/byoc/checklist.adoc[region-readiness steps] with your Akka Success Team.
+. *Region handover.* Register a user at akka.io with a corporate email; Akka makes them your organization's primary owner, so your team can begin using the region through the console and CLI. A production-labeled region isn't fully handed over until you complete the region-readiness steps with your Akka Success Team.
 
 == The akka-bootstrap utility
 
@@ -354,7 +355,7 @@ AAO can also be installed on a Kubernetes cluster _you provision_, in your cloud
 . *Teleport.* Install the Akka-provided Teleport Helm chart to grant Akka its access. Deploy it promptly, as the join token Akka gives you has a 3-hour TTL.
 . *Installation.* Akka configures the cluster as an application-plane region and sets up internal platform observability. You seed database credentials into the namespaces provided by Akka.
 . *Akka smoke tests.* Akka attaches the region to the Federation Plane and runs smoke tests, so the region can then accept deployments.
-. *Region handover.* Akka concludes smoke tests and assigns the region to your Akka organization on the console. A production-labeled region isn't fully handed over until you complete the xref:operations:production-readiness/byok8s/checklist.adoc[region-readiness steps] with your Akka Success Team.
+. *Region handover.* Akka concludes smoke tests and assigns the region to your Akka organization on the console. A production-labeled region isn't fully handed over until you complete the region-readiness steps with your Akka Success Team.
 
 === Infrastructure requirements
 

--- a/docs/src/modules/operations/pages/technical-overview.adoc
+++ b/docs/src/modules/operations/pages/technical-overview.adoc
@@ -8,6 +8,11 @@ include::ROOT:partial$include.adoc[]
 
 Akka Automated Operations (AAO) is a remotely installed, actively maintained Akka region that runs inside your own cloud account, on Kubernetes across AWS, Azure, or GCP. You keep custodial ownership of the infrastructure; Akka installs, monitors, patches, and scales it, targeting up to six-nines (99.9999%) availability with low latency.
 
+[NOTE]
+====
+This overview is also available as a downloadable link:_attachments/whitepapers/aao-technical-overview.pdf[PDF].
+====
+
 image::concepts:akka-automated-operations.png[Akka Automated Operations]
 
 == Overview

--- a/docs/src/modules/operations/pages/technical-overview.adoc
+++ b/docs/src/modules/operations/pages/technical-overview.adoc
@@ -1,7 +1,7 @@
 = Akka Automated Operations technical overview
 :page-summary: A technical overview of Akka Automated Operations (AAO): the two-plane architecture, what Akka automates and provisions, and how a region is installed and operated across Kubernetes on AWS, Azure, and GCP — including the BYOC and BYOK8s models.
 :page-when-to-use: Use this to understand how AAO works end to end and to plan an installation, whether Akka provisions a region in your cloud (BYOC) or you bring your own Kubernetes cluster (BYOK8s).
-:page-related: xref:concepts:deployment-model.adoc[], xref:operations:akka-platform.adoc[], xref:operations:regions/index.adoc[]
+:page-related: xref:concepts:deployment-model.adoc[], xref:operations:akka-platform.adoc[], xref:operations:regions/index.adoc[], xref:operations:production-readiness/index.adoc[]
 :page-persona: operator-platform, operator-sre
 
 include::ROOT:partial$include.adoc[]
@@ -124,8 +124,7 @@ Akka Operators:: Route management, elasticity automation, metadata sync, rolling
 
 == Shared responsibility
 
-System management is shared between you and Akka across provisioning and ongoing operations. The table below summarizes who owns what across the lifecycle.
-// TODO: cross-link to the production-readiness RACI once we're ready to couple these documents.
+System management is shared between you and Akka across provisioning and ongoing operations. The table below is a summary; for the authoritative, row-by-row breakdown with the full Responsible / Accountable / Consulted / Informed split, see the xref:operations:production-readiness/index.adoc[production readiness] section and its xref:operations:production-readiness/byoc/raci.adoc[BYOC RACI].
 
 [cols="1,2,2", options="header"]
 |===
@@ -188,7 +187,7 @@ Eight steps take you from first contact to a region ready for deployments. This 
 . *Provision.* Akka remotely provisions the region and attaches it to a platform organization created for you.
 . *DNS.* Create record sets in your DNS zone mapping to the region's load-balancer IP so users and the Federation Plane can reach it.
 . *Smoke tests.* Akka attaches the region to the Federation Plane and runs smoke tests, so the region can then accept deployments.
-. *Region handover.* Register a user at akka.io with a corporate email; Akka makes them your organization's primary owner, so your team can begin using the region through the console and CLI. A production-labeled region isn't fully handed over until you complete the region-readiness steps with your Akka Success Team.
+. *Region handover.* Register a user at akka.io with a corporate email; Akka makes them your organization's primary owner, so your team can begin using the region through the console and CLI. A production-labeled region isn't fully handed over until you complete the xref:operations:production-readiness/byoc/checklist.adoc[region-readiness steps] with your Akka Success Team.
 
 == The akka-bootstrap utility
 
@@ -355,7 +354,7 @@ AAO can also be installed on a Kubernetes cluster _you provision_, in your cloud
 . *Teleport.* Install the Akka-provided Teleport Helm chart to grant Akka its access. Deploy it promptly, as the join token Akka gives you has a 3-hour TTL.
 . *Installation.* Akka configures the cluster as an application-plane region and sets up internal platform observability. You seed database credentials into the namespaces provided by Akka.
 . *Akka smoke tests.* Akka attaches the region to the Federation Plane and runs smoke tests, so the region can then accept deployments.
-. *Region handover.* Akka concludes smoke tests and assigns the region to your Akka organization on the console. A production-labeled region isn't fully handed over until you complete the region-readiness steps with your Akka Success Team.
+. *Region handover.* Akka concludes smoke tests and assigns the region to your Akka organization on the console. A production-labeled region isn't fully handed over until you complete the xref:operations:production-readiness/byok8s/checklist.adoc[region-readiness steps] with your Akka Success Team.
 
 === Infrastructure requirements
 

--- a/docs/styles/config/vocabularies/Akka/accept.txt
+++ b/docs/styles/config/vocabularies/Akka/accept.txt
@@ -1,3 +1,4 @@
+[Aa]utoscales?
 accessor
 Ack
 ACLs
@@ -12,6 +13,11 @@ allowedAlgorithms
 allowMethods
 allowOrigins
 [Aa]ntora
+APIs
+Artifactory
+AZs?
+CIDRs
+DEKs?
 (?i)API
 [Aa]rchitecting
 artifactId
@@ -118,6 +124,7 @@ JUnit
 JVM's
 (?i)JWT
 (?i)JWTs
+KEKs?
 [Kk]afka
 [Kk]alix
 Kerberos
@@ -127,6 +134,7 @@ keySets
 keysets?
 Kolesnikov
 Lagom
+Linkerd
 [Ll]angchain4j
 [Ll]ightbend
 LLM
@@ -148,6 +156,7 @@ mutators
 mvnw
 namespace
 newname
+[Nn]amespaces?
 npx
 npm
 nullable
@@ -171,6 +180,7 @@ passwordKey
 passwordSecret
 pathPrefix
 PDFs
+performant
 plaintext
 platformManaged
 plist
@@ -211,6 +221,7 @@ regionalization
 repartitions
 replayability
 replicatedRead
+repo
 reshard
 resourceVersion
 [Rr]eusability
@@ -240,6 +251,7 @@ sourceType
 [Ss]plunk
 src
 SREs
+[Ss]ubnets?
 stdin
 [Ss]tackdriver
 stigmergy
@@ -290,10 +302,13 @@ valueFrom
 versionHistory
 versionLabel
 VMs
+VNet
 volumeMounts
 [Ww]alkthrough
 winget
 workloadIdentity
+XLarge
+XSmall
 Yugabyte
 Zolotko
 [Zz]sh


### PR DESCRIPTION
## What

Publishes the **AAO Technical Overview** as a native docs page under Akka Automated Operations, and generates a **downloadable, branded PDF from that same page** — one source of truth, two ways to consume it.

- **Read online:** `operations/technical-overview.adoc` → the docs page (interactive tabs, indexable — the SEO win).
- **Download PDF:** a "Download PDF" link on the page; the PDF is rendered from the page at build time.
- **Find it:** a *White papers* section on the AAO summary page (`akka-platform.adoc`) links the overview.

## How the PDF is made

`docs/bin/whitepaper/render-pdf.mjs` (Playwright) loads the built Antora page and:
- flattens the `[tabs]` (AWS/Azure/GCP) into labeled sections, so the PDF contains every cloud, not just the active tab;
- applies `docs/bin/whitepaper/print.css`, a print skin that recreates the white paper look — a cover page, the gold/teal palette, Instrument Sans / Roboto Mono, styled tables, dark code blocks;
- hides the docs chrome and cookie banner.

Single source of truth: the `.adoc` is authoritative; the HTML and PDF are both derived. No PDF binary is committed — it is a build artifact written under `target/site`.

## Build / publish wiring

- `make whitepapers` renders locally (installs Playwright + Chromium, writes the PDF into `target/site/...`). Kept out of the default `make prod` so a normal docs build needs no Node.
- `docs-prod.yml` runs the render after `make managed prod` and before the rsync, so the PDF **republishes on every docs deploy**.

## Supersedes earlier direction

- Started as a full AsciiDoc conversion, then a plan to host a static PDF on S3/Drive. Landed here: native page (kept from the original conversion) + PDF derived from it, all in git, served from doc.akka.io.
- Issue #1792 (split into per-hyperscaler pages) is **closed** — marginal SEO gain for real duplication, and crawlers read the tabbed content.

## Reviewer notes

- The PDF styling was verified by rendering against a local build (cover, flattened tabs, tables, code all check out). The first prod CI render is worth a visual glance.
- The CI render uses `playwright install --with-deps chromium` (needs the runner's apt/sudo, which the workflow already uses elsewhere).
