### PR TITLE
docs: allowing origin:runtime logs export in kalixobservability

### DIFF
--- a/docs/src/modules/operations/pages/observability-and-monitoring/observability-exports.adoc
+++ b/docs/src/modules/operations/pages/observability-and-monitoring/observability-exports.adoc
@@ -126,6 +126,71 @@ spec:
 
 With this configuration, 2% of the traces are sent while the 98% are filtered. More on how much sampling https://opentelemetry.io/docs/concepts/sampling/#when-to-sample[here, window="new"].
 
+=== Exporting runtime logs
+
+Besides the logs your application produces, the Akka runtime emits its own logs, identified by the `origin: runtime` attribute on the log record. By default, runtime logs with severity `warn` or higher are exported to your configured log exporters, alongside your application logs. Logs produced by your application are always exported in full, regardless of this setting.
+
+To tune which runtime logs are exported, set `runtimeLogs` at the top level of the observability descriptor and xref:_updating_the_observability_configuration[update the observability configuration]:
+
+[source,yaml]
+----
+resource: Observability
+resourceVersion: v2
+spec:
+  exporters:
+    - kalixConsole: {}
+  logs:
+    - otlpHttp:
+        endpointBaseUrl: https://logs.example.com
+  runtimeLogs:
+    minSeverity: info
+----
+
+`minSeverity` accepts the following values:
+
+[cols="1,4"]
+|===
+|Value |Behavior
+
+|`none`
+|No runtime logs are exported.
+
+|`error`
+|Runtime logs with severity `error` or higher are exported.
+
+|`warn`
+|Runtime logs with severity `warn` or higher are exported. This is the default.
+
+|`info`
+|Runtime logs with severity `info` or higher are exported.
+
+|`debug`
+|Runtime logs with severity `debug` or higher are exported.
+|===
+
+Runtime log records whose severity cannot be determined, for example a raw stack trace emitted during service startup, are always exported unless `minSeverity` is set to `none`.
+
+Removing `runtimeLogs` from the descriptor reverts the project to the default for the region it is deployed in.
+
+[NOTE]
+====
+Lowering the minimum severity increases the volume of log data sent to your exporter. If your logging backend bills by ingested volume, prefer `warn` or `error`.
+====
+
+The same setting can be changed without a descriptor, using the `config runtime-logs` command:
+
+[source,command line]
+----
+akka project observability config runtime-logs --min-severity info
+----
+
+To remove the project-level setting and revert to the region default, run:
+
+[source,command line]
+----
+akka project observability config runtime-logs --min-severity default
+----
+
 == Updating the configuration using commands
 
 The Akka observability configuration can also be updated using commands. To view a human-readable summary of the observability configuration, run:

--- a/docs/src/modules/reference/pages/descriptors/observability-descriptor.adoc
+++ b/docs/src/modules/reference/pages/descriptors/observability-descriptor.adoc
@@ -16,6 +16,7 @@ An Akka observability descriptor describes how metrics, logs, and traces are exp
 |*traces*         |[]<<ObservabilityTraces>>  |The exporters to use for traces. Overrides the exporters defined in `exporters`, but just for traces.
 |*heapDump*       |<<HeapDump>>               |Heap dump export configuration.
 |*traceSampling*  |<<TraceSampling>>          |Trace sampling configuration. Applies to all trace exporters.
+|*runtimeLogs*    |<<RuntimeLogs>>            |Controls which runtime logs are exported to the configured log exporters. Applies to all log exporters.
 |*logLevel*       |string                     |Log level for the OpenTelemetry collector. Valid values are `debug`, `info`, `warn`, and `error`.
 |===
 
@@ -265,6 +266,17 @@ References to secrets containing AWS credentials for heap dump uploads.
 
 |*awsAccessKeyId*     |<<SecretKeyRef>> |A reference to the secret and key containing the AWS access key ID.
 |*awsSecretAccessKey* |<<SecretKeyRef>> |A reference to the secret and key containing the AWS secret access key.
+|===
+
+=== RuntimeLogs
+
+Controls export of runtime logs to the configured log exporters. Logs produced by your application are always exported, regardless of this setting. See xref:operations:observability-and-monitoring/observability-exports.adoc#_exporting_runtime_logs[Exporting runtime logs] for details.
+
+[cols="1,1,1"]
+|===
+|Field            |Type    |Description
+
+|*minSeverity*    |string  |The minimum severity of runtime logs to export. One of `none`, `error`, `warn`, `info` or `debug`. Runtime logs below this severity are not exported; `none` disables runtime log export entirely. Runtime log records whose severity cannot be determined are always exported unless set to `none`. When unset, the region default applies (`warn` unless configured otherwise).
 |===
 
 === TraceSampling

--- a/docs/src/modules/reference/pages/release-notes.adoc
+++ b/docs/src/modules/reference/pages/release-notes.adoc
@@ -12,6 +12,9 @@ Current versions
 
 == August 2026
 
+* Platform update 2026-08-20
+    - Runtime logs with severity `warn` and above are now exported to the log exporters configured for your project, alongside your application logs. Previously, runtime logs were never exported. This gives you visibility into runtime warnings and errors (for example, failures during service startup) in your own logging backend, but may increase the volume of ingested log data. The behavior can be tuned per project with the new `runtimeLogs.minSeverity` setting in the observability descriptor or the `akka project observability config runtime-logs` command; setting it to `none` restores the previous behavior. See xref:operations:observability-and-monitoring/observability-exports.adoc#_exporting_runtime_logs[Exporting runtime logs].
+
 * Akka CLI 3,0.71
 - Updates to Akka Specify exit conditions
 - Manage project stores

--- a/docs/styles/config/vocabularies/Akka/accept.txt
+++ b/docs/styles/config/vocabularies/Akka/accept.txt
@@ -140,6 +140,7 @@ materializer
 maxInstances
 migratable
 minInstances
+minSeverity
 mountPath
 multimodal
 Multimodal
@@ -216,6 +217,7 @@ resourceVersion
 [Rr]eusability
 RNGs
 roleArn
+runtimeLogs
 runtimes
 runtime's
 (?i)RPC


### PR DESCRIPTION
References
- lightbend/kalix#16173
- Documents lightbend/kalix#16505 (operator) and akka/cli#163 (CLI)

## Description
Documents the new platform log export control (`platformLogs.minSeverity`):

- `operations/observability-exports.adoc`: new "Exporting platform logs" section - what platform logs are, the `warn` default, descriptor example, value table, behavior for logs with undetermined severity, how to revert to the region default, ingest-volume warning, and the new `config platform-logs` CLI command.
- `reference/descriptor-reference.adoc`: `platformLogs` field in the observability descriptor table plus a `KalixObservabilityPlatformLogs` section (v2 descriptor only).
- `reference/release-notes.adoc`: August 2026 entry describing the behavior change (platform WARN/ERROR now exported by default; may increase ingested volume; opt-out via `platformLogs.minSeverity: none`).

## Dependency / merge order
- This describes behavior that ships with the platform release containing
lightbend/kalix#16505. Merge together with (or immediately after) that release.