### PR TITLE
docs: added platform-api documentation

### DIFF
--- a/docs/src/modules/ROOT/partials/external-links.adoc
+++ b/docs/src/modules/ROOT/partials/external-links.adoc
@@ -129,3 +129,9 @@
 :url-akka-github: https://github.com/akka
 :url-akka-blog: https://akka.io/blog
 :url-akka-support: https://support.akka.io
+
+// -- akka/platform-api GitHub repo --
+:url-platform-api-repo: https://github.com/akka/platform-api
+:url-platform-api-java-client: https://github.com/akka/platform-api/tree/main/java-client
+:url-platform-api-schemas-federation: https://github.com/akka/platform-api/tree/main/schemas/federation-plane/protobuf
+:url-platform-api-schemas-control-plane: https://github.com/akka/platform-api/blob/main/schemas/control-plane/openapi/api.json

--- a/docs/src/modules/operations/nav.adoc
+++ b/docs/src/modules/operations/nav.adoc
@@ -49,6 +49,8 @@
 ***** xref:operations:integrating-cicd/github-actions.adoc[]
 ***** xref:operations:integrating-cicd/scanning-dependencies.adoc[]
 
+**** xref:operations:platform-api.adoc[]
+
 **** xref:operations:cli/index.adoc[]
 ***** xref:operations:cli/installation.adoc[]
 ***** xref:operations:cli/using-cli.adoc[]

--- a/docs/src/modules/operations/pages/organizations/manage-users.adoc
+++ b/docs/src/modules/operations/pages/organizations/manage-users.adoc
@@ -47,7 +47,7 @@ fd21044c-b973-4220-8f65-0f7d317bb23b   superuser   jane.citizen   jane.citizen@e
 
 NOTE: When using _OpenID Connect_ (OIDC), see xref:reference:security/oidc-setup.adoc#assigning_organization_level_roles[OIDC setup].
 
-You can grant a role to a user in two ways:
+You can grant a role to a user in two ways, or grant a role directly to a service:
 
 === 1. Invite a User by Email
 Send an email invitation with the following command:
@@ -78,6 +78,18 @@ akka organization users add-binding --organization <organization name> \
 akka organizations users add-binding --organization <organization name> \
   --username <username> --role <role>
 ----
+
+=== 3. Grant a role to a service
+
+A service can also authenticate as itself against the Akka platform API using workload identity, and be granted a role directly:
+
+[source,command window]
+----
+akka organizations users add-binding --organization <organization name> \
+  --service <service name> --role <role>
+----
+
+For the full walkthrough, including how to configure the service to authenticate, see xref:services/workload-identity.adoc#authenticating-with-the-akka-platform-api[Authenticating with the Akka platform API].
 
 == Deleting a role binding
 
@@ -119,6 +131,7 @@ To resend an invitation, cancel the previous one and reissue the invite.
 == See also
 
 - xref:projects/manage-project-access.adoc[]
+- xref:services/workload-identity.adoc[]
 - xref:reference:security/oidc-setup.adoc[]
 - xref:reference:cli/akka-cli/akka_organizations_users.adoc#_see_also[`akka organizations users` commands]
 - xref:reference:cli/akka-cli/akka_organizations_invitations.adoc#_see_also[`akka organizations invitations` commands]

--- a/docs/src/modules/operations/pages/platform-api.adoc
+++ b/docs/src/modules/operations/pages/platform-api.adoc
@@ -1,0 +1,276 @@
+= Platform API
+include::ROOT:partial$include.adoc[]
+
+The Akka Platform API is the set of gRPC and REST APIs that the Akka CLI and console use to manage organizations, projects, and services. Akka publishes the protobuf and OpenAPI schemas for these APIs, together with a Java client library, in the link:{url-platform-api-repo}[`akka/platform-api`,window="_blank"] GitHub repository, so you can call the same APIs from your own tools and services.
+
+== API planes
+
+The Platform API has two planes:
+
+Federation plane:: A gRPC API for managing projects, organizations, billing, users, and authentication. Served at `api.kalix.io:443`.
+Control plane:: A REST API (OpenAPI) for managing resources within a project, such as services, routes, and secrets. Served at a region-specific endpoint, for example `https://api.gcp-us-east1.akka.io`.
+
+== Authentication
+
+All API calls require a short-lived access token, obtained by one of the following mechanisms.
+
+=== Refresh token
+
+A refresh token is a long-lived token exchanged for a short-lived access token via the Auth API. There are two kinds:
+
+User token:: Grants access to all projects belonging to your user account.
++
+[source, command line]
+----
+akka auth tokens create --description "My refresh token"
+----
+
+Service token:: Grants access to a single project. Use this for CI/CD pipelines and other automation.
++
+[source, command line]
+----
+akka projects tokens create --description "My service token"
+----
+
+Store the token value securely. It is shown only once.
+
+=== OAuth token exchange (RFC 8693)
+
+Exchange an existing identity token, such as a GitHub Actions OIDC token or an Akka workload identity token, for an Akka access token using OAuth 2.0 token exchange. No long-lived Akka credential needs to be stored. The audience parameter identifies the configured OpenID Connect identity provider and is required.
+
+To use this mechanism to authenticate an Akka service that calls the Platform API from another Akka service, configure xref:services/workload-identity.adoc#authenticating-with-the-akka-platform-api[Akka platform workload identity] on the calling service.
+
+== Java client
+
+The link:{url-platform-api-java-client}[`java-client`,window="_blank"] module provides a ready-to-use SDK that handles token acquisition and caching, gRPC channel management, and automatic routing of control plane requests to the correct regional endpoint.
+
+=== Configuring the client
+
+==== Refresh token: environment variable
+
+Set `AKKA_TOKEN` before starting your application. Optionally set `AKKA_API_HOST` to override the federation plane host (defaults to `api.kalix.io:443`).
+
+[source, command line]
+----
+export AKKA_TOKEN=<your-refresh-token>
+----
+
+[source, java]
+----
+AkkaPlatformSdk sdk = AkkaPlatformSdk.create();
+----
+
+==== Refresh token: automatic fallback to the Akka CLI
+
+If `AKKA_TOKEN` is not set and the `akka` CLI is installed and logged in, the SDK runs `akka config get refresh-token` (and `akka config get api-server-host` for non-default installations) automatically. No code changes are needed.
+
+==== Refresh token: programmatic
+
+[source, java]
+----
+AkkaPlatformSdk sdk = AkkaPlatformSdk.create(
+    AkkaPlatformSdkConfig.withRefreshToken("your-refresh-token"));
+----
+
+To also override the federation plane host:
+
+[source, java]
+----
+AkkaPlatformSdk sdk = AkkaPlatformSdk.create(
+    AkkaPlatformSdkConfig.withRefreshToken("your-refresh-token", "api.kalix.io:443"));
+----
+
+==== OAuth token exchange: environment variables
+
+Set `AKKA_OAUTH_TOKEN` (or `AKKA_OAUTH_TOKEN_FILE` to point to a file containing the token) and `AKKA_OAUTH_TOKEN_AUDIENCE`. When either OAuth variable is present, it takes precedence over `AKKA_TOKEN`. If the audience variable is missing, the SDK throws an exception at startup.
+
+[source, command line]
+----
+export AKKA_OAUTH_TOKEN="$(cat /var/run/secrets/token)"   # or a static value
+export AKKA_OAUTH_TOKEN_AUDIENCE="regions/gcp-us-east1"
+# -- or --
+export AKKA_OAUTH_TOKEN_FILE=/var/run/secrets/token
+export AKKA_OAUTH_TOKEN_AUDIENCE="regions/gcp-us-east1"
+----
+
+[source, java]
+----
+AkkaPlatformSdk sdk = AkkaPlatformSdk.create();  // picks up the env vars automatically
+----
+
+When `AKKA_OAUTH_TOKEN_FILE` is used, the file is re-read on every token exchange, so rotating the file contents is sufficient to rotate the credential without restarting the application.
+
+TIP: When xref:services/workload-identity.adoc#authenticating-with-the-akka-platform-api[Akka platform workload identity] is configured for an Akka service, these environment variables are injected automatically into the service at runtime. Calling `AkkaPlatformSdk.create()` with no further configuration is sufficient.
+
+==== OAuth token exchange: programmatic
+
+[source, java]
+----
+// Fixed token value
+AkkaPlatformSdk sdk = AkkaPlatformSdk.create(
+    AkkaPlatformSdkConfig.withOAuthToken(myOidcToken, "regions/gcp-us-east1"));
+
+// File-based (re-read on every exchange)
+AkkaPlatformSdk sdk = AkkaPlatformSdk.create(
+    AkkaPlatformSdkConfig.withOAuthTokenFile("/var/run/secrets/token", "regions/gcp-us-east1"));
+----
+
+==== Custom token fetcher
+
+For authentication mechanisms not covered above, implement both `TokenConfig` and `TokenFetcher` on the same class. `TokenFetcher.getToken()` must return a `CompletableFuture<TokenWithExpiry>` containing a bearer token and its expiry instant. The SDK caches the token until 60 seconds before expiry, then calls `getToken()` again.
+
+[source, java]
+----
+public class MyTokenConfig implements TokenConfig, TokenFetcher {
+    @Override
+    public CompletableFuture<TokenWithExpiry> getToken() {
+        return fetchMyToken().thenApply(t ->
+            new TokenWithExpiry(t.value(), t.expiresAt()));
+    }
+}
+
+AkkaPlatformSdk sdk = AkkaPlatformSdk.create(
+    AkkaPlatformSdkConfig.of(new MyTokenConfig(), "api.kalix.io:443"));
+----
+
+=== Looking up a project
+
+Projects are identified by a UUID internally. Use `resolveProjectId` to translate a friendly name to the UUID required by the control plane API:
+
+[source, java]
+----
+sdk.resolveProjectId("my-project")
+    .thenAccept(projectId -> System.out.println("Project ID: " + projectId));
+----
+
+To list all projects directly:
+
+[source, java]
+----
+sdk.projects()
+    .listProjects(ListProjectsRequest.newBuilder().build())
+    .thenAccept(response ->
+        response.getProjectsList().forEach(p ->
+            System.out.println(p.getFriendlyName() + " → " + p.getName())));
+----
+
+=== Getting a service
+
+The control plane API is accessed via `sdk.controlPlaneApi()`. Each call is automatically routed to the project's primary region: the project UUID is parsed from the request URI, the region list is fetched and cached, and the request is forwarded to the correct regional endpoint.
+
+[source, java]
+----
+AkkaControlPlaneApi api = sdk.controlPlaneApi();
+
+sdk.resolveProjectId("my-project").thenCompose(projectId ->
+    api.getService("my-service", projectId)
+).thenAccept(service ->
+    System.out.println(service.getMetadata().getName()
+        + " — " + service.getStatus()));
+----
+
+To list all services in a project:
+
+[source, java]
+----
+sdk.resolveProjectId("my-project").thenCompose(projectId ->
+    api.listServices(projectId, null)
+).thenAccept(list ->
+    list.getItems().forEach(s -> System.out.println(s.getMetadata().getName())));
+----
+
+=== Creating a service
+
+[source, java]
+----
+import io.akka.platformapi.controlplane.model.*;
+
+Service service = new Service()
+    .metadata(new ObjectMeta()
+        .name("my-service"))
+    .spec(new ServiceSpec()
+        .containers(List.of(new ServiceSpecContainer()
+            .name("main")
+            .image("my-registry.example.com/my-image:1.0.0"))));
+
+sdk.resolveProjectId("my-project").thenCompose(projectId ->
+    api.createService(projectId, service)
+).thenAccept(created ->
+    System.out.println("Created: " + created.getMetadata().getName()));
+----
+
+=== Explicit region routing
+
+By default, `controlPlaneApi()` routes to the primary region. To target a specific region, for example for multi-region projects:
+
+[source, java]
+----
+// Region name format: "<region-id>" e.g. "gcp-us-east1"
+AkkaControlPlaneApi regionalApi = sdk.controlPlaneApiForRegion("gcp-us-east1");
+----
+
+If the specified region is not associated with the project identified in the request URI, the call fails asynchronously with `IllegalArgumentException`.
+
+Region information is cached. After a region configuration change, call `sdk.clearRegionCache()` to force a fresh lookup on the next request.
+
+=== Closing the client
+
+Close the SDK when your application shuts down, to release the underlying gRPC channels and, if applicable, the managed `ActorSystem`:
+
+[source, java]
+----
+sdk.close();
+----
+
+== Using the schemas directly
+
+The federation plane protobuf schemas are in link:{url-platform-api-schemas-federation}[`schemas/federation-plane/protobuf/`,window="_blank"] and the control plane OpenAPI schema is at link:{url-platform-api-schemas-control-plane}[`schemas/control-plane/openapi/api.json`,window="_blank"], both in the `akka/platform-api` repository. This section describes the authentication and region discovery flow for clients that use these schemas without the Java client.
+
+=== Authenticating
+
+All requests require a short-lived access token. Exchange your refresh token for one by calling `CreateAccessToken` on the Auth service (`api.kalix.io:443`, TLS):
+
+----
+Service:  kalix.api.auth.v1alpha.Auth
+Method:   CreateAccessToken
+Request:  CreateAccessTokenRequest {}   (empty body)
+Header:   Authorization: Bearer <refresh-token>
+----
+
+The response `AccessToken.token` is your access token. Send it as `Authorization: Bearer <access-token>` on all subsequent requests. Tokens are short-lived: cache them and refresh before `expire_time`.
+
+To authenticate an Akka service that calls the Platform API using its own identity, instead of a stored refresh token, configure xref:services/workload-identity.adoc#authenticating-with-the-akka-platform-api[Akka platform workload identity] on the service.
+
+=== Region endpoint discovery
+
+Control plane REST requests must be directed to the region-specific endpoint for the project, not to `api.kalix.io`. Discover the endpoint by calling `ListProjects` on the Projects service, authenticated with your access token:
+
+----
+Service:  kalix.api.projects.v1alpha.Projects
+Method:   ListProjects
+Request:  ListProjectsRequest {}
+Header:   Authorization: Bearer <access-token>
+----
+
+Each `Project` in the response contains a `regions` list. Each `Region` has:
+
+`endpoint`:: The base URL for control plane REST requests, for example `https://api.gcp-us-east1.akka.io`.
+`primary`:: `true` for the region that should be used by default.
+`name`:: The fully-qualified resource name, for example `projects/<id>/regions/gcp-us-east1`.
+
+In most cases, use the region where `primary == true`. Use its `endpoint` as the base URL for all control plane REST calls for that project:
+
+----
+GET https://api.gcp-us-east1.akka.io/apis/kalix.io/v1alpha1/namespaces/<project-id>/kalixservices
+Authorization: Bearer <access-token>
+----
+
+If you already have the project ID, you can also call `ListRegions` directly with `parent = "projects/<project-id>"`, instead of iterating through `ListProjects`.
+
+Page through `ListProjects` using the `next_page_token` field in the response until it is empty, since projects are returned in pages.
+
+== See also
+
+- link:{url-platform-api-repo}[`akka/platform-api`,window="_blank"] on GitHub, for the full schemas, the Java client source, and release notes
+- xref:services/workload-identity.adoc[]
+- xref:cli/using-cli.adoc[]

--- a/docs/src/modules/operations/pages/platform-api.adoc
+++ b/docs/src/modules/operations/pages/platform-api.adoc
@@ -46,7 +46,7 @@ The link:{url-platform-api-java-client}[`java-client`,window="_blank"] module pr
 
 === Configuring the client
 
-==== Refresh token: environment variable
+==== Refresh token: Environment variable
 
 Set `AKKA_TOKEN` before starting your application. Optionally set `AKKA_API_HOST` to override the federation plane host (defaults to `api.kalix.io:443`).
 
@@ -60,11 +60,11 @@ export AKKA_TOKEN=<your-refresh-token>
 AkkaPlatformSdk sdk = AkkaPlatformSdk.create();
 ----
 
-==== Refresh token: automatic fallback to the Akka CLI
+==== Refresh token: Automatic fallback to the Akka CLI
 
 If `AKKA_TOKEN` is not set and the `akka` CLI is installed and logged in, the SDK runs `akka config get refresh-token` (and `akka config get api-server-host` for non-default installations) automatically. No code changes are needed.
 
-==== Refresh token: programmatic
+==== Refresh token: Programmatic
 
 [source, java]
 ----
@@ -80,7 +80,7 @@ AkkaPlatformSdk sdk = AkkaPlatformSdk.create(
     AkkaPlatformSdkConfig.withRefreshToken("your-refresh-token", "api.kalix.io:443"));
 ----
 
-==== OAuth token exchange: environment variables
+==== OAuth token exchange: Environment variables
 
 Set `AKKA_OAUTH_TOKEN` (or `AKKA_OAUTH_TOKEN_FILE` to point to a file containing the token) and `AKKA_OAUTH_TOKEN_AUDIENCE`. When either OAuth variable is present, it takes precedence over `AKKA_TOKEN`. If the audience variable is missing, the SDK throws an exception at startup.
 
@@ -102,7 +102,7 @@ When `AKKA_OAUTH_TOKEN_FILE` is used, the file is re-read on every token exchang
 
 TIP: When xref:services/workload-identity.adoc#authenticating-with-the-akka-platform-api[Akka platform workload identity] is configured for an Akka service, these environment variables are injected automatically into the service at runtime. Calling `AkkaPlatformSdk.create()` with no further configuration is sufficient.
 
-==== OAuth token exchange: programmatic
+==== OAuth token exchange: Programmatic
 
 [source, java]
 ----
@@ -254,11 +254,11 @@ Header:   Authorization: Bearer <access-token>
 
 Each `Project` in the response contains a `regions` list. Each `Region` has:
 
-`endpoint`:: The base URL for control plane REST requests, for example `https://api.gcp-us-east1.akka.io`.
+`endpoint`:: The base URL of the control plane REST requests, for example `https://api.gcp-us-east1.akka.io`.
 `primary`:: `true` for the region that should be used by default.
 `name`:: The fully-qualified resource name, for example `projects/<id>/regions/gcp-us-east1`.
 
-In most cases, use the region where `primary == true`. Use its `endpoint` as the base URL for all control plane REST calls for that project:
+In most cases, use the region where `primary == true`. Use its `endpoint` as the base URL of all control plane REST calls for that project:
 
 ----
 GET https://api.gcp-us-east1.akka.io/apis/kalix.io/v1alpha1/namespaces/<project-id>/kalixservices

--- a/docs/src/modules/operations/pages/projects/manage-project-access.adoc
+++ b/docs/src/modules/operations/pages/projects/manage-project-access.adoc
@@ -59,7 +59,7 @@ akka config set project <project name>
 
 NOTE: When using _OpenID Connect_ (OIDC), see xref:reference:security/oidc-setup.adoc#assigning_project_level_roles[OIDC setup].
 
-You can grant a project role to a user in two ways:
+You can grant a project role to a user in two ways, or grant a role directly to a service:
 
 === 1. Invite a user to the project by e-mail
 Invite a user to join the project and assign them a role by using the following command:
@@ -87,6 +87,17 @@ akka roles add-binding --email <email address> --role <role>
 ----
 akka roles add-binding --username <username> --role <role>
 ----
+
+=== 3. Grant a role to a service
+
+A service can also authenticate as itself against the Akka platform API using workload identity, and be granted a role directly:
+
+[source,command window]
+----
+akka roles add-binding --service <service name> --role <role>
+----
+
+For the full walkthrough, including how to configure the service to authenticate, see xref:services/workload-identity.adoc#authenticating-with-the-akka-platform-api[Authenticating with the Akka platform API].
 
 == Deleting a project role bindings
 
@@ -140,4 +151,5 @@ To resend an invitation, first delete the expired invitation and then issue a ne
 == See also
 
 - xref:organizations/manage-users.adoc[]
+- xref:services/workload-identity.adoc[]
 - xref:reference:cli/akka-cli/akka_roles.adoc#_see_also[`akka roles` commands]

--- a/docs/src/modules/operations/pages/services/workload-identity.adoc
+++ b/docs/src/modules/operations/pages/services/workload-identity.adoc
@@ -1,7 +1,7 @@
 = Workload Identity
 include::ROOT:partial$include.adoc[]
 
-Akka services can authenticate with cloud provider APIs and third-party services using workload identity. Rather than managing long-lived credentials, Akka issues short-lived OpenID Connect (OIDC) tokens that prove the identity of your service. The target service verifies these tokens against Akka's OIDC issuer for your services region and grants access based on its own identity and access policies.
+Akka services can authenticate with cloud provider APIs, the Akka platform API, and third-party services using workload identity. Rather than managing long-lived credentials, Akka issues short-lived OpenID Connect (OIDC) tokens that prove the identity of your service. The target service verifies these tokens against Akka's OIDC issuer for your services region and grants access based on its own identity and access policies.
 
 This approach works with the local cloud provider where your Akka service is running (AWS, Azure, or GCP), as well as with any other cloud provider or third-party service that supports OIDC-based workload identity authentication.
 
@@ -375,6 +375,70 @@ spec:
 
 The GCP SDK in your service automatically authenticates using the workload identity — no additional code is needed.
 
+[#authenticating-with-the-akka-platform-api]
+== Authenticating with the Akka platform API
+
+Akka services can authenticate with the Akka platform API itself, the same API used by the Akka CLI and by the platform API client libraries. This allows code running in a service to call the platform API — for example to look up other services in a project, or to manage projects and organizations — without embedding a token or credentials of its own.
+
+=== Configuring the service
+
+Configure this in the xref:reference:descriptors/service-descriptor.adoc[service descriptor] by setting an empty `akka` object under `workloadIdentity`:
+
+[source, yaml]
+----
+resource: Service
+resourceVersion: v1
+metadata:
+  name: my-service
+spec:
+  image: my-container-registry/my-image:latest
+  workloadIdentity:
+    akka: {}
+----
+
+For the full configuration reference, see xref:reference:descriptors/service-descriptor.adoc#AkkaWorkloadIdentity[AkkaWorkloadIdentity] in the service descriptor reference.
+
+Once configured, Akka mounts a token into the service container and sets the environment variables that the Akka CLI and the platform API client libraries read automatically. No additional code is needed to authenticate.
+
+=== Authorizing the service
+
+Configuring workload identity gives the service an identity, `system:serviceaccount:<project-id>:klx-<service-name>` — the same identity described in <<Token subject claim,above>>. It does not by itself grant the service any permissions. To authorize the service to act on a project or organization, grant it a role, the same way you would grant a role to a user.
+
+==== Granting a project role to a service
+
+Use the `--service` flag on `akka roles add-binding` in place of `--email` or `--username`:
+
+[source, command line]
+----
+akka roles add-binding --service my-service --role developer
+----
+
+If the service belongs to a different project than the one the role is being granted on, specify it with `--service-project`:
+
+[source, command line]
+----
+akka roles add-binding --service my-service --service-project my-service-project \
+  --role viewer
+----
+
+If the target project has more than one region, specify which region the service is running in with `--service-region`. To grant the role to the service in every region belonging to the project's region group, use `--service-region-group` instead.
+
+For the full set of options, see xref:reference:cli/akka-cli/akka_roles_add-binding.adoc[akka roles add-binding] and xref:operations:projects/manage-project-access.adoc[Managing project users].
+
+==== Granting an organization role to a service
+
+Use the same `--service` flag on `akka organizations users add-binding`:
+
+[source, command line]
+----
+akka organizations users add-binding --organization my-organization \
+  --service my-service --role member
+----
+
+The `--service-project`, `--service-region`, and `--service-region-group` flags work the same way as for `akka roles add-binding`, above.
+
+For the full set of options, see xref:reference:cli/akka-cli/akka_organizations_users_add-binding.adoc[akka organizations users add-binding] and xref:operations:organizations/manage-users.adoc[Managing organization users].
+
 == Authenticating with third-party and non-local cloud providers
 
 For any service that supports OIDC-based workload identity — whether it is a different cloud provider, a SaaS platform, or a self-hosted service — you configure trust by registering Akka's OIDC issuer and granting access based on the token's `sub` claim.
@@ -403,3 +467,9 @@ String token = Files.readString(Path.of("/var/run/secrets/tokens/my-service-toke
 ----
 
 Because the token is rotated automatically by Akka, always read it fresh from the file before each use rather than caching it in memory.
+
+== See also
+
+- xref:reference:descriptors/service-descriptor.adoc#WorkloadIdentity[WorkloadIdentity in the service descriptor reference]
+- xref:projects/manage-project-access.adoc[]
+- xref:organizations/manage-users.adoc[]

--- a/docs/src/modules/reference/pages/descriptors/service-descriptor.adoc
+++ b/docs/src/modules/reference/pages/descriptors/service-descriptor.adoc
@@ -458,6 +458,7 @@ service:
       passwordKey: truststore-password
 ----
 
+[#WorkloadIdentity]
 === WorkloadIdentity
 
 Workload identity configuration for a service.
@@ -469,6 +470,7 @@ Workload identity configuration for a service.
 |*aws*   |<<AwsWorkloadIdentity>>   |AWS workload identity configuration. Only relevant for AWS regions, ignored in other regions.
 |*azure* |<<AzureWorkloadIdentity>> |Azure workload identity configuration. Only relevant for Azure regions, ignored in other regions.
 |*gcp*   |<<GcpWorkloadIdentity>>   |GCP workload identity configuration. Only relevant for GCP regions, ignored in other regions.
+|*akka*  |<<AkkaWorkloadIdentity>>  |Akka platform workload identity configuration. Allows the service to authenticate with the Akka platform API.
 |===
 
 === AwsWorkloadIdentity
@@ -507,3 +509,18 @@ Workload identity configuration for GCP regions to authenticate with the GCP API
 
 |*gcpServiceAccount* |string |If you wish your service to impersonate a GCP service account, rather than using their own principal directly, the service account that you wish them to assume.
 |===
+
+[#AkkaWorkloadIdentity]
+=== AkkaWorkloadIdentity
+
+Workload identity configuration for authenticating with the Akka platform API itself, rather than a cloud provider's API. Configuring this mounts a token and sets the environment variables that the Akka platform API client libraries and the Akka CLI use to authenticate with the Akka platform automatically, without additional configuration.
+
+This type has no fields. Its presence in the descriptor, with an empty object as its value, enables the feature:
+
+[source, yaml]
+----
+name: <<service-name>>
+service:
+  workloadIdentity:
+    akka: {}
+----


### PR DESCRIPTION
This adds documentaiton for accessing the platform API, as well as how to configure Akka services to be able to access it.