### PR TITLE
docs-publish: handle merge-commit PRs and don't die on cleanup

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -71,10 +71,23 @@ jobs:
             SHA=$(jq -r '.mergeCommit.oid' <<<"$ROW")
             TITLE=$(jq -r '.title'         <<<"$ROW")
             git fetch --no-tags origin "$SHA"
-            if git cherry-pick -x "$SHA"; then
+            # True merge commits (>1 parent) need `-m 1` to pick the mainline
+            # diff. `rev-list --parents -n 1` prints "<sha> <parent>..."; a
+            # merge commit yields 3+ tokens.
+            PARENTS=$(git rev-list --parents -n 1 "$SHA" | wc -w)
+            if [[ "$PARENTS" -gt 2 ]]; then
+              M_OPT=(-m 1)
+            else
+              M_OPT=()
+            fi
+            if git cherry-pick -x "${M_OPT[@]}" "$SHA"; then
               printf '#%s %s %s\n' "$NUM" "$SHA" "$TITLE" >> picked.txt
             else
-              git cherry-pick --abort
+              # If the pick failed before entering the sequenced state (e.g.
+              # bad args), `--abort` exits non-zero and would kill the step
+              # under `bash -eo pipefail`. Swallow that and hard-reset.
+              git cherry-pick --abort 2>/dev/null || true
+              git reset --hard HEAD
               printf '#%s %s %s\n' "$NUM" "$SHA" "$TITLE" >> skipped.txt
               gh pr comment "$NUM" --body \
                 "Automatic cherry-pick to \`docs-current\` failed for \`$SHA\` (run ${{ github.run_id }}). Skipped — resolve manually or re-label after fixing."


### PR DESCRIPTION
## Summary

Two fixes to `.github/workflows/docs-publish.yml`, both surfaced by a run against merged PRs on `main`:

- **Merge commits refused.** A PR merged with a true merge commit (2+ parents) fails `git cherry-pick` with `commit ... is a merge but no -m option was given`. Detect parent count via `git rev-list --parents -n 1` and pass `-m 1` in that case so the mainline diff is picked.
- **Cleanup killed the loop.** When the pick fails *before* entering the sequenced state, `git cherry-pick --abort` exits non-zero, which under Actions' default `bash -eo pipefail` killed the whole step — so subsequent candidates were never attempted. Swallow the `--abort` error and hard-reset instead.

## Test plan

- [ ] Re-label the same PRs that failed the previous run and dispatch the workflow; verify the merge-committed PR is picked with `-m 1` and the batch PR is opened with all candidates.
- [ ] Trigger a real cherry-pick conflict; verify that PR is skipped with a comment and the loop continues.