### PR TITLE
docs: document component call failure to HTTP status mapping

### DIFF
--- a/akka-javasdk/src/main/java/akka/javasdk/CommandException.java
+++ b/akka-javasdk/src/main/java/akka/javasdk/CommandException.java
@@ -26,7 +26,8 @@ import akka.javasdk.workflow.Workflow;
  *
  * <p><strong>Network Serialization:</strong> Only {@code CommandException} and its subtypes are
  * serialized and sent over the network when components are called across different nodes. Other
- * exceptions are transformed into generic HTTP 500 errors. The Jackson serialization is configured
+ * exceptions, including a {@link java.util.concurrent.TimeoutException} from a component call that
+ * times out, are transformed into generic HTTP 500 errors. The Jackson serialization is configured
  * to ignore fields like stack trace or cause from the {@link Throwable} class.
  *
  * <p><strong>Usage Examples:</strong>

--- a/docs/src/modules/sdk/pages/errors-and-failures.adoc
+++ b/docs/src/modules/sdk/pages/errors-and-failures.adoc
@@ -4,6 +4,7 @@ include::ROOT:partial$include.adoc[]
 
 The Akka SDK provides several mechanisms dealing with validation or when something is going wrong.
 
+[#errors]
 == Errors
 
 The first line of the defense is the validation of the incoming data on the `Endpoint` level. Already described is details in the xref:http-endpoints.adoc#_advanced_http_requests_and_responses[request and response] section. This is a basic request validation, which does not require domain state. It is better to handle it as soon as possible, since it will reduce the load on the system. The logic can reject the request before it reaches the entity.
@@ -87,6 +88,6 @@ That same correlation ID `2c74bdfb-3130-464c-8852-cf9c3c2180ad` is included in t
 
 When an `Endpoint` calls a component through the `componentClient`, the call runs between Akka nodes. It is not an HTTP request, so it does not produce an upstream HTTP `503` or `504`. When the called component fails, the blocking `invoke()` throws and the asynchronous `invokeAsync()` returns a failed `CompletionStage`.
 
-Only `CommandException` and its subtypes are serialized across the node boundary, as described above. Every other failure reaches the calling `Endpoint` as a non-`CommandException`. A common case is a call timeout, which fails with a `java.util.concurrent.TimeoutException`. Component calls use a default call timeout; see xref:component-and-service-calls.adoc[Component and service calls].
+Only `CommandException` and its subtypes are serialized across the node boundary, as described in the xref:#errors[Errors] section. Every other failure reaches the calling `Endpoint` as a non-`CommandException`. A common case is a call timeout, which fails with a `java.util.concurrent.TimeoutException`. Component calls use a default call timeout; see xref:component-and-service-calls.adoc[Component and service calls].
 
-An uncaught non-`CommandException` from a component call is transformed into an HTTP 500 error with a correlation ID, the same as any other unexpected exception. To return a different status, catch the exception in the `Endpoint` and map it, following the same pattern used above for `CommandException`. For example, catch a `TimeoutException` from a component call and return `504 Gateway Timeout`.
+An uncaught non-`CommandException` from a component call is transformed into an HTTP 500 error with a correlation ID, the same as any other unexpected exception. To return a different status, catch the exception in the `Endpoint` and map it, following the same pattern the xref:#errors[Errors] section uses to catch a `CommandException`. For example, catch a `TimeoutException` from a component call and return `504 Gateway Timeout`.

--- a/docs/src/modules/sdk/pages/errors-and-failures.adoc
+++ b/docs/src/modules/sdk/pages/errors-and-failures.adoc
@@ -82,3 +82,11 @@ Unexpected error [2c74bdfb-3130-464c-8852-cf9c3c2180ad]
 ----
 
 That same correlation ID `2c74bdfb-3130-464c-8852-cf9c3c2180ad` is included in the log entry for the error as an MDC value with the key `correlationID`. This makes it possible to find the specific error in the logs using `akka logs` or by querying your configured logging backend for the service.
+
+=== Failures from component calls
+
+When an `Endpoint` calls a component through the `componentClient`, the call runs between Akka nodes. It is not an HTTP request, so it does not produce an upstream HTTP `503` or `504`. When the called component fails, the blocking `invoke()` throws and the asynchronous `invokeAsync()` returns a failed `CompletionStage`.
+
+Only `CommandException` and its subtypes are serialized across the node boundary, as described above. Every other failure reaches the calling `Endpoint` as a non-`CommandException`. A common case is a call timeout, which fails with a `java.util.concurrent.TimeoutException`. Component calls use a default call timeout; see xref:component-and-service-calls.adoc[Component and service calls].
+
+An uncaught non-`CommandException` from a component call is transformed into an HTTP 500 error with a correlation ID, the same as any other unexpected exception. To return a different status, catch the exception in the `Endpoint` and map it, following the same pattern used above for `CommandException`. For example, catch a `TimeoutException` from a component call and return `504 Gateway Timeout`.


### PR DESCRIPTION
## What

Documents how failures from a `componentClient` call surface as HTTP status codes in an `HTTPEndpoint`.

The existing [errors-and-failures](docs/src/modules/sdk/pages/errors-and-failures.adoc) page already covers `effects().error(...)` → `CommandException` → **400**, and the generic "everything else → **500**" mapping. It did **not** cover the case that actually drove a support investigation: a `componentClient` **call timeout**.

## Changes

- **errors-and-failures.adoc** — new `Failures from component calls` subsection under *Failures*:
  - A `componentClient` call is node-to-node, not an HTTP request, so it does not produce an upstream `503`/`504`; on failure `invoke()` throws / `invokeAsync()` returns a failed `CompletionStage`.
  - Only `CommandException` and subtypes cross the node boundary; everything else (commonly a `TimeoutException`) arrives as a non-`CommandException` and, uncaught, maps to **500** with a correlation ID.
  - To return a different status, catch it in the `Endpoint` (same pattern already shown for `CommandException`) — e.g. `TimeoutException` → `504 Gateway Timeout`.
- **CommandException.java** — javadoc now names `TimeoutException` as the canonical "other exception → 500" case, so narrative and API doc agree.

Prose-only; no new compiled snippet (the catch pattern is already demonstrated on the page for `CommandException`).

## Out of scope

The platform-level timeout layering (Akka HTTP `request-timeout` 503 vs Envoy/Contour `route.timeout` 504, and their alignment) — operational, config-dependent, and better suited to platform docs.

## Verification notes

- Behavior confirmed empirically in the source thread (local test: component-call `TimeoutException` → 500).
- The 400/500 endpoint mapping itself is runtime behavior (in `akka-runtime`), consistent with what this page and the `CommandException` javadoc already assert.

Ref: support case 427921000084766247
