### PR TITLE
docs: Mermaid extension for Antora

### DIFF
--- a/docs/antora-docker/Dockerfile
+++ b/docs/antora-docker/Dockerfile
@@ -5,6 +5,7 @@ RUN npm install -g @antora/lunr-extension
 RUN npm install -g @antora/site-generator
 RUN npm install -g asciidoc-link-check
 RUN npm install -g @asciidoctor/tabs@1.0.0-beta.6
+RUN npm install -g @sntke/antora-mermaid-extension@0.0.13
 
 ENV NODE_PATH=/usr/local/lib/node_modules
 

--- a/docs/antora-playbook-local.yml
+++ b/docs/antora-playbook-local.yml
@@ -37,6 +37,7 @@ asciidoc:
 antora:
   extensions:
   - require: '@antora/lunr-extension'
+  - require: '@sntke/antora-mermaid-extension'
 
 output:
   destinations:

--- a/docs/antora-playbook-prod.yml
+++ b/docs/antora-playbook-prod.yml
@@ -36,6 +36,7 @@ asciidoc:
 antora:
   extensions:
   - require: '@antora/lunr-extension'
+  - require: '@sntke/antora-mermaid-extension'
 
 output:
   destinations:

--- a/docs/src/modules/reference/pages/specify/exit-condition-states.adoc
+++ b/docs/src/modules/reference/pages/specify/exit-condition-states.adoc
@@ -77,7 +77,7 @@ Transitions are triggered by named events. Nothing else moves the state.
 
 Rendered as a state diagram:
 
-[source,mermaid]
+[mermaid]
 ----
 stateDiagram-v2
     [*] --> open: activate


### PR DESCRIPTION
Add the Mermaid extension to Antora so it can render Mermaid blocks in the documentation.

<img width="658" height="411" alt="image" src="https://github.com/user-attachments/assets/57a8a07c-ee6b-4231-88c9-8760a78a1c6a" />


<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Fixes
- https://github.com/akka/akka-sdk/issues/1804