### PR TITLE
doc: network policies

### DIFF
--- a/docs/src/modules/operations/nav.adoc
+++ b/docs/src/modules/operations/nav.adoc
@@ -24,6 +24,7 @@
 ****** xref:operations:projects/broker-azure-eventhubs.adoc[Azure Event Hubs]
 ***** xref:operations:projects/secrets.adoc[]
 ***** xref:operations:projects/external-secrets.adoc[]
+***** xref:operations:projects/network-policies.adoc[]
 
 **** xref:operations:services/index.adoc[]
 ***** xref:operations:services/deploy-service.adoc[]

--- a/docs/src/modules/operations/pages/projects/index.adoc
+++ b/docs/src/modules/operations/pages/projects/index.adoc
@@ -25,3 +25,4 @@ Akka services are deployed to _Projects_ within an xref:operations:organizations
 **** xref:operations:projects/broker-kafka.adoc[Self-hosted Kafka]
 **** xref:operations:projects/broker-azure-eventhubs.adoc[Azure Event Hubs]
 *** xref:operations:projects/secrets.adoc[]
+*** xref:operations:projects/network-policies.adoc[]

--- a/docs/src/modules/operations/pages/projects/network-policies.adoc
+++ b/docs/src/modules/operations/pages/projects/network-policies.adoc
@@ -1,0 +1,175 @@
+= Manage network policies
+include::ROOT:partial$include.adoc[]
+
+A network policy controls, at the network level, what ingress and egress traffic is allowed to and from the services in an Akka project. Every project has exactly one network policy, named `default`. It cannot be created or deleted, only configured, using the `akka projects network-policy` command (alias `akka projects netpol`).
+
+Traffic between services in the same project, and traffic required by Akka platform infrastructure, is always allowed regardless of this configuration. A network policy only needs to be configured when a service in your project needs to talk to, or be talked to by, something outside the project: a service in another project, or a destination or source reachable by IP address, such as a database or third party API.
+
+[IMPORTANT]
+====
+**Network policies do not override ACLs.** A network policy controls connectivity at the network layer: whether a peer can open a connection to a service at all. xref:sdk:access-control.adoc[Access Control Lists (ACLs)] control, once a connection is allowed, which principals can invoke which service methods. Both must permit a request for it to succeed — opening up a network policy does not grant any access that an ACL still denies.
+
+**Ingress rules only apply to Akka's private network.** They match traffic from a service in another project, or from a CIDR range reachable within that network. They have no effect on traffic reaching your services through a route exposed to the internet — that traffic is always allowed at the network level, and access to it is controlled instead by xref:services/invoke-service.adoc[routes] and by ACLs using the internet principal.
+====
+
+== Viewing the network policy
+
+To see the current network policy configuration for your project:
+
+[source, command line]
+----
+akka projects network-policy get
+----
+
+If no rules have been configured, the output looks like this:
+
+[source, text]
+----
+Akka Network Policy Configuration
+=================================
+
+Ingress Rules: (none)
+
+Egress Rules: (none)
+----
+
+With this default configuration, no traffic beyond same-project and infrastructure traffic is allowed in or out. Once rules have been added, they are listed with a 1-based index that you use to refer to them when removing a rule:
+
+[source, text]
+----
+Akka Network Policy Configuration
+=================================
+
+Ingress Rules:
+  [1]
+    Ports:
+      akka-service/TCP
+    From:
+      Service: order-service (project: 3f29b6d8-9c34-4a1a-8f77-2b6e9d9a5b21)
+
+Egress Rules:
+  [1]
+    Ports:
+      443/TCP
+    To:
+      CIDR: 0.0.0.0/0
+----
+
+If your project spans multiple regions, `akka projects network-policy get` shows the primary region's configuration by default. Pass `--region` to view a specific region, or `--all-regions` to view every region. See xref:regions/setup.adoc#multi-region-resources[Managing resources in a multi region project] for background on how resources like this one are synced across regions.
+
+== Adding rules
+
+Rules are added one at a time with `akka projects network-policy add ingress-rule` and `akka projects network-policy add egress-rule`. Each command accepts repeatable `--port` flags and a repeatable peer flag (`--from` for ingress, `--to` for egress). Within a single rule, ports are combined with a logical OR, and peers are combined with a logical OR; a rule matches traffic that satisfies both a port and a peer. A rule with no ports allows all ports, and a rule with no peers allows all sources or destinations. If neither is given, the rule allows all traffic from all sources (ingress) or to all destinations (egress).
+
+=== Port syntax
+
+The `--port` flag accepts:
+
+[cols="1,2"]
+|===
+|Syntax          |Meaning
+
+|`N`             |A numeric port, for example `8080`.
+|`N/PROTO`       |A numeric port with an explicit protocol (`TCP`, `UDP`, or `SCTP`), for example `8080/UDP`. Defaults to `TCP` if omitted.
+|`N-M`           |A numeric port range, for example `8080-8090`.
+|`N-M/PROTO`     |A numeric port range with an explicit protocol.
+|`akka-service`  |Traffic on the internal port Akka services receive their traffic on.
+|===
+
+=== Peer syntax
+
+The `--from` and `--to` flags accept:
+
+[cols="1,2"]
+|===
+|Syntax                     |Meaning
+
+|`service:NAME`             |A service in the local project.
+|`service:NAME@PROJECT_ID`  |A service in another project.
+|`project:PROJECT_ID`       |All services in another project.
+|`cidr:CIDR[,EXCEPT...]`    |An IP block, optionally excluding one or more sub-blocks.
+|===
+
+=== Examples
+
+Allow another project's `order-service` to call your services over the internal Akka service port:
+
+[source, command line]
+----
+akka projects network-policy add ingress-rule \
+  --port akka-service \
+  --from service:order-service@3f29b6d8-9c34-4a1a-8f77-2b6e9d9a5b21
+----
+
+Allow ingress from an internal CIDR range, excluding a sub-block:
+
+[source, command line]
+----
+akka projects network-policy add ingress-rule \
+  --from cidr:10.20.0.0/16,10.20.30.0/24
+----
+
+Allow your services to make outbound HTTPS calls to any destination:
+
+[source, command line]
+----
+akka projects network-policy add egress-rule --port 443
+----
+
+A rule can combine multiple ports and multiple peers by repeating the flags:
+
+[source, command line]
+----
+akka projects network-policy add egress-rule \
+  --port 80 --port 443 \
+  --to cidr:0.0.0.0/0
+----
+
+== Removing rules
+
+Rules are removed by their 1-based index, as shown by `akka projects network-policy get`:
+
+[source, command line]
+----
+akka projects network-policy remove ingress-rule 1
+akka projects network-policy remove egress-rule 2
+----
+
+== Working with a network policy descriptor
+
+For more complex configurations, or to keep your network policy in version control, you can work with it as a YAML descriptor. This is checked into source control the same way as other Akka descriptors — see xref:reference:descriptors/network-policy-descriptor.adoc[] for the complete field reference.
+
+Export the current configuration:
+
+[source, command line]
+----
+akka projects network-policy export -f network-policy.yaml
+----
+
+Edit and re-apply it:
+
+[source, command line]
+----
+akka projects network-policy apply -f network-policy.yaml
+----
+
+Or edit it directly in your configured editor, applying it on save:
+
+[source, command line]
+----
+akka projects network-policy edit
+----
+
+A network policy document can also be included as one of the documents in a multi-resource xref:reference:descriptors/project-descriptor.adoc[project descriptor], applied with `akka projects apply`.
+
+[NOTE]
+====
+Changes to the network policy do not take effect for already-running service instances until they are restarted.
+====
+
+== See also
+
+* xref:reference:descriptors/network-policy-descriptor.adoc[Network Policy Descriptor reference]
+* xref:sdk:access-control.adoc[Access Control Lists (ACLs)]
+* xref:services/invoke-service.adoc[Invoking Akka services]
+* xref:regions/setup.adoc#multi-region-resources[Managing resources in a multi region project]

--- a/docs/src/modules/operations/pages/services/invoke-service.adoc
+++ b/docs/src/modules/operations/pages/services/invoke-service.adoc
@@ -16,7 +16,7 @@ A route declares how traffic to a particular hostname gets routed to your servic
 
 All traffic to Akka uses Transport Layer Security (TLS). Akka will automatically provision a certificate for you using https://letsencrypt.org/[Let's Encrypt, window="new"]. The certificate is provisioned whether you use an Akka provided hostname, or bring your own.
 
-NOTE: Routes are global by default and will be replicated over to a new region if/when the project gets to be multi-region, unless created with flag `--region [region]` or converted to regional after the fact. Refer to xref:operations:regions/index.adoc#multi-region-resources[Managing resources in multi-region] for more information.
+NOTE: Routes are global by default and will be replicated over to a new region if/when the project gets to be multi-region, unless created with flag `--region [region]` or converted to regional after the fact. Refer to xref:operations:regions/setup.adoc#multi-region-resources[Managing resources in multi-region] for more information.
 
 === Exposing a single service
 

--- a/docs/src/modules/reference/nav.adoc
+++ b/docs/src/modules/reference/nav.adoc
@@ -5,6 +5,7 @@
 *** xref:descriptors/project-descriptor.adoc[Project descriptor]
 *** xref:descriptors/service-descriptor.adoc[Service descriptor]
 *** xref:descriptors/route-descriptor.adoc[Route descriptor]
+*** xref:descriptors/network-policy-descriptor.adoc[Network policy descriptor]
 *** xref:descriptors/external-secret-descriptor.adoc[External secret descriptor]
 *** xref:descriptors/observability-descriptor.adoc[Observability descriptor]
 *** xref:descriptors/model-descriptor.adoc[Model descriptor]

--- a/docs/src/modules/reference/pages/descriptors/index.adoc
+++ b/docs/src/modules/reference/pages/descriptors/index.adoc
@@ -8,6 +8,7 @@ Descriptors support structured configuration across multiple Akka regions and Ak
 and may even be used to create a new project.
 * The xref:descriptors/service-descriptor.adoc[Service descriptor] defines the configuration for a service resource.
 * The xref:descriptors/route-descriptor.adoc[Route descriptor] describes the way ingress traffic is routed to your Akka services.
+* The xref:descriptors/network-policy-descriptor.adoc[Network policy descriptor] describes what ingress and egress traffic is allowed to and from the services in an Akka project, at the network level.
 * Through the xref:descriptors/external-secret-descriptor.adoc[External secret descriptor] an Akka service is configured
 to source secrets from an external secret manager.
 * The xref:descriptors/observability-descriptor.adoc[Observability descriptor] describes how metrics, logs,

--- a/docs/src/modules/reference/pages/descriptors/network-policy-descriptor.adoc
+++ b/docs/src/modules/reference/pages/descriptors/network-policy-descriptor.adoc
@@ -1,0 +1,137 @@
+= Network Policy Descriptor reference
+include::ROOT:partial$include.adoc[]
+
+[#network-policy]
+== Akka Network Policy descriptor
+
+An Akka network policy descriptor describes, at the network level, what ingress and egress traffic is allowed to and from the services in an Akka project. It is used by the `akka projects network-policy apply` command, described in xref:operations:projects/network-policies.adoc[Managing network policies].
+
+Every project has exactly one network policy, named `default`. It cannot be created or deleted, only configured. Traffic between services in the same project, and traffic required by Akka platform infrastructure, is always allowed regardless of this configuration.
+
+[IMPORTANT]
+====
+Network policies do not override xref:sdk:access-control.adoc[Access Control Lists (ACLs)]. A network policy controls connectivity at the network layer: whether a peer can open a connection to a service at all. An ACL controls, once a connection is allowed, which principals can invoke which service methods. Both must permit a request for it to succeed.
+
+Ingress rules also only match traffic arriving over Akka's private network, for example from a service in another project, or from a CIDR range reachable within that network. They have no effect on traffic reaching your services through a route exposed to the internet. That traffic is always allowed at the network level, and access to it is controlled instead by xref:operations:services/invoke-service.adoc[routes] and by ACLs using the internet principal.
+====
+
+[cols="1,1,1"]
+|===
+|Field     |Type                            |Description
+
+|*ingress* |[]<<NetworkPolicyIngressRule>>  |Rules describing additional traffic allowed into the services in the project. If empty, no additional ingress traffic is allowed beyond same-project and infrastructure traffic.
+|*egress*  |[]<<NetworkPolicyEgressRule>>   |Rules describing additional traffic allowed out of the services in the project. If empty, no additional egress traffic is allowed beyond same-project and infrastructure traffic.
+|===
+
+=== NetworkPolicyIngressRule
+
+Describes a set of traffic that is allowed into the services in the project. Incoming traffic must match both `ports` and `from` for the rule to apply.
+
+[cols="1,1,1"]
+|===
+|Field    |Type                     |Description
+
+|*ports*  |[]<<NetworkPolicyPort>>  |The ports this rule allows traffic on. Items are combined with a logical OR. If empty or omitted, the rule matches all ports.
+|*from*   |[]<<NetworkPolicyPeer>>  |The sources this rule allows traffic from. Items are combined with a logical OR. If empty or omitted, the rule matches all sources.
+|===
+
+=== NetworkPolicyEgressRule
+
+Describes a set of traffic that is allowed out of the services in the project. Outgoing traffic must match both `ports` and `to` for the rule to apply.
+
+[cols="1,1,1"]
+|===
+|Field    |Type                     |Description
+
+|*ports*  |[]<<NetworkPolicyPort>>  |The destination ports this rule allows traffic on. Items are combined with a logical OR. If empty or omitted, the rule matches all ports.
+|*to*     |[]<<NetworkPolicyPeer>>  |The destinations this rule allows traffic to. Items are combined with a logical OR. If empty or omitted, the rule matches all destinations.
+|===
+
+=== NetworkPolicyPort
+
+A port to match traffic on.
+
+[cols="1,1,1"]
+|===
+|Field       |Type    |Description
+
+|*protocol*  |string  |The protocol to match: `TCP`, `UDP`, or `SCTP`. Defaults to `TCP`.
+|*port*      |string  |The port to match, either a number (for example `8080`) or `akka-service`, which matches traffic on the internal port Akka services receive their traffic on. If omitted, the rule matches all ports.
+|*endPort*   |int     |Together with `port`, defines an inclusive range of ports to match, for example `port: 8080` and `endPort: 8090` matches ports 8080 through 8090. Can only be set when `port` is a number, and must be greater than or equal to `port`.
+|===
+
+=== NetworkPolicyPeer
+
+Describes a peer to allow traffic to or from. Specify either `service` and/or `projectId`, or `ipBlock`, but not both.
+
+[cols="1,1,1"]
+|===
+|Field        |Type                  |Description
+
+|*service*    |string                |The name of a service to match. If `projectId` is not set, matches a service with this name in the local project.
+|*projectId*  |string                |The ID of a project to match. If `service` is not set, matches all services in that project.
+|*ipBlock*    |<<NetworkPolicyIPBlock>> |An IP block to match. Cannot be combined with `service` or `projectId`.
+|===
+
+To match a service in another project, set both `service` and `projectId`. To match all services in another project, set only `projectId`.
+
+=== NetworkPolicyIPBlock
+
+A CIDR block to allow traffic to or from.
+
+[cols="1,1,1"]
+|===
+|Field     |Type                |Description
+
+|*cidr*    |string _required_   |A CIDR range, for example `192.168.1.0/24` or `2001:db8::/64`.
+|*except*  |[]string            |CIDR ranges to exclude from `cidr`. Each must be a sub-range of `cidr`.
+|===
+
+[#example]
+== Complete descriptor example
+
+[source,yaml]
+----
+resource: NetworkPolicy
+resourceVersion: v1
+spec:
+  ingress:
+    - ports:
+        - port: akka-service
+      from:
+        - service: order-service
+          projectId: 3f29b6d8-9c34-4a1a-8f77-2b6e9d9a5b21
+    - from:
+        - ipBlock:
+            cidr: 10.20.0.0/16
+            except:
+              - 10.20.30.0/24
+  egress:
+    - ports:
+        - port: 443
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+    - ports:
+        - port: 5432
+      to:
+        - service: shared-database
+          projectId: 91f0c1a4-6b3f-4e2a-9d2e-9a7d5f6c0b12
+----
+
+This example allows two ingress rules: traffic on the internal Akka service port from a service named `order-service` in another project, and traffic from any port in the `10.20.0.0/16` CIDR range except `10.20.30.0/24`. It also allows two egress rules: HTTPS traffic (port 443) to anywhere, and PostgreSQL traffic (port 5432) to a service named `shared-database` in another project.
+
+Note that this descriptor has no `metadata`, since a project's network policy is a singleton resource; it is always named `default` and does not need to be identified by name.
+
+== Using the network policy descriptor
+
+The network policy descriptor is a single-document YAML file, unlike the xref:reference:descriptors/project-descriptor.adoc[project descriptor], which can bundle multiple resources. It can be exported from and applied to a project using the `akka projects network-policy export` and `akka projects network-policy apply` commands, or edited in place with `akka projects network-policy edit`. It can also be included as one document within a multi-document xref:reference:descriptors/project-descriptor.adoc[project descriptor] applied with `akka project apply`, using `resource: NetworkPolicy`.
+
+For a walkthrough of managing network policies with the CLI, see xref:operations:projects/network-policies.adoc[Managing network policies].
+
+== Related documentation
+
+* xref:operations:projects/network-policies.adoc[Managing network policies]
+* xref:sdk:access-control.adoc[Access Control Lists (ACLs)]
+* xref:reference:descriptors/project-descriptor.adoc[Project Descriptor reference]
+* xref:reference:cli/akka-cli/akka_projects.adoc[`akka projects` CLI commands]

--- a/docs/src/modules/reference/pages/descriptors/project-descriptor.adoc
+++ b/docs/src/modules/reference/pages/descriptors/project-descriptor.adoc
@@ -8,6 +8,7 @@ Akka's _Project Descriptor_ is a multi-document YAML file that defines the compl
 . xref:#project[the project itself],
 . xref:#service[services],
 . xref:#route[routes],
+. xref:#network-policy[network policy],
 . xref:#observability[observability settings],
 . xref:#external-secret[external secrets],
 . xref:#secret[secrets],
@@ -23,7 +24,7 @@ Each document in the project descriptor represents a single resource and follows
 |===
 |Field   |Type                    |Description
 
-|*resource*         |string _required_  |The type of resource: `Project`, `Service`, `Route`, `Observability`, `ExternalSecret`, `Secret`, `ServiceConfig`, `Broker`, or `RoleBindings`
+|*resource*         |string _required_  |The type of resource: `Project`, `Service`, `Route`, `NetworkPolicy`, `Observability`, `ExternalSecret`, `Secret`, `ServiceConfig`, `Broker`, or `RoleBindings`
 |*resourceVersion*  |string _required_  |The version of the resource schema. Currently only `v1` is supported.
 |*metadata*         |<<Metadata>>       |Optional metadata for the resource. Required for `Project`, `Service`, `Route`, `ExternalSecret`, `Secret`, and `ServiceConfig` resources.
 |*spec*             |object _required_  |The specification for the resource. Structure depends on the resource type.
@@ -41,7 +42,7 @@ Each document in the project descriptor represents a single resource and follows
 
 == Resource types
 
-The project descriptor supports the following resource types. A single descriptor can contain multiple `Service`, `Route`, `ExternalSecret`, `Secret`, and `ServiceConfig` documents, each with a unique name. The `Project`, `Observability`, `Broker`, and `RoleBindings` resources are project-level singletons—only one of each can exist per project.
+The project descriptor supports the following resource types. A single descriptor can contain multiple `Service`, `Route`, `ExternalSecret`, `Secret`, and `ServiceConfig` documents, each with a unique name. The `Project`, `NetworkPolicy`, `Observability`, `Broker`, and `RoleBindings` resources are project-level singletons—only one of each can exist per project.
 
 [#project]
 === Project
@@ -117,6 +118,30 @@ spec:
     - prefix: /api
       route:
         service: my-service
+----
+
+[#network-policy]
+=== NetworkPolicy
+
+Configures the project's network policy, controlling what ingress and egress traffic is allowed to and from the project's services at the network level. Only one network policy configuration exists per project, and it does not require a `metadata.name`. See xref:reference:descriptors/network-policy-descriptor.adoc[] for the complete reference.
+
+[source,yaml]
+----
+resource: NetworkPolicy
+resourceVersion: v1
+spec:
+  ingress:
+    - ports:
+        - port: akka-service
+      from:
+        - service: order-service
+          projectId: 3f29b6d8-9c34-4a1a-8f77-2b6e9d9a5b21
+  egress:
+    - ports:
+        - port: 443
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
 ----
 
 [#observability]
@@ -589,5 +614,6 @@ spec:
 
 * xref:reference:descriptors/service-descriptor.adoc[Service Descriptor reference]
 * xref:reference:descriptors/route-descriptor.adoc[Route Descriptor reference]
+* xref:reference:descriptors/network-policy-descriptor.adoc[Network Policy Descriptor reference]
 * xref:reference:descriptors/observability-descriptor.adoc[Observability Descriptor reference]
 * xref:reference:cli/akka-cli/akka_projects.adoc[`akka projects` CLI commands]

--- a/docs/src/modules/sdk/pages/access-control.adoc
+++ b/docs/src/modules/sdk/pages/access-control.adoc
@@ -7,6 +7,7 @@ specify lists of what can access your services, at multiple granularity. For exa
 initiates a payment on a payment service to only accept requests from the shopping cart service. You can also control
 whether services or methods can be invoked from the Internet.
 
+NOTE: ACLs operate at the application layer, controlling which principals can invoke which service methods. They are independent of xref:operations:projects/network-policies.adoc[network policies], which control connectivity at the network layer. Neither overrides the other — a request must be permitted by both to succeed.
 
 ==  Principals
 

--- a/docs/styles/config/vocabularies/Akka/accept.txt
+++ b/docs/styles/config/vocabularies/Akka/accept.txt
@@ -143,6 +143,7 @@ effectful
 enablement
 Entra
 enums?
+endPort
 env
 etcd
 eval
@@ -212,6 +213,7 @@ instanceType
 interconnectivity
 interoperate
 Intune
+ipBlock
 iss
 Jamf
 jank


### PR DESCRIPTION
Part of https://github.com/lightbend/kalix/issues/16186

This adds documentation for configuring network policies.

Note, none of this is available in production yet, so potentially hold off merging till the CLI has been released, and prod deployed with everything.