### PR TITLE
feat: Support ephemeral port for testkit

### DIFF
--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -79,6 +79,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiFunction;
@@ -960,7 +961,7 @@ public class TestKit {
   public TestKit start() {
     if (started) throw new IllegalStateException("Testkit already started");
 
-    eventingTestKitPort = availableLocalPort();
+    eventingTestKitPort = availableEventingTestKitPort();
     startRuntime(settings.additionalConfig);
     started = true;
 
@@ -1655,6 +1656,44 @@ public class TestKit {
     } catch (IOException e) {
       throw new RuntimeException("Couldn't get available local port", e);
     }
+  }
+
+  /**
+   * A band below the range operating systems draw ephemeral ports from: 32768 and up on Linux,
+   * 49152 and up on macOS and Windows.
+   */
+  private static final int EVENTING_PORT_BAND_FIRST = 20000;
+
+  private static final int EVENTING_PORT_BAND_LAST = 32767;
+
+  private static final int EVENTING_PORT_ATTEMPTS = 50;
+
+  /**
+   * The eventing testkit port is chosen when the testkit starts but only bound once the runtime has
+   * booted, and the runtime opens plenty of outbound connections in between. A port from the
+   * ephemeral range can be taken for one of those in that gap, so the port is drawn from a band
+   * below that range instead. This narrows the window rather than closing it: the port is handed to
+   * the runtime through the settings long before anything binds it.
+   */
+  private static int availableEventingTestKitPort() {
+    for (int attempt = 0; attempt < EVENTING_PORT_ATTEMPTS; attempt++) {
+      int port =
+          ThreadLocalRandom.current()
+              .nextInt(EVENTING_PORT_BAND_FIRST, EVENTING_PORT_BAND_LAST + 1);
+      // bound on the wildcard address, the same as the eventing testkit binds it on
+      try (ServerSocket socket = new ServerSocket()) {
+        socket.setReuseAddress(true);
+        socket.bind(new InetSocketAddress(port));
+        return port;
+      } catch (IOException taken) {
+        // try another one
+      }
+    }
+    log.warn(
+        "Found no free port in [{}-{}] for the eventing testkit, asking for any free port instead",
+        EVENTING_PORT_BAND_FIRST,
+        EVENTING_PORT_BAND_LAST);
+    return availableLocalPort();
   }
 
   /**

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -1228,9 +1228,7 @@ public class TestKit {
       body =
           response
               .entity()
-              .toStrict(
-                  RUNTIME_STARTED_TIMEOUT.toMillis(),
-                  getMaterializer())
+              .toStrict(RUNTIME_STARTED_TIMEOUT.toMillis(), getMaterializer())
               .toCompletableFuture()
               .get(RUNTIME_STARTED_TIMEOUT.toSeconds(), TimeUnit.SECONDS)
               .getData()

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -8,7 +8,6 @@ import static akka.javasdk.testkit.TestKit.Settings.EventingSupport.TEST_BROKER;
 
 import akka.actor.typed.ActorSystem;
 import akka.grpc.javadsl.AkkaGrpcClient;
-import akka.http.javadsl.Http;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
 import akka.javasdk.DependencyProvider;
@@ -41,7 +40,6 @@ import akka.javasdk.testkit.impl.SseRouteTesterImpl;
 import akka.javasdk.testkit.impl.WebSocketRouteTesterImpl;
 import akka.javasdk.timer.TimerScheduler;
 import akka.javasdk.workflow.Workflow;
-import akka.pattern.Patterns;
 import akka.runtime.sdk.spi.ComponentClients;
 import akka.runtime.sdk.spi.EventLogClient;
 import akka.runtime.sdk.spi.SpiBackofficeSettings$;
@@ -67,6 +65,7 @@ import akka.stream.SystemMaterializer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -77,8 +76,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -92,6 +89,7 @@ import org.slf4j.LoggerFactory;
 import scala.Option;
 import scala.Some;
 import scala.concurrent.duration.FiniteDuration;
+import scala.jdk.javaapi.FutureConverters;
 
 /**
  * Testkit for running services locally.
@@ -826,6 +824,13 @@ public class TestKit {
 
   private static final Logger log = LoggerFactory.getLogger(TestKit.class);
 
+  /**
+   * How long to wait for the runtime to report the address it bound. The runtime completes that as
+   * soon as it binds or as soon as it knows it cannot, so this bound only comes into play when the
+   * runtime hangs before getting that far.
+   */
+  private static final Duration RUNTIME_BINDING_TIMEOUT = Duration.ofSeconds(60);
+
   private final Settings settings;
 
   private EventingTestKit.MessageBuilder messageBuilder;
@@ -997,8 +1002,13 @@ public class TestKit {
       runtimeActorSystem = AkkaRuntimeMain.start(Some.apply(runtimeConfig), runner);
       // wait for SDK to get on start callback (or fail starting), we need it to set up the
       // component client
-      final Sdk.StartupContext startupContext =
-          runner.started().toCompletableFuture().get(20, TimeUnit.SECONDS);
+      final Sdk.StartupContext startupContext;
+      try {
+        startupContext = runner.started().toCompletableFuture().get(20, TimeUnit.SECONDS);
+      } catch (TimeoutException e) {
+        throw new IllegalStateException(
+            "Timed out after 20 seconds waiting for the service components to start.", e);
+      }
       final ComponentClients componentClients = startupContext.componentClients();
       serializer = startupContext.serializer();
       dependencyProvider =
@@ -1013,57 +1023,40 @@ public class TestKit {
 
       startEventingTestkit();
 
-      Http http = Http.get(runtimeActorSystem);
-      log.info("Checking runtime status");
-      CompletionStage<String> checkingProxyStatus =
-          Patterns.retry(
-              () ->
-                  http.singleRequest(
-                          HttpRequest.GET(
-                              "http://"
-                                  + runtimeHost
-                                  + ":"
-                                  + runtimePort
-                                  + "/akka/dev-mode/health-check"))
-                      .thenCompose(
-                          response -> {
-                            int responseCode = response.status().intValue();
-                            if (responseCode == 404) {
-                              log.info("Runtime started");
-                              return CompletableFuture.completedStage("Ok");
-                            } else {
-                              log.info(
-                                  "Waiting for runtime, current response code is {}", responseCode);
-                              return CompletableFuture.failedFuture(
-                                  new IllegalStateException("Runtime not started."));
-                            }
-                          })
-                      .exceptionally(
-                          ex -> {
-                            log.error("Failed to connect to runtime:", ex);
-                            throw new IllegalStateException("Runtime not started.", ex);
-                          }),
-              10,
-              Duration.ofSeconds(1),
-              runtimeActorSystem);
-
+      // The runtime completes this with the address it bound, or fails it with the reason it could
+      // not.
+      // It can also stay pending, when the runtime hangs before it gets as far as binding, so the
+      // wait is
+      // bounded. This is the test's own thread, after start() returned, so awaiting here cannot
+      // deadlock
+      // the runtime's startup.
+      log.debug("Waiting for the runtime to bind its HTTP endpoint");
+      final InetSocketAddress boundAddress;
       try {
-        CompletableFuture.anyOf(
-                checkingProxyStatus.toCompletableFuture(),
-                runtimeActorSystem.getWhenTerminated().toCompletableFuture())
-            .get(60, TimeUnit.SECONDS);
+        boundAddress =
+            FutureConverters.asJava(startupContext.httpEndpointBound())
+                .toCompletableFuture()
+                .get(RUNTIME_BINDING_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
       } catch (ExecutionException e) {
-        RuntimeException cause = ErrorHandling.unwrapExecutionException(e);
-        log.error("Failed to connect to Runtime with:", cause);
-        throw cause;
-      } catch (InterruptedException | TimeoutException e) {
-        log.error("Failed to connect to Runtime with:", e);
-        throw new RuntimeException(e);
+        // the runtime's own failure, which already names the interface and the port
+        throw ErrorHandling.unwrapExecutionException(e);
+      } catch (TimeoutException e) {
+        throw new IllegalStateException(
+            "Timed out after "
+                + RUNTIME_BINDING_TIMEOUT.toSeconds()
+                + " seconds waiting for the runtime to bind its HTTP endpoint on port "
+                + runtimePort
+                + ".",
+            e);
       }
+      log.info("Runtime bound {}", boundAddress);
 
       // In case of failed validations in the runtime the ActorSystem will be terminated
       if (runtimeActorSystem.whenTerminated().isCompleted())
-        throw new IllegalStateException("Runtime was terminated.");
+        throw new IllegalStateException(
+            "Runtime bound "
+                + boundAddress
+                + " and was then terminated. The reason is in the runtime log above.");
 
       // once runtime is started
 

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -6,8 +6,10 @@ package akka.javasdk.testkit;
 
 import static akka.javasdk.testkit.TestKit.Settings.EventingSupport.TEST_BROKER;
 
+import akka.actor.ExtendedActorSystem;
 import akka.actor.typed.ActorSystem;
 import akka.grpc.javadsl.AkkaGrpcClient;
+import akka.http.javadsl.Http;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
 import akka.javasdk.DependencyProvider;
@@ -83,6 +85,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import kalix.runtime.AkkaRuntimeMain;
+import kalix.runtime.Serve;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -831,6 +834,11 @@ public class TestKit {
    */
   private static final Duration RUNTIME_BINDING_TIMEOUT = Duration.ofSeconds(60);
 
+  /**
+   * How long to wait for the runtime to answer the dev mode startup check on the address it bound.
+   */
+  private static final Duration RUNTIME_STARTED_TIMEOUT = Duration.ofSeconds(10);
+
   private final Settings settings;
 
   private EventingTestKit.MessageBuilder messageBuilder;
@@ -1051,6 +1059,8 @@ public class TestKit {
       }
       log.info("Runtime bound {}", boundAddress);
 
+      confirmRuntimeStarted(boundAddress);
+
       // In case of failed validations in the runtime the ActorSystem will be terminated
       if (runtimeActorSystem.whenTerminated().isCompleted())
         throw new IllegalStateException(
@@ -1089,6 +1099,71 @@ public class TestKit {
 
     } catch (Exception ex) {
       throw new RuntimeException("Error while starting testkit", ex);
+    }
+  }
+
+  /**
+   * Confirms that the runtime this testkit started is the one serving on the address it bound.
+   *
+   * <p>The binding tells us the socket is this runtime's, but not that the endpoint serves
+   * requests. The runtime's dev mode startup check answers affirmatively only when the ActorSystem
+   * uid in the request is its own, so a different runtime on the same address is reported as such
+   * instead of being mistaken for this one. The expected uid is read off the ActorSystem this
+   * testkit started, so nothing has to hand it out.
+   *
+   * <p>This is a startup confirmation only. It says nothing about the health of user components, so
+   * a slow component does not look like a startup failure.
+   */
+  private void confirmRuntimeStarted(InetSocketAddress boundAddress)
+      throws ExecutionException, InterruptedException {
+    long expectedUid = ((ExtendedActorSystem) runtimeActorSystem.classicSystem()).uid();
+    String url =
+        "http://"
+            + boundAddress.getHostString()
+            + ":"
+            + boundAddress.getPort()
+            + Serve.DevModeStartedPath()
+            + "?uid="
+            + expectedUid;
+
+    HttpResponse response;
+    String body;
+    try {
+      response =
+          Http.get(runtimeActorSystem)
+              .singleRequest(HttpRequest.GET(url))
+              .toCompletableFuture()
+              .get(RUNTIME_STARTED_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+      body =
+          response
+              .entity()
+              .toStrict(
+                  RUNTIME_STARTED_TIMEOUT.toMillis(),
+                  SystemMaterializer.get(runtimeActorSystem).materializer())
+              .toCompletableFuture()
+              .get(RUNTIME_STARTED_TIMEOUT.toSeconds(), TimeUnit.SECONDS)
+              .getData()
+              .utf8String();
+    } catch (TimeoutException e) {
+      throw new IllegalStateException(
+          "Timed out after "
+              + RUNTIME_STARTED_TIMEOUT.toSeconds()
+              + " seconds waiting for the runtime at "
+              + boundAddress
+              + " to answer the startup check.",
+          e);
+    }
+
+    if (response.status().intValue() != 200) {
+      throw new IllegalStateException(
+          "The runtime serving "
+              + boundAddress
+              + " is not the one this testkit started. Expected the runtime with ActorSystem uid ["
+              + expectedUid
+              + "], the startup check answered "
+              + response.status().intValue()
+              + ": "
+              + body);
     }
   }
 

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -1228,7 +1228,9 @@ public class TestKit {
       body =
           response
               .entity()
-              .toStrict(RUNTIME_STARTED_TIMEOUT.toMillis(), getMaterializer())
+              .toStrict(
+                  RUNTIME_STARTED_TIMEOUT.toMillis(),
+                  SystemMaterializer.get(runtimeActorSystem).materializer())
               .toCompletableFuture()
               .get(RUNTIME_STARTED_TIMEOUT.toSeconds(), TimeUnit.SECONDS)
               .getData()

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -269,13 +269,20 @@ public class TestKit {
             new HashMap<>(),
             new HashMap<>(),
             new HashMap<>(),
-            Collections.emptyList());
+            Collections.emptyList(),
+            false);
 
     /** The name of this service when deployed. */
     public final String serviceName;
 
     /** Whether ACL checking is enabled. */
     public final boolean aclEnabled;
+
+    /**
+     * Whether the runtime is asked for a port assigned by the operating system rather than the
+     * configured one. See {@link #withEphemeralPort()}.
+     */
+    public final boolean ephemeralPort;
 
     public final EventingSupport eventingSupport;
 
@@ -343,7 +350,8 @@ public class TestKit {
         Map<String, ModelProvider> modelProvidersByAgentId,
         Map<String, Function<HttpRequest, HttpResponse>> httpMocks,
         Map<String, Map<Class<? extends AkkaGrpcClient>, AkkaGrpcClient>> grpcMocks,
-        List<ObjectStorageBucketConfig> objectStorageBuckets) {
+        List<ObjectStorageBucketConfig> objectStorageBuckets,
+        boolean ephemeralPort) {
       this.serviceName = serviceName;
       this.aclEnabled = aclEnabled;
       this.eventingSupport = eventingSupport;
@@ -356,6 +364,7 @@ public class TestKit {
       this.httpMocks = httpMocks;
       this.grpcMocks = grpcMocks;
       this.objectStorageBuckets = objectStorageBuckets;
+      this.ephemeralPort = ephemeralPort;
     }
 
     /**
@@ -380,7 +389,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /**
@@ -401,7 +411,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /**
@@ -422,7 +433,46 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
+    }
+
+    /**
+     * Ask the operating system for a free port instead of using the configured {@code
+     * akka.javasdk.testkit.http-port}. Read the assigned port with {@link TestKit#getPort()}.
+     *
+     * <p>Use this when several test classes run in the same JVM: they otherwise take turns on one
+     * configured port, and a class fails to start while the previous runtime still holds it.
+     *
+     * <p>The service is reached on one port, whether the request is HTTP or gRPC, so this is the
+     * port for both.
+     *
+     * <p>The assigned port cannot be named in configuration, because a {@code
+     * ${akka.javasdk.testkit.http-port}} interpolation is resolved when the config is loaded, long
+     * before a port is assigned. Under this setting that key reads {@code 0}, so a client
+     * configured that way fails rather than reaching some other service. The entry the testkit
+     * writes for calling the service under test over gRPC is set from the assigned port and works
+     * either way.
+     *
+     * <p>Setting {@code akka.javasdk.testkit.http-port = 0} does the same thing.
+     *
+     * @return The updated settings.
+     */
+    public Settings withEphemeralPort() {
+      return new Settings(
+          serviceName,
+          aclEnabled,
+          eventingSupport,
+          mockedEventing,
+          dependencyProvider,
+          additionalConfig,
+          disabledComponents,
+          overrideDisabledComponents,
+          modelProvidersByAgentId,
+          httpMocks,
+          grpcMocks,
+          objectStorageBuckets,
+          true);
     }
 
     /** Mock the incoming messages flow from a KeyValueEntity. */
@@ -441,7 +491,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /** Mock the incoming events flow from an EventSourcedEntity. */
@@ -460,7 +511,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /** Mock the incoming state updates flow from a Workflow. */
@@ -478,7 +530,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /**
@@ -497,7 +550,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /** Mock the incoming events flow from a Topic. */
@@ -514,7 +568,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /** Mock the outgoing events flow for a Topic. */
@@ -531,7 +586,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /**
@@ -551,7 +607,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     public Settings withEventingSupport(EventingSupport eventingSupport) {
@@ -567,7 +624,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /**
@@ -587,7 +645,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /**
@@ -615,7 +674,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /**
@@ -635,7 +695,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /**
@@ -656,7 +717,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /**
@@ -679,7 +741,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /**
@@ -702,7 +765,8 @@ public class TestKit {
           newModelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /**
@@ -737,7 +801,8 @@ public class TestKit {
           modelProvidersByAgentId,
           newHttpMocks,
           grpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     /**
@@ -762,7 +827,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           grpcMocks,
-          newBuckets);
+          newBuckets,
+          ephemeralPort);
     }
 
     /**
@@ -804,7 +870,8 @@ public class TestKit {
           modelProvidersByAgentId,
           httpMocks,
           newGrpcMocks,
-          objectStorageBuckets);
+          objectStorageBuckets,
+          ephemeralPort);
     }
 
     @Override
@@ -845,6 +912,7 @@ public class TestKit {
   private boolean started = false;
   private String runtimeHost;
   private int runtimePort;
+  private boolean ephemeralPort;
   private EventingTestKit eventingTestKit;
   private ActorSystem<?> runtimeActorSystem;
   private ComponentClient componentClient;
@@ -938,6 +1006,12 @@ public class TestKit {
             public Config applicationConfig() {
               var userConfig = config.withFallback(super.applicationConfig());
               runtimePort = userConfig.getInt("akka.javasdk.testkit.http-port");
+              // 0 in configuration asks for the same thing as the setting
+              ephemeralPort = settings.ephemeralPort || runtimePort == 0;
+              // There is no port to point the self client at yet, and 0 is a port no client can
+              // reach, so one built from it fails instead of finding some other service. The real
+              // port is written to this entry once the runtime has bound it.
+              if (ephemeralPort) runtimePort = 0;
 
               if (settings.serviceName.isEmpty())
                 serviceName = userConfig.getString("akka.javasdk.dev-mode.service-name");
@@ -998,7 +1072,8 @@ public class TestKit {
                       new SpiTestSettings(true, true),
                       Some.apply(serviceName),
                       SpiBackofficeSettings$.MODULE$.empty(),
-                      spiObjectStorageBuckets);
+                      spiObjectStorageBuckets,
+                      /* ephemeralHttpPort */ ephemeralPort);
 
               return s.withDevMode(devModeSettings);
             }
@@ -1029,15 +1104,11 @@ public class TestKit {
                   .overrideModelProvider()
                   .setModelProviderForAgent(agentId, modelProvider));
 
-      startEventingTestkit();
-
-      // The runtime completes this with the address it bound, or fails it with the reason it could
-      // not.
-      // It can also stay pending, when the runtime hangs before it gets as far as binding, so the
-      // wait is
-      // bounded. This is the test's own thread, after start() returned, so awaiting here cannot
-      // deadlock
-      // the runtime's startup.
+      // The runtime completes this with the address it bound, or fails it with the reason it
+      // could not. It can also stay pending, when the runtime hangs before it gets as far as
+      // either, so the wait is bounded. This runs on the thread that called start(), after the
+      // runtime's own startup chain has returned, where awaiting cannot deadlock it.
+      final int configuredPort = runtimePort;
       log.debug("Waiting for the runtime to bind its HTTP endpoint");
       final InetSocketAddress boundAddress;
       try {
@@ -1053,10 +1124,21 @@ public class TestKit {
             "Timed out after "
                 + RUNTIME_BINDING_TIMEOUT.toSeconds()
                 + " seconds waiting for the runtime to bind its HTTP endpoint on port "
-                + runtimePort
+                + configuredPort
                 + ".",
             e);
       }
+
+      // A configured port is used as configured. An operating system assigned one becomes a real
+      // number only here. Everything that reads runtimePort runs after this.
+      runtimePort = boundAddress.getPort();
+      if (!ephemeralPort && configuredPort != runtimePort)
+        throw new IllegalStateException(
+            "Runtime was configured with port "
+                + configuredPort
+                + " but bound "
+                + boundAddress
+                + ". A configured port is always used as configured, so this should not happen.");
       log.info("Runtime bound {}", boundAddress);
 
       confirmRuntimeStarted(boundAddress);
@@ -1069,6 +1151,8 @@ public class TestKit {
                 + " and was then terminated. The reason is in the runtime log above.");
 
       // once runtime is started
+
+      startEventingTestkit();
 
       // The runtime surfaces the in-memory tracing exporter (when the test tracing setup is active)
       // through the SPI StartupContext, so the testkit reads captured spans without referencing
@@ -1094,6 +1178,12 @@ public class TestKit {
               runtimeActorSystem.executionContext());
       httpClientProvider = startupContext.httpClientProvider();
       grpcClientProvider = startupContext.grpcClientProvider();
+      // The entry written in applicationConfig() above could not carry the port when the configured
+      // port was
+      // 0. gRPC clients are created lazily, so setting it here, before any test can ask for one, is
+      // in time.
+      // Applied unconditionally: with a configured port the value is the same one.
+      grpcClientProvider.overrideClientConfigFor(serviceName, runtimeHost, runtimePort, false);
       timerScheduler = new TimerSchedulerImpl(componentClients.timerClient(), Metadata.EMPTY);
       this.messageBuilder = new EventingTestKit.MessageBuilder(serializer);
 
@@ -1178,7 +1268,19 @@ public class TestKit {
     return runtimeHost;
   }
 
-  /** Get the local port where the service is available. */
+  /**
+   * Get the local port where the service is available, for HTTP and gRPC alike.
+   *
+   * <p>This is the port from {@code akka.javasdk.testkit.http-port}, which is used exactly as
+   * configured, unless the operating system was asked to assign one with {@link
+   * Settings#withEphemeralPort()}, in which case this is the assigned port.
+   *
+   * <p>An assigned port cannot be named in configuration: a hand written entry that interpolates
+   * {@code ${akka.javasdk.testkit.http-port}} resolves to {@code 0}, because HOCON resolves it when
+   * the config is loaded, long before a port is assigned. This method is the only way to learn it.
+   * The entry the testkit writes for calling the service under test over gRPC is set from the
+   * assigned port and works either way.
+   */
   public int getPort() {
     if (!started)
       throw new IllegalStateException("Need to start the testkit before accessing the port");

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -1074,7 +1074,7 @@ public class TestKit {
                       Some.apply(serviceName),
                       SpiBackofficeSettings$.MODULE$.empty(),
                       spiObjectStorageBuckets,
-                      /* ephemeralHttpPort */ ephemeralPort);
+                      ephemeralPort);
 
               return s.withDevMode(devModeSettings);
             }
@@ -1230,7 +1230,7 @@ public class TestKit {
               .entity()
               .toStrict(
                   RUNTIME_STARTED_TIMEOUT.toMillis(),
-                  SystemMaterializer.get(runtimeActorSystem).materializer())
+                  getMaterializer())
               .toCompletableFuture()
               .get(RUNTIME_STARTED_TIMEOUT.toSeconds(), TimeUnit.SECONDS)
               .getData()

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/TestKitPortTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/TestKitPortTest.java
@@ -79,7 +79,6 @@ public class TestKitPortTest {
     TestKit testKit = new TestKit(TestKit.Settings.DEFAULT.withEphemeralPort()).start();
     try {
       assertAssignedPort(testKit);
-      System.out.println("Ephemeral testkit port: " + testKit.getPort());
 
       // requests reach the assigned port
       assertThat(statusOf(testKit, "/query/one?a=a&b=1&c=-1")).isEqualTo(200);

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/TestKitPortTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/TestKitPortTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2021-2026 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akkajavasdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import akka.actor.ExtendedActorSystem;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.javasdk.testkit.TestKit;
+import akkajavasdk.protocol.TestGrpcServiceClient;
+import akkajavasdk.protocol.TestGrpcServiceOuterClass;
+import com.typesafe.config.ConfigFactory;
+import java.io.IOException;
+import java.net.BindException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import kalix.runtime.Serve;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * The testkit binds the port it was configured with, or fails saying why. Every other test class in
+ * this JVM binds the same configured port in turn, so these tests start their own testkits rather
+ * than extending TestKitSupport, and wait for the port to be free before starting.
+ */
+@ExtendWith(Junit5LogCapturing.class)
+public class TestKitPortTest {
+
+  private static final String INTERFACE = "127.0.0.1";
+
+  private static final int CONFIGURED_PORT =
+      ConfigFactory.load().getInt("akka.javasdk.testkit.http-port");
+
+  @Test
+  public void shouldUseTheConfiguredPort() {
+    awaitPortFree(CONFIGURED_PORT);
+    TestKit testKit = new TestKit(TestKit.Settings.DEFAULT).start();
+    try {
+      assertThat(testKit.getPort()).isEqualTo(CONFIGURED_PORT);
+      // and the port it reports is the one serving
+      assertThat(statusOf(testKit, "/query/one?a=a&b=1&c=-1")).isEqualTo(200);
+    } finally {
+      testKit.stop();
+    }
+  }
+
+  @Test
+  @Timeout(value = 2, unit = TimeUnit.MINUTES)
+  public void shouldFailWhenTheConfiguredPortIsTaken() throws IOException {
+    awaitPortFree(CONFIGURED_PORT);
+    try (ServerSocket squatter = boundSocket(CONFIGURED_PORT)) {
+      assertThat(squatter.isBound()).isTrue();
+
+      TestKit testKit = new TestKit(TestKit.Settings.DEFAULT);
+      Throwable thrown = catchThrowable(testKit::start);
+
+      // it fails rather than blocking on a port it never got
+      assertThat(thrown).isNotNull();
+      String reason = allMessages(thrown);
+      assertThat(reason).contains(INTERFACE).contains(String.valueOf(CONFIGURED_PORT));
+      // and the reason is the runtime's own bind failure, not a timeout waiting for one
+      assertThat(causeChain(thrown)).hasAtLeastOneElementOfType(BindException.class);
+    }
+  }
+
+  @Test
+  public void shouldAssignAnEphemeralPortWhenAskedFor() {
+    TestKit testKit = new TestKit(TestKit.Settings.DEFAULT.withEphemeralPort()).start();
+    try {
+      assertAssignedPort(testKit);
+      System.out.println("Ephemeral testkit port: " + testKit.getPort());
+
+      // requests reach the assigned port
+      assertThat(statusOf(testKit, "/query/one?a=a&b=1&c=-1")).isEqualTo(200);
+
+      // and the gRPC client entry the testkit writes carries the assigned port. The entries written
+      // by hand in application.conf cannot, so delegateToAkkaService and delegateToExternal are not
+      // called here.
+      var client = testKit.getGrpcEndpointClient(TestGrpcServiceClient.class);
+      var request = TestGrpcServiceOuterClass.In.newBuilder().setData("Hello world").build();
+      assertThat(client.simple(request).getData()).isEqualTo("Hello world");
+    } finally {
+      testKit.stop();
+    }
+  }
+
+  @Test
+  public void shouldTreatAConfiguredZeroAsAskingForOne() {
+    TestKit testKit =
+        new TestKit(
+                TestKit.Settings.DEFAULT.withAdditionalConfig("akka.javasdk.testkit.http-port = 0"))
+            .start();
+    try {
+      assertAssignedPort(testKit);
+      assertThat(statusOf(testKit, "/query/one?a=a&b=1&c=-1")).isEqualTo(200);
+    } finally {
+      testKit.stop();
+    }
+  }
+
+  private static void assertAssignedPort(TestKit testKit) {
+    assertThat(testKit.getPort()).isNotZero();
+    assertThat(testKit.getPort()).isNotEqualTo(CONFIGURED_PORT);
+    // the runtime reads a dev mode port of 0 as "not configured" and falls back to a fixed port,
+    // which would collide the same way an assigned port is asked for to avoid
+    assertThat(testKit.getPort())
+        .isNotEqualTo(ConfigFactory.defaultReference().getInt("akka.runtime.http-port"));
+  }
+
+  @Test
+  public void shouldRejectAnotherRuntimesUid() {
+    awaitPortFree(CONFIGURED_PORT);
+    TestKit testKit = new TestKit(TestKit.Settings.DEFAULT).start();
+    try {
+      long selfUid = ((ExtendedActorSystem) testKit.getActorSystem().classicSystem()).uid();
+
+      // this runtime confirms its own uid
+      assertThat(statusOf(testKit, Serve.DevModeStartedPath() + "?uid=" + selfUid)).isEqualTo(200);
+
+      // and does not confirm another runtime's
+      assertThat(statusOf(testKit, Serve.DevModeStartedPath() + "?uid=" + (selfUid + 1)))
+          .isNotEqualTo(200);
+    } finally {
+      testKit.stop();
+    }
+  }
+
+  private static int statusOf(TestKit testKit, String path) {
+    String url = "http://" + INTERFACE + ":" + testKit.getPort() + path;
+    HttpResponse response =
+        Http.get(testKit.getActorSystem())
+            .singleRequest(HttpRequest.GET(url))
+            .toCompletableFuture()
+            .join();
+    response.discardEntityBytes(testKit.getMaterializer());
+    return response.status().intValue();
+  }
+
+  private static ServerSocket boundSocket(int port) throws IOException {
+    ServerSocket socket = new ServerSocket();
+    socket.setReuseAddress(true);
+    socket.bind(new InetSocketAddress(INTERFACE, port));
+    return socket;
+  }
+
+  /** Other test classes in this JVM hold the same port, so wait for the previous one to let go. */
+  private static void awaitPortFree(int port) {
+    Awaitility.await("port " + port + " to be free")
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofMillis(200))
+        .until(() -> isFree(port));
+  }
+
+  private static boolean isFree(int port) {
+    try (ServerSocket ignored = boundSocket(port)) {
+      return true;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  private static List<Throwable> causeChain(Throwable thrown) {
+    List<Throwable> chain = new ArrayList<>();
+    for (Throwable t = thrown; t != null && !chain.contains(t); t = t.getCause()) {
+      chain.add(t);
+    }
+    return chain;
+  }
+
+  private static String allMessages(Throwable thrown) {
+    StringBuilder messages = new StringBuilder();
+    for (Throwable t : causeChain(thrown)) {
+      messages.append(t).append('\n');
+    }
+    return messages.toString();
+  }
+}

--- a/akka-javasdk/src/main/resources/reference.conf
+++ b/akka-javasdk/src/main/resources/reference.conf
@@ -122,7 +122,13 @@ akka.javasdk {
   }
 
   testkit {
-    # The port used by the testkit when running integration tests
+    # The port used by the testkit when running integration tests, for HTTP and gRPC alike. It is
+    # used exactly as configured, and startup fails right away if it is already in use.
+    #
+    # Set it to 0, or use TestKit.Settings.withEphemeralPort(), to have the operating system
+    # assign a free port instead. Read the assigned port with TestKit.getPort(): a config entry
+    # that interpolates ${akka.javasdk.testkit.http-port} resolves to 0, because that is resolved
+    # when the config is loaded, before a port is assigned.
     http-port = 39390
   }
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -7,6 +7,7 @@ package akka.javasdk.impl
 import java.lang.reflect.Constructor
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
+import java.net.InetSocketAddress
 import java.time.Instant
 import java.util
 import java.util.Locale
@@ -396,7 +397,8 @@ class SdkRunner private (
         startContext.sanitizer,
         httpMockLookup,
         grpcMockLookup,
-        startContext.inMemorySpanExporter)
+        startContext.inMemorySpanExporter,
+        startContext.httpEndpointBound)
       Future.successful(app.spiComponents)
     } catch {
       case NonFatal(ex) =>
@@ -447,7 +449,11 @@ private[javasdk] object Sdk {
       overrideModelProvider: OverrideModelProvider,
       serializer: Serializer,
       sanitizer: Sanitizer,
-      inMemorySpanExporter: Option[InMemorySpanExporter])
+      inMemorySpanExporter: Option[InMemorySpanExporter],
+      // Completed by the runtime with the address its HTTP endpoint was bound to, see StartContext. Carried
+      // here for the testkit, which awaits it from the thread that started the testkit. Nothing in the SDK
+      // awaits it, because the runtime binds the endpoint only after preStart has returned.
+      httpEndpointBound: Future[InetSocketAddress])
 
   private val platformManagedDependency = Set[Class[_]](
     classOf[ComponentClient],
@@ -500,7 +506,8 @@ private final class Sdk(
     httpMockLookup: String => Option[
       java.util.function.Function[akka.http.javadsl.model.HttpRequest, akka.http.javadsl.model.HttpResponse]],
     grpcMockLookup: GrpcClientProviderImpl.ClientKey => Option[AkkaGrpcClient],
-    inMemorySpanExporter: Option[InMemorySpanExporter]) {
+    inMemorySpanExporter: Option[InMemorySpanExporter],
+    httpEndpointBound: Future[InetSocketAddress]) {
 
   import Sdk._
 
@@ -1184,7 +1191,8 @@ private final class Sdk(
               overrideModelProvider,
               serializer,
               sanitizer,
-              inMemorySpanExporter))
+              inMemorySpanExporter,
+              httpEndpointBound))
           Future.successful(Done)
         case Some(setup) =>
           if (dependencyProviderOpt.nonEmpty) {
@@ -1222,7 +1230,8 @@ private final class Sdk(
               overrideModelProvider,
               serializer,
               sanitizer,
-              inMemorySpanExporter))
+              inMemorySpanExporter,
+              httpEndpointBound))
           Future.successful(Done)
       }
     }

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/SdkRunner.scala
@@ -213,6 +213,7 @@ object SdkRunner {
             selfServiceName = None,
             backoffice = backofficeSettings,
             objectStorageBuckets = objectStorageBuckets,
+            // running locally binds the configured port; only the testkit asks for an assigned one
             ephemeralHttpPort = false))
       } else None
 

--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/grpc/GrpcClientProviderImpl.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/grpc/GrpcClientProviderImpl.scala
@@ -29,6 +29,7 @@ import akka.javasdk.impl.grpc.GrpcClientProviderImpl.AuthHeaders
 import akka.runtime.sdk.spi.SpiBackofficeServiceSettings
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigUtil
 import io.grpc.CallCredentials
 import io.grpc.Metadata
 import io.grpc.Status
@@ -102,7 +103,28 @@ private[akka] final class GrpcClientProviderImpl(
 
   private val clients = new ConcurrentHashMap[ClientKey, AkkaGrpcClient]()
 
-  private val clientConfig = userServiceConfig.getConfig("akka.javasdk.grpc.client")
+  // A var because of overrideClientConfigFor, which is the only thing that ever replaces it.
+  @volatile private var clientConfig = userServiceConfig.getConfig("akka.javasdk.grpc.client")
+
+  /**
+   * INTERNAL API: Override the host, port and use-tls of the `akka.javasdk.grpc.client` entry for one service.
+   *
+   * For the testkit, which points a client back at the service under test but only learns the port once the runtime has
+   * bound it. Clients are created lazily, so an entry set before the first lookup for that service is the one used.
+   */
+  @InternalApi
+  private[akka] def overrideClientConfigFor(serviceName: String, host: String, port: Int, useTls: Boolean): Unit = {
+    val quotedServiceName = ConfigUtil.quoteString(serviceName)
+    val quotedHost = ConfigUtil.quoteString(host)
+    val entry = ConfigFactory.parseString(s"""
+        $quotedServiceName {
+          host = $quotedHost
+          port = $port
+          use-tls = $useTls
+        }
+        """)
+    clientConfig = entry.withFallback(clientConfig)
+  }
 
   CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseServiceStop, "stop-grpc-clients")(() =>
     Future

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,7 +71,6 @@ object Dependencies {
       jacksonAnnotations,
       jacksonCore,
       jacksonDatabind,
-      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % JacksonVersion,
       jacksonJdk8,
       jacksonJsr310,
       jacksonParameterNames,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val ProtocolVersionMinor = 1
   }
 
-  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.16")
+  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.15-28-e9b89c8e-SNAPSHOT")
 
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned
@@ -71,6 +71,7 @@ object Dependencies {
       jacksonAnnotations,
       jacksonCore,
       jacksonDatabind,
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % JacksonVersion,
       jacksonJdk8,
       jacksonJsr310,
       jacksonParameterNames,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val ProtocolVersionMinor = 1
   }
 
-  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.15-28-e9b89c8e-SNAPSHOT")
+  val AkkaRuntimeVersion = sys.props.getOrElse("akka-runtime.version", "1.6.16")
 
   // NOTE: embedded SDK should have the AkkaVersion aligned, when updating RuntimeVersion, make sure to check
   // if AkkaVersion and AkkaHttpVersion are aligned


### PR DESCRIPTION
Requires runtime https://github.com/lightbend/akka-runtime/pull/5595
and should probably go in after https://github.com/akka/akka-sdk/pull/1767