### PR TITLE
docs: use second-person voice in operations pages

### DIFF
--- a/docs/src/modules/operations/pages/configuring.adoc
+++ b/docs/src/modules/operations/pages/configuring.adoc
@@ -97,7 +97,7 @@ include::sdk:example$doc-snippets/standalone/namespace.yml[]
 
 . rbac.yml
 +
-For Akka Cluster bootstrap and rolling updates we need to define role based access control.
+Akka Cluster bootstrap and rolling updates require role-based access control.
 +
 [source,yaml]
 ----
@@ -236,7 +236,7 @@ You find more configuration options in reference documentation:
 
 === More advanced configuration
 
-There are many things that can be configured to control the Akka runtime behavior. Please https://akka.io/contact-us[ask support, window="new"].  and we will guide you to the right way to adjust the configuration for what you need.
+There are many things that can be configured to control the Akka runtime behavior. https://akka.io/contact-us[Contact support, window="new"] for guidance on adjusting the configuration.
 
 A few examples of things that can be configured:
 

--- a/docs/src/modules/operations/pages/observability-and-monitoring/observability-exports.adoc
+++ b/docs/src/modules/operations/pages/observability-and-monitoring/observability-exports.adoc
@@ -409,7 +409,7 @@ Google Cloud is supported for exporting logs, metrics, and traces. The primary p
 
 To create such a service account and key using the `gcloud` command, assuming you are logged in and have a Google project configured:
 
-. Create a service account. In this example, we will call it `akka-exporter`.
+. Create a service account. This example uses the name `akka-exporter`.
 +
 [source,shellscript]
 ----
@@ -426,7 +426,7 @@ gcloud projects add-iam-policy-binding <gcp-project-id> \
     --member "serviceAccount:akka-exporter@<gcp-project-id>.iam.gserviceaccount.com" \
     --role "roles/logging.logWriter"
 ----
-. Generate a key file for your service account, we will place it into a file called `key.json`.
+. Generate a key file for your service account and save it as `key.json`.
 +
 [source,shellscript]
 ----

--- a/docs/src/modules/operations/pages/organizations/regions.adoc
+++ b/docs/src/modules/operations/pages/organizations/regions.adoc
@@ -52,7 +52,7 @@ aws-us-east-2   db805ff5-4fbd-4442-ab56-6e6a9a3c200a
 By default organizations are limited to which regions they can use, particularly for trial organizations. If you would like access to other regions, you can use the *?* in the upper right of the https://console.akka.io/[Akka Console, window="new"] to request additional regions via the *Contact support* menu item.
 
 == BYOC and self-hosted regions
-Akka also supports Bring Your Own Cloud (BYOC) meaning that we can run regions in your AWS, Azure, or Google Cloud account. These are not available to trial users.
+Akka also supports Bring Your Own Cloud (BYOC): Akka runs regions in your own AWS, Azure, or Google Cloud account. These are not available to trial users.
 
 These regions work just like any other regions and are exclusive to your workloads.
 

--- a/docs/src/modules/operations/pages/projects/broker-aiven.adoc
+++ b/docs/src/modules/operations/pages/projects/broker-aiven.adoc
@@ -3,7 +3,7 @@ include::ROOT:partial$include.adoc[]
 
 Akka connects to https://aiven.io[Aiven, window="new"]'s Kafka service via TLS, using a CA certificate provided by Aiven for the service, authenticating using SASL (Simple Authentication and Security Layer) SCRAM.
 
-NOTE: In this guide we use the default `avnadmin` account, but you may want to create a specific service user to use for your Akka service connection.
+NOTE: This guide uses the default `avnadmin` account. Consider creating a dedicated service user for the Akka connection instead.
 
 == Steps to connect to an Aiven Kafka service
 

--- a/docs/src/modules/operations/pages/projects/external-secrets.adoc
+++ b/docs/src/modules/operations/pages/projects/external-secrets.adoc
@@ -44,12 +44,12 @@ Akka services running on AWS can access external secrets from AWS Secrets Manage
 
 === Setting up
 
-Before you set up AWS external secrets, you will need the following information:
+Before you set up AWS external secrets, gather the following. The scripts below reference each value through an environment variable:
 
-* The account ID of your AWS account, which we will refer to in the scripts below using the environment variable `AWS_ACCOUNT_ID`.
-* The region for your AWS account, which we will refer to in the scripts below using the environment variable `AWS_REGION`.
-* The ID of the Akka project that you wish to access to the secrets, which we will refer to in the scripts below using the environment variable `AKKA_PROJECT_ID`. This is a UUID, and can be obtained using the `akka project get` command.
-* The name of the service that you wish to access the secrets, which we will refer to in the scripts below using the environment variable `AKKA_SERVICE_NAME`.
+* `AWS_ACCOUNT_ID` — your AWS account ID.
+* `AWS_REGION` — the region for your AWS account.
+* `AKKA_PROJECT_ID` — the ID of the Akka project that will access the secrets. This is a UUID; obtain it with the `akka project get` command.
+* `AKKA_SERVICE_NAME` — the name of the service that will access the secrets.
 
 The following script can set them:
 
@@ -87,7 +87,7 @@ aws iam create-open-id-connect-provider --url $AKKA_OIDC_ISSUER \
   --tags Key=akka-region,Value=akka-region-name
 ----
 
-AWS often refers to an OIDC provider via the issuer with the `https://` stripped off of it, so for convenience, we will also set that here:
+AWS often refers to an OIDC provider by the issuer with `https://` stripped off. Set that as a separate variable for convenience:
 
 [source, command window]
 ----
@@ -152,7 +152,7 @@ aws iam attach-role-policy --role-name akka-service-role \
 
 Note the `klx-` prefix before the service name in the OIDC provider subject.
 
-Finally, we can tell Akka to assume this role for your service:
+Finally, tell Akka to assume this role for your service:
 
 [source, command window]
 ----
@@ -212,11 +212,11 @@ Akka services running on Azure can access external secrets from Azure KeyVault.
 
 === Setting up
 
-Before you set up Azure KeyVault, you will need the following information:
+Before you set up Azure KeyVault, gather the following. The scripts below reference each value through an environment variable:
 
-* The name of the Azure KeyVault that you wish to access, which we will refer to in the scripts below using the environment variable `KEYVAULT_NAME`.
-* The ID of the Akka project that you wish to access to the secrets, which we will refer to in the scripts below using the environment variable `AKKA_PROJECT_ID`. This is a UUID, and can be obtained using the `akka project get` command.
-* The name of the service that you wish to access the secrets, which we will refer to in the scripts below using the environment variable `AKKA_SERVICE_NAME`.
+* `KEYVAULT_NAME` — the name of the Azure KeyVault to access.
+* `AKKA_PROJECT_ID` — the ID of the Akka project that will access the secrets. This is a UUID; obtain it with the `akka project get` command.
+* `AKKA_SERVICE_NAME` — the name of the service that will access the secrets.
 
 The following script can set them:
 
@@ -253,7 +253,7 @@ az ad sp create-for-rbac --name "${APPLICATION_NAME}"
 export APPLICATION_CLIENT_ID=$(az ad sp list --display-name ${APPLICATION_NAME} --query '[0].appId' -otsv)
 ----
 
-Now we need to grant this application access to keys, secrets and certs in the KeyVault:
+Grant this application access to keys, secrets, and certificates in the KeyVault:
 
 [source, command window]
 ----
@@ -262,14 +262,14 @@ az keyvault set-policy -n $KEYVAULT_NAME --secret-permissions get --spn ${APPLIC
 az keyvault set-policy -n $KEYVAULT_NAME --certificate-permissions get --spn ${APPLICATION_CLIENT_ID}
 ----
 
-Now to federate the credentials, we need the application object id of the application:
+To federate the credentials, get the application object ID:
 
 [source, command window]
 ----
 export APPLICATION_OBJECT_ID="$(az ad app show --id ${APPLICATION_CLIENT_ID} --query id -otsv)"
 ----
 
-Now we will create a JSON parameters file for federating the credentials:
+Create a JSON parameters file for federating the credentials:
 
 [source, command window]
 ----
@@ -354,7 +354,7 @@ Akka services running on GCP can access external secrets from GCP Secret Manager
 
 Before setting up GCP Secret Manager, you will need:
 
-* A GCP project with billing enabled, which we will refer to below using the environment variable `GCP_PROJECT_ID`.
+* `GCP_PROJECT_ID` — the ID of a GCP project with billing enabled.
 * The https://cloud.google.com/sdk/docs/install[Google Cloud CLI (`gcloud`)] installed and authenticated.
 * The Secret Manager API enabled in your GCP project.
 

--- a/docs/src/modules/operations/pages/tls-certificates.adoc
+++ b/docs/src/modules/operations/pages/tls-certificates.adoc
@@ -40,7 +40,7 @@ step certificate create client.acme.org my-client.crt my-client.key \
 
 === Configuring client CA in Akka
 
-Now that we have a CA certificate, we can configure it as a secret in Akka.
+With a CA certificate in hand, configure it as a secret in Akka.
 
 . *Create a CA secret*: To use your CA certificate in Akka, configure it as a TLS CA secret:
 +


### PR DESCRIPTION
## Summary

- Applies the second-person / no-"we" rule from `docs/CLAUDE.md` to the `operations/` module, which was the largest cluster of violations found in a review of the docs against the current writing standards.
- Six pages, 15 line-level rewrites; the total diff is +22/-22.

Three mechanical patterns cover almost all the changes:

1. `we can/will/need to X` → imperative (`configure X`, `grant X`).
2. `…which we will refer to in the scripts below using the environment variable X` intro lists → `X — <description>` (the meta was longer than the description).
3. Akka-team "we" (`we will guide you`, `we can run regions`) → `Akka` or a neutral construction.

No content changes — same instructions, same commands, same order — just voice.

## Test plan

- [ ] `make local` renders the changed pages without AsciiDoc errors.
- [ ] Spot-check each changed page in the rendered site for readability regressions in the bullet-list rewrites (`external-secrets.adoc` in particular reformats intro lists).
- [ ] Confirm no lingering `we` in the six changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)