### PR TITLE
docs: Aid AI harnesses to properly figure out how to install Akka Specify

### DIFF
--- a/docs/src/modules/getting-started/pages/spec-your-first-agent.adoc
+++ b/docs/src/modules/getting-started/pages/spec-your-first-agent.adoc
@@ -21,7 +21,7 @@ New installs start in *À la carte* mode. To use Enforced, switch first:
 == Prerequisites
 
 * Complete xref:getting-started:set-up-dev-env.adoc#_set_up_your_ai_harness[Set up your AI harness] -- install the Akka Specify Plugin and run `/akka:setup`.
-* An https://platform.openai.com/api-keys[OpenAI API key, window="new"], required only for this tutorial's generated agent -- not for installing the Specify Plugin. The application code calls OpenAI directly, independently of your AI coding assistant. Set `OPENAI_API_KEY` in your environment before starting your assistant; on Mac/Linux use `export` so child processes inherit it.
+* An https://platform.openai.com/api-keys[OpenAI API key, window="new"], required only for this tutorial's generated agent -- not for installing the Akka Specify Plugin. The application code calls OpenAI directly, independently of your AI coding assistant. Set `OPENAI_API_KEY` in your environment before starting your assistant; on Mac/Linux use `export` so child processes inherit it.
 
 [#enforced]
 == Build in Enforced mode

--- a/docs/src/modules/getting-started/pages/spec-your-first-agent.adoc
+++ b/docs/src/modules/getting-started/pages/spec-your-first-agent.adoc
@@ -21,7 +21,7 @@ New installs start in *À la carte* mode. To use Enforced, switch first:
 == Prerequisites
 
 * Complete xref:getting-started:set-up-dev-env.adoc#_set_up_your_ai_harness[Set up your AI harness] -- install the Akka Specify Plugin and run `/akka:setup`.
-* An https://platform.openai.com/api-keys[OpenAI API key, window="new"]. The application code calls OpenAI, independently of your AI coding assistant. Set `OPENAI_API_KEY` in your environment before starting your assistant; on Mac/Linux use `export` so child processes inherit it.
+* An https://platform.openai.com/api-keys[OpenAI API key, window="new"], required only for this tutorial's generated agent -- not for installing the Specify Plugin. The application code calls OpenAI directly, independently of your AI coding assistant. Set `OPENAI_API_KEY` in your environment before starting your assistant; on Mac/Linux use `export` so child processes inherit it.
 
 [#enforced]
 == Build in Enforced mode

--- a/docs/src/modules/sdk/pages/ai-coding-assistant.adoc
+++ b/docs/src/modules/sdk/pages/ai-coding-assistant.adoc
@@ -1,10 +1,14 @@
 = Using an AI coding assistant
+:page-summary: Configure an AI coding assistant to call the Akka CLI directly, without the Akka Specify Plugin's spec-driven workflow. To install the Specify Plugin itself, see Set up your AI harness.
+:page-when-to-use: Prompting a coding assistant to write Akka code outside spec-driven development, or configuring an assistant the Specify Plugin does not support.
+:page-related: xref:sdk:spec-driven-development.adoc[], xref:getting-started:set-up-dev-env.adoc[], xref:sdk:ai-coding-assistant-guidelines.adoc[]
+:page-persona: Developer, Tech Lead, Architect
 
 include::ROOT:partial$include.adoc[]
 
 [NOTE]
 ====
-These guidelines are for enabling AI assistants to use the Akka CLI natively. If you are using the xref:sdk:spec-driven-development.adoc[Akka Specify Plugin] with spec-driven development, all of this configuration and these best practices are enabled within the Akka Specify Plugin automatically.
+This page configures an AI assistant to call the Akka CLI natively, without spec-driven development. To install the Akka Specify Plugin instead, see xref:getting-started:set-up-dev-env.adoc#_set_up_your_ai_harness[Set up your AI harness] -- the plugin enables this configuration and these best practices automatically, and you do not need the steps below.
 ====
 
 AI coding assistants can increase your productivity when developing Akka services. This guide will give you some practical hints of how to setup Akka knowledge and how to prompt the AI assistant. We are using https://docs.claude.com/en/docs/claude-code/overview[Claude code, window="new"],  https://www.qodo.ai[Qodo, window="new"], https://www.cursor.com[Cursor, window="new"] and https://www.jetbrains.com/help/idea/ai-assistant-in-jetbrains-ides.html[IntelliJ IDEA, window="new"] as examples of such coding assistants, but the techniques are applicable for other tools as well.

--- a/docs/src/modules/sdk/pages/ai-coding-assistant.adoc
+++ b/docs/src/modules/sdk/pages/ai-coding-assistant.adoc
@@ -1,6 +1,6 @@
 = Using an AI coding assistant
-:page-summary: Configure an AI coding assistant to call the Akka CLI directly, without the Akka Specify Plugin's spec-driven workflow. To install the Specify Plugin itself, see Set up your AI harness.
-:page-when-to-use: Prompting a coding assistant to write Akka code outside spec-driven development, or configuring an assistant the Specify Plugin does not support.
+:page-summary: Configure an AI coding assistant to call the Akka CLI directly, without the Akka Specify Plugin's spec-driven workflow. To install the Akka Specify Plugin itself, see Set up your AI harness.
+:page-when-to-use: Prompting a coding assistant to write Akka code outside spec-driven development, or configuring an assistant the Akka Specify Plugin does not support.
 :page-related: xref:sdk:spec-driven-development.adoc[], xref:getting-started:set-up-dev-env.adoc[], xref:sdk:ai-coding-assistant-guidelines.adoc[]
 :page-persona: Developer, Tech Lead, Architect
 


### PR DESCRIPTION
## Summary

An AI agent researching how to install the Akka Specify Plugin can land on `sdk:ai-coding-assistant.adoc` (native Akka CLI usage, no SDD) and mistake its `akka code init` instructions for the plugin install path, because that page had no page metadata and only mentioned the Specify Plugin as an aside. Separately, `getting-started:spec-your-first-agent.adoc` listed an OpenAI API key prerequisite directly next to the plugin-install prerequisite with no indication it applies only to that tutorial's generated agent, not to installing the plugin.

- Add `:page-*:` metadata to `ai-coding-assistant.adoc` and reword its top NOTE to lead with what the page covers and link straight to the real install steps (`set-up-dev-env.adoc#_set_up_your_ai_harness`).
- Scope the OpenAI API key bullet in `spec-your-first-agent.adoc` to the tutorial's sample agent, explicitly not plugin installation.
- Use the full "Akka Specify Plugin" term consistently (per `docs/AGENTS.md`: one term for one thing, everywhere).

## Test plan

- [x] Reviewed by an independent read-only agent per `/akka-pr-review` (three rounds; final verdict READY TO PUSH, no blockers).
- [x] Verified with a local Antora build (`npx antora docs/antora-playbook-local.yml`) — both changed pages render, the new cross-page xref resolves, no new build warnings.
- [x] `docs/bin/verify-include-paths.sh` clean for both changed files.
- [ ] Vale lint (`docs/bin/vale.sh`) not run — Vale is not installed in this environment; CI will run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G44WZ8whpvNXMURqPVj6DB