### PR TITLE
bump: errata-ai/vale-action v2.1.1 -> v3.0.0

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -68,7 +68,7 @@ jobs:
       # https://vale.sh
       - name: Vale
         # https://github.com/errata-ai/vale-action/releases
-        uses: errata-ai/vale-action@v2.1.1
+        uses: errata-ai/vale-action@v3.0.0
         with:
           version: 3.7.1
           files: docs/src


### PR DESCRIPTION
Bumps `errata-ai/vale-action` from v2.1.1 (Node 20) to v3.0.0 (Node 24). No config changes needed — repo's `MinAlertLevel = error` makes v3's behavior changes a no-op here.