### PR TITLE
fix: don't close the JVM-wide shared JarFile in ComponentLocator

### DIFF
--- a/akka-javasdk/src/main/scala/akka/javasdk/impl/ComponentLocator.scala
+++ b/akka-javasdk/src/main/scala/akka/javasdk/impl/ComponentLocator.scala
@@ -10,7 +10,6 @@ import java.net.URI
 
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
-import scala.util.Using
 
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
@@ -114,9 +113,16 @@ private[javasdk] object ComponentLocator {
           }
 
         case "jar" =>
-          // Inside a JAR file
+          // Inside a JAR file. When useCaches is true (the default), getJarFile() returns the
+          // JVM-wide instance owned by JarURLConnection's JarFileFactory, shared by every reader
+          // of that jar in the process - it must not be closed here, or every other reader
+          // breaks concurrently (e.g. akka.util.ManifestInfo, which re-reads every classpath
+          // jar's manifest on each ActorSystem start). With caching off, getJarFile() instead
+          // opens a fresh JarFile that only we hold, so closing it is our responsibility - not
+          // closing it there would leak a file handle every call.
           val jarConnection = metaInfUrl.openConnection().asInstanceOf[JarURLConnection]
-          Using(jarConnection.getJarFile) { jarFile =>
+          val jarFile = jarConnection.getJarFile
+          try {
             val entries = jarFile.entries().asScala
             entries
               .filter(e =>
@@ -126,8 +132,8 @@ private[javasdk] object ComponentLocator {
                 logger.debug("Found descriptor file in JAR: [{}]", url)
                 descriptorUrls += url
               }
-          }.recover { case ex =>
-            logger.warn("Failed to read JAR file for META-INF scanning: [{}]", ex.getMessage)
+          } finally {
+            if (!jarConnection.getUseCaches) jarFile.close()
           }
 
         case protocol =>

--- a/akka-javasdk/src/test/scala/akka/javasdk/impl/ComponentLocatorSpec.scala
+++ b/akka-javasdk/src/test/scala/akka/javasdk/impl/ComponentLocatorSpec.scala
@@ -4,6 +4,8 @@
 
 package akka.javasdk.impl
 
+import java.net.JarURLConnection
+
 import scala.jdk.CollectionConverters._
 
 import akka.javasdk.impl.ComponentLocator._
@@ -233,6 +235,35 @@ class ComponentLocatorSpec extends AnyWordSpec with Matchers {
       val result = ComponentLocator.mergeDescriptorConfigs(Seq(config1, config2))
 
       result.hasPath(DescriptorServiceSetupEntryPath) shouldBe false
+    }
+  }
+
+  "ComponentLocator.findAllDescriptorFiles" should {
+
+    // Regression test for a shared-JarFile-cache bug: getJarFile() on a JarURLConnection
+    // returns the JVM-wide cached instance (JarFileFactory) when useCaches is true (the
+    // default), so it's shared by every reader of that jar in the process - including
+    // another caller that already holds a reference to it, e.g. akka.util.ManifestInfo,
+    // which reads every classpath jar's manifest on each ActorSystem start. A naive
+    // `Using(jarConnection.getJarFile) { ... }` closes that shared instance, breaking
+    // anyone else still holding it - reproduced deterministically below without relying
+    // on thread-scheduling luck: grab a JarFile handle up front (standing in for a
+    // concurrent holder), run the scan, then confirm the handle obtained beforehand is
+    // still usable afterwards.
+    "not break a JarFile handle obtained by another caller before the scan runs" in {
+      val classLoader = getClass.getClassLoader
+      val jarMetaInfUrl = classLoader.getResources("META-INF/").asScala.find(_.getProtocol == "jar").getOrElse {
+        fail("test classpath has no jar-protocol META-INF resource to exercise the cache with")
+      }
+
+      // Stand-in for a concurrent reader (e.g. ManifestInfo) that already obtained the
+      // cached JarFile before ComponentLocator's scan runs.
+      val priorHandle = jarMetaInfUrl.openConnection().asInstanceOf[JarURLConnection].getJarFile
+
+      ComponentLocator.findAllDescriptorFiles(classLoader)
+
+      // Must not throw java.lang.IllegalStateException: zip file closed.
+      priorHandle.entries().asScala.size should be > 0
     }
   }
 


### PR DESCRIPTION
## Context

Found while trying to run TestKit-based integration tests in parallel in a single JVM (multiple `ActorSystem`/testkit starts concurrently). The symptom was `akka.util.ManifestInfo` throwing:

```
IllegalStateException: zip file closed
  at java.util.zip.ZipFile.ensureOpen
  at sun.net.www.protocol.jar.JarURLConnection.connect
  at akka.util.ManifestInfo.liftedTree1$1(ManifestInfo.scala:118)
```

`ManifestInfo` is the victim, not the cause — the actual bug is in `ComponentLocator.findAllDescriptorFiles`.

## Root cause

`metaInfUrl.openConnection()` leaves `useCaches` at its JDK default of `true`, so `JarURLConnection.getJarFile()` returns the instance owned by the JVM-wide `JarFileFactory` cache — shared by every reader of that jar in the process (including `ManifestInfo`, which re-reads every classpath jar's manifest on each `ActorSystem` start). The previous `Using(jarConnection.getJarFile) { ... }` block closed that shared instance after each scan, breaking any other concurrent reader still holding it.

Profiling one module's parallel test suite (15 test classes, each starting a testkit) showed ~225 `ZipFile.close()` calls per `Sdk` init — one per classpath jar, every start — all originating from `ComponentLocator.findAllDescriptorFiles`.

## Fix

- Only close the `JarFile` when `useCaches` is `false`: in that case `getJarFile()` opens a fresh, non-shared instance we exclusively own, so not closing it would leak a file handle per call. When caching is on (the default), leave the shared instance alone and let `JarFileFactory` own its lifecycle.
- Drop the `.recover`-and-warn on jar read failure: a lost race here previously produced an incomplete, silently-wrong component list rather than a failure.

## Testing

Added a deterministic regression test in `ComponentLocatorSpec` that grabs a `JarFile` handle before the scan runs (standing in for a concurrent holder like `ManifestInfo`), then confirms it's still usable afterwards. Verified it fails with the pre-fix code (`IllegalStateException: zip file closed`) and passes with the fix.

True concurrent-thread reproduction turned out to be unreliable as a unit test — the JDK's `JarFileFactory` self-heals on the next fresh `getJarFile()` call, and the operations are fast enough that the interleaving window is rarely hit in a tight loop — so the deterministic reproduction is more useful as a regression guard.