### PR TITLE
chore: stop a runtime that came up before the start failed

### DIFF
--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/TestKit.java
@@ -1189,6 +1189,18 @@ public class TestKit {
       this.messageBuilder = new EventingTestKit.MessageBuilder(serializer);
 
     } catch (Exception ex) {
+      // The runtime may already be up and holding the port. Nothing will call stop(), because
+      // start() never returns, so every later testkit in this JVM would fail to bind.
+      if (runtimeActorSystem != null) {
+        try {
+          akka.testkit.javadsl.TestKit.shutdownActorSystem(
+              runtimeActorSystem.classicSystem(),
+              FiniteDuration.create(10, TimeUnit.SECONDS),
+              true);
+        } catch (Exception shutdownFailure) {
+          ex.addSuppressed(shutdownFailure);
+        }
+      }
       throw new RuntimeException("Error while starting testkit", ex);
     }
   }
@@ -1228,6 +1240,7 @@ public class TestKit {
       body =
           response
               .entity()
+              // not getMaterializer(), which requires the testkit to have finished starting
               .toStrict(
                   RUNTIME_STARTED_TIMEOUT.toMillis(),
                   SystemMaterializer.get(runtimeActorSystem).materializer())


### PR DESCRIPTION
I think this was lost in a rebase of https://github.com/akka/akka-sdk/pull/1799

start() never returns when startRuntime throws, so nothing calls stop(). A failure after the runtime has bound therefore left it running and holding the port for the rest of the JVM, and every later test class in it failed to bind. One failure became a whole suite.

