### PR TITLE
chore: abstain becomes inconclusive

### DIFF
--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/eval/Evaluator.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/eval/Evaluator.java
@@ -19,7 +19,10 @@ public interface Evaluator {
    */
   String name();
 
-  /** Checks one turn. Abstain when the evidence this check needs is absent. */
+  /**
+   * Checks one turn. Inconclusive when the evidence this check needs is absent or does not support
+   * a verdict.
+   */
   EvalResult evaluate(EvalCase evalCase, Interaction interaction);
 
   /**
@@ -34,8 +37,11 @@ public interface Evaluator {
     public enum Verdict {
       PASS,
       FAIL,
-      /** The evidence this check needs is absent; neither a pass nor a fail. */
-      ABSTAIN
+      /**
+       * The evidence this check needs is absent or does not support a verdict; neither a pass nor a
+       * fail.
+       */
+      INCONCLUSIVE
     }
 
     public EvalResult {
@@ -57,9 +63,12 @@ public interface Evaluator {
       return new EvalResult("", Verdict.FAIL, detail);
     }
 
-    /** The evidence this check needs is absent; neither a pass nor a fail. */
-    public static EvalResult abstain(String detail) {
-      return new EvalResult("", Verdict.ABSTAIN, detail);
+    /**
+     * The evidence this check needs is absent or does not support a verdict; neither a pass nor a
+     * fail.
+     */
+    public static EvalResult inconclusive(String detail) {
+      return new EvalResult("", Verdict.INCONCLUSIVE, detail);
     }
 
     /** The same result, attributed to the named evaluator. */

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/eval/Evaluators.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/eval/Evaluators.java
@@ -19,9 +19,10 @@ import java.util.regex.PatternSyntaxException;
  * The built-in evaluators, and the names every evaluator reports under.
  *
  * <p>Each factory returns an {@link Evaluator} for one check over the reply and the traced tool
- * calls. An evaluator reads only the evidence it names and abstains when that evidence is absent: a
- * tool that was never called fails {@link #tools}, and {@link #toolArgument} abstains. Give the
- * evaluators to an {@link EvalCase}, next to a {@link Judge} or a custom evaluator.
+ * calls. An evaluator reads only the evidence it names and is inconclusive when that evidence is
+ * absent: a tool that was never called fails {@link #tools}, and {@link #toolArgument} is
+ * inconclusive. Give the evaluators to an {@link EvalCase}, next to a {@link Judge} or a custom
+ * evaluator.
  *
  * <p>The name constants are what the report prints and what {@link Gate#evaluatorRateAtLeast}
  * refers to. {@link #TARGET} and {@link #SETUP} are reported by the runner when a case did not
@@ -86,15 +87,15 @@ public final class Evaluators {
 
   /**
    * These tools must be called in this relative order. Calls to other tools may come between.
-   * Abstains when one of them was never called.
+   * Inconclusive when one of them was never called.
    */
   public static Evaluator toolOrder(String... names) {
     return new ToolOrder(List.copyOf(toolNames(names)));
   }
 
   /**
-   * The named tool must be called with this argument value. Numbers compare by value. Abstains when
-   * the tool was never called.
+   * The named tool must be called with this argument value. Numbers compare by value. Inconclusive
+   * when the tool was never called.
    */
   public static Evaluator toolArgument(String tool, String argument, Object value) {
     requireName(tool, "tool");
@@ -103,8 +104,8 @@ public final class Evaluators {
   }
 
   /**
-   * The result of the named tool must contain this text, case-insensitively. Abstains when the tool
-   * was never called or the trace carries no result for it.
+   * The result of the named tool must contain this text, case-insensitively. Inconclusive when the
+   * tool was never called or the trace carries no result for it.
    */
   public static Evaluator toolResult(String tool, String text) {
     requireName(tool, "tool");
@@ -124,7 +125,7 @@ public final class Evaluators {
   }
 
   /**
-   * The agent may make at most this many model calls while answering. Abstains when the trace
+   * The agent may make at most this many model calls while answering. Inconclusive when the trace
    * carried no model calls.
    */
   public static Evaluator modelCallsAtMost(int calls) {
@@ -133,8 +134,8 @@ public final class Evaluators {
   }
 
   /**
-   * The turn may use at most this many tokens, input and output together. Abstains when no model
-   * call reported tokens, as with a mocked model.
+   * The turn may use at most this many tokens, input and output together. Inconclusive when no
+   * model call reported tokens, as with a mocked model.
    */
   public static Evaluator tokensAtMost(long tokens) {
     if (tokens < 1) throw new IllegalArgumentException("a token budget is positive");
@@ -142,7 +143,8 @@ public final class Evaluators {
   }
 
   /**
-   * The agent command must complete within this time. Abstains when the trace carries no timing.
+   * The agent command must complete within this time. Inconclusive when the trace carries no
+   * timing.
    */
   public static Evaluator latencyAtMost(Duration latency) {
     if (latency == null || latency.isNegative() || latency.isZero())
@@ -208,7 +210,7 @@ public final class Evaluators {
       var called = names(calls);
       var missing = expected.stream().filter(t -> !called.contains(t)).toList();
       if (!missing.isEmpty()) {
-        return EvalResult.abstain("never called " + missing);
+        return EvalResult.inconclusive("never called " + missing);
       }
       return isSubsequence(expected, calls)
           ? EvalResult.pass()
@@ -236,7 +238,7 @@ public final class Evaluators {
       var calls = interaction.toolCalls();
       var toTheTool = calls.stream().filter(c -> c.name().equals(tool)).toList();
       if (toTheTool.isEmpty()) {
-        return EvalResult.abstain(tool + " was never called");
+        return EvalResult.inconclusive(tool + " was never called");
       }
       var carried = toTheTool.stream().anyMatch(c -> sameValue(value, c.arguments().get(argument)));
       return carried
@@ -281,7 +283,7 @@ public final class Evaluators {
               .flatMap(c -> c.result().stream())
               .toList();
       if (results.isEmpty()) {
-        return EvalResult.abstain(tool + " has no recorded result");
+        return EvalResult.inconclusive(tool + " has no recorded result");
       }
       var lowerText = text.toLowerCase(Locale.ROOT);
       return results.stream().anyMatch(r -> r.toLowerCase(Locale.ROOT).contains(lowerText))
@@ -331,7 +333,7 @@ public final class Evaluators {
     public EvalResult evaluate(EvalCase evalCase, Interaction interaction) {
       var made = interaction.modelCalls().size();
       if (made == 0) {
-        return EvalResult.abstain("no model calls in the evidence");
+        return EvalResult.inconclusive("no model calls in the evidence");
       }
       return made <= limit
           ? EvalResult.pass()
@@ -349,7 +351,7 @@ public final class Evaluators {
     public EvalResult evaluate(EvalCase evalCase, Interaction interaction) {
       var used = interaction.totalTokens();
       if (used == 0) {
-        return EvalResult.abstain("no token counts in the evidence");
+        return EvalResult.inconclusive("no token counts in the evidence");
       }
       return used <= limit
           ? EvalResult.pass()
@@ -375,7 +377,7 @@ public final class Evaluators {
     public EvalResult evaluate(EvalCase evalCase, Interaction interaction) {
       var took = interaction.latency();
       if (took.isZero()) {
-        return EvalResult.abstain("no timing in the evidence");
+        return EvalResult.inconclusive("no timing in the evidence");
       }
       return took.compareTo(limit) <= 0
           ? EvalResult.pass()

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/eval/ExperimentRunner.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/eval/ExperimentRunner.java
@@ -392,7 +392,7 @@ public final class ExperimentRunner {
               results.size()));
     }
 
-    /** Pass counts per evaluator, over the cases where it did not abstain. */
+    /** Pass counts per evaluator, over the cases where it was conclusive. */
     private Map<String, Rate> rates() {
       var rates = new LinkedHashMap<String, Rate>();
       for (var result : results) {
@@ -409,7 +409,7 @@ public final class ExperimentRunner {
   private static final class Rate {
     private int passed;
     private int judged;
-    private int abstained;
+    private int inconclusive;
 
     private void count(EvalResult.Verdict verdict) {
       switch (verdict) {
@@ -418,13 +418,13 @@ public final class ExperimentRunner {
           judged++;
         }
         case FAIL -> judged++;
-        case ABSTAIN -> abstained++;
+        case INCONCLUSIVE -> inconclusive++;
       }
     }
 
     private String render(String evaluator) {
-      var abstentions = abstained == 0 ? "" : " (" + abstained + " abstained)";
-      return evaluator + " " + passed + "/" + judged + abstentions;
+      var undecided = inconclusive == 0 ? "" : " (" + inconclusive + " inconclusive)";
+      return evaluator + " " + passed + "/" + judged + undecided;
     }
   }
 }

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/eval/Gate.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/eval/Gate.java
@@ -66,7 +66,7 @@ public final class Gate {
   }
 
   /**
-   * The pass rate of one evaluator, over the cases where it did not abstain, must be at least this.
+   * The pass rate of one evaluator, over the cases where it was conclusive, must be at least this.
    * Fails when the evaluator judged no case. Evaluator names are in {@link Evaluators}.
    */
   public static Gate evaluatorRateAtLeast(String evaluator, double rate) {
@@ -78,7 +78,7 @@ public final class Gate {
               results.stream()
                   .flatMap(result -> result.evalResults().stream())
                   .filter(evalResult -> evalResult.evaluator().equals(evaluator))
-                  .filter(evalResult -> evalResult.verdict() != EvalResult.Verdict.ABSTAIN)
+                  .filter(evalResult -> evalResult.verdict() != EvalResult.Verdict.INCONCLUSIVE)
                   .toList();
           if (evalResults.isEmpty()) {
             return Verdict.fail(evaluator + " judged no case, so its rate cannot be read");

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/eval/Judge.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/eval/Judge.java
@@ -43,7 +43,7 @@ public interface Judge {
    * The judge's answer.
    *
    * @param score between 0 and 1. Any other value, {@code NaN} included, makes the evaluator
-   *     abstain
+   *     inconclusive
    * @param reason one line, printed under a failed case. Empty when the model gave none
    */
   record Verdict(double score, String reason) {
@@ -59,8 +59,8 @@ public interface Judge {
   }
 
   /**
-   * The criterion must score at least this. Abstains when there is no reply, when the judge throws
-   * or gives no verdict, or when the score is not between 0 and 1.
+   * The criterion must score at least this. Inconclusive when there is no reply, when the judge
+   * throws or gives no verdict, or when the score is not between 0 and 1.
    */
   default Evaluator scoringAtLeast(String criterion, double threshold) {
     if (criterion == null || criterion.isBlank())

--- a/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/eval/JudgeEvaluator.java
+++ b/akka-javasdk-testkit/src/main/java/akka/javasdk/testkit/eval/JudgeEvaluator.java
@@ -20,20 +20,20 @@ record JudgeEvaluator(Judge judge, String criterion, double threshold) implement
   @Override
   public EvalResult evaluate(EvalCase evalCase, Interaction interaction) {
     if (interaction.reply().isBlank()) {
-      return EvalResult.abstain(criterion + ": there is no reply to judge");
+      return EvalResult.inconclusive(criterion + ": there is no reply to judge");
     }
     Judge.Verdict verdict;
     try {
       verdict = judge.decide(criterion, interaction);
     } catch (RuntimeException e) {
-      return EvalResult.abstain(criterion + ": the judge failed: " + e.getMessage());
+      return EvalResult.inconclusive(criterion + ": the judge failed: " + e.getMessage());
     }
     if (verdict == null) {
-      return EvalResult.abstain(criterion + ": the judge gave no verdict");
+      return EvalResult.inconclusive(criterion + ": the judge gave no verdict");
     }
     var score = verdict.score();
     if (Double.isNaN(score) || score < 0 || score > 1) {
-      return EvalResult.abstain(
+      return EvalResult.inconclusive(
           criterion + ": the judge scored " + score + ", which is not a share");
     }
     var detail =

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eval/ExperimentRunnerTest.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eval/ExperimentRunnerTest.java
@@ -75,7 +75,7 @@ class ExperimentRunnerTest {
   }
 
   @Test
-  void aMissingToolFailsToolsAndOnlyAbstainsTheChecksThatNeededIt() {
+  void aMissingToolFailsToolsAndOnlyLeavesTheChecksThatNeededItInconclusive() {
     var run =
         run(
             targetThat("I do not know."),
@@ -86,9 +86,9 @@ class ExperimentRunnerTest {
     assertThat(run.evalResult(Evaluators.TOOLS).verdict()).isEqualTo(EvalResult.Verdict.FAIL);
     assertThat(run.evalResult(Evaluators.TOOLS).detail()).contains("no tools");
     assertThat(run.evalResult(Evaluators.TOOL_ORDER).verdict())
-        .isEqualTo(EvalResult.Verdict.ABSTAIN);
+        .isEqualTo(EvalResult.Verdict.INCONCLUSIVE);
     assertThat(run.evalResult(Evaluators.TOOL_ARGUMENTS).verdict())
-        .isEqualTo(EvalResult.Verdict.ABSTAIN);
+        .isEqualTo(EvalResult.Verdict.INCONCLUSIVE);
     assertThat(run.result().passed()).isFalse();
   }
 
@@ -166,7 +166,7 @@ class ExperimentRunnerTest {
   }
 
   @Test
-  void aToolResultExpectationAbstainsWhereTheEvidenceCarriesNoResults() {
+  void aToolResultExpectationIsInconclusiveWhereTheEvidenceCarriesNoResults() {
     var run =
         run(
             targetThat("Ada Lovelace", call("getCustomer", "customerId", "cust_1")),
@@ -174,7 +174,7 @@ class ExperimentRunnerTest {
 
     assertThat(run.result().passed()).isTrue();
     assertThat(run.evalResult(Evaluators.TOOL_RESULTS).verdict())
-        .isEqualTo(EvalResult.Verdict.ABSTAIN);
+        .isEqualTo(EvalResult.Verdict.INCONCLUSIVE);
     assertThat(run.evalResult(Evaluators.TOOL_RESULTS).detail()).contains("no recorded result");
   }
 
@@ -209,7 +209,7 @@ class ExperimentRunnerTest {
   }
 
   @Test
-  void aModelCallBudgetReadsTheTracedCallsAndAbstainsWithoutThem() {
+  void aModelCallBudgetReadsTheTracedCallsAndIsInconclusiveWithoutThem() {
     var threeCalls = tracedThat("done", 3, 100, Duration.ofMillis(40));
 
     var within = run(threeCalls, Evaluators.modelCallsAtMost(3));
@@ -224,12 +224,12 @@ class ExperimentRunnerTest {
 
     var untraced = run(targetThat("done"), Evaluators.modelCallsAtMost(1));
     assertThat(untraced.evalResult(Evaluators.MODEL_CALL_BUDGET).verdict())
-        .isEqualTo(EvalResult.Verdict.ABSTAIN);
+        .isEqualTo(EvalResult.Verdict.INCONCLUSIVE);
     assertThat(untraced.result().passed()).isTrue();
   }
 
   @Test
-  void aTokenBudgetSumsInputAndOutputAndAbstainsWhenNoneWereReported() {
+  void aTokenBudgetSumsInputAndOutputAndIsInconclusiveWhenNoneWereReported() {
     var threeHundred = tracedThat("done", 3, 100, Duration.ofMillis(40));
 
     var within = run(threeHundred, Evaluators.tokensAtMost(300));
@@ -244,11 +244,11 @@ class ExperimentRunnerTest {
     var unreported =
         run(tracedThat("done", 2, 0, Duration.ofMillis(40)), Evaluators.tokensAtMost(10));
     assertThat(unreported.evalResult(Evaluators.TOKEN_BUDGET).verdict())
-        .isEqualTo(EvalResult.Verdict.ABSTAIN);
+        .isEqualTo(EvalResult.Verdict.INCONCLUSIVE);
   }
 
   @Test
-  void aLatencyBudgetReadsTheCommandsDurationAndAbstainsWithoutTiming() {
+  void aLatencyBudgetReadsTheCommandsDurationAndIsInconclusiveWithoutTiming() {
     var forty = tracedThat("done", 1, 10, Duration.ofMillis(40));
 
     var within = run(forty, Evaluators.latencyAtMost(Duration.ofMillis(40)));
@@ -263,7 +263,7 @@ class ExperimentRunnerTest {
 
     var untimed = run(targetThat("done"), Evaluators.latencyAtMost(Duration.ofSeconds(1)));
     assertThat(untimed.evalResult(Evaluators.LATENCY_BUDGET).verdict())
-        .isEqualTo(EvalResult.Verdict.ABSTAIN);
+        .isEqualTo(EvalResult.Verdict.INCONCLUSIVE);
   }
 
   @Test

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eval/GateTest.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eval/GateTest.java
@@ -45,7 +45,7 @@ class GateTest {
   }
 
   @Test
-  void anEvaluatorIsRatedOverTheCasesThatDidNotAbstain() {
+  void anEvaluatorIsRatedOverTheCasesWhereItWasConclusive() {
     var cases =
         List.of(
             EvalCase.of("c1", "q", Evaluators.toolArgument("getCustomer", "customerId", "c1")),
@@ -55,7 +55,7 @@ class GateTest {
     var report = run(Gate.evaluatorRateAtLeast(Evaluators.TOOL_ARGUMENTS, 0.5), cases);
 
     assertThat(report.passed()).isTrue();
-    assertThat(report.render()).contains("tool-arguments 1/2 (1 abstained)");
+    assertThat(report.render()).contains("tool-arguments 1/2 (1 inconclusive)");
     assertThat(run(Gate.evaluatorRateAtLeast(Evaluators.TOOL_ARGUMENTS, 0.9), cases).passed())
         .isFalse();
   }

--- a/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eval/JudgeTest.java
+++ b/akka-javasdk-testkit/src/test/java/akka/javasdk/testkit/eval/JudgeTest.java
@@ -98,17 +98,17 @@ class JudgeTest {
   }
 
   @Test
-  void aScoreOffTheScaleAbstainsRatherThanFailingTheCase() {
+  void aScoreOffTheScaleIsInconclusiveRatherThanFailingTheCase() {
     Judge judge = (criterion, interaction) -> Judge.Verdict.of(7, "seven out of ten");
 
     var result = judged(judge, "an answer", judge.mustSatisfy(CRITERION));
 
-    assertThat(resultOf(result).verdict()).isEqualTo(EvalResult.Verdict.ABSTAIN);
+    assertThat(resultOf(result).verdict()).isEqualTo(EvalResult.Verdict.INCONCLUSIVE);
     assertThat(result.passed()).isTrue();
   }
 
   @Test
-  void aJudgeThatThrowsAbstainsAndSaysSo() {
+  void aJudgeThatThrowsIsInconclusiveAndSaysSo() {
     Judge judge =
         (criterion, interaction) -> {
           throw new IllegalStateException("the judge's provider is not configured");
@@ -116,7 +116,7 @@ class JudgeTest {
 
     var result = judged(judge, "an answer", judge.mustSatisfy(CRITERION));
 
-    assertThat(resultOf(result).verdict()).isEqualTo(EvalResult.Verdict.ABSTAIN);
+    assertThat(resultOf(result).verdict()).isEqualTo(EvalResult.Verdict.INCONCLUSIVE);
     assertThat(resultOf(result).detail()).contains("provider is not configured");
   }
 
@@ -132,7 +132,7 @@ class JudgeTest {
             turn -> EvalTarget.Outcome.answered(Interaction.of(turn.userMessage(), "")),
             EvalCase.of("c", "a question", judge.mustSatisfy(CRITERION)));
 
-    assertThat(resultOf(result).verdict()).isEqualTo(EvalResult.Verdict.ABSTAIN);
+    assertThat(resultOf(result).verdict()).isEqualTo(EvalResult.Verdict.INCONCLUSIVE);
   }
 
   @Test
@@ -169,12 +169,12 @@ class JudgeTest {
   }
 
   @Test
-  void aJudgeThatGivesNoVerdictAbstains() {
+  void aJudgeThatGivesNoVerdictIsInconclusive() {
     Judge judge = (criterion, interaction) -> null;
 
     var result = judged(judge, "an answer", judge.mustSatisfy(CRITERION));
 
-    assertThat(resultOf(result).verdict()).isEqualTo(EvalResult.Verdict.ABSTAIN);
+    assertThat(resultOf(result).verdict()).isEqualTo(EvalResult.Verdict.INCONCLUSIVE);
     assertThat(resultOf(result).detail()).contains("no verdict");
     assertThat(result.passed()).isTrue();
   }

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/eval/SupportAgentEvalTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/eval/SupportAgentEvalTest.java
@@ -213,7 +213,7 @@ public class SupportAgentEvalTest extends TestKitSupport {
   }
 
   @Test
-  public void budgetsReadTheTraceAndTokensAbstainUnderAScriptedModel() {
+  public void budgetsReadTheTraceAndTokensAreInconclusiveUnderAScriptedModel() {
     var tickets =
         EvalCase.of(
             "open-tickets-budget",
@@ -226,12 +226,12 @@ public class SupportAgentEvalTest extends TestKitSupport {
     var result = runOne(tickets);
 
     // Three model calls against a budget of two is the one failure; the test model reports no
-    // tokens, so that budget abstains rather than passing on nothing.
+    // tokens, so that budget is inconclusive rather than passing on nothing.
     assertThat(result.passed()).isFalse();
     assertThat(result.describe())
         .contains("PASS tool-call-budget")
         .contains("FAIL model-call-budget: made 3 model calls, allowed 2")
-        .contains("ABSTAIN token-budget")
+        .contains("INCONCLUSIVE token-budget")
         .contains("PASS latency-budget");
   }
 
@@ -278,8 +278,7 @@ public class SupportAgentEvalTest extends TestKitSupport {
   @Test
   public void replayBaseline() {
     // The captures carry production's spend too, so each case is held to its model call count
-    // and to its recorded latency times the tolerance; the token budget abstains under the
-    // scripted model.
+    // and to its recorded latency times the tolerance; the token budget is inconclusive under the scripted model.
     var replayed = EvalCaseParser.parse(captures());
     var bindings =
         ToolBindings.builder()
@@ -299,7 +298,7 @@ public class SupportAgentEvalTest extends TestKitSupport {
     assertThat(report.render())
         .contains("model-call-budget 3/3")
         .contains("latency-budget 3/3")
-        .contains("token-budget 0/0 (3 abstained)")
+        .contains("token-budget 0/0 (3 inconclusive)")
         .contains("spend: ")
         .contains("over 6/6 cases with evidence");
   }
@@ -364,7 +363,7 @@ public class SupportAgentEvalTest extends TestKitSupport {
   }
 
   @Test
-  public void aJudgeThatWillNotScoreAbstainsInsteadOfFailingTheCase() {
+  public void aJudgeThatWillNotScoreIsInconclusiveInsteadOfFailingTheCase() {
     judgeModel.fixedResponse(
         JsonSupport.encodeToString(new Judge.Verdict(-1, "I cannot judge this")));
     var judge = Judge.modelBased(testKit);
@@ -375,7 +374,7 @@ public class SupportAgentEvalTest extends TestKitSupport {
                 "unjudgeable", "Who is cust_1?", judge.mustSatisfy("the reply is helpful")));
 
     assertThat(result.passed()).isTrue();
-    assertThat(result.describe()).contains("ABSTAIN judge");
+    assertThat(result.describe()).contains("INCONCLUSIVE judge");
   }
 
   @Test

--- a/akka-javasdk-tests/src/test/java/akkajavasdk/eval/SupportAgentEvalTest.java
+++ b/akka-javasdk-tests/src/test/java/akkajavasdk/eval/SupportAgentEvalTest.java
@@ -278,7 +278,8 @@ public class SupportAgentEvalTest extends TestKitSupport {
   @Test
   public void replayBaseline() {
     // The captures carry production's spend too, so each case is held to its model call count
-    // and to its recorded latency times the tolerance; the token budget is inconclusive under the scripted model.
+    // and to its recorded latency times the tolerance; the token budget is inconclusive under the
+    // scripted model.
     var replayed = EvalCaseParser.parse(captures());
     var bindings =
         ToolBindings.builder()

--- a/docs/src/modules/testing/pages/evaluation/eval-cases.adoc
+++ b/docs/src/modules/testing/pages/evaluation/eval-cases.adoc
@@ -1,5 +1,5 @@
 = Eval cases and evaluators
-:page-summary: An EvalCase carries the user message and its evaluators; the built-in evaluators check the tool calls, the reply and the spend of a turn, and abstain when their evidence is absent.
+:page-summary: An EvalCase carries the user message and its evaluators; the built-in evaluators check the tool calls, the reply and the spend of a turn, and are inconclusive when their evidence is absent.
 :page-when-to-use: Writing cases by hand and choosing what each one checks.
 :page-related: testing:evaluation/getting-started.adoc, testing:evaluation/judges.adoc, testing:evaluation/replay.adoc
 :page-persona: builder-developer, builder-ai-ml
@@ -45,7 +45,7 @@ A replayed case is the exception: its recorded results are loaded per case, see 
 == Evaluators
 
 An link:{attachmentsdir}/testkit/akka/javasdk/testkit/eval/Evaluator.html[Evaluator] is one check over the reply and the traced tool calls of a turn.
-It reports a result: pass, fail, or abstain when the evidence it needs is absent.
+It reports a result: pass, fail, or inconclusive when the evidence it needs is absent.
 A case carries any number of evaluators, and they are all of the same type:
 
 * the built-in evaluators, created through the factories in link:{attachmentsdir}/testkit/akka/javasdk/testkit/eval/Evaluators.html[Evaluators];
@@ -78,15 +78,15 @@ include::sdk:example$doc-snippets/src/test/java/com/example/eval/OrderAgentQuali
 
 | `tool-order`
 | `Evaluators.toolOrder(names...)`
-| The named tools were called in this relative order. Calls to other tools may come between. Abstains when one of the named tools was never called.
+| The named tools were called in this relative order. Calls to other tools may come between. Inconclusive when one of the named tools was never called.
 
 | `tool-arguments`
 | `Evaluators.toolArgument(tool, argument, value)`
-| A call to the tool carried the argument with this value. Abstains when the tool was never called.
+| A call to the tool carried the argument with this value. Inconclusive when the tool was never called.
 
 | `tool-results`
 | `Evaluators.toolResult(tool, text)`
-| The result of the tool contains the text, case-insensitively. Abstains when the tool was never called or the trace carries no result for it.
+| The result of the tool contains the text, case-insensitively. Inconclusive when the tool was never called or the trace carries no result for it.
 
 | `forbidden-tools`
 | `Evaluators.forbiddenTools(names...)`
@@ -132,17 +132,17 @@ include::sdk:example$doc-snippets/src/test/java/com/example/eval/OrderAgentQuali
 
 | `token-budget`
 | `Evaluators.tokensAtMost(tokens)`
-| Input and output tokens together stay within the limit. Abstains when the model reported no tokens.
+| Input and output tokens together stay within the limit. Inconclusive when the model reported no tokens.
 
 | `latency-budget`
 | `Evaluators.latencyAtMost(duration)`
-| The agent command completed within the duration. Abstains when the trace carries no timing.
+| The agent command completed within the duration. Inconclusive when the trace carries no timing.
 |===
 
 [#custom-evaluators]
 == Custom evaluator
 
-A custom evaluator implements link:{attachmentsdir}/testkit/akka/javasdk/testkit/eval/Evaluator.html[Evaluator]: `name()` returns the name its results are reported under, and `evaluate(...)` receives the case and the `Interaction`, the reply and everything the runtime traced for the turn, and returns an `EvalResult`: a pass, a fail with a reason, or an abstention.
+A custom evaluator implements link:{attachmentsdir}/testkit/akka/javasdk/testkit/eval/Evaluator.html[Evaluator]: `name()` returns the name its results are reported under, and `evaluate(...)` receives the case and the `Interaction`, the reply and everything the runtime traced for the turn, and returns an `EvalResult`: a pass, a fail with a reason, or an inconclusive result.
 
 `RefundWithinTotal` is an evaluator that checks that the amount the agent passed to `issueRefund` does not exceed the total of the order.
 
@@ -152,7 +152,7 @@ A custom evaluator implements link:{attachmentsdir}/testkit/akka/javasdk/testkit
 include::sdk:example$doc-snippets/src/test/java/com/example/eval/RefundWithinTotal.java[tag=class]
 ----
 <1> The name the report prints the results under, and a gate can rate.
-<2> No refund call means nothing to check. Abstain rather than fail; the `tools` evaluator on the case reports the missing call.
+<2> No refund call means nothing to check. Report an inconclusive result rather than a fail; the `tools` evaluator on the case reports the missing call.
 <3> Tool arguments arrive as the runtime decoded them from the model's JSON: a number is a `Number`, an object is a `Map`.
 
 It goes into a case next to the built-in evaluators.
@@ -164,14 +164,14 @@ include::sdk:example$doc-snippets/src/test/java/com/example/eval/OrderAgentQuali
 ----
 <1> The evaluator carries what it needs to know about the case.
 
-[#abstaining]
-== Abstaining when the evidence is absent
+[#inconclusive]
+== Inconclusive results
 
-An evaluator reads only what it names and abstains when that evidence is absent.
-A tool that was never called fails `tools` and makes `tool-order` and `tool-arguments` abstain, so one missing call is reported once.
-An abstention is neither a pass nor a fail.
-A case with abstentions and no failed result passes.
-The report counts abstentions per evaluator name, and `Gate.evaluatorRateAtLeast` rates evaluators over the results that did not abstain.
+An evaluator reads only what it names and is inconclusive when that evidence is absent or does not support a verdict.
+A tool that was never called fails `tools` and makes `tool-order` and `tool-arguments` inconclusive, so one missing call is reported once.
+An inconclusive result is neither a pass nor a fail.
+A case with inconclusive results and no failed result passes.
+The report counts inconclusive results per evaluator name, and `Gate.evaluatorRateAtLeast` rates evaluators over the conclusive results.
 
 == See also
 

--- a/docs/src/modules/testing/pages/evaluation/gates-and-reports.adoc
+++ b/docs/src/modules/testing/pages/evaluation/gates-and-reports.adoc
@@ -26,7 +26,7 @@ A link:{attachmentsdir}/testkit/akka/javasdk/testkit/eval/Gate.html[Gate] is wha
 | The share of cases with no failed result is at least the rate.
 
 | `Gate.evaluatorRateAtLeast(evaluator, rate)`
-| One evaluator's pass rate, over the cases where it did not abstain, is at least the rate. Fails when the evaluator judged no case. Evaluator names are in `Evaluators`, or the name a custom evaluator reports under.
+| One evaluator's pass rate, over the cases where it was conclusive, is at least the rate. Fails when the evaluator judged no case. Evaluator names are in `Evaluators`, or the name a custom evaluator reports under.
 
 | `Gate.noTargetFailures()`
 | No case failed while loading its recorded calls or in the agent call.
@@ -81,7 +81,7 @@ Line by line:
 
 . The cases with no failed result, and the pass rate.
 . The gate's verdict and its detail. A combined gate lists the detail of each part.
-. One line per evaluator: the cases it passed over the cases it judged. An evaluator that abstained on some cases shows the count in brackets, for example `token-budget 0/0 (2 abstained)`.
+. One line per evaluator: the cases it passed over the cases it judged. An evaluator that was inconclusive on some cases shows the count in brackets, for example `token-budget 0/0 (2 inconclusive)`.
 . The spend: model calls, tokens and latency summed over the cases whose trace carried model calls, and the slowest case. The line is absent when no case carried model calls.
 . After these lines, every failed case with its evidence, see <<reading-a-failed-case>>.
 

--- a/docs/src/modules/testing/pages/evaluation/getting-started.adoc
+++ b/docs/src/modules/testing/pages/evaluation/getting-started.adoc
@@ -158,6 +158,6 @@ xref:testing:evaluation/gates-and-reports.adoc#reading-the-report[Reading the re
 
 == See also
 
-* xref:testing:evaluation/eval-cases.adoc[] lists every built-in evaluator and when it abstains.
+* xref:testing:evaluation/eval-cases.adoc[] lists every built-in evaluator and when it is inconclusive.
 * xref:testing:evaluation/judges.adoc[] scores criteria that have no exact answer.
 * xref:testing:evaluation/replay.adoc[] turns recorded production traffic into cases.

--- a/docs/src/modules/testing/pages/evaluation/index.adoc
+++ b/docs/src/modules/testing/pages/evaluation/index.adoc
@@ -35,7 +35,7 @@ Evaluation is not the place for the following.
 . The case's recorded tool calls, if any, are loaded into the stubs through the runner's `ToolBindings`.
 . The runner calls the agent's command handler through the TestKit component client, in a fresh session, with the case's user message.
 . The runner reads the trace the runtime wrote for that session through `TelemetryReader`: the tool calls with their arguments, results and errors, the model calls with their token counts, the guardrail evaluations and the latency.
-. Every evaluator of the case reads the reply and the trace and reports a result: pass, fail, or abstain when the evidence it needs is absent.
+. Every evaluator of the case reads the reply and the trace and reports a result: pass, fail, or inconclusive when the evidence it needs is absent.
 . The gate checks the aggregated results and the report is returned.
 
 [mermaid]

--- a/docs/src/modules/testing/pages/evaluation/judges.adoc
+++ b/docs/src/modules/testing/pages/evaluation/judges.adoc
@@ -1,5 +1,5 @@
 = Model judges
-:page-summary: A Judge scores a reply against a criterion in plain language; Judge.modelBased asks a model through the TestKit, and the score becomes a pass, a fail or an abstention on the case.
+:page-summary: A Judge scores a reply against a criterion in plain language; Judge.modelBased asks a model through the TestKit, and the score becomes a pass, a fail or an inconclusive result on the case.
 :page-when-to-use: Criteria the built-in evaluators cannot state, such as tone, completeness or faithfulness to the tool results.
 :page-related: testing:evaluation/eval-cases.adoc, testing:evaluation/gates-and-reports.adoc
 :page-persona: builder-developer, builder-ai-ml
@@ -115,22 +115,22 @@ The judge appends `ModelBasedJudge.REPLY_FORMAT` to the system message, which as
 `ModelBasedJudge.defaultUserMessage(criterion, interaction)` is the default rendering in <<what-the-judge-sees>>.
 A custom rendering must carry what the system message asks the model to judge.
 
-== When the judge abstains
+== When the judge is inconclusive
 
-The `judge` evaluator abstains, and the case is not failed, when:
+The `judge` evaluator is inconclusive, and the case is not failed, when:
 
 * the reply is empty or blank, so there is nothing to judge;
 * the judge throws, for example because the model is unavailable;
 * the score is not between 0 and 1.
 
-The abstention carries the reason and appears in the report as `ABSTAIN judge:` followed by the criterion and the reason.
-xref:testing:evaluation/eval-cases.adoc#abstaining[Abstaining when the evidence is absent] describes how the report and the gates count abstentions.
+The inconclusive result carries the reason and appears in the report as `INCONCLUSIVE judge:` followed by the criterion and the reason.
+xref:testing:evaluation/eval-cases.adoc#inconclusive[Inconclusive results] describes how the report and the gates count inconclusive results.
 
 [#gating-a-judged-batch]
 == Gating a judged batch
 
 With a real model, hold a batch to the rate the judge passed.
-`Gate.evaluatorRateAtLeast(Evaluators.JUDGE, rate)` rates the `judge` evaluator over the cases where it did not abstain, and fails when it judged no case.
+`Gate.evaluatorRateAtLeast(Evaluators.JUDGE, rate)` rates the `judge` evaluator over the cases where it was conclusive, and fails when it judged no case.
 
 [source,java,indent=0]
 .{sample-base-url}/doc-snippets/src/test/java/com/example/eval/OrderAgentQualityIntegrationTest.java[OrderAgentQualityIntegrationTest.java]

--- a/docs/src/modules/testing/pages/evaluation/replay.adoc
+++ b/docs/src/modules/testing/pages/evaluation/replay.adoc
@@ -142,7 +142,7 @@ Each field present becomes a budget evaluator on the case.
 A rerun almost never spends the same as the recording, so the token and latency budgets allow more than the recorded figures.
 `EvalCaseParser.parse(path)` uses `EvalCaseParser.DEFAULT_TOLERANCE`, which is 1.5.
 `parse(path, tolerance)` sets another tolerance; `1.0` holds a case to exactly what was recorded, and a value below `1.0` is rejected.
-Under a `TestModelProvider` the token budget abstains, because a mocked model reports no tokens.
+Under a `TestModelProvider` the token budget is inconclusive, because a mocked model reports no tokens.
 
 == The replayed batch
 
@@ -164,13 +164,13 @@ gate: passed — pass rate 1.00 over 5 cases, required 0.90
   tool-order 3/3
   tool-arguments 5/5
   model-call-budget 2/2
-  token-budget 0/0 (2 abstained)
+  token-budget 0/0 (2 inconclusive)
   latency-budget 2/2
 spend: 9 model calls, 0 tokens in, 0 out, 30 ms in total, slowest prod-2 at 7 ms, over 5/5 cases with evidence
 ----
 
 Three recordings name tools, so three cases have `tools` and `tool-order` results, and their five recorded arguments give five `tool-arguments` results.
-Two recordings carry spend figures, so two cases have budgets, and their token budgets abstained.
+Two recordings carry spend figures, so two cases have budgets, and their token budgets were inconclusive.
 
 == See also
 

--- a/samples/doc-snippets/src/test/java/com/example/eval/RefundWithinTotal.java
+++ b/samples/doc-snippets/src/test/java/com/example/eval/RefundWithinTotal.java
@@ -27,7 +27,7 @@ public final class RefundWithinTotal implements Evaluator {
       .filter(call -> call.name().equals("issueRefund"))
       .findFirst();
     if (refund.isEmpty()) {
-      return EvalResult.abstain("no refund was issued"); // <2>
+      return EvalResult.inconclusive("no refund was issued"); // <2>
     }
     var amount = ((Number) refund.get().arguments().get("amountCents")).intValue(); // <3>
     return amount <= totalCents


### PR DESCRIPTION
@aludwiko, trying to find a middle ground for the Verdict. The RedKit had HELD, BROKE and INCONCLUSIVE while the EvalKit PASS, FAIL and ABSTAIN. 

I suggest that we use PASS, FAIL and INCONCLUSIVE. 

A little semantic difference. At the end, you abstain because the evident you have is not enough to make a judgement. And then, it's fine to say the verdict is inconclusive.