### PR TITLE
docs: lock Site Generator and plugin versions

### DIFF
--- a/docs/antora-docker/Dockerfile
+++ b/docs/antora-docker/Dockerfile
@@ -1,9 +1,9 @@
 FROM antora/antora:3.1.15
 
 # "Alpine Linux v3.11"
-RUN npm install -g @antora/lunr-extension
-RUN npm install -g @antora/site-generator
-RUN npm install -g asciidoc-link-check
+RUN npm install -g @antora/lunr-extension@1.0.0-alpha.13
+RUN npm install -g @antora/site-generator@3.1.15
+RUN npm install -g asciidoc-link-check@1.0.18
 RUN npm install -g @asciidoctor/tabs@1.0.0-beta.6
 RUN npm install -g @sntke/antora-mermaid-extension@0.0.13
 


### PR DESCRIPTION
Antora 3.2.0 was released and having our plugins hang loose doesn't work anymore.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
- https://docs.antora.org/antora/latest/whats-new/#antora-3-2-0