### PR TITLE
Document porting, the discovery probes, and the contract for custom conditions

### DIFF
--- a/docs/antora-docker/Dockerfile
+++ b/docs/antora-docker/Dockerfile
@@ -2,7 +2,7 @@ FROM antora/antora:3.1.15
 
 # "Alpine Linux v3.11"
 RUN npm install -g @antora/lunr-extension
-RUN npm install -g @antora/site-generator
+RUN npm install -g @antora/site-generator@3.1.15
 RUN npm install -g asciidoc-link-check
 RUN npm install -g @asciidoctor/tabs@1.0.0-beta.6
 RUN npm install -g @sntke/antora-mermaid-extension@0.0.13

--- a/docs/src/modules/reference/nav.adoc
+++ b/docs/src/modules/reference/nav.adoc
@@ -347,6 +347,7 @@
 **** xref:specify/issues.adoc[/akka:issues]
 **** xref:specify/mode.adoc[/akka:mode]
 **** xref:specify/plan.adoc[/akka:plan]
+**** xref:specify/port.adoc[/akka:port]
 **** xref:specify/reliability.adoc[/akka:reliability]
 **** xref:specify/review.adoc[/akka:review]
 **** xref:specify/setup.adoc[/akka:setup]
@@ -360,6 +361,8 @@
 **** xref:specify/coverage-gate.adoc[The coverage gate]
 **** xref:specify/adequacy-review.adoc[The adequacy review]
 **** xref:specify/requirement-analysis.adoc[Requirement analysis]
+**** xref:specify/probes.adoc[Discovery probes]
+**** xref:specify/custom-conditions.adoc[Custom exit conditions and auditors]
 *** Project surface
 **** xref:specify/project-surface.adoc[Project surface coverage]
 **** xref:specify/content-governance.adoc[Content governance]
@@ -367,6 +370,7 @@
 *** Exit conditions
 **** xref:specify/exit-condition-schema.adoc[Exit condition schema]
 **** xref:specify/exit-condition-states.adoc[Exit condition states]
+**** xref:specify/spec-conformance.adoc[Specification conformance]
 **** xref:specify/prohibitions.adoc[Prohibitions]
 **** xref:specify/default-library.adoc[Default exit-condition library]
 **** xref:specify/catalog/index.adoc[Exit condition catalog]

--- a/docs/src/modules/reference/pages/specify/auditors.adoc
+++ b/docs/src/modules/reference/pages/specify/auditors.adoc
@@ -6,7 +6,7 @@ Every auditor is one of three xref:reference:specify/auditor-kinds.adoc[kinds] â
 
 == Built-in and inline auditors
 
-Akka's built-in auditors are introspective: they inspect the working tree and read a tool's exit code. `maven-compile` and `maven-test` for Java/Akka, `git-clean` and `git-secrets` over the git tree, `no-build-output` and `deps-pinned` for repository hygiene, `content-vale` over `docs/`, `ci-green` for prior CI runs, `file-adr` for a recorded decision. A condition binds one by naming its id in the `check` field.
+Akka's built-in auditors are introspective: they inspect the working tree and read a tool's exit code. `maven-compile` and `maven-test` for Java/Akka, `git-clean` and `git-secrets` over the git tree, `no-build-output` and `deps-pinned` for repository hygiene, `content-vale` over `docs/`, `ci-green` for prior CI runs, `file-adr` for a recorded decision, `spec-schema` and `rule-evidence` over the specification. A condition binds one by naming its id in the `check` field.
 
 Where a project introduces an ecosystem the built-ins do not cover, it authors an *inline* introspective auditor: a command plus the surface it applies to, written under the condition's `auditor` field.
 
@@ -50,6 +50,8 @@ Two Process-integrity conditions are always on and cannot be struck. They make t
 A detected surface that genuinely needs no check (a demos or scripts folder) can be marked intentionally unaudited, with a recorded reason; the coverage gate then skips it. This is the escape hatch for the "every surface is material" rule.
 
 == Related
+
+* xref:reference:specify/custom-conditions.adoc[Custom exit conditions and auditors]
 
 * xref:reference:specify/requirement-analysis.adoc[Requirement analysis] â€” how a requirement becomes an exit condition and an auditor
 * xref:reference:specify/exit-condition-schema.adoc[Exit condition schema]

--- a/docs/src/modules/reference/pages/specify/custom-conditions.adoc
+++ b/docs/src/modules/reference/pages/specify/custom-conditions.adoc
@@ -180,16 +180,48 @@ An auditor that writes nothing to standard output and exits `0` is read as `gree
 
 == Testing locally
 
+Run the auditor against the current project and see what the engine would make of it:
+
 [source,bash]
 ----
 akka specify auditor-test CORP-LICENCE-SCAN
 ----
 
-Runs the auditor against the current project and prints the request it received, its raw output, and the verdict the engine would record.
+That prints the request the auditor received, its raw output, and the verdict the engine would record.
 
-Before distributing an auditor, exercise it against the cases that break implementations: a requirement declared and not met, a dependency that refuses connections, a malformed request, a timeout, and output that is not JSON.
+`auditor-test` answers whether the auditor works on the case you had in mind. `extension verify` answers whether it holds up on the cases you did not:
 
-An auditor reporting `red` when its target was merely unreachable passes an ordinary test. It blocks a ship for a reason that has nothing to do with the project.
+[source,bash]
+----
+akka specify extension verify -- python examples/extensions/licence-scan.py   --params '{"allowed":["Apache-2.0","MIT"]}'
+----
+
+[source]
+----
+  ✓ completes          answered in 148ms
+  ✓ answers            wrote an answer this contract recognises
+  ✓ exit-status        exited zero, reporting that it ran
+  ✓ malformed-request  answered open, establishing nothing
+  ✓ empty-request      answered open, establishing nothing
+  ✓ future-version     answered open, establishing nothing
+  ✓ repeatable         the same request answered red twice
+  ✓ reads-the-request  answered a request naming a different project differently
+
+Speaks the contract.
+----
+
+Three of those requests are ones no auditor can answer: a body that is not JSON, an empty body, and a request declaring a contract version this build does not speak. Each must be answered `open`. An auditor that answers `red` has stated something about a project it was never told about, and an auditor that exits non-zero without answering is read by the engine as the condition failing, which reaches the developer as a blocked ship with a reason that has nothing to do with their code.
+
+Pass `--condition` to verify the auditor a declared condition already names, rather than a command you type out:
+
+[source,bash]
+----
+akka specify extension verify --condition CORP-LICENCE-SCAN
+----
+
+Add `--kind probe` to hold a discovery probe to the same contract. A probe declines differently, because a probe that fails is recorded as having failed, and the requirement on it is that it reports no findings about a request it could not read.
+
+The command exits non-zero when a rule the engine relies on is broken, so it can stand in a build.
 
 == Distribution
 

--- a/docs/src/modules/reference/pages/specify/custom-conditions.adoc
+++ b/docs/src/modules/reference/pages/specify/custom-conditions.adoc
@@ -1,0 +1,168 @@
+= Custom exit conditions and auditors
+
+An organization writes its own exit conditions in `policy.yaml`, and implements them as commands in any language. This page covers declaring a condition, writing the auditor that answers it, testing it locally, and distributing it.
+
+The command contract described here is shared with xref:reference:specify/probes.adoc[discovery probes]. An auditor and a probe are asked different questions and answer with different shapes, over the same interface.
+
+== Declaring a condition
+
+Two forms. Reference one the library already ships and set the level it applies at:
+
+[source,yaml]
+----
+exit_conditions:
+  - ref: OPS-COMPILES
+    level: ALWAYS-APPLY
+----
+
+Or supply the whole condition, with the command that answers it:
+
+[source,yaml]
+----
+exit_conditions:
+  - id: CORP-LICENCE-SCAN
+    tier: project
+    dod_type: pipeline-scanning
+    level: ALWAYS-APPLY
+    invariant: "no dependency carries a licence outside the approved set"
+    signal: scan
+    probe: "licence scanner over the resolved dependency set"
+    pass: "disallowed_licences == 0"
+    autonomy: auto-close
+    auditor:
+      run: ["corp-licence-scan"]
+      applies_to:
+        requirement: maven
+        module: services/billing
+      params:
+        allowed: ["Apache-2.0", "MIT", "BSD-3-Clause"]
+      timeout: 120s
+----
+
+`params` reaches the auditor untouched. Tuning what a condition permits is a policy change rather than a new binary.
+
+`applies_to.requirement` gates whether the auditor runs at all. A condition requiring `maven` in a project with no `pom.xml` resolves `OPEN` with the reason `blocked-outside-project`, and never runs.
+
+See xref:reference:specify/exit-condition-schema.adoc[Exit condition schema] for every field, and xref:reference:specify/policies.adoc[Policies] for how a policy reaches a project.
+
+== The command contract
+
+An auditor is a command. Its request arrives as JSON on standard input and its answer leaves as JSON on standard output, so it can be written in any language and exercised with a pipe:
+
+[source,bash]
+----
+echo '{"kind":"auditor","version":1,...}' | ./corp-licence-scan
+----
+
+Nothing is read from the environment, no flag carries meaning, and the working directory is set without being load-bearing. Standard error is captured and shown to a developer, and is never parsed.
+
+=== The request
+
+[source,json]
+----
+{
+  "kind": "auditor",
+  "version": 1,
+  "project": {
+    "root": "/home/dev/billing",
+    "module": "services/billing"
+  },
+  "condition": {
+    "id": "CORP-LICENCE-SCAN",
+    "invariant": "no dependency carries a licence outside the approved set",
+    "pass": "disallowed_licences == 0",
+    "params": { "allowed": ["Apache-2.0", "MIT", "BSD-3-Clause"] }
+  }
+}
+----
+
+=== The answer
+
+[source,json]
+----
+{
+  "version": 1,
+  "status": "red",
+  "reason": "3 dependencies carry GPL-3.0",
+  "detail": { "offenders": ["libfoo@2.1", "libbar@0.9", "libbaz@1.4"] }
+}
+----
+
+`status` is `green`, `red`, or `open`. `reason` is one line and is the only prose the engine reads. `detail` is opaque, and is stored beside the result for anyone who wants it.
+
+An auditor that cannot reach what it needs says so:
+
+[source,json]
+----
+{ "version": 1, "status": "open", "reason": "the licence service is unreachable" }
+----
+
+`open` and `red` are different answers. `red` states that the project violates the condition. `open` states that the auditor could not establish anything. An auditor that reports `red` when its dependency was unavailable blocks a ship for a reason that has nothing to do with the project.
+
+== Exit status
+
+Exit status reports whether the auditor ran. The verdict is in the answer.
+
+[cols="1,2,2",options="header"]
+|===
+| Exit | Meaning | The condition resolves
+
+| `0` | The auditor ran | as the answer says
+| non-zero | The auditor itself failed | `OPEN`, reason `blocked-outside-project`
+| timeout | The engine stopped it | `OPEN`, reason `blocked-outside-project`
+|===
+
+A crashed auditor and a violated condition are different things. A violation is a finding about the project; a crash is the absence of a finding.
+
+An auditor that writes nothing to standard output and exits `0` is read as `green`, and one that writes nothing and exits non-zero as `red`. That is the behaviour of an auditor written before this contract existed, and it continues to work.
+
+== Versioning
+
+`version` appears in both directions. The engine sends the highest version it speaks. An auditor answering with a lower version is served that version's contract; one answering with a higher version is refused rather than guessed at.
+
+== Testing locally
+
+[source,bash]
+----
+akka specify auditor test CORP-LICENCE-SCAN
+----
+
+Runs the auditor against the current project and prints the request it received, its raw output, and the verdict the engine would record.
+
+[source,bash]
+----
+akka specify extension verify
+----
+
+Runs every declared auditor and probe against fixtures the Plugin ships, and checks the cases that break implementations: a requirement declared and not met, a dependency that refuses connections, a malformed request, a timeout, and output that is not JSON.
+
+Run this before distributing an auditor. An auditor that reports `red` when its target was merely unreachable passes an ordinary test and fails this one.
+
+== Distribution
+
+An extension bundle is a directory holding a manifest and the commands it names:
+
+[source,yaml]
+----
+auditors:
+  - id: CORP-LICENCE-SCAN
+    run: ["corp-licence-scan"]
+    applies_to: { requirement: maven }
+    timeout: 120s
+----
+
+The bundle is fetched from an `extensions-url` in the CLI's system config to `.akka/extensions/`, the same mechanism that delivers a governance policy. Commands resolve from the bundle first and from `PATH` second, so an organization that installs its tools separately can.
+
+== Trust and approval
+
+Where an auditor comes from decides how far it is trusted, and that is unchanged by this contract. An auditor declared in an organization's `policy.yaml` runs without a separate approval. One authored in a project or by an assistant runs only after its exact command is approved, and is reviewed adversarially for adequacy.
+
+See xref:reference:specify/auditors.adoc[Auditors] for the trust model, and xref:reference:specify/adequacy-review.adoc[The adequacy review].
+
+== Related
+
+* xref:reference:specify/auditors.adoc[Auditors]
+* xref:reference:specify/auditor-kinds.adoc[Auditor kinds]
+* xref:reference:specify/exit-condition-schema.adoc[Exit condition schema]
+* xref:reference:specify/policies.adoc[Policies]
+* xref:reference:specify/probes.adoc[Discovery probes]

--- a/docs/src/modules/reference/pages/specify/custom-conditions.adoc
+++ b/docs/src/modules/reference/pages/specify/custom-conditions.adoc
@@ -124,19 +124,14 @@ An auditor that writes nothing to standard output and exits `0` is read as `gree
 
 [source,bash]
 ----
-akka specify auditor test CORP-LICENCE-SCAN
+akka specify auditor-test CORP-LICENCE-SCAN
 ----
 
 Runs the auditor against the current project and prints the request it received, its raw output, and the verdict the engine would record.
 
-[source,bash]
-----
-akka specify extension verify
-----
+Before distributing an auditor, exercise it against the cases that break implementations: a requirement declared and not met, a dependency that refuses connections, a malformed request, a timeout, and output that is not JSON.
 
-Runs every declared auditor and probe against fixtures the Plugin ships, and checks the cases that break implementations: a requirement declared and not met, a dependency that refuses connections, a malformed request, a timeout, and output that is not JSON.
-
-Run this before distributing an auditor. An auditor that reports `red` when its target was merely unreachable passes an ordinary test and fails this one.
+An auditor reporting `red` when its target was merely unreachable passes an ordinary test. It blocks a ship for a reason that has nothing to do with the project.
 
 == Distribution
 

--- a/docs/src/modules/reference/pages/specify/custom-conditions.adoc
+++ b/docs/src/modules/reference/pages/specify/custom-conditions.adoc
@@ -2,8 +2,6 @@
 
 An organization writes its own exit conditions in `policy.yaml`, and implements them as commands in any language. This page covers declaring a condition, writing the auditor that answers it, testing it locally, and distributing it.
 
-The command contract described here is shared with xref:reference:specify/probes.adoc[discovery probes]. An auditor and a probe are asked different questions and answer with different shapes, over the same interface.
-
 == Declaring a condition
 
 Two forms. Reference one the library already ships and set the level it applies at:
@@ -160,4 +158,3 @@ See xref:reference:specify/auditors.adoc[Auditors] for the trust model, and xref
 * xref:reference:specify/auditor-kinds.adoc[Auditor kinds]
 * xref:reference:specify/exit-condition-schema.adoc[Exit condition schema]
 * xref:reference:specify/policies.adoc[Policies]
-* xref:reference:specify/probes.adoc[Discovery probes]

--- a/docs/src/modules/reference/pages/specify/custom-conditions.adoc
+++ b/docs/src/modules/reference/pages/specify/custom-conditions.adoc
@@ -161,18 +161,21 @@ exit 0
 
 Exit status reports whether the auditor ran. The verdict is in the answer.
 
+Where the auditor wrote an answer, the answer decides the condition and the exit status is not consulted. Where it wrote none, the exit status decides:
+
 [cols="1,2,2",options="header"]
 |===
-| Exit | Meaning | The condition resolves
+| How it ended | What that says | The condition resolves
 
-| `0` | The auditor ran | as the answer says
-| non-zero | The auditor itself failed | `OPEN`, reason `blocked-outside-project`
-| timeout | The engine stopped it | `OPEN`, reason `blocked-outside-project`
+| Exited `0` | The auditor ran and found nothing to report | `GREEN`
+| Started, exited non-zero | The auditor ran and the check failed | `RED`, with the first line of standard error
+| Never started | The command is missing or is not executable | `OPEN`, with the reason it could not start
+| Timed out | The engine stopped it | `OPEN`, reason `timed out after <duration>`
 |===
 
-A crashed auditor and a violated condition are different things. A violation is a finding about the project; a crash is the absence of a finding.
+The last two rows are the ones worth reading twice. An auditor that never started established nothing about the project, so the condition is open rather than failed. An auditor that ran and exited non-zero is the reading auditors had before this contract existed, and it continues to work.
 
-An auditor that writes nothing to standard output and exits `0` is read as `green`, and one that writes nothing and exits non-zero as `red`. That is the behaviour of an auditor written before this contract existed, and it continues to work.
+A crashed auditor and a violated condition are different things. A violation is a finding about the project; a crash is the absence of a finding. That is why an auditor answering the contract should answer `open` rather than exit non-zero when it cannot establish anything: exiting non-zero without an answer is read as the check failing.
 
 == Versioning
 

--- a/docs/src/modules/reference/pages/specify/custom-conditions.adoc
+++ b/docs/src/modules/reference/pages/specify/custom-conditions.adoc
@@ -97,6 +97,66 @@ An auditor that cannot reach what it needs says so:
 
 `open` and `red` are different answers. `red` states that the project violates the condition. `open` states that the auditor could not establish anything. An auditor that reports `red` when its dependency was unavailable blocks a ship for a reason that has nothing to do with the project.
 
+== A worked example
+
+The Plugin ships two auditors as examples, both driven by its own tests so they cannot drift from the contract. Neither is written in the language the Plugin is.
+
+`examples/extensions/licence-scan.py` answers the condition declared above. It reads the request, takes the approved set from `params`, checks a dependency list, and answers with one of the three statuses:
+
+[source,python]
+----
+def answer(status, reason, **detail):
+    out = {"version": VERSION, "status": status, "reason": reason}
+    if detail:
+        out["detail"] = detail
+    json.dump(out, sys.stdout)
+    sys.exit(0)          # the auditor ran; the verdict is in the answer
+
+request = json.load(sys.stdin)
+allowed = set(request["condition"]["params"]["allowed"])
+
+try:
+    lines = open(os.path.join(request["project"]["root"], "licences.txt")).read().splitlines()
+except OSError as exc:
+    answer("open", f"could not read the dependency list: {exc.strerror}")
+
+offenders = [f"{n} ({lic})" for n, lic in (l.split() for l in lines if l) if lic not in allowed]
+if offenders:
+    answer("red", f"{len(offenders)} carry an unapproved licence", offenders=offenders)
+answer("green", f"{len(lines)} dependencies, all approved")
+----
+
+The missing-file branch is the point. An auditor that cannot read what it needs has established nothing, and answers `open`.
+
+Run it by hand, since a request is only text on standard input:
+
+[source,bash]
+----
+echo '{"kind":"auditor","version":1,"project":{"root":"."},
+       "condition":{"params":{"allowed":["Apache-2.0","MIT"]}}}'   | python examples/extensions/licence-scan.py
+----
+
+[source,json]
+----
+{"version": 1, "status": "red", "reason": "1 dependency carries an unapproved licence",
+ "detail": {"offenders": ["libbaz (GPL-3.0)"]}}
+----
+
+`examples/extensions/file-present.sh` is the same contract in POSIX shell, and shows how little an auditor has to do:
+
+[source,sh]
+----
+request=$(cat)
+root=$(printf '%s' "$request" | sed -n 's/.*"root"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+if [ -d "$root/docs/adr" ]; then
+  printf '{"version":1,"status":"green","reason":"docs/adr is present"}'
+else
+  printf '{"version":1,"status":"red","reason":"no docs/adr directory"}'
+fi
+exit 0
+----
+
 == Exit status
 
 Exit status reports whether the auditor ran. The verdict is in the answer.
@@ -133,18 +193,23 @@ An auditor reporting `red` when its target was merely unreachable passes an ordi
 
 == Distribution
 
-An extension bundle is a directory holding a manifest and the commands it names:
+An organization distributes an auditor by declaring it in the governance policy the Plugin already fetches. Set `governance-policy-url` in the CLI system configuration, and every project downloads that policy and resolves the conditions in it. An auditor declared there arrives with the condition it answers.
 
 [source,yaml]
 ----
-auditors:
+exit_conditions:
   - id: CORP-LICENCE-SCAN
-    run: ["corp-licence-scan"]
-    applies_to: { requirement: maven }
-    timeout: 120s
+    tier: project
+    invariant: "no dependency carries a licence outside the approved set"
+    auditor:
+      run: ["corp-licence-scan"]
+      applies_to: { requirement: maven }
+      timeout: 120s
+      params:
+        allowed: ["Apache-2.0", "MIT", "BSD-3-Clause"]
 ----
 
-The bundle is fetched from an `extensions-url` in the CLI's system config to `.akka/extensions/`, the same mechanism that delivers a governance policy. Commands resolve from the bundle first and from `PATH` second, so an organization that installs its tools separately can.
+The policy carries the declaration; it does not carry the command. Install that separately, the way the rest of your build tooling is installed. A bare name in `run` is found on `PATH`. A name containing a separator is resolved against the project root, or against the module named by `applies_to`, which is how an auditor checked into the repository alongside the code it examines is reached.
 
 == Trust and approval
 

--- a/docs/src/modules/reference/pages/specify/custom-conditions.adoc
+++ b/docs/src/modules/reference/pages/specify/custom-conditions.adoc
@@ -26,7 +26,7 @@ exit_conditions:
     signal: scan
     probe: "licence scanner over the resolved dependency set"
     pass: "disallowed_licences == 0"
-    autonomy: auto-close
+    autonomy: auto
     auditor:
       run: ["corp-licence-scan"]
       applies_to:
@@ -122,7 +122,10 @@ except OSError as exc:
 
 offenders = [f"{n} ({lic})" for n, lic in (l.split() for l in lines if l) if lic not in allowed]
 if offenders:
-    answer("red", f"{len(offenders)} carry an unapproved licence", offenders=offenders)
+    answer("red",
+       f"{len(offenders)} dependenc{'y' if len(offenders) == 1 else 'ies'} "
+       f"carr{'ies' if len(offenders) == 1 else 'y'} an unapproved licence",
+       offenders=offenders)
 answer("green", f"{len(lines)} dependencies, all approved")
 ----
 
@@ -132,8 +135,14 @@ Run it by hand, since a request is only text on standard input:
 
 [source,bash]
 ----
+cat > licences.txt <<'EOF'
+libfoo Apache-2.0
+libbaz GPL-3.0
+EOF
+
 echo '{"kind":"auditor","version":1,"project":{"root":"."},
-       "condition":{"params":{"allowed":["Apache-2.0","MIT"]}}}'   | python examples/extensions/licence-scan.py
+       "condition":{"params":{"allowed":["Apache-2.0","MIT"]}}}' \
+  | python examples/extensions/licence-scan.py
 ----
 
 [source,json]
@@ -196,7 +205,7 @@ That prints the request the auditor received, its raw output, and the verdict th
 
 [source,bash]
 ----
-akka specify extension verify -- python examples/extensions/licence-scan.py   --params '{"allowed":["Apache-2.0","MIT"]}'
+akka specify extension verify --params '{"allowed":["Apache-2.0","MIT"]}'   -- python examples/extensions/licence-scan.py
 ----
 
 [source]

--- a/docs/src/modules/reference/pages/specify/default-library.adoc
+++ b/docs/src/modules/reference/pages/specify/default-library.adoc
@@ -59,6 +59,7 @@ Every library condition has a stable *id*. That id is the registry key: a policy
 | `CONTENT-TONE` | Content & Brand Governance | `off-but-dev-configurable` | *Off by default.* Prose passes an attested tone judge (delegated).
 | `PROC-SOURCE-GROUNDING` | Process Integrity | `on-but-dev-configurable` | API usage is cited to official documentation; invented APIs are caught under coverage.
 | `PROC-RULE-EVIDENCE` | Process Integrity | `on-but-dev-configurable` | Every requirement not chosen by you records how it was established.
+| `PROJ-PROVENANCE-DECLARED` | Documentation & Training | `off-but-dev-configurable` | Every requirement declares where it came from.
 | `PROC-AUDITOR-COVERAGE` | Process Integrity | `always-apply` | Every material build surface has a covering auditor (the coverage gate).
 | `PROC-ADEQUACY-REVIEWED` | Process Integrity | `always-apply` | A fresh adequacy review covers every active auditor.
 | `BUILD-WITHIN-BUDGET` | Build Efficiency | `on-but-dev-configurable` | The build stays within its time budget (human sign-off).
@@ -66,7 +67,7 @@ Every library condition has a stable *id*. That id is the registry key: a policy
 
 [NOTE]
 ====
-Four library conditions are *prohibitions* — a prohibition must never become true, and an unaudited prohibition is red rather than open: `SEC-SECRETS-NOT-COMMITTED`, `NEVER-COMMIT-BUILD-OUTPUT`, `NEVER-UNPINNED-DEP`, and `CONTENT-LANGUAGE`. The two Content & Brand Governance conditions (`CONTENT-LANGUAGE` and `CONTENT-TONE`) are the only library conditions *off by default*; opt in per project, or promote them in a policy.
+Four library conditions are *prohibitions* — a prohibition must never become true, and an unaudited prohibition is red rather than open: `SEC-SECRETS-NOT-COMMITTED`, `NEVER-COMMIT-BUILD-OUTPUT`, `NEVER-UNPINNED-DEP`, and `CONTENT-LANGUAGE`. Three library conditions are *off by default*: the two Content & Brand Governance conditions (`CONTENT-LANGUAGE` and `CONTENT-TONE`), and `PROJ-PROVENANCE-DECLARED`. Opt in per project, or promote them in a policy.
 ====
 
 Some conditions are UI-only and apply only when a feature has a user interface; for a headless Akka service they are struck as a group. The catalog of further candidates to consider is in the xref:reference:specify/catalog/index.adoc[exit condition catalog].

--- a/docs/src/modules/reference/pages/specify/default-library.adoc
+++ b/docs/src/modules/reference/pages/specify/default-library.adoc
@@ -51,12 +51,14 @@ Every library condition has a stable *id*. That id is the registry key: a policy
 | `NEVER-COMMIT-BUILD-OUTPUT` | Repository Hygiene | `on-but-dev-configurable` | *Prohibition.* No build output (`target`, `dist`, `node_modules`, `build`) is tracked.
 | `PROJ-TEST-COVERAGE` | Code & Test Health | `on-but-dev-configurable` | Line/branch coverage at or above a threshold.
 | `PROJ-ADR-RECORDED` | Documentation & Training | `on-but-dev-configurable` | Architecture decision records are present (human sign-off).
+| `PROJ-SPEC-SCHEMA` | Documentation & Training | `on-but-dev-configurable` | The specification is well-formed and every requirement traces to a test.
 | `ENV-SETUP-CURRENT` | Environment & Dependencies | `on-but-dev-configurable` | The project's environment setup is current.
 | `ENV-DEPS-RESOLVE` | Environment & Dependencies | `on-but-dev-configurable` | Declared dependencies resolve (`mvn dependency:resolve`).
 | `NEVER-UNPINNED-DEP` | Environment & Dependencies | `on-but-dev-configurable` | *Prohibition.* No dependency is unpinned; a lockfile or `go.sum` is present.
 | `CONTENT-LANGUAGE` | Content & Brand Governance | `off-but-dev-configurable` | *Prohibition, off by default.* Prose passes the content class's Vale configuration (`content-vale`).
 | `CONTENT-TONE` | Content & Brand Governance | `off-but-dev-configurable` | *Off by default.* Prose passes an attested tone judge (delegated).
 | `PROC-SOURCE-GROUNDING` | Process Integrity | `on-but-dev-configurable` | API usage is cited to official documentation; invented APIs are caught under coverage.
+| `PROC-RULE-EVIDENCE` | Process Integrity | `on-but-dev-configurable` | Every requirement not chosen by you records how it was established.
 | `PROC-AUDITOR-COVERAGE` | Process Integrity | `always-apply` | Every material build surface has a covering auditor (the coverage gate).
 | `PROC-ADEQUACY-REVIEWED` | Process Integrity | `always-apply` | A fresh adequacy review covers every active auditor.
 | `BUILD-WITHIN-BUDGET` | Build Efficiency | `on-but-dev-configurable` | The build stays within its time budget (human sign-off).

--- a/docs/src/modules/reference/pages/specify/exit-condition-schema.adoc
+++ b/docs/src/modules/reference/pages/specify/exit-condition-schema.adoc
@@ -29,6 +29,7 @@ Where the condition comes from, which determines whether a developer can change 
 | `recommended-default` | From the default library; on by default, may be marked inapplicable.
 | `corporate` | Inherited from the organization policy; locked according to its governance level.
 | `developer` | Added by the developer for this feature.
+| `generated` | Written by a tool rather than a person, such as xref:reference:specify/port.adoc[/akka:port] deriving conditions from a system it studied. Held in its own set, so a tool that rewrites its own conditions never reaches one you wrote.
 |===
 
 `governance_level`::

--- a/docs/src/modules/reference/pages/specify/index.adoc
+++ b/docs/src/modules/reference/pages/specify/index.adoc
@@ -29,6 +29,7 @@ The commands are used from within an AI coding assistant (such as Claude Code) a
 |xref:specify/conform.adoc[`/akka:conform`]           | Run the auditors and return the definition-of-done verdict
 |xref:specify/ship.adoc[`/akka:ship`]                 | Run the auditors for the requested ship target and, on pass, run the organization's ship steps
 |xref:specify/mode.adoc[`/akka:mode`]                 | Switch between Enforced and À la carte modes
+|xref:specify/port.adoc[`/akka:port`]                 | Derive a specification from a system that already exists and hold a rebuild to it
 |xref:specify/docs.adoc[`/akka:docs`]                 | Generate rendered project documentation into `docs/`
 |====
 
@@ -40,6 +41,9 @@ The commands are used from within an AI coding assistant (such as Claude Code) a
 * xref:reference:specify/default-library.adoc[Default exit-condition library] — the built-in conditions and their ids.
 * xref:reference:specify/requirement-analysis.adoc[Requirement analysis] — how feedback becomes a checkable exit condition.
 * xref:reference:specify/auditors.adoc[Auditors] — how a check is authored and bound to a condition.
+* xref:reference:specify/custom-conditions.adoc[Custom conditions and auditors] — the contract an auditor of your own is written against.
+* xref:reference:specify/probes.adoc[Discovery probes] — what each probe establishes, and what it needs in order to run.
+* xref:reference:specify/spec-conformance.adoc[Specification conformance] — the conditions that check a specification accounts for itself.
 * xref:reference:specify/auditor-kinds.adoc[Auditor kinds] — introspective, provisioned, and delegated checks.
 * xref:reference:specify/project-surface.adoc[Project surface coverage] — the code, harness, and doc surfaces a build must account for.
 * xref:reference:specify/coverage-gate.adoc[The coverage gate] — `PROC-AUDITOR-COVERAGE` over every surface.

--- a/docs/src/modules/reference/pages/specify/mode.adoc
+++ b/docs/src/modules/reference/pages/specify/mode.adoc
@@ -26,9 +26,44 @@ The mode controls two things: whether Akka Specify creates exit conditions on it
 
 Use `--exit-conditions=honor` to start using conditions in à la carte mode, or `--exit-conditions=ignore` to set them aside. Setting them aside does not delete anything. The captured conditions stay in `.akka/exit-conditions.yaml` and `--exit-conditions=honor` brings them back.
 
-Every Specify command is available in both modes. The mode changes what the engine does on its own, not the command set. The two locked process-integrity gates, `PROC-AUDITOR-COVERAGE` and `PROC-ADEQUACY-REVIEWED`, apply whenever the exit-condition set is active. Enforced mode blocks ship while either is red, and à la carte computes them as advisory. While the set is dormant they do not resolve at all, because there is nothing yet to have covered or reviewed.
+The mode also decides which commands you may run. See <<_commands_available_in_each_mode>>.
+
+The two locked process-integrity gates, `PROC-AUDITOR-COVERAGE` and `PROC-ADEQUACY-REVIEWED`, apply whenever the exit-condition set is active. Enforced mode blocks ship while either is red, and à la carte computes them as advisory. While the set is dormant they do not resolve at all, because there is nothing yet to have covered or reviewed.
 
 A developer can switch only within the modes the organization allows. If the organization has locked the mode (see xref:reference:specify/policies.adoc[Policies]), the command refuses and says so.
+
+== Commands available in each mode
+
+À la carte places no restriction on any command. You choose which step to run and when.
+
+Enforced mode gives the sequence to the engine. It decides when to plan, break work into tasks, implement, build, review, and conform, and in what order. Running one of those steps by hand is choosing the sequence, so enforced mode rejects it.
+
+Five commands stay available, because each one is a place where you state intent or take responsibility for a result:
+
+[cols="1,3",options="header"]
+|===
+| Command | Why it stays available
+
+| `/akka:mode` | Leaving enforcement stays possible, so a project is never trapped in it
+| `/akka:specify` | State what is to be built
+| `/akka:port` | State what is to be built, by naming a system to match
+| `/akka:ship` | Take responsibility for a release
+| `/akka:status` | Report the current state. It changes nothing.
+|===
+
+Any other command is refused, and the message names the remedy:
+
+[source]
+----
+/akka:implement
+
+This project is in enforced mode, where the engine runs implement as part of
+the sequence it controls. To run it yourself, switch with
+`/akka:mode a-la-carte`. The project keeps its exit conditions, and you can
+return to enforced mode afterwards.
+----
+
+Switching to à la carte to run one step by hand loses no work. The project keeps every exit condition it has captured, and switching back to enforced mode restores the gate.
 
 == Switching a project that already has conditions
 

--- a/docs/src/modules/reference/pages/specify/port.adoc
+++ b/docs/src/modules/reference/pages/specify/port.adoc
@@ -179,6 +179,9 @@ A port that carries no additional obligations omits the flag.
 
 == Discovery
 
+Discovery runs through `akka specify probes run`, which resolves what the environment offers, executes the selected probes, and writes `.akka/discovery/`. See xref:reference:specify/probes.adoc[Discovery probes].
+
+
 Enumeration produces the interface list without depending on anyone's recollection of the system.
 
 [source]

--- a/docs/src/modules/reference/pages/specify/port.adoc
+++ b/docs/src/modules/reference/pages/specify/port.adoc
@@ -227,8 +227,12 @@ An assumption stays visible in every status report until someone strengthens it 
     143 traceability rows
 
   PROJ-SPEC-SCHEMA  green
-  PROC-RULE-EVIDENCE  green · 143 requirements account for their evidence
+  PROC-RULE-EVIDENCE  green · 143 requirement(s) account for their evidence
 ----
+
+Both conditions count success criteria as requirements, which is why the last
+line reads 143 rather than 132: the eleven success criteria carry provenance and
+traceability on the same terms as the functional requirements.
 
 The specification is written in the standard template. Every requirement carries an identifier, appears in the traceability table with a source and a test, and records how it was established. No `[NEEDS CLARIFICATION]` marker survives into the specification, so the handoff never waits on a person. See xref:reference:specify/spec-conformance.adoc[Specification conformance].
 

--- a/docs/src/modules/reference/pages/specify/port.adoc
+++ b/docs/src/modules/reference/pages/specify/port.adoc
@@ -59,6 +59,14 @@ run at every condition, so the question is put once, here, while you are present
 
 › 2
 
+  This run will write one check per requirement and run them against your
+  rebuild. Approve them as they are written?
+
+  Declining is fine. The checks are still written, and each waits for its own
+  approval before it can go green.
+
+› yes
+
   Which probes should run? Defaults for `run` are marked ●.
 
     Interface and reachability
@@ -91,14 +99,6 @@ run at every condition, so the question is put once, here, while you are present
       +clock +concurrency -appearance
 
 › +concurrency
-
-  This run will write one check per requirement and run them against your
-  rebuild. Approve them as they are written?
-
-  Declining is fine. The checks are still written, and each waits for its own
-  approval before it can go green.
-
-› yes
 
   Porting knadh/listmonk
 
@@ -140,7 +140,7 @@ Selects how deeply the original is examined. Each level costs more than the one 
 | Keeping the original running alongside the rebuild until the port completes.
 |===
 
-The default is `read`. A requirement derived by reading source is weaker evidence than one derived by calling an endpoint and recording the answer, so a port studied at `read` produces a specification whose claims are all at the weakest rung. xref:reference:specify/spec-conformance.adoc[`PROC-RULE-EVIDENCE`] reports that in every status output.
+The default is `read`. A requirement derived by reading source is weaker evidence than one derived by calling an endpoint and recording the answer, so a port studied at `read` produces a specification whose claims are all at the weakest rung. Each requirement records the rung it earned, and xref:reference:specify/spec-conformance.adoc[`PROC-RULE-EVIDENCE`] checks that every one of them accounts for its evidence.
 
 === --probe
 
@@ -267,7 +267,7 @@ Every element carries a disposition. An element the command could not describe i
   Progress updates follow. Nothing needs you until one says otherwise.
 ----
 
-The project is now in enforced mode, where the engine sequences the work, so no next command is named. Running one of the sequenced steps yourself is refused with an explanation and the remedy. See xref:reference:specify/mode.adoc[/akka:mode].
+The project is now in enforced mode, where the engine sequences the work. `/akka:specify` is that engine, and it is one of the five commands enforcement permits: under enforcement it carries the sequence out rather than recommending a following command. Running one of the sequenced steps yourself is refused with an explanation and the remedy. See xref:reference:specify/mode.adoc[/akka:mode].
 
 Each parity condition carries an auditor the port wrote, and a command nobody has seen does not run until it is approved. Approving them one at a time would stop the run at each condition, so the consent is taken at invocation and covers the set. Declining is a legitimate answer: the conditions are still written, and each waits for its own approval before it can go green.
 

--- a/docs/src/modules/reference/pages/specify/port.adoc
+++ b/docs/src/modules/reference/pages/specify/port.adoc
@@ -1,0 +1,381 @@
+= /akka:port
+
+Build a specification from a system that already exists, generate the exit conditions that hold a rebuild to that system's behaviour, and hand the result to the xref:reference:specify/index.adoc[Akka Specify Plugin] as an ordinary project.
+
+The command runs at two moments. The first invocation studies the original and hands off. `/akka:port finalize` runs after the rebuild matches it. Between them the port proceeds without you, because every decision you make is made at invocation.
+
+== Usage
+
+[source]
+----
+/akka:port knadh/listmonk
+/akka:port knadh/listmonk --study=run
+/akka:port knadh/listmonk --study=diff --also=soc2,load:1000rps
+/akka:port finalize
+----
+
+The system argument accepts a repository reference, a URL, or the address of a running instance.
+
+== When flags are omitted
+
+Every question is asked before the work starts, and none afterwards. A fully specified invocation runs unattended. A bare one asks for what is missing, then runs unattended.
+
+[cols="1,2",options="header"]
+|===
+| Given | Behaviour
+
+| Nothing | Ask for the system, the study level, then the probes
+| The system only | Ask for the study level, then the probes
+| The system and `--study` | Ask for the probes
+| The system, `--study`, and `--probe` | Run
+|===
+
+`--also` is never prompted for. Its absence is a legitimate answer.
+
+[source]
+----
+› /akka:port
+
+  What are you porting?
+  A repository reference, a URL, or the address of a running instance.
+
+› knadh/listmonk
+
+  Reading knadh/listmonk…
+
+  Go · Echo · PostgreSQL · Redis
+  AGPL-3.0, © the knadh/listmonk authors
+
+  How deeply should this system be studied?
+
+    [1] read    Static analysis only. Nothing is executed.          ~5 min
+    [2] run     The original is started and exercised.             ~40 min
+    [3] diff    Adds a proxy comparing both systems throughout.
+                                                          ~40 min, continuous
+
+› 2
+
+  Which probes should run? Defaults for `run` are marked ●.
+
+    Interface and reachability
+      ● surface        the routes, configuration keys, scheduled jobs, and
+                       tables the system exposes
+        coverage       which of the original's own tests touch each element
+
+    Behaviour
+      ● sequence       behaviour across a sequence of calls rather than one
+      ● ordering       behaviour when events arrive out of order
+        concurrency    behaviour under two conflicting writes at once
+      ● distribution   behaviour across the range of an input
+
+    Comparison
+      ● answers        what both systems return for the same question
+        stream-cut     divergence through a live proxy
+
+    Confidence
+      ● mutation       whether the checker fails when the answer is wrong
+        determinism    whether the same input twice produces the same answer
+
+    Interface appearance and performance
+      ● appearance     the rendered surface, captured and compared
+      ● timing         a measured figure, with its own noise floor
+
+    Unavailable for this system
+      ✗ reachability   needs toolchain
+      ✗ clock          needs clock
+      ✗ adverse        needs deps
+
+    Enter to accept the defaults, or name the changes:
+      +clock +concurrency -appearance
+
+› +concurrency
+
+  Porting knadh/listmonk
+
+    study      run
+    probes     answers, appearance, concurrency, distribution, mutation,
+               ordering, sequence, surface, timing
+    also       nothing
+
+  This runs unattended for several hours. You will not be asked anything
+  else. Equivalent invocation:
+
+    /akka:port knadh/listmonk --study=run --probe=+concurrency
+
+  Begin? [Y/n]
+›
+----
+
+The equivalent invocation is printed because it is what a second person runs to reproduce the port.
+
+== Flags
+
+=== --study
+
+Selects how deeply the original is examined. Each level costs more than the one before it, and the level you choose sets an upper bound on the evidence any requirement may claim.
+
+[cols="1,2,2",options="header"]
+|===
+| Level | What it does | What it requires of you
+
+| `read`
+| Static analysis of the source. Route declarations, configuration schemas, job registrations, and migrations are read to produce the interface list.
+| Nothing. The original is never executed.
+
+| `run`
+| Starts the original and exercises it, so behaviour is observed rather than inferred.
+| Executing software you may not control, on hardware you do.
+
+| `diff`
+| Adds a comparison proxy that answers each request from both systems for the duration of the rebuild, reporting divergence as it appears.
+| Keeping the original running alongside the rebuild until the port completes.
+|===
+
+The default is `read`. A requirement derived by reading source is weaker evidence than one derived by calling an endpoint and recording the answer, so a port studied at `read` produces a specification whose claims are all at the weakest rung. xref:reference:specify/spec-conformance.adoc[`PROC-RULE-EVIDENCE`] reports that in every status output.
+
+=== --probe
+
+Selects which discovery probes run. Each `--study` level carries a default set, and `--probe` states the changes against it. A bare name is an addition, so `clock` and `+clock` mean the same thing.
+
+[source]
+----
+--probe=+clock,+concurrency,-appearance
+----
+
+A probe that cannot reach the system is reported as unavailable with the capability it lacks. Asking for one by name does not make it available, and it is still reported rather than accepted quietly. See xref:reference:specify/probes.adoc[Discovery probes] for the catalogue.
+
+=== --also
+
+Declares obligations the original never carried. Parity conditions verify that the rebuild behaves as the original behaved, and they say nothing about anything else the rebuild must satisfy.
+
+[cols="1,3",options="header"]
+|===
+| Form | Meaning
+
+| A framework name, such as `soc2`
+| Adds the conditions the organization's policy associates with that framework. See xref:reference:specify/policies.adoc[Policies].
+| A target, such as `load:1000rps`
+| Adds a Product-tier condition holding the rebuild to that figure.
+| Several, comma separated
+| `--also=soc2,load:1000rps`
+|===
+
+A port that carries no additional obligations omits the flag.
+
+== Invocation
+
+[source]
+----
+› /akka:port knadh/listmonk --study=run --also=soc2
+
+  Reading knadh/listmonk…
+
+  Go · Echo · PostgreSQL · Redis
+  AGPL-3.0, © the knadh/listmonk authors
+
+  Studying at level `run`. The original will be started on this machine and
+  exercised. Its evidence ceiling is `exercised`.
+----
+
+== Discovery
+
+Enumeration produces the interface list without depending on anyone's recollection of the system.
+
+[source]
+----
+  Enumerating the interface…
+
+    94  HTTP routes
+    41  configuration keys
+     4  scheduled jobs
+    18  database tables
+   ───
+   157  interface elements
+
+  Observing behaviour…      [########################] 157/157
+
+  Grounding
+    exercised   121   called and observed
+    documented   24   stated by the project's own documentation
+    inspected    12   inferred by reading the source
+----
+
+Where an observation is ambiguous, discovery designs a further experiment and observes again. Where that loop exhausts itself, it records an assumption and continues.
+
+[source]
+----
+  Resolving ambiguity…
+
+    FR-058  bounce processing when a mailbox reports a soft failure
+            5 further experiments · resolved: three soft bounces within
+            24 hours mark the subscriber as unconfirmed
+
+    FR-103  whether deleting a list cascades to its campaigns
+            4 further experiments · unresolved
+
+            Assumed: deletion is refused while campaigns reference the list.
+            The schema declares the foreign key without a cascade, and no
+            observation contradicted it. Evidence recorded as `inspected`.
+
+  0 unresolved questions · 1 assumption recorded
+----
+
+An assumption stays visible in every status report until someone strengthens it or accepts it.
+
+== The specification
+
+[source]
+----
+  Wrote specs/001-listmonk/spec.md
+
+    132 requirements     FR-001 … FR-132, annotated `observed`
+     11 success criteria
+    143 traceability rows
+
+  PROJ-SPEC-SCHEMA  green
+  PROC-RULE-EVIDENCE  green · 12 requirements at `inspected`
+----
+
+The specification is written in the standard template. Every requirement carries an identifier, appears in the traceability table with a source and a test, and records how it was established. No `[NEEDS CLARIFICATION]` marker survives into the specification, so the handoff never waits on a person. See xref:reference:specify/spec-conformance.adoc[Specification conformance].
+
+== Interface disposition
+
+[source]
+----
+  157 interface elements · 151 covered by a requirement · 6 dropped
+
+  Dropped, with reasons:
+
+    /api/import/upload           no observation succeeded; the endpoint
+    /api/import/status           requires a multipart upload the harness
+    /api/import/log              could not construct
+
+    /api/maintenance/analytics   requires an administrative session the
+    /api/maintenance/set-tags    harness could not establish
+    /api/maintenance/subscribers
+----
+
+Every element carries a disposition. An element the command could not describe is dropped, and the reason is recorded as a divergence that stays with the project. This list is the first thing worth reading when the port completes.
+
+== Handoff
+
+[source]
+----
+  Authored 132 parity conditions.
+  Added 6 project defaults and 4 from --also=soc2.
+
+  Mode set to enforced.
+
+    142 conditions · 0 green · 142 open
+    Next: /akka:implement
+
+  Progress updates follow. Nothing needs you until one says otherwise.
+----
+
+The project is now in enforced mode, where the engine sequences the work. Running one of the sequenced steps yourself is refused with an explanation and the remedy. See xref:reference:specify/mode.adoc[/akka:mode].
+
+== While it runs
+
+You are free to work on other projects. An update appears in this terminal when a condition changes state, and at least every thirty minutes regardless, so a stalled port stays visible.
+
+[source]
+----
+  listmonk · 1h 47m · step: implement
+
+    conditions      61 of 142 green
+    since 11:15     +14 green · 0 red
+    working on      FR-044 … FR-058, bounce processing
+
+  Nothing needs you.
+----
+
+An update names anything waiting on a person.
+
+[source]
+----
+  listmonk · 5h 02m · step: implement
+
+    conditions      118 of 142 green
+    since 14:30     +1 green · 2 red
+    working on      FR-103, list deletion
+
+  Needs you: FR-103 rests on an assumption that three attempts have now
+  contradicted. Campaigns referencing a deleted list are archived rather
+  than blocking the delete. Confirm the correction, or run the original
+  and settle it.
+----
+
+An update with nothing to report still appears.
+
+[source]
+----
+  listmonk · 5h 32m · step: implement
+
+    conditions      118 of 142 green
+    since 15:02     no change
+    working on      FR-103, list deletion
+
+  Nothing needs you.
+----
+
+== Completion
+
+[source]
+----
+  listmonk · 8h 14m · step: conform
+
+    conditions      142 of 142 green
+
+  These auditors compare the rebuild against a running listmonk. If that
+  system is decommissioned, 132 of them stop working.
+
+  Run /akka:port finalize.
+----
+
+The prompt is raised by the progress update and by xref:reference:specify/status.adoc[/akka:status].
+
+== Graduation
+
+[source]
+----
+› /akka:port finalize
+
+   124  recorded fixtures   responses captured during the port
+     5  replayed tables     bounce thresholds, campaign scheduling, retries
+     2  absolute budgets    "as fast as listmonk" became a measured figure
+     1  retired             FR-089 required a live comparison against SMTP
+                            delivery timing and cannot be recorded. The
+                            reason is kept in the project.
+
+  142 conditions still run. None requires listmonk to exist.
+
+  This is now an ordinary Akka Specify Plugin project.
+----
+
+Each condition keeps its identifier, its invariant, and its pass predicate. Only the auditor changes.
+
+[cols="1,3",options="header"]
+|===
+| Graduates to | For a condition that compared
+
+| A recorded fixture | Two responses. The auditor compares one response against a stored value.
+| A replayed table | Two decisions across a sweep of inputs, such as scheduling or expiry. The auditor replays the recorded inputs and expected outputs.
+| An absolute budget | Two timings. The comparison is replaced by the figure the original achieved.
+|===
+
+A condition that can only be expressed as a live comparison, and whose subject cannot be recorded, is retired. The reason is kept in the project.
+
+Graduation rewrites only conditions whose provenance is `generated`, so it never reaches a condition you wrote. Conditions added by `--also` are untouched, because they never referenced the original. See xref:reference:specify/exit-condition-schema.adoc[Exit condition schema].
+
+== What is enforced
+
+The discovery level is recorded when it is chosen, and it caps the evidence any requirement may claim. Every requirement carries an identifier, a traceability row naming a source and a test, and a record of how it was established. No specification reaches handoff while an unresolved clarification marker survives. Every enumerated interface element carries a disposition before handoff.
+
+== See also
+
+* xref:sdk:porting-legacy-systems.adoc[Porting legacy systems]
+* xref:reference:specify/spec-conformance.adoc[Specification conformance]
+* xref:reference:specify/mode.adoc[/akka:mode]
+* xref:reference:specify/exit-condition-schema.adoc[Exit condition schema]
+* xref:reference:specify/policies.adoc[Policies]
+* xref:reference:specify/index.adoc[]

--- a/docs/src/modules/reference/pages/specify/port.adoc
+++ b/docs/src/modules/reference/pages/specify/port.adoc
@@ -18,17 +18,22 @@ The system argument accepts a repository reference, a URL, or the address of a r
 
 == When flags are omitted
 
-Every question is asked before the work starts, and none afterwards. A fully specified invocation runs unattended. A bare one asks for what is missing, then runs unattended.
+Every question is asked before the work starts, and none afterwards. A fully specified invocation asks only for the consent below; a bare one asks for what is missing. Either way the run proceeds unattended once the questions are answered.
 
 [cols="1,2",options="header"]
 |===
 | Given | Behaviour
 
-| Nothing | Ask for the system, the study level, then the probes
-| The system only | Ask for the study level, then the probes
-| The system and `--study` | Ask for the probes
-| The system, `--study`, and `--probe` | Run
+| Nothing | Ask for the system, the study level, the consent, then the probes
+| The system only | Ask for the study level, the consent, then the probes
+| The system and `--study` | Ask for the consent, then the probes
+| The system, `--study`, and `--probe` | Ask for the consent, then run
 |===
+
+The consent is always asked, because it cannot be given on a command line. Each
+parity condition carries an auditor the port wrote, and a command nobody has seen
+does not run until it is approved. Approving them one at a time would stop the
+run at every condition, so the question is put once, here, while you are present.
 
 
 [source]
@@ -66,6 +71,7 @@ Every question is asked before the work starts, and none afterwards. A fully spe
       ● ordering       behaviour when events arrive out of order
         concurrency    behaviour under two conflicting writes at once
       ● distribution   behaviour across the range of an input
+        clock          behaviour that changes with time alone
 
     Confidence
       ● mutation       whether the checker fails when the answer is wrong
@@ -77,7 +83,6 @@ Every question is asked before the work starts, and none afterwards. A fully spe
 
     Unavailable for this system
       ✗ reachability   needs toolchain
-      ✗ clock          needs clock
       ✗ adverse        needs deps
       ✗ answers        needs rebuild
       ✗ stream-cut     needs rebuild
@@ -86,6 +91,14 @@ Every question is asked before the work starts, and none afterwards. A fully spe
       +clock +concurrency -appearance
 
 › +concurrency
+
+  This run will write one check per requirement and run them against your
+  rebuild. Approve them as they are written?
+
+  Declining is fine. The checks are still written, and each waits for its own
+  approval before it can go green.
+
+› yes
 
   Porting knadh/listmonk
 
@@ -243,7 +256,7 @@ Every element carries a disposition. An element the command could not describe i
 [source]
 ----
   Authored 132 parity conditions.
-  Added 6 project defaults, and turned on PROJ-PROVENANCE-DECLARED.
+  Added 9 project defaults, and turned on PROJ-PROVENANCE-DECLARED.
 
   Their auditors are approved to run, on the consent you gave at invocation.
 

--- a/docs/src/modules/reference/pages/specify/port.adoc
+++ b/docs/src/modules/reference/pages/specify/port.adoc
@@ -227,7 +227,7 @@ An assumption stays visible in every status report until someone strengthens it 
     143 traceability rows
 
   PROJ-SPEC-SCHEMA  green
-  PROC-RULE-EVIDENCE  green · 12 requirements account for their evidence
+  PROC-RULE-EVIDENCE  green · 143 requirements account for their evidence
 ----
 
 The specification is written in the standard template. Every requirement carries an identifier, appears in the traceability table with a source and a test, and records how it was established. No `[NEEDS CLARIFICATION]` marker survives into the specification, so the handoff never waits on a person. See xref:reference:specify/spec-conformance.adoc[Specification conformance].

--- a/docs/src/modules/reference/pages/specify/port.adoc
+++ b/docs/src/modules/reference/pages/specify/port.adoc
@@ -10,7 +10,7 @@ The command runs at two moments. The first invocation studies the original and h
 ----
 /akka:port knadh/listmonk
 /akka:port knadh/listmonk --study=run
-/akka:port knadh/listmonk --study=diff --also=soc2,load:1000rps
+/akka:port knadh/listmonk --study=diff
 /akka:port finalize
 ----
 
@@ -30,7 +30,6 @@ Every question is asked before the work starts, and none afterwards. A fully spe
 | The system, `--study`, and `--probe` | Run
 |===
 
-`--also` is never prompted for. Its absence is a legitimate answer.
 
 [source]
 ----
@@ -68,10 +67,6 @@ Every question is asked before the work starts, and none afterwards. A fully spe
         concurrency    behaviour under two conflicting writes at once
       ● distribution   behaviour across the range of an input
 
-    Comparison
-      ● answers        what both systems return for the same question
-        stream-cut     divergence through a live proxy
-
     Confidence
       ● mutation       whether the checker fails when the answer is wrong
         determinism    whether the same input twice produces the same answer
@@ -84,6 +79,8 @@ Every question is asked before the work starts, and none afterwards. A fully spe
       ✗ reachability   needs toolchain
       ✗ clock          needs clock
       ✗ adverse        needs deps
+      ✗ answers        needs rebuild
+      ✗ stream-cut     needs rebuild
 
     Enter to accept the defaults, or name the changes:
       +clock +concurrency -appearance
@@ -93,9 +90,8 @@ Every question is asked before the work starts, and none afterwards. A fully spe
   Porting knadh/listmonk
 
     study      run
-    probes     answers, appearance, concurrency, distribution, mutation,
+    probes     appearance, concurrency, distribution, mutation,
                ordering, sequence, surface, timing
-    also       nothing
 
   This runs unattended for several hours. You will not be asked anything
   else. Equivalent invocation:
@@ -144,29 +140,11 @@ Selects which discovery probes run. Each `--study` level carries a default set, 
 
 A probe that cannot reach the system is reported as unavailable with the capability it lacks. Asking for one by name does not make it available, and it is still reported rather than accepted quietly. See xref:reference:specify/probes.adoc[Discovery probes] for the catalogue.
 
-=== --also
-
-Declares obligations the original never carried. Parity conditions verify that the rebuild behaves as the original behaved, and they say nothing about anything else the rebuild must satisfy.
-
-[cols="1,3",options="header"]
-|===
-| Form | Meaning
-
-| A framework name, such as `soc2`
-| Adds the conditions the organization's policy associates with that framework. See xref:reference:specify/policies.adoc[Policies].
-| A target, such as `load:1000rps`
-| Adds a Product-tier condition holding the rebuild to that figure.
-| Several, comma separated
-| `--also=soc2,load:1000rps`
-|===
-
-A port that carries no additional obligations omits the flag.
-
 == Invocation
 
 [source]
 ----
-› /akka:port knadh/listmonk --study=run --also=soc2
+› /akka:port knadh/listmonk --study=run
 
   Reading knadh/listmonk…
 
@@ -265,17 +243,20 @@ Every element carries a disposition. An element the command could not describe i
 [source]
 ----
   Authored 132 parity conditions.
-  Added 6 project defaults and 4 from --also=soc2.
+  Added 6 project defaults, and turned on PROJ-PROVENANCE-DECLARED.
 
-  Mode set to enforced.
+  Their auditors are approved to run, on the consent you gave at invocation.
+
+  Mode set to enforced. The engine now sequences the work.
 
     142 conditions · 0 green · 142 open
-    Next: /akka:implement
 
   Progress updates follow. Nothing needs you until one says otherwise.
 ----
 
-The project is now in enforced mode, where the engine sequences the work. Running one of the sequenced steps yourself is refused with an explanation and the remedy. See xref:reference:specify/mode.adoc[/akka:mode].
+The project is now in enforced mode, where the engine sequences the work, so no next command is named. Running one of the sequenced steps yourself is refused with an explanation and the remedy. See xref:reference:specify/mode.adoc[/akka:mode].
+
+Each parity condition carries an auditor the port wrote, and a command nobody has seen does not run until it is approved. Approving them one at a time would stop the run at each condition, so the consent is taken at invocation and covers the set. Declining is a legitimate answer: the conditions are still written, and each waits for its own approval before it can go green.
 
 == While it runs
 
@@ -350,12 +331,14 @@ The prompt is raised by the progress update and by xref:reference:specify/status
                             delivery timing and cannot be recorded. The
                             reason is kept in the project.
 
-  142 conditions still run. None requires listmonk to exist.
+  141 conditions still run. None requires listmonk to exist.
 
   This is now an ordinary Akka Specify Plugin project.
 ----
 
 Each condition keeps its identifier, its invariant, and its pass predicate. Only the auditor changes.
+
+Underneath, the command reads the derived set with `akka specify conditions list --json`, rewrites each auditor, and writes the result back with `akka specify conditions graduate`. A condition left out of that file is retired, and `graduate` names it, so a check that goes leaves an account of itself in the project.
 
 [cols="1,3",options="header"]
 |===
@@ -368,7 +351,7 @@ Each condition keeps its identifier, its invariant, and its pass predicate. Only
 
 A condition that can only be expressed as a live comparison, and whose subject cannot be recorded, is retired. The reason is kept in the project.
 
-Graduation rewrites only conditions whose provenance is `generated`, so it never reaches a condition you wrote. Conditions added by `--also` are untouched, because they never referenced the original. See xref:reference:specify/exit-condition-schema.adoc[Exit condition schema].
+Graduation rewrites only conditions whose provenance is `generated`, so it never reaches a condition you wrote. See xref:reference:specify/exit-condition-schema.adoc[Exit condition schema].
 
 == What is enforced
 

--- a/docs/src/modules/reference/pages/specify/port.adoc
+++ b/docs/src/modules/reference/pages/specify/port.adoc
@@ -227,7 +227,7 @@ An assumption stays visible in every status report until someone strengthens it 
     143 traceability rows
 
   PROJ-SPEC-SCHEMA  green
-  PROC-RULE-EVIDENCE  green · 12 requirements at `inspected`
+  PROC-RULE-EVIDENCE  green · 12 requirements account for their evidence
 ----
 
 The specification is written in the standard template. Every requirement carries an identifier, appears in the traceability table with a source and a test, and records how it was established. No `[NEEDS CLARIFICATION]` marker survives into the specification, so the handoff never waits on a person. See xref:reference:specify/spec-conformance.adoc[Specification conformance].
@@ -263,6 +263,7 @@ Every element carries a disposition. An element the command could not describe i
   Mode set to enforced. The engine now sequences the work.
 
     142 conditions · 0 green · 142 open
+    Next: /akka:specify
 
   Progress updates follow. Nothing needs you until one says otherwise.
 ----
@@ -329,7 +330,7 @@ An update with nothing to report still appears.
   Run /akka:port finalize.
 ----
 
-The prompt is raised by the progress update and by xref:reference:specify/status.adoc[/akka:status].
+The prompt is raised by the run that evaluates the auditors. A status read resolves the condition set without running them, so nothing is green there to raise it.
 
 == Graduation
 

--- a/docs/src/modules/reference/pages/specify/probes.adoc
+++ b/docs/src/modules/reference/pages/specify/probes.adoc
@@ -123,7 +123,7 @@ This makes the evidence claim checkable rather than asserted. xref:reference:spe
 
 A probe that recognises an ecosystem and then reads nothing from it reports a *gap* rather than an empty result. An empty result and a complete one are otherwise indistinguishable, so a system whose ecosystem is recognised and whose route count is zero is treated as a framework the probe cannot read.
 
-A gap is reported per ecosystem, in the run record and in the picker.
+A gap is reported per ecosystem, in the result the probe writes under `.akka/discovery/`.
 
 === Kinds of gap
 

--- a/docs/src/modules/reference/pages/specify/probes.adoc
+++ b/docs/src/modules/reference/pages/specify/probes.adoc
@@ -198,7 +198,7 @@ A probe receives the capabilities it declared, already resolved, and the element
 }
 ----
 
-A probe uses the capabilities it is given rather than discovering its own. A probe that finds a base URL for itself will find a different one than the engine recorded, and the record is what a requirement cites.
+A probe uses the capabilities it is given rather than discovering its own. A probe that finds its own base URL will find a different one than the engine recorded, and the record is what a requirement cites.
 
 `elements` is the enumerated interface, so a probe examining the surface works from the same list every other probe does.
 

--- a/docs/src/modules/reference/pages/specify/probes.adoc
+++ b/docs/src/modules/reference/pages/specify/probes.adoc
@@ -39,6 +39,19 @@ Asking for a probe by name does not make it available. A probe that was asked fo
 | `coverage` | which of the original's own tests touch each interface element | `source` | —
 |===
 
+`reachability` drives the system through its own tests and reads the coverage its
+own toolchain reports, so the clone is never instrumented. It recognises Go from
+`go.mod`, Python from `pyproject.toml` or a test configuration, JavaScript and
+TypeScript from `package.json`, and Java from `pom.xml`. A system written in more
+than one language is measured once per language and the results are reported
+separately.
+
+Measuring a language requires its coverage tool to be installed and its
+dependencies present. Where either is missing, the language is reported with the
+reason it could not be measured. A language that was recognised and produced no
+measurement reads exactly like a language whose every statement ran, so the
+reason is recorded rather than the absence.
+
 === Behaviour
 
 [cols="1,2,1,1",options="header"]

--- a/docs/src/modules/reference/pages/specify/probes.adoc
+++ b/docs/src/modules/reference/pages/specify/probes.adoc
@@ -19,6 +19,7 @@ A probe declares what it needs of the environment, and `/akka:port` resolves tho
 | `deps` | The original's dependencies can be withdrawn one at a time
 | `toolchain` | The original's build toolchain is installed
 | `browser` | A browser can drive the interface
+| `rebuild` | A running instance of the rebuild exists to compare against
 |===
 
 A probe whose capabilities are unmet is reported as unavailable with the reason. It is never skipped silently, because a specification missing a probe's findings reads exactly like one where the probe ran and found nothing.
@@ -72,9 +73,16 @@ reason is recorded rather than the absence.
 |===
 | Probe | Answers | Needs | Default at
 
-| `answers` | what both systems return for the same question | `execute`, `http` | run, diff
-| `stream-cut` | divergence between the two systems through a live proxy | `execute`, `http` | diff
+| `answers` | what both systems return for the same question | `execute`, `http`, `rebuild` | run, diff
+| `stream-cut` | divergence between the two systems through a live proxy | `execute`, `http`, `rebuild` | diff
 |===
+
+The comparison probes need two systems. During a discovery of the original there
+is usually one, so they are withheld until `--rebuild` names a running instance
+of the rebuild. A probe that could not have produced anything is reported as
+unavailable with the capability it lacks, rather than selected and then counted
+among the probes that failed.
+
 
 === Confidence
 

--- a/docs/src/modules/reference/pages/specify/probes.adoc
+++ b/docs/src/modules/reference/pages/specify/probes.adoc
@@ -221,10 +221,20 @@ A probe claims the rung it actually reached. One that read source reports `inspe
 
 [source,bash]
 ----
-akka specify probe test tenancy --target http://127.0.0.1:8399
+akka specify probes test tenancy --source ./clone --target http://127.0.0.1:8399
 ----
 
-Runs the probe, prints the request it received and its raw output, and validates the answer against the envelope above.
+Runs the probe, prints the request it received and its raw output, and reports the finding the engine would record. A probe whose capabilities this environment does not offer says so rather than running.
+
+=== Seeing and running them
+
+[source,bash]
+----
+akka specify probes list --source ./clone --target http://127.0.0.1:8399 --study=run
+akka specify probes run  --source ./clone --target http://127.0.0.1:8399 --study=run --probe=+clock
+----
+
+`list` reports the capabilities this environment offers, then the catalogue with defaults marked and each unavailable probe named with what it lacks. `run` executes the selection and writes `.akka/discovery/`.
 
 == See also
 

--- a/docs/src/modules/reference/pages/specify/probes.adoc
+++ b/docs/src/modules/reference/pages/specify/probes.adoc
@@ -1,0 +1,233 @@
+= Discovery probes
+
+A probe answers one question about a system xref:reference:specify/port.adoc[/akka:port] is deriving a specification from. It is not a test. A test asserts an expectation, and a probe discovers what the expectation should be.
+
+What a specification can honestly claim depends on how the system was examined, so the probe that established a requirement is recorded alongside it. A requirement claiming it was established by running something can then be checked against what actually ran.
+
+== Capabilities
+
+A probe declares what it needs of the environment, and `/akka:port` resolves those against the system in front of it.
+
+[cols="1,3",options="header"]
+|===
+| Capability | Meaning
+
+| `source` | The original's source is readable
+| `execute` | The original can be started on this machine
+| `http` | The original exposes an HTTP surface that can be driven
+| `clock` | The original's clock can be controlled
+| `deps` | The original's dependencies can be withdrawn one at a time
+| `toolchain` | The original's build toolchain is installed
+| `browser` | A browser can drive the interface
+|===
+
+A probe whose capabilities are unmet is reported as unavailable with the reason. It is never skipped silently, because a specification missing a probe's findings reads exactly like one where the probe ran and found nothing.
+
+Asking for a probe by name does not make it available. A probe that was asked for and withheld is still reported, since the caller expected a finding they are not going to get.
+
+== The catalogue
+
+`Default at` names the study levels where a probe runs without being asked for. See xref:reference:specify/port.adoc[/akka:port] for `--study` and `--probe`.
+=== Interface and reachability
+
+[cols="1,2,1,1",options="header"]
+|===
+| Probe | Answers | Needs | Default at
+
+| `surface` | the routes, configuration keys, scheduled jobs, and tables the system exposes | `source` | read, run, diff
+| `reachability` | which statements execute when the system is driven the way it drives itself | `source`, `toolchain` | run, diff
+| `coverage` | which of the original's own tests touch each interface element | `source` | —
+|===
+
+=== Behaviour
+
+[cols="1,2,1,1",options="header"]
+|===
+| Probe | Answers | Needs | Default at
+
+| `sequence` | behaviour across a sequence of calls rather than one call | `execute`, `http` | run, diff
+| `ordering` | behaviour when events arrive out of order | `execute`, `http` | run, diff
+| `clock` | behaviour that changes with time alone: expiry, scheduling, caching | `execute`, `http` | —
+| `concurrency` | behaviour under two conflicting writes at once | `execute`, `http` | —
+| `distribution` | behaviour across the range of an input rather than one value | `execute`, `http` | run, diff
+| `adverse` | behaviour when a dependency is withdrawn | `execute`, `deps` | —
+|===
+
+=== Comparison
+
+[cols="1,2,1,1",options="header"]
+|===
+| Probe | Answers | Needs | Default at
+
+| `answers` | what both systems return for the same question | `execute`, `http` | run, diff
+| `stream-cut` | divergence between the two systems through a live proxy | `execute`, `http` | diff
+|===
+
+=== Confidence
+
+[cols="1,2,1,1",options="header"]
+|===
+| Probe | Answers | Needs | Default at
+
+| `mutation` | whether the checker fails when the answer is wrong | — | run, diff
+| `determinism` | whether the same input twice produces the same answer | `execute`, `http` | —
+|===
+
+=== Interface appearance and performance
+
+[cols="1,2,1,1",options="header"]
+|===
+| Probe | Answers | Needs | Default at
+
+| `appearance` | the rendered surface, captured and compared | `execute`, `browser` | run, diff
+| `timing` | a measured figure, with the harness's own noise floor beside it | `execute`, `http` | run, diff
+|===
+
+== The record
+
+A discovery run writes `.akka/discovery/run.json`, naming the system, the study level, the probes that ran, and the probes that were withheld with the capabilities they lacked.
+
+A requirement then names the probe that established it:
+
+[source,markdown]
+----
+- **FR-058** (observed, exercised: sequence): three soft bounces within 24
+  hours mark the subscriber as unconfirmed
+----
+
+This makes the evidence claim checkable rather than asserted. xref:reference:specify/spec-conformance.adoc[`PROC-RULE-EVIDENCE`] reads the record and reds when a requirement names a probe that did not run. A project with no discovery record is unaffected, since a requirement in a project that was never derived from another system has no probe to name.
+
+== Gaps
+
+A probe that recognises an ecosystem and then reads nothing from it reports a *gap* rather than an empty result. An empty result and a complete one are otherwise indistinguishable, so a system whose ecosystem is recognised and whose route count is zero is treated as a framework the probe cannot read.
+
+A gap is reported per ecosystem, in the run record and in the picker.
+
+=== Kinds of gap
+
+[cols="1,2,2",options="header"]
+|===
+| Kind | What it looks like | How it is closed
+
+| Undeclared convention
+| The framework routes by file path, directory layout, or naming rather than by a declaration in the source. The probe reads declarations and finds none.
+| Add the convention to the probe's extractors for that ecosystem. A path derived from a filename is as good a route as one read from a decorator.
+
+| Unrecognised framework
+| The ecosystem is right and the framework is one the probe has no patterns for.
+| Add its patterns. The route, configuration, and table extractors are per-framework, and a new one is a small addition rather than a change to the probe.
+
+| Generated surface
+| Routes are registered at run time from data, so nothing in the source names them.
+| Raise the study level. A generated surface is visible to a probe that starts the system and reads what it registered, and invisible to one that only reads source.
+
+| Out of reach
+| The surface exists behind authentication, a build step, or an ecosystem whose toolchain is absent.
+| Supply the missing capability, or accept the gap and record it. A gap that is understood is a different thing from one nobody noticed.
+|===
+
+=== Working with a gap
+
+A gap does not stop a port. It bounds what the port can claim.
+
+The elements a probe could not read are not enumerated, so they are not offered for disposition, and a requirement covering them is written from observation alone. Where the gap is closed later, re-running discovery enumerates them and the specification is checked against the fuller list.
+
+== Authoring a probe
+
+A probe is a command. It shares its interface with an auditor: the request arrives as JSON on standard input, the answer leaves as JSON on standard output, and exit status reports whether the probe ran rather than what it found. See xref:reference:specify/custom-conditions.adoc[Custom exit conditions and auditors] for the parts that are common — exit status, versioning, distribution, and trust.
+
+What follows is what differs for a probe.
+
+=== Declaring one
+
+[source,yaml]
+----
+probes:
+  - name: tenancy
+    group: Behaviour
+    answers: "behaviour when two tenants share a record"
+    needs: [execute, http]
+    default_at: [run, diff]
+    run: ["corp-tenancy-probe"]
+    timeout: 300s
+----
+
+`answers` is read by the person choosing in the picker, so it says what the probe establishes rather than how it works. `needs` and `default_at` place it in the same resolution as every built-in probe: it is offered where its capabilities are met, reported as unavailable where they are not, and runs without being asked for at the levels named.
+
+=== The request
+
+A probe receives the capabilities it declared, already resolved, and the elements the surface probe enumerated.
+
+[source,json]
+----
+{
+  "kind": "probe",
+  "version": 1,
+  "project": { "root": "/home/dev/billing" },
+  "probe": { "name": "tenancy", "study": "run" },
+  "capabilities": {
+    "http":   { "base_url": "http://127.0.0.1:8399" },
+    "source": { "root": "/home/dev/clones/listmonk" }
+  },
+  "elements": [
+    { "kind": "route", "name": "/api/subscribers/{}" },
+    { "kind": "route", "name": "/api/lists" }
+  ]
+}
+----
+
+A probe uses the capabilities it is given rather than discovering its own. A probe that finds a base URL for itself will find a different one than the engine recorded, and the record is what a requirement cites.
+
+`elements` is the enumerated interface, so a probe examining the surface works from the same list every other probe does.
+
+=== The answer
+
+[source,json]
+----
+{
+  "version": 1,
+  "probe": "tenancy",
+  "examined": 42,
+  "findings": [
+    {
+      "element": "/api/subscribers/{}",
+      "says": "a subscriber from one tenant is readable by another",
+      "evidence": "exercised"
+    }
+  ],
+  "detail": { }
+}
+----
+
+`findings` is what a specification may cite. Each names the element it concerns, states in one line what was established, and records the evidence rung it earned.
+
+`examined` is how many elements the probe looked at. It is what separates a probe that found nothing from a probe that looked at nothing, and it is recorded whether or not there were findings.
+
+`detail` is the probe's own shape, and the engine does not read it.
+
+=== Evidence a probe earns
+
+The `evidence` value on a finding is what a requirement carries when it cites the probe:
+
+[source,markdown]
+----
+- **FR-058** (observed, exercised: tenancy): a subscriber from one tenant is
+  readable by another
+----
+
+A probe claims the rung it actually reached. One that read source reports `inspected`, and one that called the system and observed the result reports `exercised`. xref:reference:specify/spec-conformance.adoc[`PROC-RULE-EVIDENCE`] checks the citation against the run record, so a requirement naming a probe that did not run is a finding.
+
+=== Testing one
+
+[source,bash]
+----
+akka specify probe test tenancy --target http://127.0.0.1:8399
+----
+
+Runs the probe, prints the request it received and its raw output, and validates the answer against the envelope above.
+
+== See also
+
+* xref:reference:specify/port.adoc[/akka:port]
+* xref:reference:specify/spec-conformance.adoc[Specification conformance]
+* xref:sdk:porting-legacy-systems.adoc[Porting legacy systems]

--- a/docs/src/modules/reference/pages/specify/probes.adoc
+++ b/docs/src/modules/reference/pages/specify/probes.adoc
@@ -29,6 +29,7 @@ Asking for a probe by name does not make it available. A probe that was asked fo
 == The catalogue
 
 `Default at` names the study levels where a probe runs without being asked for. See xref:reference:specify/port.adoc[/akka:port] for `--study` and `--probe`.
+
 === Interface and reachability
 
 [cols="1,2,1,1",options="header"]

--- a/docs/src/modules/reference/pages/specify/spec-conformance.adoc
+++ b/docs/src/modules/reference/pages/specify/spec-conformance.adoc
@@ -1,0 +1,88 @@
+= Specification conformance
+
+Two exit conditions check the specification itself. `PROJ-SPEC-SCHEMA` requires that *the specification is well-formed and every requirement traces to a test.* `PROC-RULE-EVIDENCE` requires that *every requirement not chosen by you records how it was established.*
+
+Every other condition checks the build, the repository, or the process. These two check the document those conditions are derived from.
+
+Both read `specs/*/spec.md` and need nothing from the environment, so they run in any project.
+
+== A well-formed specification
+
+The xref:reference:specify/specify.adoc[/akka:specify] template numbers each functional requirement `FR-001` and each success criterion `SC-001`. `PROJ-SPEC-SCHEMA` holds those identifiers to four rules.
+
+[cols="1,3",options="header"]
+|===
+| Rule | Why
+
+| Each identifier is used once | A duplicate identifier makes a requirement impossible to point at, sign off, or trace
+| Every requirement appears in the Traceability table | A requirement outside the table is a promise nothing checks
+| Every table row names a source and a test | A row with an empty test column records the intention to verify rather than the verification
+| Every table row names a real requirement | A row for an identifier that no longer exists describes a promise that was withdrawn
+|===
+
+An obligation stated without an identifier reds the condition. The parser recognises an obligation by the keywords `MUST`, `SHALL`, `SHOULD`, and `MAY`, so ordinary prose in the requirements section is left alone.
+
+== Unresolved questions
+
+`/akka:specify` marks a question it cannot settle with `[NEEDS CLARIFICATION: the question]`, and permits at most three. `PROJ-SPEC-SCHEMA` reds while any marker survives.
+
+Run xref:reference:specify/clarify.adoc[/akka:clarify] to settle them. Each answer removes its marker and adds the traceability row for the requirement it produced.
+
+== Where a requirement came from
+
+A requirement you chose needs no further account of itself. A requirement imposed from outside, or read off a system that already exists, is a claim about the world, and a claim can be wrong. `PROC-RULE-EVIDENCE` separates the two.
+
+Annotate a requirement in parentheses after its identifier:
+
+[source,markdown]
+----
+- **FR-008** (constrained, documented): System MUST retain audit records for seven years
+- **FR-009** (observed, exercised): System MUST return 409 when an order is submitted twice
+----
+
+The first value records where the obligation came from.
+
+[cols="1,3",options="header"]
+|===
+| Provenance | Meaning
+
+| `decided` | Your choice. No evidence is required.
+| `constrained` | Imposed by a platform, a protocol, or a regulation.
+| `observed` | Read off a system that already exists.
+|===
+
+The second value records how the claim was established, weakest first.
+
+[cols="1,3",options="header"]
+|===
+| Evidence | Meaning
+
+| `inspected` | Inferred by reading the source
+| `documented` | Stated by a manual or a specification
+| `exercised` | Called it and observed the result
+|===
+
+Where a xref:reference:specify/probes.adoc[discovery probe] established the requirement, the evidence names it:
+
+[source,markdown]
+----
+- **FR-058** (observed, exercised: sequence): three soft bounces within 24
+  hours mark the subscriber as unconfirmed
+----
+
+Naming the probe is what makes the claim checkable. `PROC-RULE-EVIDENCE` reads `.akka/discovery/run.json` and reds when a requirement names a probe that did not run. A project with no discovery record is unaffected.
+
+A requirement carrying no annotation is read as `decided`. A specification written before these conditions existed therefore stays GREEN, and a project whose requirements are genuinely all decisions never sees the condition speak.
+
+`PROC-RULE-EVIDENCE` reds when a `constrained` or `observed` requirement records no evidence.
+
+== When the specification is absent
+
+A project with no `specs/` directory resolves both conditions OPEN rather than RED. A specification that has not been written yet is a different state from one that is malformed, and OPEN is the state a sign-off closes.
+
+== Related
+
+* xref:reference:specify/specify.adoc[/akka:specify]
+* xref:reference:specify/clarify.adoc[/akka:clarify]
+* xref:reference:specify/default-library.adoc[Default exit-condition library]
+* xref:reference:specify/exit-condition-states.adoc[Exit condition states]

--- a/docs/src/modules/reference/pages/specify/spec-conformance.adoc
+++ b/docs/src/modules/reference/pages/specify/spec-conformance.adoc
@@ -76,6 +76,16 @@ A requirement carrying no annotation is read as `decided`. A specification writt
 
 `PROC-RULE-EVIDENCE` reds when a `constrained` or `observed` requirement records no evidence.
 
+== Requiring every requirement to declare itself
+
+Reading an unannotated requirement as `decided` leaves one thing unsaid. A requirement with no annotation is either a decision somebody made or an assumption about a system nobody checked, and the document does not distinguish them.
+
+`PROJ-PROVENANCE-DECLARED` closes that. It reds when any requirement carries no provenance at all, whatever the value would have been.
+
+The condition ships `off-but-dev-configurable`, because turning it on is a statement about your specification rather than a rule every project should meet. Opt in per project once your requirements carry their annotations, or promote it in a xref:reference:specify/policies.adoc[policy] to hold every project in the organization to it.
+
+A port opts in as a matter of course. Every requirement in a ported specification was read off a system that already exists, so a requirement that declares nothing is an assumption that nobody has been asked to confirm.
+
 == When the specification is absent
 
 A project with no `specs/` directory resolves both conditions OPEN rather than RED. A specification that has not been written yet is a different state from one that is malformed, and OPEN is the state a sign-off closes.

--- a/docs/src/modules/sdk/nav.adoc
+++ b/docs/src/modules/sdk/nav.adoc
@@ -3,6 +3,7 @@
 *** xref:sdk:spec-driven-development.adoc[]
 *** xref:sdk:enforced-mode.adoc[]
 *** xref:sdk:a-la-carte-mode.adoc[]
+*** xref:sdk:porting-legacy-systems.adoc[]
 *** xref:sdk:ai-coding-assistant.adoc[]
 ** xref:sdk:components/index.adoc[]
 *** xref:sdk:agents.adoc[Agents]

--- a/docs/src/modules/sdk/pages/enforced-mode.adoc
+++ b/docs/src/modules/sdk/pages/enforced-mode.adoc
@@ -188,7 +188,7 @@ Beyond the organization policy, the xref:reference:specify/default-library.adoc[
 
 == Working in Enforced mode
 
-Every Specify command remains available -- Enforced mode changes the ship gate, not the command set (see xref:reference:specify/mode.adoc[`/akka:mode`]). In practice you drive an Enforced build through `/akka:specify` as the re-entrant engine, and use the governance commands to inspect progress and release:
+Enforced mode gives the sequence to the engine, so it also decides which commands you may run. Five stay available; the steps the engine sequences are refused, with the remedy named (see xref:reference:specify/mode.adoc[`/akka:mode`]). You drive an Enforced build through `/akka:specify` as the re-entrant engine, and use the governance commands to inspect progress and release:
 
 [cols="1,3"]
 |===
@@ -197,5 +197,7 @@ Every Specify command remains available -- Enforced mode changes the ship gate, 
 | xref:reference:specify/status.adoc[`/akka:status`] | Read-only rollup of the definition of done by business category.
 | xref:reference:specify/ship.adoc[`/akka:ship`] | Run the auditors for the requested ship target and, on pass, run the organization's ship steps.
 | xref:reference:specify/mode.adoc[`/akka:mode`] | Switch mode within the organization-allowed set.
-| xref:reference:specify/setup.adoc[`/akka:setup`] | Install and repair the local environment and source the governance policy.
+| xref:reference:specify/port.adoc[`/akka:port`] | Derive a specification from a system that already exists and hold a rebuild to it.
 |===
+
+`/akka:setup` is refused under enforcement, because re-running it would change the ground the conditions were verified against. Return to À la carte mode to run it.

--- a/docs/src/modules/sdk/pages/porting-legacy-systems.adoc
+++ b/docs/src/modules/sdk/pages/porting-legacy-systems.adoc
@@ -75,7 +75,7 @@ The `--study` flag selects the depth, and the choice sets an upper bound on the 
 
 Parity conditions verify that the rebuild behaves as the original behaved. They say nothing about obligations the original never carried.
 
-A team rebuilding a system frequently intends to add something at the same time: a compliance framework, a load target, a data residency requirement. Declare those with `--also` at invocation, and they become ordinary exit conditions alongside the parity ones. A port with no additional obligations omits the flag.
+A team rebuilding a system frequently intends to add something at the same time: a compliance framework, a load target, a data residency requirement. Those are ordinary exit conditions, and the project carries them alongside the parity ones. A parity condition says the rebuild behaves as the original behaved, and says nothing about anything else the rebuild must satisfy.
 
 == What the port leaves behind
 

--- a/docs/src/modules/sdk/pages/porting-legacy-systems.adoc
+++ b/docs/src/modules/sdk/pages/porting-legacy-systems.adoc
@@ -28,11 +28,11 @@ Porting onto Akka has one advantage that ordinary development does not. The orig
 | xref:reference:specify/port.adoc[/akka:port]
 | Studies the original, enumerates its interface, observes what each element does, writes the specification, and generates the exit conditions that hold the rebuild to it. Sets the project to enforced mode and hands off.
 
-| xref:reference:specify/implement.adoc[/akka:implement], xref:reference:specify/build.adoc[/akka:build], xref:reference:specify/conform.adoc[/akka:conform]
-| Build the rebuild. In enforced mode the engine sequences these, so the port proceeds without you.
+| xref:reference:specify/specify.adoc[/akka:specify]
+| The engine. Under enforcement it carries out planning, implementation, building, and conformance itself rather than recommending each in turn, so the port proceeds without you.
 
 | xref:reference:specify/status.adoc[/akka:status]
-| Reports progress, and raises the prompt to graduate once every parity condition is green.
+| Reports progress. The prompt to graduate is raised by the run that evaluates the auditors, because a status read resolves the set without running them.
 
 | `/akka:port finalize`
 | Rewrites each parity auditor so its reference is a recorded value rather than the live original.
@@ -41,7 +41,7 @@ Porting onto Akka has one advantage that ordinary development does not. The orig
 | Releases, once every condition is green and unstale.
 |===
 
-xref:reference:specify/specify.adoc[/akka:specify] and xref:reference:specify/clarify.adoc[/akka:clarify] have no part in a port. Discovery writes the specification, and it settles its own open questions by running further experiments against the original.
+xref:reference:specify/clarify.adoc[/akka:clarify] has no part in a port, and enforced mode refuses it. Discovery writes the specification, and it settles its own open questions by running further experiments against the original rather than by asking you.
 
 == How the original becomes a specification
 

--- a/docs/src/modules/sdk/pages/porting-legacy-systems.adoc
+++ b/docs/src/modules/sdk/pages/porting-legacy-systems.adoc
@@ -62,7 +62,7 @@ The `--study` flag selects the depth, and the choice sets an upper bound on the 
 | Level | What it means for the specification
 
 | `read`
-| Requirements are inferred from source. Every claim sits at the weakest rung, and xref:reference:specify/spec-conformance.adoc[`PROC-RULE-EVIDENCE`] reports that in every status output.
+| Requirements are inferred from source. Every claim sits at the weakest rung, and each requirement records which rung it earned so xref:reference:specify/spec-conformance.adoc[`PROC-RULE-EVIDENCE`] can check that it accounts for its evidence.
 | `run`
 | The original is started and exercised, so requirements record observed behaviour.
 | `diff`

--- a/docs/src/modules/sdk/pages/porting-legacy-systems.adoc
+++ b/docs/src/modules/sdk/pages/porting-legacy-systems.adoc
@@ -1,0 +1,101 @@
+= Porting legacy systems
+:page-summary: Rebuild a system that already exists onto Akka, with the original as the reference. Discovery derives the specification by running the system; generated exit conditions hold the rebuild to it; graduation converts those conditions into regression tests once the original is retired.
+:page-when-to-use: Use when the behaviour you must reproduce is defined by software that is already running, rather than by a requirement someone can write down.
+:page-related: xref:sdk:spec-driven-development.adoc[], xref:sdk:enforced-mode.adoc[], xref:reference:specify/port.adoc[]
+:page-prerequisites: Akka CLI installed, a supported AI coding assistant, and access to the system being replaced
+:page-persona: Developer, Tech Lead, Architect
+
+include::ROOT:partial$include.adoc[]
+
+A port begins with a system that works and no specification of what it does. The behaviour you have to reproduce is whatever the running software does, including the parts nobody documented and the parts nobody remembers.
+
+That changes what the Akka Specify Plugin has to do. In ordinary xref:sdk:spec-driven-development.adoc[spec-driven development] you state what you want and the Plugin holds the build to it. In a port, the statement of what you want has to be derived from the original first, and then the rebuild has to be held to the original as well as to the specification.
+
+== Why a port is a different problem
+
+An authored specification cannot be factually wrong. You decided it. A requirement may turn out to be unwise or may go unmet, and both of those are visible.
+
+A derived specification can be wrong. It is a claim about somebody else's system, and a claim can misread what it describes. That is a second failure mode, and it is invisible to every check that compares a build against its specification: the build can satisfy every requirement while the requirements misdescribe the original.
+
+Porting onto Akka has one advantage that ordinary development does not. The original is running, so correctness is decidable. Two systems either return the same answer or they do not.
+
+== The workflow
+
+[cols="1,3",options="header"]
+|===
+| Command | What it contributes
+
+| xref:reference:specify/port.adoc[/akka:port]
+| Studies the original, enumerates its interface, observes what each element does, writes the specification, and generates the exit conditions that hold the rebuild to it. Sets the project to enforced mode and hands off.
+
+| xref:reference:specify/implement.adoc[/akka:implement], xref:reference:specify/build.adoc[/akka:build], xref:reference:specify/conform.adoc[/akka:conform]
+| Build the rebuild. In enforced mode the engine sequences these, so the port proceeds without you.
+
+| xref:reference:specify/status.adoc[/akka:status]
+| Reports progress, and raises the prompt to graduate once every parity condition is green.
+
+| `/akka:port finalize`
+| Rewrites each parity auditor so its reference is a recorded value rather than the live original.
+
+| xref:reference:specify/ship.adoc[/akka:ship]
+| Releases, once every condition is green and unstale.
+|===
+
+xref:reference:specify/specify.adoc[/akka:specify] and xref:reference:specify/clarify.adoc[/akka:clarify] have no part in a port. Discovery writes the specification, and it settles its own open questions by running further experiments against the original.
+
+== How the original becomes a specification
+
+Discovery runs in two passes.
+
+The first pass enumerates the interface by reading route declarations, configuration schemas, job registrations, and migrations. The result is a list of every element the system exposes, produced without depending on anyone's recollection.
+
+The second pass observes what each element does. Where an observation is ambiguous, discovery designs a further experiment and observes again. Where that loop exhausts itself, it records an assumption, writes the requirement, and sets its evidence to the weakest rung so the assumption stays visible.
+
+Every enumerated element then carries a disposition. It is covered by a requirement, or it is dropped with a reason that is recorded as a divergence. An element the port could not describe is named rather than passed over, so a capability that was missed reads differently from one that was deliberately excluded.
+
+== How deeply to study the original
+
+The `--study` flag selects the depth, and the choice sets an upper bound on the evidence any requirement may claim.
+
+[cols="1,3",options="header"]
+|===
+| Level | What it means for the specification
+
+| `read`
+| Requirements are inferred from source. Every claim sits at the weakest rung, and xref:reference:specify/spec-conformance.adoc[`PROC-RULE-EVIDENCE`] reports that in every status output.
+| `run`
+| The original is started and exercised, so requirements record observed behaviour.
+| `diff`
+| A comparison proxy answers each request from both systems for the duration of the rebuild, and divergence is reported as it appears.
+|===
+
+`run` and `diff` execute software you may not control on hardware you do. That is a decision about your environment as much as about the port.
+
+== Parity is not the whole definition of done
+
+Parity conditions verify that the rebuild behaves as the original behaved. They say nothing about obligations the original never carried.
+
+A team rebuilding a system frequently intends to add something at the same time: a compliance framework, a load target, a data residency requirement. Declare those with `--also` at invocation, and they become ordinary exit conditions alongside the parity ones. A port with no additional obligations omits the flag.
+
+== What the port leaves behind
+
+Parity conditions compare the rebuild against a running original, so they stop working when the original is decommissioned. `/akka:port finalize` prevents that.
+
+During the port each parity auditor called both systems and compared the answers, which means it captured what the original answered. Graduation points each auditor at that captured value. A condition that compared two responses compares one response against a stored fixture. A condition that compared decisions across a sweep of inputs replays a recorded table. A condition that compared timings becomes a budget set to the figure the original achieved.
+
+The identifier, the invariant, and the pass predicate are unchanged. Only the auditor changes.
+
+What remains is an ordinary Akka Specify Plugin project, carrying a specification whose every requirement traces to a test, and a suite of regression tests whose expected values were taken from a system that was already correct.
+
+== Limits
+
+A condition that can only be expressed as a live comparison, and whose subject cannot be recorded, is retired at graduation rather than rewritten. The reason is kept in the project.
+
+Enumeration is mechanical, so it finds what the original declares. Behaviour that no route, configuration key, job, or table announces is found by observation or not at all, and the divergence list is where that shows up.
+
+== See also
+
+* xref:reference:specify/port.adoc[/akka:port]
+* xref:reference:specify/spec-conformance.adoc[Specification conformance]
+* xref:sdk:enforced-mode.adoc[]
+* xref:sdk:spec-driven-development.adoc[]

--- a/docs/src/modules/sdk/pages/porting-legacy-systems.adoc
+++ b/docs/src/modules/sdk/pages/porting-legacy-systems.adoc
@@ -15,7 +15,7 @@ That changes what the Akka Specify Plugin has to do. In ordinary xref:sdk:spec-d
 
 An authored specification cannot be factually wrong. You decided it. A requirement may turn out to be unwise or may go unmet, and both of those are visible.
 
-A derived specification can be wrong. It is a claim about somebody else's system, and a claim can misread what it describes. That is a second failure mode, and it is invisible to every check that compares a build against its specification: the build can satisfy every requirement while the requirements misdescribe the original.
+A derived specification can be wrong. It is a claim about a system somebody else built, and a claim can misread what it describes. That is a second failure mode, and it is invisible to every check that compares a build against its specification: the build can satisfy every requirement while the requirements describe the original incorrectly.
 
 Porting onto Akka has one advantage that ordinary development does not. The original is running, so correctness is decidable. Two systems either return the same answer or they do not.
 
@@ -38,7 +38,7 @@ Porting onto Akka has one advantage that ordinary development does not. The orig
 | Rewrites each parity auditor so its reference is a recorded value rather than the live original.
 
 | xref:reference:specify/ship.adoc[/akka:ship]
-| Releases, once every condition is green and unstale.
+| Releases, once every condition is green and none has gone stale.
 |===
 
 xref:reference:specify/clarify.adoc[/akka:clarify] has no part in a port, and enforced mode refuses it. Discovery writes the specification, and it settles its own open questions by running further experiments against the original rather than by asking you.


### PR DESCRIPTION
## What this documents, if you have not used the product

Akka Specify is a checklist that software has to pass before it ships. Each item is a plain statement about the software — "no dependency uses an unapproved licence" — and behind each is a small program that checks whether it is true.

A companion change adds a big new capability: **rebuilding a system that already exists**. You point the tool at an old service, it works out what that service does, writes it down, and generates the checks that hold the rebuild to it.

None of that was documented. This adds the pages, and corrects several existing ones that described things the product does not do.

---

## New pages

**Porting a legacy system** — written for someone who arrives with an old service and wants to know whether this tool helps. It explains the problem before the commands, so a reader can decide if it applies to them.

**The `/akka:port` command** — the reference. What you are asked, in what order, and why. It is written as a walkthrough of a real session rather than a list of flags, because the interesting part is the shape of the conversation: everything is asked before the work starts, because the run then proceeds for hours with nobody watching.

**Discovery probes** — the fifteen tools that study the old system. What each one establishes, what it needs in order to run, and what happens when it cannot. That last part gets its own section: a tool that ran and found nothing and a tool that never ran look identical unless somebody says which happened.

**Writing your own checks** — for an organisation with its own standards. A check is just a program: it reads a question on its input and writes an answer on its output, so it can be written in any language. The page gives the exact shape of both, two worked examples, and how to test one before relying on it.

**Specification conformance** — the checks that examine the specification itself, rather than the software.

---

## Corrections

Several existing pages described behaviour the product does not have. These are worth listing individually, because a reader acting on any of them would have got it wrong.

**The most consequential one.** The page telling you how to write your own check had the rules for exit codes backwards. It said a program exiting with an error means "could not tell"; it actually means "the check failed". The two are very different — one blocks a release, the other does not. The page also contradicted its own table eleven lines further down. This is the page somebody writes a check against, so getting it wrong here propagates.

**A feature documented in seven places that does not exist.** A flag for adding extra obligations to a port was described across two pages, with its own section and a table. There is no such flag anywhere in the product. It is gone.

**A distribution mechanism that was never built.** The page described fetching bundles of custom checks from a URL. That is not implemented. It now describes the mechanism that is.

**A page contradicting the page it linked to.** One page said every command stays available in the restricted mode, and linked to the section this change rewrote to say the opposite.

**A setting spelled a way the product does not accept.** Written wrong it is ignored silently, so the check simply never applies.

**A worked example that could not be run.** Three separate problems: a flag placed where the command-line parser hands it to the wrong program, an example reading a file the page never creates, and an abridged code listing producing a different result than the output shown below it. All three now do what the page says, checked by running them.

---

## On how these were caught

Every command, flag, setting name, and claim about what something prints was checked against the source — both the tool itself and the assistant-facing commands. That is where most of the errors above came from, including one command I had invented while writing.

Several were caught by independent reviewers reading the pages against the code. A recurring pattern is worth flagging for whoever reviews this: a claim usually appears twice, once in prose and once inside a sample output block. Correcting the prose and leaving the sample happened more than once, and reads as a page arguing with itself.

---

## How to check this yourself

The site builds clean with no new warnings. Every new page is reachable from the left-hand navigation and listed in the section index. The worked example was run exactly as printed and produces the output shown.

---

## This is one change split across three repositories

The work needed edits in three places, so it arrives as three pull requests. They only make sense together.

- [The tool itself](https://github.com/akka/cli/pull/177) — the commands and checks these pages describe. **Merge that one first.**
- [The assistant commands](https://github.com/akka/ai-marketplace/pull/32) — where `/akka:port` is actually defined.
- **This one** — the documentation.

These pages document commands that exist only on those branches. Merging this first would publish documentation for something nobody can run yet.
