### PR TITLE
docs: introduce feature banners

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -92,19 +92,33 @@ For anything the template does not cover, match the structure and voice of the n
 
 ## Page metadata
 
-Every page declares `:page-*:` attributes after the `include::ROOT:partial$include.adoc[]` line.
-They feed the Antora UI and the llms.txt generator:
+Every page declares `:page-*:` attributes in the document header. They feed the Antora UI and the
+llms.txt generator:
 
 ```asciidoc
+= Agents
 :page-component-type: agent
 :page-summary: An Agent interacts with an AI model to perform a specific task, maintaining session memory and supporting multi-agent collaboration.
 :page-when-to-use: LLM-backed tasks, conversational AI, multi-agent orchestration
 :page-related: sdk:workflows.adoc, sdk:event-sourced-entities.adoc, concepts:ai-agents.adoc
 :page-prerequisites: Java 21, Akka SDK basics
 :page-persona: builder-developer, builder-ai-ml
+
+include::ROOT:partial$include.adoc[]
 ```
 
+The header is everything between the `= Title` line and the first blank line. `:page-*:` attributes
+must sit inside it — directly under the title, with no blank line before them and before the
+`include::ROOT:partial$include.adoc[]` directive. Attributes placed after a blank line are
+body-level and Antora will silently ignore them (no build error, just no `page.attributes.*` in the
+UI templates).
+
 The `:page-summary:` says what the page's subject does, not why it is good.
+
+Set `:page-banner:` to render a feature-set banner above the page body. Supported values are
+`inference` and `governance`, each rendering "Feature set: <Name> — contact our support for access."
+The banner values are defined in `supplemental_ui/partials/page-banner.hbs`; extend that partial to
+add new values.
 
 ## SDD-first, manual fallback
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -116,9 +116,10 @@ UI templates).
 The `:page-summary:` says what the page's subject does, not why it is good.
 
 Set `:page-banner:` to render a feature-set banner above the page body. Supported values are
-`inference` and `governance`, each rendering "Feature set: <Name> — contact our support for access."
-The banner values are defined in `supplemental_ui/partials/page-banner.hbs`; extend that partial to
-add new values.
+`inference`, `governance`, and `evaluations`, each rendering "Feature set: <Name> — contact our
+support for access." The `evaluations` variant also warns that the functionality and APIs may
+change between releases without notice. The banner values are defined in
+`supplemental_ui/partials/page-banner.hbs`; extend that partial to add new values.
 
 ## SDD-first, manual fallback
 

--- a/docs/src/modules/operations/pages/regions/index.adoc
+++ b/docs/src/modules/operations/pages/regions/index.adoc
@@ -1,5 +1,4 @@
 = Regions
-:page-banner: inference
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/operations/pages/regions/index.adoc
+++ b/docs/src/modules/operations/pages/regions/index.adoc
@@ -1,4 +1,5 @@
 = Regions
+:page-banner: inference
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/supplemental_ui/partials/article.hbs
+++ b/docs/supplemental_ui/partials/article.hbs
@@ -1,0 +1,26 @@
+{{#if page.attributes.get-started}}
+<article class="doc px-8 w-full col-span-full pt-28 mb-8">
+    {{#with page.title}}
+    <header class="prose-akka">
+        <h1 class="page">{{{this}}}</h1>
+    </header>
+    {{/with}}
+    {{> page-banner}}
+    {{> get-started}}
+    <footer class="border-t border-t-akka-gray-300 mt-12">
+    {{> pagination}}
+    </footer>
+</article>
+{{else}}
+<article class="doc prose-akka z-10 px-8 col-span-full xl:col-span-9 pt-28 mb-8 min-h-[calc(100vh)] max-w-[840px]">
+    {{#with page.title}}
+        <h1 class="page">{{{this}}}</h1>
+    {{/with}}
+    {{> supergroups}}
+    {{> page-banner}}
+    {{{page.contents}}}
+    <footer class="border-t border-t-akka-gray-300 mt-12">
+        {{> pagination}}
+    </footer>
+</article>
+{{/if}}

--- a/docs/supplemental_ui/partials/page-banner.hbs
+++ b/docs/supplemental_ui/partials/page-banner.hbs
@@ -2,19 +2,22 @@
     {{#if (eq page.attributes.banner 'inference')}}
         <div class="page-banner bg-akka-yellow text-akka-black p-4 mb-6 text-base flex items-center gap-3">
             <strong>Feature set: Inference</strong>
-            <span>&mdash; contact <a href="https://akka.io/contact" class="text-akka-blue-dkr underline">our support</a> for access.</span>
+            <span>Contact <a href="https://akka.io/contact" class="text-akka-blue-dkr underline">our support</a> for access.<br/>
+            <i>This functionality evolves quickly, the functionality and APIs might change between releases without further notice.</i></span>
         </div>
     {{/if}}
     {{#if (eq page.attributes.banner 'governance')}}
         <div class="page-banner bg-akka-yellow text-akka-black p-4 mb-6 text-base flex items-center gap-3">
             <strong>Feature set: Governance</strong>
-            <span>&mdash; contact <a href="https://akka.io/contact" class="text-akka-blue-dkr underline">our support</a> for access.</span>
+            <span>Contact <a href="https://akka.io/contact" class="text-akka-blue-dkr underline">our support</a> for access.<br/>
+            <i>This functionality evolves quickly, the functionality and APIs might change between releases without further notice.</i></span>
         </div>
     {{/if}}
     {{#if (eq page.attributes.banner 'evaluations')}}
         <div class="page-banner bg-akka-yellow text-akka-black p-4 mb-6 text-base flex items-center gap-3">
             <strong>Feature set: Evaluations</strong>
-            <span>&mdash; contact <a href="https://akka.io/contact" class="text-akka-blue-dkr underline">our support</a> for access. This functionality evolves quickly, the functionality and APIs might change between releases without further notice.</span>
+            <span>Contact <a href="https://akka.io/contact" class="text-akka-blue-dkr underline">our support</a> for access.<br/>
+            <i>This functionality evolves quickly, the functionality and APIs might change between releases without further notice.</i></span>
         </div>
     {{/if}}
 {{/if}}

--- a/docs/supplemental_ui/partials/page-banner.hbs
+++ b/docs/supplemental_ui/partials/page-banner.hbs
@@ -11,4 +11,10 @@
             <span>&mdash; contact <a href="https://akka.io/contact" class="text-akka-blue-dkr underline">our support</a> for access.</span>
         </div>
     {{/if}}
+    {{#if (eq page.attributes.banner 'evaluations')}}
+        <div class="page-banner bg-akka-yellow text-akka-black p-4 mb-6 text-base flex items-center gap-3">
+            <strong>Feature set: Evaluations</strong>
+            <span>&mdash; contact <a href="https://akka.io/contact" class="text-akka-blue-dkr underline">our support</a> for access. This functionality evolves quickly, the functionality and APIs might change between releases without further notice.</span>
+        </div>
+    {{/if}}
 {{/if}}

--- a/docs/supplemental_ui/partials/page-banner.hbs
+++ b/docs/supplemental_ui/partials/page-banner.hbs
@@ -1,0 +1,14 @@
+{{#if page.attributes.banner}}
+    {{#if (eq page.attributes.banner 'inference')}}
+        <div class="page-banner bg-akka-yellow text-akka-black p-4 mb-6 text-base flex items-center gap-3">
+            <strong>Feature set: Inference</strong>
+            <span>&mdash; contact <a href="https://akka.io/contact" class="text-akka-blue-dkr underline">our support</a> for access.</span>
+        </div>
+    {{/if}}
+    {{#if (eq page.attributes.banner 'governance')}}
+        <div class="page-banner bg-akka-yellow text-akka-black p-4 mb-6 text-base flex items-center gap-3">
+            <strong>Feature set: Governance</strong>
+            <span>&mdash; contact <a href="https://akka.io/contact" class="text-akka-blue-dkr underline">our support</a> for access.</span>
+        </div>
+    {{/if}}
+{{/if}}


### PR DESCRIPTION
Pages marked with `:page-banner:` show a banner to indicate they document functionality from an access-limited feature set.

It supports different banners for `inference`, `evaluations` and `governance`.

<img width="758" height="210" alt="image" src="https://github.com/user-attachments/assets/0c96631d-d779-4cb7-b4a8-06607057715e" />

