### PR TITLE
docs: nest BYOC installation content under one top-level section

### DIFF
--- a/docs/src/modules/operations/pages/technical-overview.adoc
+++ b/docs/src/modules/operations/pages/technical-overview.adoc
@@ -181,7 +181,7 @@ System management is shared between you and Akka across provisioning and ongoing
 |===
 
 [#byoc-installation]
-== Installation (BYOC)
+== Bring Your Own Cloud (BYOC)
 
 This is the *BYOC* path, where Akka provisions and operates a region inside your own cloud account. Bringing your own cluster instead? See <<byok8s,Bring Your Own Kubernetes (BYOK8s)>>.
 
@@ -346,7 +346,7 @@ Bootstrap is driven by the `modules/google` Terraform module in the `akka-bootst
 [#byok8s]
 == Bring Your Own Kubernetes (BYOK8s)
 
-AAO can also be installed on a Kubernetes cluster _you provision_, in your cloud or your own data center. You build the infrastructure to Akka's specification and install Teleport to grant access; Akka then configures the cluster as an application-plane region, runs smoke tests, and hands the region over. Want Akka to provision against your existing cloud infrastructure instead? See <<byoc-installation,Installation (BYOC)>>.
+AAO can also be installed on a Kubernetes cluster _you provision_, in your cloud or your own data center. You build the infrastructure to Akka's specification and install Teleport to grant access; Akka then configures the cluster as an application-plane region, runs smoke tests, and hands the region over. Want Akka to provision against your existing cloud infrastructure instead? See <<byoc-installation,Bring Your Own Cloud (BYOC)>>.
 
 [WARNING]
 ====

--- a/docs/src/modules/operations/pages/technical-overview.adoc
+++ b/docs/src/modules/operations/pages/technical-overview.adoc
@@ -183,7 +183,11 @@ System management is shared between you and Akka across provisioning and ongoing
 [#byoc-installation]
 == Installation (BYOC)
 
-Eight steps take you from first contact to a region ready for deployments. This is the *BYOC* path, where Akka provisions and operates a region inside your own cloud account. Bringing your own cluster instead? See <<byok8s,Bring Your Own Kubernetes (BYOK8s)>>.
+This is the *BYOC* path, where Akka provisions and operates a region inside your own cloud account. Bringing your own cluster instead? See <<byok8s,Bring Your Own Kubernetes (BYOK8s)>>.
+
+=== Installation flow
+
+Eight steps take you from first contact to a region ready for deployments.
 
 . *Understand.* This overview is your introduction to AAO. Next, receive and review the `akka-bootstrap` utility from your Akka Success Team. Reviewing it lets you inspect exactly which permissions Akka's deployment identity will require in your account.
 . *Request a region.* Submit a region request through the form in the Akka customer portal. It captures all the details Akka needs to provision the environment.
@@ -194,13 +198,13 @@ Eight steps take you from first contact to a region ready for deployments. This 
 . *Smoke tests.* Akka attaches the region to the Federation Plane and runs smoke tests, so the region can then accept deployments.
 . *Region handover.* Register a user at akka.io with a corporate email; Akka makes them your organization's primary owner, so your team can begin using the region through the console and CLI. A production-labeled region isn't fully handed over until you complete the xref:operations:production-readiness/byoc/checklist.adoc[region-readiness steps] with your Akka Success Team.
 
-== The akka-bootstrap utility
+=== The akka-bootstrap utility
 
 A utility that prepares your cloud account for AAO by creating the *Deployment Identity* role the Federation Plane uses to create and manage infrastructure.
 
 It creates and manages the Deployment Identity operations role only; the Editor, Viewer, and SRE identities must be created by you. Its outputs are consumed by the Federation Plane's provisioning module to enable automated resource management.
 
-=== Directory structure
+==== Directory structure
 
 [source]
 ----
@@ -216,7 +220,7 @@ It creates and manages the Deployment Identity operations role only; the Editor,
 
 Each module ships the standard Terraform files (`main.tf`, `variables.tf`, `outputs.tf`, `versions.tf`) plus provider-specific IAM/permission definitions.
 
-=== Usage
+==== Usage
 
 Create a `values.hcl` in the root with your backend and region details:
 
@@ -260,7 +264,7 @@ terragrunt apply    # provision identity, roles, and credentials
 ====
 
 [#platform-setup]
-== Setup by platform
+=== Setup by platform
 
 The Application Plane always runs on Kubernetes. Below are the shared Kubernetes model, followed by the identity and resource specifics for each cloud provider. These specifics cover the *BYOC* path, where Akka provisions into your cloud. If you're bringing your own Kubernetes cluster, see <<byok8s,Bring Your Own Kubernetes (BYOK8s)>>.
 


### PR DESCRIPTION
## Summary
Per feedback from Tyler in https://typesafe.slack.com/archives/C0BVCA0227J/p1788370316354959: the technical overview reads as though BYOC and BYOK8s are interleaved. The actual issue is heading structure, not content: "The akka-bootstrap utility" and "Setup by platform" were sibling top-level (`==`) sections to "Installation (BYOC)", even though both are explicitly BYOC-only ("These specifics cover the *BYOC* path..."). That put three top-level headings between the reader and BYOK8s, none of them visually signaling they belonged together.

- Nests "The akka-bootstrap utility" and "Setup by platform" as `===` subsections under "Installation (BYOC)".
- Adds an "Installation flow" subheading around the existing 8-step list, mirroring BYOK8s's own structure, which already opens with its own "Installation flow" subsection.
- No content changes, only heading levels. Internal anchors (`#byoc-installation`, `#platform-setup`, `#byok8s`) are untouched and unreferenced from any other page, so nothing else needed updating.

Resulting structure:
```
== Installation (BYOC)
=== Installation flow
=== The akka-bootstrap utility
==== Directory structure
==== Usage
=== Setup by platform

== Bring Your Own Kubernetes (BYOK8s)
=== Installation flow
=== Infrastructure requirements
...
```

Opened as a **draft**: Tyler's thread also raised wanting to compare this page against the original Google Docs/PDFs and additional attachments (network flows, security flows, the Manulife zip) in a follow-up call, which is a separate, larger content-review question this PR doesn't attempt to answer, just the structural complaint.

## Test plan
- [x] `docs/bin/verify-include-paths.sh` passes
- [x] `docs/bin/vale.sh` — 0 errors, 0 warnings
- [x] Standalone `asciidoctor` render with a TOC, checked the heading hierarchy renders as intended (Docker unavailable in the authoring environment for a full Antora build)
- [ ] `make local open` to confirm final nav/TOC rendering in the full site build